### PR TITLE
Potential fix for code scanning alert no. 57: Unmasked Secret Exposure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,9 +141,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      ARM_TENANT_ID: ${{ fromJson(secrets.AZURE_CREDENTIALS).tenantId }}
-      ARM_CLIENT_ID: ${{ fromJson(secrets.AZURE_CREDENTIALS).clientId }}
-      ARM_CLIENT_SECRET: ${{ fromJson(secrets.AZURE_CREDENTIALS).clientSecret }}
+      ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
     defaults:
       run:
         working-directory: infra


### PR DESCRIPTION
Potential fix for [https://github.com/learntocloud/learn-to-cloud-app/security/code-scanning/57](https://github.com/learntocloud/learn-to-cloud-app/security/code-scanning/57)

In general, to fix this type of problem, stop parsing a composite JSON secret and instead reference individual plain secrets (or organization/environment variables) for each sensitive value, so that the GitHub runner automatically masks them. Each sensitive value that might show up in logs should come from its own `secrets.X` entry (or a secret-backed variable), not from `fromJson` or string processing.

For this workflow, the best fix without changing existing functionality is:

- Define three separate secrets in the repository or environment settings:
  - `AZURE_TENANT_ID`
  - `AZURE_CLIENT_ID`
  - `AZURE_CLIENT_SECRET`
- Update the `terraform` job’s `env` block to reference these three secrets directly, instead of parsing `secrets.AZURE_CREDENTIALS`.

Concretely, in `.github/workflows/deploy.yml` around lines 143–146, replace:

```yaml
env:
  ARM_TENANT_ID: ${{ fromJson(secrets.AZURE_CREDENTIALS).tenantId }}
  ARM_CLIENT_ID: ${{ fromJson(secrets.AZURE_CREDENTIALS).clientId }}
  ARM_CLIENT_SECRET: ${{ fromJson(secrets.AZURE_CREDENTIALS).clientSecret }}
```

with:

```yaml
env:
  ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
  ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
  ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
```

No imports or additional methods are needed because this is a YAML workflow file. The functional behavior (values available to Terraform as env vars) stays the same, but each one is now a plain secret that will be masked by GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
