### PR TITLE
Feature/csrf protection

### DIFF
--- a/api/core/csrf.py
+++ b/api/core/csrf.py
@@ -1,0 +1,119 @@
+"""CSRF protection middleware — Synchronizer Token Pattern.
+
+Stores a random token in the server-side session and validates it on
+unsafe requests (POST, PUT, PATCH, DELETE).  The token can be submitted
+via either:
+
+- **Header**: ``X-CSRFToken`` (used automatically by HTMX via a global
+  ``htmx:configRequest`` listener in ``base.html``)
+- **Form field**: ``csrf_token`` (used by the logout ``<form>`` in the
+  navbar)
+
+This is stronger than the Double Submit Cookie pattern because the
+token lives in the signed session — an attacker who can set cookies
+on a subdomain still cannot forge requests.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from re import Pattern
+
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+_SESSION_KEY = "_csrf_token"
+_HEADER_NAME = "x-csrftoken"
+_FORM_FIELD = "csrf_token"
+
+
+class CSRFMiddleware:
+    """Synchronizer Token CSRF middleware.
+
+    Args:
+        app: The ASGI application.
+        exempt_urls: Optional regex patterns for paths that skip CSRF
+            checks (e.g. OAuth callbacks that receive external redirects).
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        exempt_urls: list[Pattern[str]] | None = None,
+    ) -> None:
+        self.app = app
+        self.exempt_urls = exempt_urls or []
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope, receive)
+
+        # Ensure a CSRF token exists in the session.
+        session = scope.get("session")
+        if session is None:
+            # SessionMiddleware not active — skip CSRF enforcement.
+            await self.app(scope, receive, send)
+            return
+
+        if _SESSION_KEY not in session:
+            session[_SESSION_KEY] = secrets.token_urlsafe(32)
+
+        # Expose the token on scope so templates can read it.
+        scope["csrf_token"] = session[_SESSION_KEY]
+
+        if request.method in _SAFE_METHODS:
+            await self.app(scope, receive, send)
+            return
+
+        if self._url_is_exempt(request.url.path):
+            await self.app(scope, receive, send)
+            return
+
+        # Validate: check header first, then form body.
+        submitted: str | None = request.headers.get(_HEADER_NAME)
+        if not submitted:
+            content_type = request.headers.get("content-type", "")
+            if "application/x-www-form-urlencoded" in content_type:
+                form = await request.form()
+                value = form.get(_FORM_FIELD)
+                if isinstance(value, str):
+                    submitted = value
+                # Close the form to release resources.
+                await form.close()
+
+        if not submitted or not secrets.compare_digest(
+            submitted, session[_SESSION_KEY]
+        ):
+            logger.warning(
+                "csrf.validation_failed",
+                extra={
+                    "path": request.url.path,
+                    "method": request.method,
+                },
+            )
+            response = self._error_response(request)
+            await response(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)
+
+    def _url_is_exempt(self, path: str) -> bool:
+        return any(pattern.match(path) for pattern in self.exempt_urls)
+
+    def _error_response(self, request: Request) -> Response:
+        """Return 403 — HTMX-aware so the client can handle it."""
+        if "hx-request" in request.headers:
+            return PlainTextResponse(
+                "CSRF token missing or invalid. Please refresh the page.",
+                status_code=403,
+            )
+        return PlainTextResponse("CSRF token verification failed", status_code=403)

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import logging
+import re
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from starlette.middleware.sessions import SessionMiddleware
 
 from core.auth import init_oauth
 from core.config import get_settings
+from core.csrf import CSRFMiddleware
 from core.database import (
     create_engine,
     create_session_maker,
@@ -266,6 +268,10 @@ app.add_exception_handler(RequestValidationError, validation_exception_handler)
 app.add_exception_handler(Exception, global_exception_handler)
 
 app.add_middleware(UserTrackingMiddleware)
+app.add_middleware(
+    CSRFMiddleware,
+    exempt_urls=[re.compile(r"^/auth/callback$")],
+)
 app.add_middleware(
     SessionMiddleware,
     secret_key=_settings.session_secret_key,

--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -34,7 +34,16 @@
                 window.location.href = '/auth/login';
             }
         });
