### PR TITLE
fix: remove dead log lines in configure_observability()

### DIFF
--- a/api/core/observability.py
+++ b/api/core/observability.py
@@ -64,13 +64,11 @@ def configure_observability() -> None:
                 "urllib3": {"enabled": True},
             },
         )
-        logger.info("telemetry.azure_monitor.configured")
     except Exception as exc:
         logger.warning("telemetry.azure_monitor.failed", extra={"error": str(exc)})
 
     # Instrument httpx so OpenAI SDK calls appear as dependencies
     HTTPXClientInstrumentor().instrument()
-    logger.info("telemetry.httpx.instrumented")
 
 
 def instrument_app(app: Any) -> None:


### PR DESCRIPTION
Two logger.info() calls ('telemetry.azure_monitor.configured' and 'telemetry.httpx.instrumented') were silently dropped because they fire before configure_logging() sets the root logger level from WARNING (Python default) to INFO. Confirmed via production AppTraces and container console logs — neither message ever appeared.

The WARNING-level failure logs in the except blocks still work correctly. telemetry.fastapi.instrumented (emitted later from instrument_app()) already confirms the OTel pipeline is alive.