### PR TITLE
Fix/legacy phase redirects only

### DIFF
--- a/api/core/redirects.py
+++ b/api/core/redirects.py
@@ -1,0 +1,68 @@
+"""Legacy /phaseN URL redirect middleware.
+
+Pure ASGI middleware — the path-resolution callable is injected at
+construction time so ``core`` never imports from ``services``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from fastapi.responses import RedirectResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+
+class LegacyPhaseRedirectMiddleware:
+    """Redirect legacy /phaseN URLs to canonical /phase/N URLs (308 Permanent).
+
+    Registered as the outermost middleware so redirects are served before
+    session or user-tracking middleware run — avoids creating sessions and
+    tracking users for requests that will immediately redirect.
+
+    Args:
+        app: The next ASGI application in the middleware stack.
+        resolver: A callable ``(path: str) -> str | None`` that returns
+            the canonical redirect target or ``None`` if no redirect is needed.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        resolver: Callable[[str], str | None] | None = None,
+    ) -> None:
+        self.app = app
+        self._resolve = resolver or (lambda path: None)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path: str = scope["path"]
+        try:
+            target_path = self._resolve(path)
+        except Exception:
+            logger.exception("legacy_url.resolve_error", extra={"path": path})
+            target_path = None
+
+        if target_path is not None and target_path != path:
+            query = scope.get("query_string", b"").decode("latin-1")
+            target_url = target_path if not query else f"{target_path}?{query}"
+            logger.info(
+                "legacy_url.redirect",
+                extra={
+                    "from_path": path,
+                    "to_path": target_path,
+                    "has_query": bool(query),
+                    "query_length": len(query),
+                    "status_code": 308,
+                },
+            )
+            response = RedirectResponse(url=target_url, status_code=308)
+            await response(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)

--- a/api/main.py
+++ b/api/main.py
@@ -285,14 +285,20 @@ def _normalize_legacy_slug(slug: str) -> str:
 
 @lru_cache(maxsize=1)
 def _topic_slug_aliases_by_phase() -> dict[str, dict[str, str]]:
-    """Build a mapping of legacy topic slugs -> current topic slugs per phase."""
+    """Build a mapping of legacy topic slugs -> current topic slugs per phase.
+
+    Note:
+        Cached for the lifetime of the process. If content YAML changes, a server
+        restart is required for this mapping to update.
+    """
+    # Deferred import to avoid circular dependency with services.content_service.
     from services.content_service import get_all_phases
 
     aliases: dict[str, dict[str, str]] = {}
     for phase in get_all_phases():
         phase_id = str(phase.order)
         phase_aliases: dict[str, str] = {}
-        for topic_slug in getattr(phase, "topic_slugs", []):
+        for topic_slug in phase.topic_slugs:
             phase_aliases[_normalize_legacy_slug(topic_slug)] = topic_slug
         aliases[phase_id] = phase_aliases
 

--- a/api/main.py
+++ b/api/main.py
@@ -342,6 +342,7 @@ async def legacy_phase_url_redirects(request: Request, call_next):
                 # fall back to the phase root so we don't redirect to a 404 topic.
                 parts = rest.lstrip("/").split("/")
                 legacy_topic = parts[0]
+                # Filter empty segments so double-slashes are normalised away.
                 remainder = [p for p in parts[1:] if p]
 
                 topic_aliases = _topic_slug_aliases_by_phase().get(str(phase_id), {})

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import logging
+import re
 from contextlib import asynccontextmanager
 from pathlib import Path
 