+        // Attach CSRF token to all HTMX requests
+        document.addEventListener('htmx:configRequest', function(event) {
+            var token = document.querySelector('meta[name="csrf-token"]');
+            if (token) {
+                event.detail.headers['X-CSRFToken'] = token.content;
+            }
+        });
     </script>
+
+    <meta name="csrf-token" content="{{ request.scope.get('csrf_token', '') }}">
 
     {% block head %}{% endblock %}
 </head>

--- a/api/templates/partials/navbar.html
+++ b/api/templates/partials/navbar.html
@@ -48,6 +48,7 @@
                         </a>
                         <div class="border-t border-gray-100 dark:border-gray-700 my-1"></div>
                         <form method="post" action="/auth/logout">
+                            <input type="hidden" name="csrf_token" value="{{ request.scope.get('csrf_token', '') }}">
                             <button type="submit" class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700">
                                 Sign out
                             </button>

--- a/api/tests/core/test_csrf.py
+++ b/api/tests/core/test_csrf.py
@@ -1,0 +1,254 @@
+"""Unit tests for core.csrf — CSRF middleware.
+
+Tests the Synchronizer Token Pattern:
+- Token auto-generated in session on first request
+- GET/HEAD/OPTIONS/TRACE skip CSRF checks
+- POST/DELETE/PUT/PATCH require a valid token
+- Token accepted from X-CSRFToken header
+- Token accepted from csrf_token form field
+- 403 on missing or wrong token
+- Exempt URLs skip checks
+- Non-HTTP scopes pass through
+- No session → middleware is a no-op
+"""
+
+import re
+from urllib.parse import urlencode
+
+import pytest
+
+from core.csrf import CSRFMiddleware
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TOKEN = "test-csrf-token-value"
+
+
+async def _noop_receive():
+    return {"type": "http.request", "body": b""}
+
+
+async def _noop_send(message):
+    pass
+
+
+async def _make_app_that_sends_response(scope, receive, send):
+    """Simulate an ASGI app that sends a 200 OK."""
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"OK"})
+
+
+def _http_scope(
+    method: str = "GET",
+    path: str = "/test",
+    headers: list[tuple[bytes, bytes]] | None = None,
+    session: dict | None = None,
+) -> dict:
+    """Build a minimal HTTP ASGI scope."""
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "query_string": b"",
+        "root_path": "",
+        "headers": headers or [],
+        "server": ("localhost", 8000),
+    }
+    if session is not None:
+        scope["session"] = session
+    return scope
+
+
+def _collect_send(sent: list):
+    """Return an async send callable that appends messages to *sent*."""
+
+    async def send(message):
+        sent.append(message)
+
+    return send
+
+
+def _form_body_receive(data: dict):
+    """Return a receive callable that yields url-encoded form data."""
+    body = urlencode(data).encode()
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return receive
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCSRFMiddleware:
+    """Test CSRFMiddleware enforces Synchronizer Token Pattern."""
+
+    async def test_get_request_passes_without_token(self):
+        """Safe methods should not require a CSRF token."""
+        session: dict = {}
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(method="GET", session=session)
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+
+        assert any(m.get("status") == 200 for m in sent)
+        # Token should have been auto-generated in the session.
+        assert "_csrf_token" in session
+
+    async def test_head_request_passes(self):
+        session: dict = {}
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(method="HEAD", session=session)
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 200 for m in sent)
+
+    async def test_post_rejected_without_token(self):
+        """POST without CSRF token should return 403."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(method="POST", session=session)
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 403 for m in sent)
+
+    async def test_delete_rejected_without_token(self):
+        """DELETE without CSRF token should return 403."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(method="DELETE", session=session)
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 403 for m in sent)
+
+    async def test_post_accepted_with_valid_header(self):
+        """POST with valid X-CSRFToken header should pass."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[(b"x-csrftoken", _TOKEN.encode())],
+        )
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 200 for m in sent)
+
+    async def test_post_accepted_with_valid_form_field(self):
+        """POST with valid csrf_token form field should pass."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[
+                (b"content-type", b"application/x-www-form-urlencoded"),
+            ],
+        )
+        sent = []
+        receive = _form_body_receive({"csrf_token": _TOKEN})
+
+        await middleware(scope, receive, _collect_send(sent))
+        assert any(m.get("status") == 200 for m in sent)
+
+    async def test_post_rejected_with_wrong_token(self):
+        """POST with incorrect CSRF token should return 403."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[(b"x-csrftoken", b"wrong-token")],
+        )
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 403 for m in sent)
+
+    async def test_exempt_url_skips_check(self):
+        """Exempt URLs should bypass CSRF validation."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(
+            _make_app_that_sends_response,
+            exempt_urls=[re.compile(r"^/auth/callback$")],
+        )
+        scope = _http_scope(method="POST", path="/auth/callback", session=session)
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 200 for m in sent)
+
+    async def test_non_exempt_url_still_checked(self):
+        """Non-exempt URLs should still enforce CSRF."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(
+            _make_app_that_sends_response,
+            exempt_urls=[re.compile(r"^/auth/callback$")],
+        )
+        scope = _http_scope(method="POST", path="/htmx/steps/complete", session=session)
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 403 for m in sent)
+
+    async def test_non_http_scope_passes_through(self):
+        """WebSocket and other non-HTTP scopes should pass through."""
+        called = False
+
+        async def inner(scope, receive, send):
+            nonlocal called
+            called = True
+
+        middleware = CSRFMiddleware(inner)
+        scope = {"type": "websocket"}
+
+        await middleware(scope, _noop_receive, _noop_send)
+        assert called
+
+    async def test_no_session_passes_through(self):
+        """If no session is available, middleware should not enforce CSRF."""
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(method="POST")
+        # No "session" key in scope.
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 200 for m in sent)
+
+    async def test_token_set_on_scope(self):
+        """Middleware should expose csrf_token on scope for templates."""
+        session: dict = {}
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(method="GET", session=session)
+
+        await middleware(scope, _noop_receive, _noop_send)
+
+        assert "csrf_token" in scope
+        assert scope["csrf_token"] == session["_csrf_token"]
+
+    async def test_htmx_error_response(self):
+        """HTMX requests should get a user-friendly 403 message."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[(b"hx-request", b"true")],
+        )
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 403 for m in sent)
+        body_msg = next((m for m in sent if m.get("type") == "http.response.body"), {})
+        assert b"refresh" in body_msg.get("body", b"").lower()

