### PR TITLE
fix: remove synthetic web test and availability alert causing deploy …

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -33,59 +33,6 @@ resource "azurerm_monitor_action_group" "critical" {
 }
 
 # ---------------------------------------------------------------------------
-# Availability Test — /ready endpoint
-# ---------------------------------------------------------------------------
-
-resource "azurerm_application_insights_standard_web_test" "readiness" {
-  name                    = "webtest-ltc-ready-${var.environment}"
-  resource_group_name     = azurerm_resource_group.main.name
-  location                = azurerm_resource_group.main.location
-  application_insights_id = azurerm_application_insights.main.id
-  description             = "Synthetic readiness probe — checks /ready (init + DB connectivity)"
-  enabled                 = true
-  frequency               = 300
-  timeout                 = 30
-  retry_enabled           = true
-  tags                    = local.tags
-
-  geo_locations = [
-    "us-va-ash-azr",   # East US
-    "emea-nl-ams-azr", # West Europe
-    "apac-sg-sin-azr"  # Southeast Asia
-  ]
-
-  request {
-    url = "https://${azurerm_container_app.api.ingress[0].fqdn}/ready"
-  }
-
-  validation_rules {
-    expected_status_code = 200
-  }
-}
-
-resource "azurerm_monitor_metric_alert" "availability" {
-  name                = "alert-ltc-availability-${var.environment}"
-  resource_group_name = azurerm_resource_group.main.name
-  description         = "Availability test failures — app unreachable from 2+ geo locations"
-  severity            = 0
-  enabled             = true
-  scopes              = [azurerm_application_insights.main.id]
-  frequency           = "PT5M"
-  window_size         = "PT5M"
-  tags                = local.tags
-
-  application_insights_web_test_location_availability_criteria {
-    web_test_id           = azurerm_application_insights_standard_web_test.readiness.id
-    component_id          = azurerm_application_insights.main.id
-    failed_location_count = 2
-  }
-
-  action {
-    action_group_id = azurerm_monitor_action_group.critical.id
-  }
-}
-
-# ---------------------------------------------------------------------------
 # Log Alerts (scheduled query rules v2)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
…failure

The azurerm_monitor_metric_alert.availability was failing with 'Alert scope is invalid' because the web test hadn't produced metrics yet. These 3-geo synthetic probes are overkill for a small learning platform — App Insights provides basic availability visibility out of the box.

Keeps: Log Analytics, App Insights, 5xx alert, LLM failure alert.
Removes: 3-continent web test, availability metric alert.