--- a/api/services/redirect_service.py
+++ b/api/services/redirect_service.py
@@ -1,0 +1,89 @@
+"""Legacy URL redirect resolution service.
+
+Resolves legacy ``/phaseN`` paths to their canonical ``/phase/N`` form,
+including fuzzy topic-slug matching against current content.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+
+_legacy_phase_path_re = re.compile(r"^/phase[-_]?(?P<phase_id>\d+)(?P<rest>/.*)?$")
+
+
+def _normalize_legacy_slug(slug: str) -> str:
+    """Strip non-alphanumeric chars so fuzzy legacy slugs can match canonical ones."""
+    slug = slug.lower()
+    if slug.endswith(".html"):
+        slug = slug.removesuffix(".html")
+    return re.sub(r"[^a-z0-9]+", "", slug)
+
+
+@lru_cache(maxsize=1)
+def _topic_slug_aliases_by_phase() -> dict[str, dict[str, str]]:
+    """Build a mapping of legacy topic slugs -> current topic slugs per phase.
+
+    Note:
+        Cached for the lifetime of the process. If content YAML changes, a server
+        restart is required for this mapping to update.
+    """
+    # Deferred import to avoid circular dependency with services.content_service.
+    from services.content_service import get_all_phases
+
+    aliases: dict[str, dict[str, str]] = {}
+    for phase in get_all_phases():
+        phase_id = str(phase.id)
+        phase_aliases: dict[str, str] = {}
+        for topic_slug in phase.topic_slugs:
+            phase_aliases[_normalize_legacy_slug(topic_slug)] = topic_slug
+        aliases[phase_id] = phase_aliases
+
+    # Known legacy slugs from older docs / bookmarks.
+    manual_aliases: dict[str, dict[str, str]] = {
+        "1": {
+            "ctf": "ctf-lab",
+            "versioncontrol": "developer-setup",
+        },
+        "2": {
+            "networkingfundamentals": "fundamentals",
+            "portsandprotocols": "protocols",
+            "troubleshooting": "troubleshooting-lab",
+        },
+    }
+    for phase_id, slug_map in manual_aliases.items():
+        phase_aliases = aliases.setdefault(phase_id, {})
+        for legacy_slug, canonical_slug in slug_map.items():
+            phase_aliases[_normalize_legacy_slug(legacy_slug)] = canonical_slug
+    return aliases
+
+
+def resolve_legacy_phase_redirect(path: str) -> str | None:
+    """Return the canonical redirect path for a legacy /phaseN URL, or None."""
+    match = _legacy_phase_path_re.match(path)
+    if not match or path.startswith("/phase/"):
+        return None
+
+    phase_id = match.group("phase_id")
+    rest = match.group("rest") or ""
+
+    # Normalize phase roots (/phase1 and /phase1/) to /phase/1.
+    if rest in ("", "/"):
+        return f"/phase/{phase_id}"
+
+    # Try to map /phaseN/<topic> to /phase/N/<topic-slug>; otherwise
+    # fall back to the phase root so we don't redirect to a 404 topic.
+    parts = rest.lstrip("/").split("/")
+    legacy_topic = parts[0]
+    # Filter empty segments so double-slashes are normalised away.
+    remainder = [p for p in parts[1:] if p]
+
+    topic_aliases = _topic_slug_aliases_by_phase().get(str(phase_id), {})
+    canonical_topic = topic_aliases.get(_normalize_legacy_slug(legacy_topic))
+    if canonical_topic:
+        target_path = f"/phase/{phase_id}/{canonical_topic}"
+        if remainder:
+            target_path = f"{target_path}/{'/'.join(remainder)}"
+        return target_path
+
+    return f"/phase/{phase_id}"

--- a/api/tests/test_legacy_phase_redirects.py
+++ b/api/tests/test_legacy_phase_redirects.py
@@ -1,61 +1,109 @@
 """Unit tests for legacy /phaseN* URL redirect middleware."""
 
+from unittest.mock import patch
+
 import pytest
 
-from main import _resolve_legacy_phase_redirect
+# Deterministic alias mapping for tests — no dependency on YAML content files.
+_TEST_ALIASES: dict[str, dict[str, str]] = {
+    "1": {
+        "clibasics": "cli-basics",
+        "ctf": "ctf-lab",
+        "versioncontrol": "developer-setup",
+    },
+    "2": {
+        "networkingfundamentals": "fundamentals",
+        "portsandprotocols": "protocols",
+        "troubleshooting": "troubleshooting-lab",
+    },
+}
+
+_PATCH_TARGET = "services.redirect_service._topic_slug_aliases_by_phase"
 
 
 @pytest.mark.unit
 class TestResolveLegacyPhaseRedirect:
     """Tests for the pure redirect-resolution function."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_aliases(self):
+        with patch(_PATCH_TARGET, return_value=_TEST_ALIASES):
+            yield
+
     def test_phase_root_no_trailing_slash(self) -> None:
-        assert _resolve_legacy_phase_redirect("/phase1") == "/phase/1"
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        assert resolve_legacy_phase_redirect("/phase1") == "/phase/1"
 
     def test_phase_root_with_trailing_slash(self) -> None:
-        assert _resolve_legacy_phase_redirect("/phase0/") == "/phase/0"
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        assert resolve_legacy_phase_redirect("/phase0/") == "/phase/0"
 
     def test_phase_hyphen_variant(self) -> None:
-        assert _resolve_legacy_phase_redirect("/phase-6") == "/phase/6"
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        assert resolve_legacy_phase_redirect("/phase-6") == "/phase/6"
 
     def test_phase_underscore_variant(self) -> None:
-        assert _resolve_legacy_phase_redirect("/phase_4") == "/phase/4"
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        assert resolve_legacy_phase_redirect("/phase_4") == "/phase/4"
 
     def test_multi_digit_phase(self) -> None:
-        assert _resolve_legacy_phase_redirect("/phase10") == "/phase/10"
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        assert resolve_legacy_phase_redirect("/phase10") == "/phase/10"
 
     def test_legacy_topic_slug(self) -> None:
+        from services.redirect_service import resolve_legacy_phase_redirect
+
         assert (
-            _resolve_legacy_phase_redirect("/phase1/clibasics/")
-            == "/phase/1/cli-basics"
+            resolve_legacy_phase_redirect("/phase1/clibasics/") == "/phase/1/cli-basics"
         )
 
     def test_legacy_topic_slug_preserves_remainder(self) -> None:
+        from services.redirect_service import resolve_legacy_phase_redirect
+
         assert (
-            _resolve_legacy_phase_redirect("/phase1/clibasics/step1/substep2")
+            resolve_legacy_phase_redirect("/phase1/clibasics/step1/substep2")
             == "/phase/1/cli-basics/step1/substep2"
         )
 
     def test_known_topic_override(self) -> None:
-        assert _resolve_legacy_phase_redirect("/phase1/ctf") == "/phase/1/ctf-lab"
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        assert resolve_legacy_phase_redirect("/phase1/ctf") == "/phase/1/ctf-lab"
 
     def test_unknown_topic_falls_back_to_phase_root(self) -> None:
-        assert _resolve_legacy_phase_redirect("/phase3/does-not-exist") == "/phase/3"
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        assert resolve_legacy_phase_redirect("/phase3/does-not-exist") == "/phase/3"
 
     def test_canonical_path_returns_none(self) -> None:
-        assert _resolve_legacy_phase_redirect("/phase/1") is None
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        assert resolve_legacy_phase_redirect("/phase/1") is None
 
     def test_canonical_path_with_topic_returns_none(self) -> None:
-        assert _resolve_legacy_phase_redirect("/phase/1/cli-basics") is None
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        assert resolve_legacy_phase_redirect("/phase/1/cli-basics") is None
 
     def test_unrelated_path_returns_none(self) -> None:
-        assert _resolve_legacy_phase_redirect("/dashboard") is None
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        assert resolve_legacy_phase_redirect("/dashboard") is None
 
     def test_no_digits_returns_none(self) -> None:
-        assert _resolve_legacy_phase_redirect("/phases") is None
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        assert resolve_legacy_phase_redirect("/phases") is None
 
     def test_double_slashes_normalised(self) -> None:
-        result = _resolve_legacy_phase_redirect("/phase1/clibasics//step1")
+        from services.redirect_service import resolve_legacy_phase_redirect
+
+        result = resolve_legacy_phase_redirect("/phase1/clibasics//step1")
         assert result == "/phase/1/cli-basics/step1"
 
 
@@ -63,19 +111,27 @@ class TestResolveLegacyPhaseRedirect:
 class TestLegacyPhaseRedirectMiddleware:
     """Integration test: middleware returns 308 or passes through."""
 
+    @pytest.fixture(autouse=True)
+    def _mock_aliases(self):
+        with patch(_PATCH_TARGET, return_value=_TEST_ALIASES):
+            yield
+
     async def test_redirects_with_query_string(self) -> None:
         from starlette.applications import Starlette
         from starlette.responses import PlainTextResponse
         from starlette.routing import Route
         from starlette.testclient import TestClient
 