--- a/api/tests/core/test_csrf_middleware_order.py
+++ b/api/tests/core/test_csrf_middleware_order.py
@@ -1,0 +1,71 @@
+"""ASGI-level tests for CSRF middleware ordering.
+
+`core.csrf` unit tests validate token logic, but they inject `scope["session"]`
+directly and therefore can't catch wiring mistakes in `main.py`.
+
+This test proves the expected behavior:
+- Session wraps CSRF (correct) -> POST without token is rejected (403)
+- CSRF wraps Session (wrong) -> CSRF becomes a no-op and POST succeeds (200)
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI, Request
+from starlette.middleware.sessions import SessionMiddleware
+
+from core.csrf import CSRFMiddleware
+
+
+def _build_app(*, correct_order: bool) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/csrf-token")
+    async def csrf_token(request: Request) -> dict[str, str]:
+        return {"csrf_token": request.scope.get("csrf_token", "")}
+
+    @app.post("/protected")
+    async def protected() -> dict[str, bool]:
+        return {"ok": True}
+
+    if correct_order:
+        # Correct: Session runs first at runtime, so CSRF can read scope["session"].
+        app.add_middleware(CSRFMiddleware)
+        app.add_middleware(SessionMiddleware, secret_key="test-secret")
+    else:
+        # Wrong: CSRF runs before Session at runtime and becomes a silent no-op.
+        app.add_middleware(SessionMiddleware, secret_key="test-secret")
+        app.add_middleware(CSRFMiddleware)
+
+    return app
+
+
+@pytest.mark.unit
+class TestCSRFMiddlewareOrdering:
+    async def test_correct_order_enforces_csrf(self) -> None:
+        app = _build_app(correct_order=True)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            token = (await client.get("/csrf-token")).json()["csrf_token"]
+            assert token  # should be set by CSRFMiddleware on safe requests
+
+            r = await client.post("/protected")
+            assert r.status_code == 403
+
+            r = await client.post("/protected", headers={"X-CSRFToken": token})
+            assert r.status_code == 200
+
+    async def test_wrong_order_disables_csrf(self) -> None:
+        app = _build_app(correct_order=False)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            token = (await client.get("/csrf-token")).json()["csrf_token"]
+            assert token == ""
+
+            r = await client.post("/protected")
+            assert r.status_code == 200


### PR DESCRIPTION
This pull request introduces robust CSRF protection middleware and strengthens SSRF defenses in the deployed API verification service. The CSRF middleware uses the Synchronizer Token Pattern, storing tokens in the server-side session and validating them on unsafe requests. Additionally, the deployed API verification logic now blocks requests to private/internal IPs both before and after connection, closing potential SSRF gaps. The frontend is updated to ensure CSRF tokens are included in HTMX and form requests.

**Security enhancements**

* Added `CSRFMiddleware` implementing Synchronizer Token Pattern, storing CSRF tokens in session and validating them via header or form field on unsafe requests; integrated into FastAPI app with path exemptions [[1]](diffhunk://#diff-c64865e3414093288cef4b805c3a5420330f57ac1dde8cd79bd9ce18aa991273R1-R119) [[2]](diffhunk://#diff-c2c3b0c64a2690193a471cfc8068fcb622a23e1b4323c693b6ba20835f26fb88R23) [[3]](diffhunk://#diff-c2c3b0c64a2690193a471cfc8068fcb622a23e1b4323c693b6ba20835f26fb88R271-R274).
* Updated templates to inject CSRF token meta tag and automatically attach it to all HTMX requests; also included hidden CSRF token field in logout form for server-side validation [[1]](diffhunk://#diff-5378590ffce2597d6de935d92413f44d5ff2ecef871b05e2a2602801a245e839R37-R47) [[2]](diffhunk://#diff-546dbc661ca2e62e1fb4b6e7a6e4f0e37193b7a875e897fb3726560f91ee899cR51).

**SSRF protection improvements**

* Added pre-flight DNS resolution and post-connect IP validation to block requests targeting private/internal IPs in `deployed_api_verification_service.py`; now returns user-friendly errors if SSRF is detected [[1]](diffhunk://#diff-f2543dd34d7c70357ce63f6aa442a150182aaba7132b571e2bdcf5b6a42645aeR25-R30) [[2]](diffhunk://#diff-f2543dd34d7c70357ce63f6aa442a150182aaba7132b571e2bdcf5b6a42645aeR118-R210) [[3]](diffhunk://#diff-f2543dd34d7c70357ce63f6aa442a150182aaba7132b571e2bdcf5b6a42645aeR518-R525) [[4]](diffhunk://#diff-f2543dd34d7c70357ce63f6aa442a150182aaba7132b571e2bdcf5b6a42645aeR541-R545) [[5]](diffhunk://#diff-f2543dd34d7c70357ce63f6aa442a150182aaba7132b571e2bdcf5b6a42645aeR590-R596).
* Modified HTTP client to disable automatic redirect following, preventing SSRF via redirects.
* Refactored challenge entry cleanup logic to use SSRF-safe fetch and log SSRF attempts during cleanup.

**Other improvements**

* Added necessary imports for `ipaddress`, `socket`, and `re` to support new security logic [[1]](diffhunk://#diff-f2543dd34d7c70357ce63f6aa442a150182aaba7132b571e2bdcf5b6a42645aeR25-R30) [[2]](diffhunk://#diff-c2c3b0c64a2690193a471cfc8068fcb622a23e1b4323c693b6ba20835f26fb88R6).