### PR TITLE
Bind containers to loopback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   db:
     image: postgres:16-alpine
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
@@ -25,7 +25,7 @@ services:
       context: .
       dockerfile: api/Dockerfile
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     environment:
       - DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud
       - GITHUB_TOKEN=test_token


### PR DESCRIPTION
Currently, when running the docker compose stack, the containers are reachable from any device on the same subnet. This isn't usually a problem on your own home wifi network, but might be an issue in a place without strict network security like a coffee shop.

...then again, sometimes it _is_ a problem on your home wifi network, see: https://cloud.google.com/blog/topics/threat-intelligence/disrupting-largest-residential-proxy-network

This commit binds the containers to the loopback interface so they're only reachable from the same machine they're running on.