-        from main import LegacyPhaseRedirectMiddleware
+        from core.redirects import LegacyPhaseRedirectMiddleware
+        from services.redirect_service import resolve_legacy_phase_redirect
 
         async def homepage(request):
             return PlainTextResponse("ok")
 
         inner_app = Starlette(routes=[Route("/phase/{phase_id:int}", homepage)])
-        inner_app.add_middleware(LegacyPhaseRedirectMiddleware)
+        inner_app.add_middleware(
+            LegacyPhaseRedirectMiddleware, resolver=resolve_legacy_phase_redirect
+        )
         client = TestClient(inner_app, raise_server_exceptions=False)
 
         resp = client.get("/phase2?utm=abc", follow_redirects=False)
@@ -88,13 +144,16 @@ class TestLegacyPhaseRedirectMiddleware:
         from starlette.routing import Route
         from starlette.testclient import TestClient
 
-        from main import LegacyPhaseRedirectMiddleware
+        from core.redirects import LegacyPhaseRedirectMiddleware
+        from services.redirect_service import resolve_legacy_phase_redirect
 
         async def homepage(request):
             return PlainTextResponse("ok")
 
         inner_app = Starlette(routes=[Route("/phase/{phase_id:int}", homepage)])
-        inner_app.add_middleware(LegacyPhaseRedirectMiddleware)
+        inner_app.add_middleware(
+            LegacyPhaseRedirectMiddleware, resolver=resolve_legacy_phase_redirect
+        )
         client = TestClient(inner_app, raise_server_exceptions=False)
 
         resp = client.get("/phase/1")

--- a/api/tests/test_legacy_phase_redirects.py
+++ b/api/tests/test_legacy_phase_redirects.py
@@ -59,6 +59,18 @@ class TestLegacyPhaseRedirects:
         assert resp.headers["location"] == "/phase/6"
         call_next.assert_not_awaited()
 
+    async def test_redirects_phase_underscore_variant(self) -> None:
+        request = MagicMock()
+        request.url = URL("https://testserver/phase_4")
+
+        call_next = AsyncMock(return_value=PlainTextResponse("ok"))
+        resp = await legacy_phase_url_redirects(request, call_next)
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 308
+        assert resp.headers["location"] == "/phase/4"
+        call_next.assert_not_awaited()
+
     async def test_redirects_legacy_topic_slug(self) -> None:
         request = MagicMock()
         request.url = URL("https://testserver/phase1/clibasics/")
@@ -69,6 +81,18 @@ class TestLegacyPhaseRedirects:
         assert isinstance(resp, RedirectResponse)
         assert resp.status_code == 308
         assert resp.headers["location"] == "/phase/1/cli-basics"
+        call_next.assert_not_awaited()
+
+    async def test_redirects_legacy_topic_slug_preserves_remainder(self) -> None:
+        request = MagicMock()
+        request.url = URL("https://testserver/phase1/clibasics/step1/substep2")
+
+        call_next = AsyncMock(return_value=PlainTextResponse("ok"))
+        resp = await legacy_phase_url_redirects(request, call_next)
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 308
+        assert resp.headers["location"] == "/phase/1/cli-basics/step1/substep2"
         call_next.assert_not_awaited()
 
     async def test_redirects_known_topic_override(self) -> None:

