### PR TITLE
fix: dark mode toggle and dropdown after HTMX boost navigation

### DIFF
--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -17,6 +17,18 @@
             'dark',
             localStorage.getItem('theme') === 'dark'
         );
+        // Theme toggle — vanilla JS with event delegation so it survives
+        // HTMX body swaps and works even if Alpine fails to load.
+        document.addEventListener('click', function(e) {
+            var btn = e.target.closest('#theme-toggle');
+            if (!btn) return;
+            var isDark = document.documentElement.classList.toggle('dark');
+            localStorage.setItem('theme', isDark ? 'dark' : 'light');
+            // Sync Alpine reactive state if available
+            if (document.documentElement._x_dataStack) {
+                document.documentElement._x_dataStack[0].darkMode = isDark;
+            }
+        });
     </script>
 
     <!-- Hide Alpine.js elements until initialized -->
@@ -40,6 +52,24 @@
             var token = document.querySelector('meta[name="csrf-token"]');
             if (token) {
                 event.detail.headers['X-CSRFToken'] = token.content;
+            }
+        });
+    </script>
+
+    <script>
+        // Fix Alpine.js + HTMX boost interaction.
+        // HTMX's settle phase (20ms after swap) copies old attributes onto
+        // new DOM, which conflicts with Alpine's MutationObserver processing.
+        // Deferring mutations prevents Alpine from seeing the intermediate
+        // attribute state. See: https://github.com/alpinejs/alpine/discussions/4485
+        document.addEventListener('htmx:beforeSwap', function(event) {
+            if (event.detail.boosted && typeof Alpine !== 'undefined') {
+                Alpine.deferMutations();
+            }
+        });
+        document.addEventListener('htmx:afterSettle', function(event) {
+            if (event.detail.boosted && typeof Alpine !== 'undefined') {
+                Alpine.flushAndStopDeferringMutations();
             }
         });
     </script>

--- a/api/templates/partials/theme_toggle.html
+++ b/api/templates/partials/theme_toggle.html
@@ -1,9 +1,11 @@
-<!-- Theme toggle — uses Tailwind dark: variant for zero-FOUC icon swap -->
+<!-- Theme toggle — vanilla JS click via event delegation in base.html -->
 <button
-    @click="darkMode = !darkMode; localStorage.setItem('theme', darkMode ? 'dark' : 'light')"
+    id="theme-toggle"
     class="rounded-md p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
     :title="darkMode ? 'Switch to light mode' : 'Switch to dark mode'"
     :aria-label="darkMode ? 'Switch to light mode' : 'Switch to dark mode'"
+    title="Toggle dark mode"
+    aria-label="Toggle dark mode"
 >
     <svg class="h-5 w-5 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" />


### PR DESCRIPTION
## Summary

Fixes #82

### Changes

1. HTMX+Alpine integration script (base.html) - defers mutations during hx-boost swaps
2. Vanilla JS theme toggle fallback (base.html + theme_toggle.html) - works without Alpine

### Testing

- 728 tests pass
- Playwright verified: toggle + dropdown work after HTMX boost
- Zero console errors