--- a/api/tests/test_legacy_phase_redirects.py
+++ b/api/tests/test_legacy_phase_redirects.py
@@ -1,0 +1,107 @@
+"""Unit tests for legacy /phaseN* URL redirect middleware."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.datastructures import URL
+from starlette.responses import PlainTextResponse, RedirectResponse
+
+from main import legacy_phase_url_redirects
+
+
+@pytest.mark.unit
+class TestLegacyPhaseRedirects:
+    async def test_redirects_phase_root_no_trailing_slash(self) -> None:
+        request = MagicMock()
+        request.url = URL("https://testserver/phase1")
+
+        call_next = AsyncMock(return_value=PlainTextResponse("ok"))
+        resp = await legacy_phase_url_redirects(request, call_next)
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 308
+        assert resp.headers["location"] == "/phase/1"
+        call_next.assert_not_awaited()
+
+    async def test_redirects_phase_root_with_trailing_slash(self) -> None:
+        request = MagicMock()
+        request.url = URL("https://testserver/phase0/")
+
+        call_next = AsyncMock(return_value=PlainTextResponse("ok"))
+        resp = await legacy_phase_url_redirects(request, call_next)
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 308
+        assert resp.headers["location"] == "/phase/0"
+        call_next.assert_not_awaited()
+
+    async def test_redirects_phase_root_with_query_string(self) -> None:
+        request = MagicMock()
+        request.url = URL("https://testserver/phase2?utm=abc")
+
+        call_next = AsyncMock(return_value=PlainTextResponse("ok"))
+        resp = await legacy_phase_url_redirects(request, call_next)
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 308
+        assert resp.headers["location"] == "/phase/2?utm=abc"
+        call_next.assert_not_awaited()
+
+    async def test_redirects_phase_hyphen_variant(self) -> None:
+        request = MagicMock()
+        request.url = URL("https://testserver/phase-6")
+
+        call_next = AsyncMock(return_value=PlainTextResponse("ok"))
+        resp = await legacy_phase_url_redirects(request, call_next)
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 308
+        assert resp.headers["location"] == "/phase/6"
+        call_next.assert_not_awaited()
+
+    async def test_redirects_legacy_topic_slug(self) -> None:
+        request = MagicMock()
+        request.url = URL("https://testserver/phase1/clibasics/")
+
+        call_next = AsyncMock(return_value=PlainTextResponse("ok"))
+        resp = await legacy_phase_url_redirects(request, call_next)
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 308
+        assert resp.headers["location"] == "/phase/1/cli-basics"
+        call_next.assert_not_awaited()
+
+    async def test_redirects_known_topic_override(self) -> None:
+        request = MagicMock()
+        request.url = URL("https://testserver/phase1/ctf")
+
+        call_next = AsyncMock(return_value=PlainTextResponse("ok"))
+        resp = await legacy_phase_url_redirects(request, call_next)
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 308
+        assert resp.headers["location"] == "/phase/1/ctf-lab"
+        call_next.assert_not_awaited()
+
+    async def test_unknown_topic_falls_back_to_phase_root(self) -> None:
+        request = MagicMock()
+        request.url = URL("https://testserver/phase3/does-not-exist")
+
+        call_next = AsyncMock(return_value=PlainTextResponse("ok"))
+        resp = await legacy_phase_url_redirects(request, call_next)
+
+        assert isinstance(resp, RedirectResponse)
+        assert resp.status_code == 308
+        assert resp.headers["location"] == "/phase/3"
+        call_next.assert_not_awaited()
+
+    async def test_canonical_paths_pass_through(self) -> None:
+        request = MagicMock()
+        request.url = URL("https://testserver/phase/1")
+
+        downstream = PlainTextResponse("ok")
+        call_next = AsyncMock(return_value=downstream)
+        resp = await legacy_phase_url_redirects(request, call_next)
+
+        assert resp is downstream
+        call_next.assert_awaited_once()


### PR DESCRIPTION
This pull request introduces middleware to handle redirects from legacy URL paths to their canonical forms, ensuring backward compatibility for users accessing older links. Additionally, it adds necessary imports to support these changes.

**URL Redirection Improvements:**

* Added a new HTTP middleware to redirect legacy `/phaseN` URLs to the canonical `/phase/N` format, including special handling for specific topic slugs (e.g., `/phase1/ctf` to `/phase/1/ctf-lab`). This ensures that users following old links are seamlessly redirected to the correct new URLs.
* Introduced a regular expression (`_legacy_phase_path_re`) and a mapping dictionary (`_legacy_topic_redirects`) to facilitate these redirects and handle special cases.

**Dependency and Import Updates:**

* Imported `re` and `RedirectResponse` to support the new URL redirection logic. [[1]](diffhunk://#diff-c2c3b0c64a2690193a471cfc8068fcb622a23e1b4323c693b6ba20835f26fb88R6) [[2]](diffhunk://#diff-c2c3b0c64a2690193a471cfc8068fcb622a23e1b4323c693b6ba20835f26fb88L14-R15)