### PR TITLE
refactor: replace log-based observability with OTel spans and attributes

### DIFF
--- a/api/core/logger.py
+++ b/api/core/logger.py
@@ -25,32 +25,9 @@ import sys
 from datetime import UTC, datetime
 from typing import ClassVar
 
-from core.middleware import request_github_username
-
 # Matches control characters except tab (0x09). Covers newlines, carriage
 # returns, null bytes, and other C0/DEL controls used in log injection.
 _CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0a-\x1f\x7f]")
-
-
-class _RequestContextFilter(logging.Filter):
-    """Inject request-scoped context vars into every log record.
-
-    Reads ``request_github_username`` from the context var set by
-    ``UserTrackingMiddleware`` and attaches it to the record so
-    formatters (JSON and console) include it automatically.
-
-    Only sets the attribute when a value is present *and* the log
-    record doesn't already have an explicit ``github_username``
-    (so manual ``extra={"github_username": ...}`` wins).
-    """
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        if not getattr(record, "github_username", None):
-            username = request_github_username.get()
-            if username:
-                record.github_username = username
-        return True
-
 
 # Built-in LogRecord attribute names — never sanitize these.
 _BUILTIN_RECORD_KEYS: set[str] = set(
@@ -58,28 +35,12 @@ _BUILTIN_RECORD_KEYS: set[str] = set(
 )
 
 
-class _LogSanitizationFilter(logging.Filter):
-    """Strip control characters from user-supplied extra fields (CWE-117).
-
-    Prevents log injection by removing ``\\n``, ``\\r``, ``\\0`` and other
-    C0 control characters from any string-valued attribute that was added
-    via ``extra={}``.  Tabs (``\\t``) are preserved.
-
-    Runs on the root logger so every handler (console, JSON, OTel) receives
-    already-sanitised records.
-    """
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        for key in record.__dict__:
-            if key not in _BUILTIN_RECORD_KEYS:
-                value = record.__dict__[key]
-                if isinstance(value, str):
-                    record.__dict__[key] = _CONTROL_CHAR_RE.sub("", value)
-        return True
-
-
 class _JSONFormatter(logging.Formatter):
-    """Format log records as single-line JSON for production log aggregation."""
+    """Format log records as single-line JSON for production log aggregation.
+
+    CWE-117 sanitization is applied inline: control characters (except tab)
+    are stripped from user-supplied extra fields to prevent log injection.
+    """
 
     _SKIP_KEYS: ClassVar[set[str]] = _BUILTIN_RECORD_KEYS
 
@@ -94,6 +55,9 @@ class _JSONFormatter(logging.Formatter):
             if key not in self._SKIP_KEYS and isinstance(
                 value, str | int | float | bool | None
             ):
+                # CWE-117: strip control chars from user-supplied strings
+                if isinstance(value, str):
+                    value = _CONTROL_CHAR_RE.sub("", value)
                 log_entry[key] = value
         if record.exc_info and record.exc_info[0] is not None:
             log_entry["exception"] = self.formatException(record.exc_info)
@@ -132,9 +96,6 @@ def configure_logging() -> None:
     )
     root.addHandler(console)
     root.setLevel(level)
-
-    root.addFilter(_RequestContextFilter())
-    root.addFilter(_LogSanitizationFilter())
 
     for name in (
         "httpx",

--- a/api/core/observability.py
+++ b/api/core/observability.py
@@ -1,7 +1,11 @@
-"""Observability configuration — Azure Monitor telemetry.
+"""Observability configuration — OTel telemetry pipeline.
 
 Called once from ``main.py`` **before** FastAPI is imported so
 auto-instrumentation hooks work.
+
+Production: exports to Azure Monitor via APPLICATIONINSIGHTS_CONNECTION_STRING.
+Local dev:  exports to any OTLP backend (Aspire, Jaeger) via
+            OTEL_EXPORTER_OTLP_ENDPOINT.
 """
 
 from __future__ import annotations
@@ -10,9 +14,6 @@ import logging
 import os
 from typing import Any
 
-from azure.monitor.opentelemetry import (
-    configure_azure_monitor as _configure_azure_monitor_sdk,
-)
 from dotenv import load_dotenv
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
@@ -23,41 +24,88 @@ logger = logging.getLogger(__name__)
 _telemetry_enabled: bool = False
 
 
+def _configure_azure_monitor(resource: Resource) -> None:
+    """Set up the Azure Monitor exporter for production."""
+    from azure.monitor.opentelemetry import (
+        configure_azure_monitor as _configure_azure_monitor_sdk,
+    )
+
+    _configure_azure_monitor_sdk(
+        resource=resource,
+        enable_live_metrics=True,
+        instrumentation_options={
+            "azure_sdk": {"enabled": True},
+            "flask": {"enabled": False},
+            "django": {"enabled": False},
+            "fastapi": {"enabled": False},  # manual via instrument_app()
+            "psycopg2": {"enabled": False},
+            "requests": {"enabled": True},
+            "urllib": {"enabled": True},
+            "urllib3": {"enabled": True},
+        },
+    )
+
+
+def _configure_otlp(resource: Resource, endpoint: str) -> None:
+    """Set up OTLP gRPC exporter for local dev (Aspire, Jaeger, etc.)."""
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter,
+    )
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint, insecure=True))
+    )
+
+    from opentelemetry import trace
+
+    trace.set_tracer_provider(provider)
+
+    # Bridge stdlib logs → OTel so they appear in the dashboard too.
+    from opentelemetry._logs import set_logger_provider
+    from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
+        OTLPLogExporter,
+    )
+    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+
+    log_provider = LoggerProvider(resource=resource)
+    log_provider.add_log_record_processor(
+        BatchLogRecordProcessor(OTLPLogExporter(endpoint=endpoint, insecure=True))
+    )
+    set_logger_provider(log_provider)
+    logging.getLogger().addHandler(LoggingHandler(logger_provider=log_provider))
+
+
 def configure_observability() -> None:
-    """Set up Azure Monitor telemetry if configured."""
+    """Set up the OTel telemetry pipeline."""
     global _telemetry_enabled
 
     load_dotenv()
 
+    resource = Resource.create(
+        {"service.name": os.getenv("OTEL_SERVICE_NAME", "learn-to-cloud-api")}
+    )
+
     conn_str = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
-    if not conn_str:
+    otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+
+    if conn_str:
+        try:
+            _configure_azure_monitor(resource)
+        except Exception as exc:
+            logger.warning("telemetry.azure_monitor.failed", extra={"error": str(exc)})
+    elif otlp_endpoint:
+        try:
+            _configure_otlp(resource, otlp_endpoint)
+        except Exception as exc:
+            logger.warning("telemetry.otlp.failed", extra={"error": str(exc)})
+    else:
         return
 
     _telemetry_enabled = True
-
-    try:
-        resource = Resource.create(
-            {
-                "service.name": os.getenv("OTEL_SERVICE_NAME", "learn-to-cloud-api"),
-            }
-        )
-        _configure_azure_monitor_sdk(
-            resource=resource,
-            enable_live_metrics=True,
-            instrumentation_options={
-                "azure_sdk": {"enabled": True},
-                "flask": {"enabled": False},
-                "django": {"enabled": False},
-                "fastapi": {"enabled": False},  # manual via instrument_app()
-                "psycopg2": {"enabled": False},
-                "requests": {"enabled": True},
-                "urllib": {"enabled": True},
-                "urllib3": {"enabled": True},
-            },
-        )
-    except Exception as exc:
-        logger.warning("telemetry.azure_monitor.failed", extra={"error": str(exc)})
-
     HTTPXClientInstrumentor().instrument()
 
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -73,6 +73,7 @@ select = ["E", "F", "I", "UP", "PLC0415"]
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["PLC0415"]
 "alembic/**" = ["PLC0415"]
+"core/observability.py" = ["PLC0415"]
 
 [tool.ty.environment]
 # Use the current Python interpreter to resolve third-party imports

--- a/api/routes/htmx_routes.py
+++ b/api/routes/htmx_routes.py
@@ -18,6 +18,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import HTMLResponse
+from opentelemetry import trace
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from starlette.responses import StreamingResponse
 
@@ -85,9 +86,10 @@ async def _render_step_toggle(
                 break
 
     if step is None:
-        logger.warning(
-            "htmx.step_toggle.step_not_found",
-            extra={"user_id": user_id, "topic_id": topic_id, "step_id": step_id},
+        span = trace.get_current_span()
+        span.add_event(
+            "step_not_found",
+            {"user_id": user_id, "topic_id": topic_id, "step_id": step_id},
         )
         return HTMLResponse("")
 
@@ -127,9 +129,10 @@ async def htmx_complete_step(
     try:
         await complete_step(db, user_id, topic_id, step_id)
     except StepValidationError as e:
-        logger.warning(
-            "htmx.step_complete.invalid",
-            extra={
+        span = trace.get_current_span()
+        span.add_event(
+            "step_complete_invalid",
+            {
                 "user_id": user_id,
                 "topic_id": topic_id,
                 "step_id": step_id,
@@ -156,9 +159,10 @@ async def htmx_uncomplete_step(
     try:
         await uncomplete_step(db, user_id, topic_id, step_id)
     except StepValidationError as e:
-        logger.warning(
-            "htmx.step_uncomplete.invalid",
-            extra={
+        span = trace.get_current_span()
+        span.add_event(
+            "step_uncomplete_invalid",
+            {
                 "user_id": user_id,
                 "topic_id": topic_id,
                 "step_id": step_id,
@@ -269,13 +273,13 @@ async def htmx_submit_verification(
         return _render_card(processing=True)
 
     except Exception as exc:
+        span = trace.get_current_span()
+        span.record_exception(exc)
         logger.exception(
             "htmx.submit.unexpected_error",
             extra={
                 "user_id": user_id,
                 "requirement_id": requirement_id,
-                "exc_type": type(exc).__name__,
-                "exc_message": str(exc),
             },
         )
         return _render_card(
@@ -337,6 +341,8 @@ async def htmx_verification_stream(
             )
             return
         except Exception:
+            span = trace.get_current_span()
+            span.record_exception(Exception("verification.stream.task_failed"))
             logger.exception(
                 "verification.stream.task_failed",
                 extra={"user_id": user_id, "requirement_id": requirement_id},
@@ -420,10 +426,8 @@ async def htmx_delete_account(
     try:
         await delete_user_account(db, user_id)
     except UserNotFoundError:
-        logger.warning(
-            "htmx.account_delete.not_found",
-            extra={"user_id": user_id},
-        )
+        span = trace.get_current_span()
+        span.add_event("account_delete_not_found", {"user_id": user_id})
         return HTMLResponse(
             '<p class="text-sm text-red-600">Account not found.</p>',
             status_code=404,

--- a/api/services/steps_service.py
+++ b/api/services/steps_service.py
@@ -1,8 +1,8 @@
 """Step progress service for learning step management."""
 
-import logging
 from typing import TYPE_CHECKING
 
+from opentelemetry import trace
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models import utcnow
@@ -12,8 +12,6 @@ from services.content_service import get_topic_by_id
 
 if TYPE_CHECKING:
     from schemas import Topic
-
-logger = logging.getLogger(__name__)
 
 
 class StepValidationError(Exception):
@@ -118,32 +116,23 @@ async def complete_step(
         step_order=step_order,
         phase_id=phase_id,
     )
+
+    span = trace.get_current_span()
+    span.set_attribute("step.topic_id", topic_id)
+    span.set_attribute("step.step_id", resolved_step_id)
+    span.set_attribute("step.order", step_order)
+
     # Step already completed — idempotent no-op
     if step_progress is None:
         completed_steps = await step_repo.get_completed_step_ids(user_id, topic_id)
-        logger.info(
-            "step.already_completed",
-            extra={
-                "user_id": user_id,
-                "topic_id": topic_id,
-                "step_id": resolved_step_id,
-            },
-        )
+        span.set_attribute("step.action", "already_completed")
         return StepCompletionResult(
             topic_id=topic_id,
             step_id=resolved_step_id,
             completed_at=utcnow(),
         ), completed_steps
 
-    logger.info(
-        "step.completed",
-        extra={
-            "user_id": user_id,
-            "topic_id": topic_id,
-            "step_id": resolved_step_id,
-            "step_order": step_order,
-        },
-    )
+    span.set_attribute("step.action", "completed")
 
     completed_steps = await step_repo.get_completed_step_ids(user_id, topic_id)
 
@@ -182,16 +171,11 @@ async def uncomplete_step(
     step_repo = StepProgressRepository(db)
     deleted = await step_repo.delete_step(user_id, topic_id, resolved_step_id)
 
-    if deleted > 0:
-        logger.info(
-            "step.uncompleted",
-            extra={
-                "user_id": user_id,
-                "topic_id": topic_id,
-                "step_id": resolved_step_id,
-                "step_order": step_order,
-            },
-        )
+    span = trace.get_current_span()
+    span.set_attribute("step.topic_id", topic_id)
+    span.set_attribute("step.step_id", resolved_step_id)
+    span.set_attribute("step.order", step_order)
+    span.set_attribute("step.action", "uncompleted")
 
     completed_steps = await step_repo.get_completed_step_ids(user_id, topic_id)
 

--- a/api/services/submissions_service.py
+++ b/api/services/submissions_service.py
@@ -15,10 +15,10 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from dataclasses import dataclass
 
 from cachetools import TTLCache
+from opentelemetry import trace
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from core.config import get_settings
@@ -39,7 +39,7 @@ from services.verification.requirements import (
     get_requirement_ids_for_phase,
 )
 
-logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 _LOCK_TTL = 7200  # 2 hours
 _submission_locks: TTLCache[tuple[int, str], asyncio.Lock] = TTLCache(
@@ -127,9 +127,10 @@ async def get_phase_submission_context(
                     "passed": passed,
                 }
             except (json.JSONDecodeError, TypeError):
-                logger.debug(
-                    "submission.feedback_parse_failed",
-                    extra={"requirement_id": sub.requirement_id},
+                span = trace.get_current_span()
+                span.add_event(
+                    "feedback_parse_failed",
+                    {"requirement_id": sub.requirement_id},
                 )
 
     return PhaseSubmissionContext(
@@ -347,75 +348,78 @@ async def submit_validation(
         # ── Run validation (NO DB session held) ─────────────────────────
         # Verification can take seconds for external API calls.  We run it
         # outside any DB session so it doesn't pin a connection pool slot.
-        validation_result = await validate_submission(
-            requirement=requirement,
-            submitted_value=submitted_value,
-            expected_username=github_username,
-        )
-
-        extracted_username = None
-        if requirement.submission_type in (
-            SubmissionType.CTF_TOKEN,
-            SubmissionType.NETWORKING_TOKEN,
-        ):
-            extracted_username = github_username
-        else:
-            parsed = parse_github_url(submitted_value)
-            extracted_username = parsed.username if parsed.is_valid else None
-
-        verification_completed = validation_result.verification_completed
-
-        feedback_json = None
-        if validation_result.task_results:
-            feedback_json = json.dumps(
-                [t.model_dump() for t in validation_result.task_results]
-            )
-
-        # Persist the user-facing message so it survives page reloads.
-        validation_message = (
-            validation_result.message if not validation_result.is_valid else None
-        )
-
-        # Cloud provider (populated for multi-cloud labs like networking).
-        cloud_provider = validation_result.cloud_provider
-
-        # ── Phase 3: Persist result (short-lived session) ───────────────
-        # A fresh session is opened just for the upsert, keeping connection
-        # hold time to ~50ms.
-        async with session_maker() as write_session:
-            write_repo = SubmissionRepository(write_session)
-
-            db_submission = await write_repo.create(
-                user_id=user_id,
-                requirement_id=requirement_id,
-                submission_type=requirement.submission_type,
-                phase_id=phase_id,
-                submitted_value=submitted_value,
-                extracted_username=extracted_username,
-                is_validated=validation_result.is_valid,
-                verification_completed=verification_completed,
-                feedback_json=feedback_json,
-                validation_message=validation_message,
-                cloud_provider=cloud_provider,
-            )
-
-            await write_session.commit()
-
-        logger.info(
-            "submission.processed",
-            extra={
-                "user_id": user_id,
-                "requirement_id": requirement_id,
-                "is_valid": validation_result.is_valid,
-                "verification_completed": verification_completed,
+        with tracer.start_as_current_span(
+            "submit_validation",
+            attributes={
+                "user.id": user_id,
+                "requirement.id": requirement_id,
+                "submission.type": requirement.submission_type,
             },
-        )
+        ) as span:
+            validation_result = await validate_submission(
+                requirement=requirement,
+                submitted_value=submitted_value,
+                expected_username=github_username,
+            )
 
-        return SubmissionResult(
-            submission=_to_submission_data(db_submission),
-            is_valid=validation_result.is_valid,
-            message=validation_result.message,
-            username_match=validation_result.username_match,
-            repo_exists=validation_result.repo_exists,
-            task_results=validation_result.task_results,
-        )
+            extracted_username = None
+            if requirement.submission_type in (
+                SubmissionType.CTF_TOKEN,
+                SubmissionType.NETWORKING_TOKEN,
+            ):
+                extracted_username = github_username
+            else:
+                parsed = parse_github_url(submitted_value)
+                extracted_username = parsed.username if parsed.is_valid else None
+
+            verification_completed = validation_result.verification_completed
+
+            feedback_json = None
+            if validation_result.task_results:
+                feedback_json = json.dumps(
+                    [t.model_dump() for t in validation_result.task_results]
+                )
+
+            # Persist the user-facing message so it survives page reloads.
+            validation_message = (
+                validation_result.message if not validation_result.is_valid else None
+            )
+
+            # Cloud provider (populated for multi-cloud labs like networking).
+            cloud_provider = validation_result.cloud_provider
+
+            # ── Phase 3: Persist result (short-lived session) ───────────────
+            # A fresh session is opened just for the upsert, keeping connection
+            # hold time to ~50ms.
+            async with session_maker() as write_session:
+                write_repo = SubmissionRepository(write_session)
+
+                db_submission = await write_repo.create(
+                    user_id=user_id,
+                    requirement_id=requirement_id,
+                    submission_type=requirement.submission_type,
+                    phase_id=phase_id,
+                    submitted_value=submitted_value,
+                    extracted_username=extracted_username,
+                    is_validated=validation_result.is_valid,
+                    verification_completed=verification_completed,
+                    feedback_json=feedback_json,
+                    validation_message=validation_message,
+                    cloud_provider=cloud_provider,
+                )
+
+                await write_session.commit()
+
+            span.set_attribute("submission.is_valid", validation_result.is_valid)
+            span.set_attribute(
+                "submission.verification_completed", verification_completed
+            )
+
+            return SubmissionResult(
+                submission=_to_submission_data(db_submission),
+                is_valid=validation_result.is_valid,
+                message=validation_result.message,
+                username_match=validation_result.username_match,
+                repo_exists=validation_result.repo_exists,
+                task_results=validation_result.task_results,
+            )

--- a/api/services/verification/ci_status.py
+++ b/api/services/verification/ci_status.py
@@ -23,9 +23,8 @@ For GitHub API helpers, see ``github_profile.py``.
 
 from __future__ import annotations
 
-import logging
-
 import httpx
+from opentelemetry import trace
 
 from schemas import ValidationResult
 from services.verification.github_profile import (
@@ -34,7 +33,7 @@ from services.verification.github_profile import (
     github_error_to_validation_result,
 )
 
-logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 # The workflow filename in learntocloud/journal-starter.
 _CI_WORKFLOW_FILE = "ci.yml"
@@ -57,121 +56,103 @@ async def verify_ci_status(
         ``ValidationResult`` — valid when the most recent CI run on
         ``main`` has ``conclusion == "success"``.
     """
-    logger.info(
-        "ci_status.started",
-        extra={"owner": owner, "repo": repo},
-    )
+    with tracer.start_as_current_span(
+        "ci_status_verification",
+        attributes={
+            "github.owner": owner,
+            "github.repo": repo,
+        },
+    ) as span:
+        # ── Fetch latest CI workflow runs on main ─────────────────────────
+        url = (
+            f"https://api.github.com/repos/{owner}/{repo}"
+            f"/actions/workflows/{_CI_WORKFLOW_FILE}/runs"
+        )
+        params = {"branch": "main", "per_page": 1}
 
-    # ── Fetch latest CI workflow runs on main ─────────────────────────
-    url = (
-        f"https://api.github.com/repos/{owner}/{repo}"
-        f"/actions/workflows/{_CI_WORKFLOW_FILE}/runs"
-    )
-    params = {"branch": "main", "per_page": 1}
-
-    try:
-        response = await github_api_get(url, params=params)
-    except (
-        httpx.HTTPStatusError,
-        *RETRIABLE_EXCEPTIONS,
-    ) as e:
-        # A 404 here means the workflow file doesn't exist (not synced
-        # from upstream) rather than the repo not existing.
-        if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
-            logger.info(
-                "ci_status.workflow_not_found",
-                extra={"owner": owner, "repo": repo},
+        try:
+            response = await github_api_get(url, params=params)
+        except (
+            httpx.HTTPStatusError,
+            *RETRIABLE_EXCEPTIONS,
+        ) as e:
+            if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
+                span.set_attribute("verification.passed", False)
+                span.set_attribute("verification.reason", "workflow_not_found")
+                return ValidationResult(
+                    is_valid=False,
+                    message=(
+                        f"CI workflow not found in {owner}/{repo}. "
+                        "Make sure you've synced your fork with the upstream "
+                        "repository to get the .github/workflows/ci.yml file, "
+                        "and that GitHub Actions is enabled on your fork."
+                    ),
+                )
+            span.record_exception(e)
+            return github_error_to_validation_result(
+                e,
+                event="ci_status.api_error",
+                context={"owner": owner, "repo": repo},
             )
+
+        data = response.json()
+        runs: list[dict] = data.get("workflow_runs", [])
+
+        if not runs:
+            span.set_attribute("verification.passed", False)
+            span.set_attribute("verification.reason", "no_runs")
             return ValidationResult(
                 is_valid=False,
                 message=(
-                    f"CI workflow not found in {owner}/{repo}. "
-                    "Make sure you've synced your fork with the upstream "
-                    "repository to get the .github/workflows/ci.yml file, "
-                    "and that GitHub Actions is enabled on your fork."
+                    "No CI runs found on the main branch. "
+                    "Push a commit to main or merge a PR to trigger "
+                    "the CI workflow, then try again."
                 ),
             )
-        return github_error_to_validation_result(
-            e,
-            event="ci_status.api_error",
-            context={"owner": owner, "repo": repo},
-        )
 
-    data = response.json()
-    runs: list[dict] = data.get("workflow_runs", [])
+        latest_run = runs[0]
+        conclusion = latest_run.get("conclusion")
+        status = latest_run.get("status")
+        run_url = latest_run.get("html_url", "")
+        run_number = latest_run.get("run_number", 0)
 
-    if not runs:
-        logger.info(
-            "ci_status.no_runs",
-            extra={"owner": owner, "repo": repo},
-        )
+        span.set_attribute("ci.status", status or "unknown")
+        span.set_attribute("ci.conclusion", conclusion or "unknown")
+        span.set_attribute("ci.run_number", run_number)
+
+        # ── Still running ─────────────────────────────────────────────────
+        if status != "completed":
+            span.set_attribute("verification.passed", False)
+            span.set_attribute("verification.reason", "still_running")
+            return ValidationResult(
+                is_valid=False,
+                message=(
+                    f"CI run #{run_number} is still {status}. "
+                    "Wait for it to finish, then try again."
+                ),
+            )
+
+        # ── Completed — check conclusion ──────────────────────────────────
+        if conclusion == "success":
+            span.set_attribute("verification.passed", True)
+            return ValidationResult(
+                is_valid=True,
+                message=(
+                    f"CI tests are passing on main (run #{run_number}). "
+                    "Your Journal API implementation is verified!"
+                ),
+            )
+
+        # CI ran but did not succeed
+        span.set_attribute("verification.passed", False)
+        span.set_attribute("verification.reason", f"conclusion:{conclusion}")
         return ValidationResult(
             is_valid=False,
             message=(
-                "No CI runs found on the main branch. "
-                "Push a commit to main or merge a PR to trigger "
-                "the CI workflow, then try again."
+                f"CI run #{run_number} finished with "
+                f"conclusion '{conclusion}'. "
+                f"Check the run details at {run_url} "
+                "to see which tests are failing, fix them, "
+                "and push to main."
             ),
         )
-
-    latest_run = runs[0]
-    conclusion = latest_run.get("conclusion")
-    status = latest_run.get("status")
-    run_url = latest_run.get("html_url", "")
-    run_number = latest_run.get("run_number", 0)
-
-    logger.info(
-        "ci_status.run_found",
-        extra={
-            "owner": owner,
-            "repo": repo,
-            "status": status,
-            "conclusion": conclusion,
-            "run_number": run_number,
-        },
-    )
-
-    # ── Still running ─────────────────────────────────────────────────
-    if status != "completed":
-        return ValidationResult(
-            is_valid=False,
-            message=(
-                f"CI run #{run_number} is still {status}. "
-                "Wait for it to finish, then try again."
-            ),
-        )
-
-    # ── Completed — check conclusion ──────────────────────────────────
-    if conclusion == "success":
-        logger.info(
-            "ci_status.passed",
-            extra={"owner": owner, "repo": repo, "run_number": run_number},
-        )
-        return ValidationResult(
-            is_valid=True,
-            message=(
-                f"CI tests are passing on main (run #{run_number}). "
-                "Your Journal API implementation is verified!"
-            ),
-        )
-
-    # CI ran but did not succeed
-    logger.info(
-        "ci_status.failed",
-        extra={
-            "owner": owner,
-            "repo": repo,
-            "conclusion": conclusion,
-            "run_number": run_number,
-        },
-    )
-    return ValidationResult(
-        is_valid=False,
-        message=(
-            f"CI run #{run_number} finished with "
-            f"conclusion '{conclusion}'. "
-            f"Check the run details at {run_url} "
-            "to see which tests are failing, fix them, "
-            "and push to main."
-        ),
-    )

--- a/api/services/verification/deployed_api.py
+++ b/api/services/verification/deployed_api.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import json
-import logging
 import re
 import secrets
 import socket
@@ -32,6 +31,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import httpx
+from opentelemetry import trace
 from tenacity import (
     RetryCallState,
     retry,
@@ -47,8 +47,6 @@ from services.verification.errors import (
     deployed_api_error_to_result,
     make_retriable,
 )
-
-logger = logging.getLogger(__name__)
 
 # Shared HTTP client for deployed API requests (connection pooling)
 _deployed_api_client: httpx.AsyncClient | None = None
@@ -145,9 +143,10 @@ async def _validate_url_target(url: str) -> str | None:
     try:
         ip = ipaddress.ip_address(hostname)
         if _is_private_ip(str(ip)):
-            logger.warning(
-                "deployed_api.ssrf_blocked",
-                extra={"url": url, "reason": "private_ip_literal"},
+            span = trace.get_current_span()
+            span.add_event(
+                "ssrf_blocked",
+                {"url": url, "reason": "private_ip_literal"},
             )
             return "URL must point to a publicly accessible server."
         return None
@@ -169,13 +168,10 @@ async def _validate_url_target(url: str) -> str | None:
     for _family, _type, _proto, _canonname, sockaddr in addrinfo:
         addr = sockaddr[0]
         if _is_private_ip(addr):
-            logger.warning(
-                "deployed_api.ssrf_blocked",
-                extra={
-                    "url": url,
-                    "resolved_ip": addr,
-                    "reason": "private_ip_resolved",
-                },
+            span = trace.get_current_span()
+            span.add_event(
+                "ssrf_blocked",
+                {"url": url, "resolved_ip": addr, "reason": "private_ip_resolved"},
             )
             return "URL must point to a publicly accessible server."
 
@@ -200,9 +196,10 @@ def _check_response_ip(response: httpx.Response) -> None:
         return
     addr = server_addr[0]
     if _is_private_ip(addr):
-        logger.warning(
-            "deployed_api.ssrf_blocked",
-            extra={"resolved_ip": addr, "reason": "dns_rebinding"},
+        span = trace.get_current_span()
+        span.add_event(
+            "ssrf_blocked",
+            {"resolved_ip": addr, "reason": "dns_rebinding"},
         )
         raise _SsrfError(addr)
 
@@ -400,15 +397,13 @@ async def _cleanup_challenge_entry(
         delete_url = f"{entries_url}/{entry_id}"
         await _fetch_with_retry(delete_url, method="DELETE")
     except _SsrfError:
-        logger.warning(
-            "deployed_api.ssrf_blocked",
-            extra={"entry_id": entry_id, "reason": "cleanup_dns_rebinding"},
+        span = trace.get_current_span()
+        span.add_event(
+            "ssrf_blocked",
+            {"entry_id": entry_id, "reason": "cleanup_dns_rebinding"},
         )
     except Exception:
-        logger.debug(
-            "deployed_api.challenge_cleanup_failed",
-            extra={"entry_id": entry_id},
-        )
+        pass  # best-effort cleanup
 
 
 async def _post_challenge(
@@ -553,10 +548,8 @@ async def _verify_challenge(
             break
 
     if not nonce_found:
-        logger.warning(
-            "deployed_api.challenge_failed",
-            extra={"url": base_url, "nonce": nonce},
-        )
+        span = trace.get_current_span()
+        span.add_event("challenge_failed", {"url": base_url})
         return (
             ValidationResult(
                 is_valid=False,
@@ -584,14 +577,9 @@ async def _verify_challenge(
         if not validation.is_valid:
             return validation, discovered_id
 
-    logger.info(
-        "deployed_api.verified",
-        extra={
-            "url": base_url,
-            "entries_count": len(real_entries),
-            "challenge": "passed",
-        },
-    )
+    span = trace.get_current_span()
+    span.set_attribute("deployed_api.verified", True)
+    span.set_attribute("deployed_api.entries_count", len(real_entries))
 
     count = len(real_entries)
     entry_word = "entry" if count == 1 else "entries"

--- a/api/services/verification/devops_analysis.py
+++ b/api/services/verification/devops_analysis.py
@@ -5,9 +5,9 @@ Dockerfile, CI/CD, Terraform, and K8s artifacts to their journal-starter fork.
 from __future__ import annotations
 
 import asyncio
-import logging
 
 import httpx
+from opentelemetry import trace
 
 from core.github_client import get_github_client
 from schemas import TaskResult, ValidationResult
@@ -25,7 +25,7 @@ from services.verification.tasks.phase5 import (
     TaskDefinition,
 )
 
-logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 # Patterns that suggest prompt injection attempts.
 # Logged as warnings for monitoring.
@@ -240,9 +240,10 @@ async def _fetch_file_content(
     content_lower = content.lower()
     for pattern in _SUSPICIOUS_PATTERNS:
         if pattern in content_lower:
-            logger.warning(
-                "devops_analysis.suspicious_pattern",
-                extra={"pattern": pattern, "file": path},
+            span = trace.get_current_span()
+            span.add_event(
+                "suspicious_pattern",
+                {"pattern": pattern, "file": path},
             )
             break
 
@@ -306,115 +307,101 @@ async def _fetch_all_devops_files(
 
 async def run_devops_workflow(owner: str, repo: str) -> ValidationResult:
     """Run the full Phase 5 DevOps verification."""
-    logger.info(
-        "devops_analysis.started",
-        extra={"owner": owner, "repo": repo},
-    )
+    with tracer.start_as_current_span(
+        "devops_verification",
+        attributes={
+            "github.owner": owner,
+            "github.repo": repo,
+        },
+    ) as span:
+        # ── Step 1: Fetch repo tree ──────────────────────────────
+        try:
+            all_files = await fetch_repo_tree(owner, repo)
+        except (
+            httpx.HTTPStatusError,
+            *RETRIABLE_EXCEPTIONS,
+        ) as e:
+            if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
+                span.set_attribute("verification.passed", False)
+                span.set_attribute("verification.reason", "repo_not_found")
+                return ValidationResult(
+                    is_valid=False,
+                    message=(
+                        f"Repository '{owner}/{repo}' not found. "
+                        "Make sure the repository is public."
+                    ),
+                )
+            span.record_exception(e)
+            return github_error_to_validation_result(
+                e,
+                event="devops_analysis.repo_tree_error",
+                context={"owner": owner, "repo": repo},
+            )
 
-    # ── Step 1: Fetch repo tree ──────────────────────────────
-    try:
-        all_files = await fetch_repo_tree(owner, repo)
-    except (
-        httpx.HTTPStatusError,
-        *RETRIABLE_EXCEPTIONS,
-    ) as e:
-        if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
+        span.set_attribute("repo.total_files", len(all_files))
+
+        # ── Step 2: Check required files exist ───────────────────
+        existence_failures = _check_required_files(all_files)
+
+        if existence_failures:
+            span.set_attribute("verification.passed", False)
+            span.set_attribute("verification.reason", "missing_files")
+            span.set_attribute(
+                "verification.failed_tasks",
+                ",".join(f.task_name for f in existence_failures),
+            )
+            failed_count = len(existence_failures)
+            total = len(PHASE5_TASKS)
             return ValidationResult(
                 is_valid=False,
                 message=(
-                    f"Repository '{owner}/{repo}' not found. "
-                    "Make sure the repository is public."
+                    f"{failed_count} of {total} tasks are missing required files. "
+                    "Add the missing files listed below, then re-submit."
                 ),
+                task_results=existence_failures,
             )
-        return github_error_to_validation_result(
-            e,
-            event="devops_analysis.repo_tree_error",
-            context={"owner": owner, "repo": repo},
+
+        # ── Step 3: Fetch file contents ──────────────────────────
+        devops_files = _filter_devops_files(all_files)
+        file_contents = await _fetch_all_devops_files(owner, repo, devops_files)
+
+        span.set_attribute(
+            "repo.fetched_files",
+            sum(len(v) for v in file_contents.values()),
         )
 
-    logger.info(
-        "devops_analysis.repo_tree_fetched",
-        extra={"owner": owner, "repo": repo, "total_files": len(all_files)},
-    )
+        # ── Step 4: Run indicator checks per task ────────────────
+        task_results: list[TaskResult] = []
+        for task_def in PHASE5_TASKS:
+            task_files = file_contents.get(task_def["id"], [])
+            result = _check_task_indicators(task_def, task_files)
+            task_results.append(result)
 
-    # ── Step 2: Check required files exist ───────────────────
-    existence_failures = _check_required_files(all_files)
+        # ── Step 5: Aggregate results ────────────────────────────
+        passed_count = sum(1 for t in task_results if t.passed)
+        total_count = len(PHASE5_TASKS)
+        all_passed = passed_count == total_count
 
-    if existence_failures:
-        logger.info(
-            "devops_analysis.required_files_missing",
-            extra={
-                "owner": owner,
-                "repo": repo,
-                "failed_tasks": [f.task_name for f in existence_failures],
-            },
-        )
-        failed_count = len(existence_failures)
-        total = len(PHASE5_TASKS)
+        if all_passed:
+            message = (
+                f"All {total_count} DevOps tasks verified! "
+                "Your journal-starter fork has proper "
+                "containerization, CI/CD, Terraform, and "
+                "Kubernetes artifacts."
+            )
+        else:
+            message = (
+                f"Completed {passed_count}/{total_count} tasks. "
+                "Review the feedback below and try again "
+                "after making improvements."
+            )
+
+        span.set_attribute("verification.passed", all_passed)
+        span.set_attribute("verification.passed_count", passed_count)
+        span.set_attribute("verification.total_count", total_count)
+
         return ValidationResult(
-            is_valid=False,
-            message=(
-                f"{failed_count} of {total} tasks are missing required files. "
-                "Add the missing files listed below, then re-submit."
-            ),
-            task_results=existence_failures,
+            is_valid=all_passed,
+            message=message,
+            task_results=task_results,
         )
-
-    # ── Step 3: Fetch file contents ──────────────────────────
-    devops_files = _filter_devops_files(all_files)
-    file_contents = await _fetch_all_devops_files(owner, repo, devops_files)
-
-    logger.info(
-        "devops_analysis.files_fetched",
-        extra={
-            "owner": owner,
-            "repo": repo,
-            "fetched_per_task": {
-                tid: len(contents) for tid, contents in file_contents.items()
-            },
-        },
-    )
-
-    # ── Step 4: Run indicator checks per task ────────────────
-    task_results: list[TaskResult] = []
-    for task_def in PHASE5_TASKS:
-        task_files = file_contents.get(task_def["id"], [])
-        result = _check_task_indicators(task_def, task_files)
-        task_results.append(result)
-
-    # ── Step 5: Aggregate results ────────────────────────────
-    passed_count = sum(1 for t in task_results if t.passed)
-    total_count = len(PHASE5_TASKS)
-    all_passed = passed_count == total_count
-
-    if all_passed:
-        message = (
-            f"All {total_count} DevOps tasks verified! "
-            "Your journal-starter fork has proper "
-            "containerization, CI/CD, Terraform, and "
-            "Kubernetes artifacts."
-        )
-    else:
-        message = (
-            f"Completed {passed_count}/{total_count} tasks. "
-            "Review the feedback below and try again "
-            "after making improvements."
-        )
-
-    logger.info(
-        "devops_analysis.completed",
-        extra={
-            "owner": owner,
-            "repo": repo,
-            "passed": passed_count,
-            "total": total_count,
-            "all_passed": all_passed,
-            "task_grades": {t.task_name: t.passed for t in task_results},
-        },
-    )
-
-    return ValidationResult(
-        is_valid=all_passed,
-        message=message,
-        task_results=task_results,
-    )

--- a/api/services/verification/dispatcher.py
+++ b/api/services/verification/dispatcher.py
@@ -22,10 +22,9 @@ For CI-based code verification, see ci_status.py
 For phase requirements, see requirements.py
 """
 
-import logging
 import time
 
-from opentelemetry import metrics
+from opentelemetry import metrics, trace
 
 from models import SubmissionType
 from schemas import HandsOnRequirement, ValidationResult
@@ -42,8 +41,6 @@ from services.verification.repo_utils import VerificationError, validate_repo_ur
 from services.verification.security_scanning import validate_security_scanning
 from services.verification.token_base import verify_ctf_token, verify_networking_token
 from services.verification.url_derivation import fork_name_from_required_repo
-
-logger = logging.getLogger(__name__)
 
 _meter = metrics.get_meter("learn_to_cloud")
 _VERIFICATION_COUNTER = _meter.create_counter(
@@ -90,13 +87,11 @@ async def validate_submission(
         TimeoutError,
         VerificationError,
     ) as e:
-        logger.error(
-            "verification.failed",
-            extra={
-                "submission_type": submission_type,
-                "error_type": type(e).__name__,
-                "error": str(e),
-            },
+        span = trace.get_current_span()
+        span.record_exception(e)
+        span.add_event(
+            "verification_failed",
+            {"submission_type": submission_type, "error_type": type(e).__name__},
         )
         return ValidationResult(
             is_valid=False,
@@ -104,12 +99,11 @@ async def validate_submission(
             verification_completed=False,
         )
     except Exception as e:
-        logger.exception(
-            "verification.unexpected_error",
-            extra={
-                "submission_type": submission_type,
-                "error_type": type(e).__name__,
-            },
+        span = trace.get_current_span()
+        span.record_exception(e)
+        span.add_event(
+            "verification_unexpected_error",
+            {"submission_type": submission_type, "error_type": type(e).__name__},
         )
         return ValidationResult(
             is_valid=False,

--- a/api/services/verification/errors.py
+++ b/api/services/verification/errors.py
@@ -7,13 +7,11 @@ a single source of truth.
 
 from __future__ import annotations
 
-import logging
-
 import httpx
+from opentelemetry import trace
+from opentelemetry.util.types import AttributeValue
 
 from schemas import ValidationResult
-
-logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Base retriable exceptions (httpx network / timeout errors)
@@ -61,7 +59,7 @@ def github_error_to_result(
     e: Exception,
     *,
     event: str,
-    context: dict[str, object],
+    context: dict[str, AttributeValue],
 ) -> ValidationResult:
     """Map GitHub API exceptions to a user-facing ValidationResult.
 
@@ -76,7 +74,8 @@ def github_error_to_result(
                 is_valid=False,
                 message="Resource not found on GitHub. Check the URL and try again.",
             )
-        logger.warning(event, extra={**context, "status": e.response.status_code})
+        span = trace.get_current_span()
+        span.add_event(event, {**context, "status": e.response.status_code})
         return ValidationResult(
             is_valid=False,
             message=f"GitHub API error ({e.response.status_code}). Try again later.",
@@ -84,7 +83,8 @@ def github_error_to_result(
         )
 
     # RETRIABLE_EXCEPTIONS (RequestError, TimeoutException, etc.)
-    logger.warning(event, extra={**context, "error": str(e)})
+    span = trace.get_current_span()
+    span.add_event(event, {**context, "error": str(e)})
     return ValidationResult(
         is_valid=False,
         message="Could not reach GitHub. Please try again later.",
@@ -106,10 +106,8 @@ def deployed_api_error_to_result(
     step_prefix = f"{step}: " if step else ""
 
     if isinstance(exc, httpx.TimeoutException):
-        logger.warning(
-            "deployed_api.timeout",
-            extra={"url": entries_url, "step": step},
-        )
+        span = trace.get_current_span()
+        span.add_event("deployed_api_timeout", {"url": entries_url, "step": step})
         return ValidationResult(
             is_valid=False,
             message=(
@@ -119,9 +117,10 @@ def deployed_api_error_to_result(
         )
 
     if isinstance(exc, DeployedApiServerError):
-        logger.warning(
-            "deployed_api.server_error",
-            extra={"url": entries_url, "error": str(exc), "step": step},
+        span = trace.get_current_span()
+        span.add_event(
+            "deployed_api_server_error",
+            {"url": entries_url, "error": str(exc), "step": step},
         )
         return ValidationResult(
             is_valid=False,
@@ -132,9 +131,10 @@ def deployed_api_error_to_result(
         )
 
     if isinstance(exc, httpx.RequestError):
-        logger.warning(
-            "deployed_api.request_error",
-            extra={"url": entries_url, "error": str(exc), "step": step},
+        span = trace.get_current_span()
+        span.add_event(
+            "deployed_api_request_error",
+            {"url": entries_url, "error": str(exc), "step": step},
         )
         return ValidationResult(
             is_valid=False,

--- a/api/services/verification/github_profile.py
+++ b/api/services/verification/github_profile.py
@@ -13,10 +13,10 @@ SCALABILITY:
 - Connection pooling via shared httpx.AsyncClient
 """
 
-import logging
 import re
 
 import httpx
+from opentelemetry import trace
 from tenacity import (
     RetryCallState,
     retry,
@@ -33,8 +33,6 @@ from services.verification.errors import (
     github_error_to_result,
     make_retriable,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def _parse_retry_after(header_value: str | None) -> float | None:
@@ -208,24 +206,18 @@ async def check_github_url_exists(url: str) -> ValidationResult:
         exists, msg = await _check_github_url_exists_with_retry(url)
         return ValidationResult(is_valid=exists, message=msg)
     except RETRIABLE_EXCEPTIONS as e:
-        logger.warning(
-            "github.url_check.failed",
-            extra={"url": url, "error": str(e)},
-        )
+        span = trace.get_current_span()
+        span.record_exception(e)
+        span.add_event("url_check_failed", {"url": url})
         return ValidationResult(
             is_valid=False,
             message=f"Request error: {e!s}",
             verification_completed=False,
         )
     except Exception as e:
-        logger.error(
-            "github.url_check.unexpected_error",
-            extra={
-                "url": url,
-                "exc_type": type(e).__name__,
-                "exc_message": str(e),
-            },
-        )
+        span = trace.get_current_span()
+        span.record_exception(e)
+        span.add_event("url_check_unexpected_error", {"url": url})
         return ValidationResult(
             is_valid=False,
             message=f"Unexpected error: {e!s}",
@@ -300,24 +292,20 @@ async def check_repo_is_fork_of(
         )
         return ValidationResult(is_valid=is_fork, message=msg)
     except RETRIABLE_EXCEPTIONS as e:
-        logger.warning(
-            "github.fork_check.failed",
-            extra={"username": username, "repo": repo_name, "error": str(e)},
-        )
+        span = trace.get_current_span()
+        span.record_exception(e)
+        span.add_event("fork_check_failed", {"username": username, "repo": repo_name})
         return ValidationResult(
             is_valid=False,
             message=f"Request error: {e!s}",
             verification_completed=False,
         )
     except Exception as e:
-        logger.error(
-            "github.fork_check.unexpected_error",
-            extra={
-                "username": username,
-                "repo": repo_name,
-                "exc_type": type(e).__name__,
-                "exc_message": str(e),
-            },
+        span = trace.get_current_span()
+        span.record_exception(e)
+        span.add_event(
+            "fork_check_unexpected_error",
+            {"username": username, "repo": repo_name},
         )
         return ValidationResult(
             is_valid=False,

--- a/api/services/verification/indicator_engine.py
+++ b/api/services/verification/indicator_engine.py
@@ -16,13 +16,12 @@ Indicator matching rules:
 
 from __future__ import annotations
 
-import logging
 import re
 from dataclasses import dataclass, field
 
-from schemas import HandsOnRequirement
+from opentelemetry import trace
 
-logger = logging.getLogger(__name__)
+from schemas import HandsOnRequirement
 
 
 @dataclass(frozen=True)
@@ -109,13 +108,9 @@ def check_indicators(
             matched_fail.append(indicator)
 
     if matched_fail:
-        logger.info(
-            "indicator_engine.fail_indicators_found",
-            extra={
-                "requirement": requirement.id,
-                "matched": matched_fail,
-            },
-        )
+        span = trace.get_current_span()
+        span.set_attribute("indicator.result", "fail_indicators_found")
+        span.set_attribute("indicator.matched_fail", ",".join(matched_fail))
         return IndicatorResult(
             passed=False,
             matched_fail=matched_fail,
@@ -137,24 +132,17 @@ def check_indicators(
             missing_pass.append(indicator)
 
     if not pass_indicators:
-        # No indicators defined — cannot determine pass deterministically
-        logger.warning(
-            "indicator_engine.no_pass_indicators",
-            extra={"requirement": requirement.id},
-        )
+        span = trace.get_current_span()
+        span.add_event("no_pass_indicators_defined", {"requirement": requirement.id})
         return IndicatorResult(
             passed=False,
             reason="No pass indicators defined for this requirement.",
         )
 
     if not matched_pass:
-        logger.info(
-            "indicator_engine.no_pass_indicators_matched",
-            extra={
-                "requirement": requirement.id,
-                "missing": missing_pass,
-            },
-        )
+        span = trace.get_current_span()
+        span.set_attribute("indicator.result", "no_pass_matched")
+        span.set_attribute("indicator.missing", ",".join(missing_pass))
         return IndicatorResult(
             passed=False,
             matched_pass=matched_pass,
@@ -166,13 +154,9 @@ def check_indicators(
         )
 
     # At least one pass indicator found, no fail indicators
-    logger.info(
-        "indicator_engine.all_indicators_passed",
-        extra={
-            "requirement": requirement.id,
-            "matched": matched_pass,
-        },
-    )
+    span = trace.get_current_span()
+    span.set_attribute("indicator.result", "passed")
+    span.set_attribute("indicator.matched", ",".join(matched_pass))
     return IndicatorResult(
         passed=True,
         matched_pass=matched_pass,

--- a/api/services/verification/pull_request.py
+++ b/api/services/verification/pull_request.py
@@ -16,9 +16,8 @@ indicators deterministically.  Results are instant and reproducible.
 
 from __future__ import annotations
 
-import logging
-
 import httpx
+from opentelemetry import trace
 
 from schemas import HandsOnRequirement, TaskResult, ValidationResult
 from services.verification.github_profile import (
@@ -31,7 +30,7 @@ from services.verification.indicator_engine import check_indicators
 # Maximum diff size to prevent memory exhaustion (50 KB)
 MAX_FILE_SIZE_BYTES: int = 50 * 1024
 
-logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 # Patterns that suggest prompt injection attempts in PR diffs.
 # Logged as warnings for monitoring but do not affect pass/fail.
@@ -65,9 +64,10 @@ async def _fetch_pr_diff(owner: str, repo: str, pr_number: int) -> str:
     diff_lower = diff_text.lower()
     for pattern in _SUSPICIOUS_PATTERNS:
         if pattern in diff_lower:
-            logger.warning(
-                "pr_verification.suspicious_pattern_in_diff",
-                extra={"pattern": pattern, "owner": owner, "pr": pr_number},
+            span = trace.get_current_span()
+            span.add_event(
+                "suspicious_pattern_in_diff",
+                {"pattern": pattern, "owner": owner, "pr": pr_number},
             )
             break
 
@@ -102,123 +102,120 @@ async def validate_pr(
     repo = parts[4]
     pr_number = int(parts[6])
 
-    logger.info(
-        "pr_verification.started",
-        extra={
-            "pr_url": pr_url,
-            "requirement": requirement.id,
+    with tracer.start_as_current_span(
+        "pr_verification",
+        attributes={
+            "pr.url": pr_url,
+            "pr.number": pr_number,
+            "requirement.id": requirement.id,
+            "github.owner": owner,
+            "github.repo": repo,
         },
-    )
+    ) as span:
+        # ── Step 1: Fetch PR metadata ────────────────────────────
+        try:
+            pr_data = await _fetch_pr_data(owner, repo, pr_number)
+        except (
+            httpx.HTTPStatusError,
+            *RETRIABLE_EXCEPTIONS,
+        ) as e:
+            if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
+                span.set_attribute("verification.passed", False)
+                span.set_attribute("verification.reason", "pr_not_found")
+                return ValidationResult(
+                    is_valid=False,
+                    message=(
+                        f"Pull request #{pr_number} not found. "
+                        "Check the PR number and try again."
+                    ),
+                )
+            span.record_exception(e)
+            return github_error_to_validation_result(
+                e,
+                event="pr_verification.api_error",
+                context={"owner": owner, "repo": repo, "pr": pr_number},
+            )
 
-    # ── Step 1: Fetch PR metadata ────────────────────────────
-    try:
-        pr_data = await _fetch_pr_data(owner, repo, pr_number)
-    except (
-        httpx.HTTPStatusError,
-        *RETRIABLE_EXCEPTIONS,
-    ) as e:
-        if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
+        # ── Step 2: Verify PR is merged ──────────────────────────
+        if not pr_data.get("merged"):
+            state = pr_data.get("state", "unknown")
+            span.set_attribute("verification.passed", False)
+            span.set_attribute("verification.reason", f"not_merged:{state}")
+            fail_msg = (
+                f"PR #{pr_number} is still open. "
+                "Merge it into main first, then resubmit."
+                if state == "open"
+                else f"PR #{pr_number} was closed without "
+                "merging. Create a new PR, merge it, "
+                "then submit that link."
+            )
+            return ValidationResult(is_valid=False, message=fail_msg)
+
+        branch = pr_data.get("head", {}).get("ref", "unknown")
+
+        # ── Step 3: Fetch PR diff ────────────────────────────────
+        try:
+            diff = await _fetch_pr_diff(owner, repo, pr_number)
+        except (
+            httpx.HTTPStatusError,
+            *RETRIABLE_EXCEPTIONS,
+        ) as e:
+            span.record_exception(e)
+            return github_error_to_validation_result(
+                e,
+                event="pr_verification.diff_error",
+                context={"owner": owner, "pr": pr_number},
+            )
+
+        # ── Step 4: Deterministic indicator check ────────────────
+        indicator_result = check_indicators(diff, requirement)
+
+        if not indicator_result.passed:
+            if indicator_result.matched_fail:
+                next_steps = f"Remove or replace: {indicator_result.matched_fail[0]}"
+            elif indicator_result.missing_pass:
+                next_steps = (
+                    f"Missing implementation for: "
+                    f"{', '.join(indicator_result.missing_pass[:3])}"
+                )
+            else:
+                next_steps = "Review the requirement and try again."
+
+            task_result = TaskResult(
+                task_name=requirement.name,
+                passed=False,
+                feedback=indicator_result.reason,
+                next_steps=next_steps,
+            )
+
+            span.set_attribute("verification.passed", False)
+            span.set_attribute("verification.reason", "indicators_failed")
+
             return ValidationResult(
                 is_valid=False,
                 message=(
-                    f"Pull request #{pr_number} not found. "
-                    "Check the PR number and try again."
+                    f"PR #{pr_number} was merged but doesn't "
+                    f"fully implement the required task. "
+                    f"Review the feedback below."
                 ),
+                username_match=True,
+                task_results=[task_result],
             )
-        return github_error_to_validation_result(
-            e,
-            event="pr_verification.api_error",
-            context={"owner": owner, "repo": repo, "pr": pr_number},
-        )
 
-    # ── Step 2: Verify PR is merged ──────────────────────────
-    if not pr_data.get("merged"):
-        state = pr_data.get("state", "unknown")
-        fail_msg = (
-            f"PR #{pr_number} is still open. Merge it into main first, then resubmit."
-            if state == "open"
-            else f"PR #{pr_number} was closed without "
-            "merging. Create a new PR, merge it, "
-            "then submit that link."
-        )
-        return ValidationResult(is_valid=False, message=fail_msg)
-
-    branch = pr_data.get("head", {}).get("ref", "unknown")
-
-    # ── Step 3: Fetch PR diff ────────────────────────────────
-    try:
-        diff = await _fetch_pr_diff(owner, repo, pr_number)
-    except (
-        httpx.HTTPStatusError,
-        *RETRIABLE_EXCEPTIONS,
-    ) as e:
-        return github_error_to_validation_result(
-            e,
-            event="pr_verification.diff_error",
-            context={"owner": owner, "pr": pr_number},
-        )
-
-    # ── Step 4: Deterministic indicator check ────────────────
-    indicator_result = check_indicators(diff, requirement)
-
-    if not indicator_result.passed:
-        if indicator_result.matched_fail:
-            next_steps = f"Remove or replace: {indicator_result.matched_fail[0]}"
-        elif indicator_result.missing_pass:
-            next_steps = (
-                f"Missing implementation for: "
-                f"{', '.join(indicator_result.missing_pass[:3])}"
-            )
-        else:
-            next_steps = "Review the requirement and try again."
-
+        # ── Passed ───────────────────────────────────────────────
         task_result = TaskResult(
             task_name=requirement.name,
-            passed=False,
-            feedback=indicator_result.reason,
-            next_steps=next_steps,
+            passed=True,
+            feedback="All required implementation indicators verified.",
+            next_steps="",
         )
 
-        logger.info(
-            "pr_verification.completed",
-            extra={
-                "pr": pr_number,
-                "requirement": requirement.id,
-                "passed": False,
-            },
-        )
+        span.set_attribute("verification.passed", True)
+        span.set_attribute("pr.branch", branch)
 
         return ValidationResult(
-            is_valid=False,
-            message=(
-                f"PR #{pr_number} was merged but doesn't "
-                f"fully implement the required task. "
-                f"Review the feedback below."
-            ),
+            is_valid=True,
+            message=f"PR #{pr_number} verified! Merged from branch '{branch}'.",
             username_match=True,
             task_results=[task_result],
         )
-
-    # ── Passed ───────────────────────────────────────────────
-    task_result = TaskResult(
-        task_name=requirement.name,
-        passed=True,
-        feedback="All required implementation indicators verified.",
-        next_steps="",
-    )
-
-    logger.info(
-        "pr_verification.completed",
-        extra={
-            "pr": pr_number,
-            "requirement": requirement.id,
-            "passed": True,
-        },
-    )
-
-    return ValidationResult(
-        is_valid=True,
-        message=f"PR #{pr_number} verified! Merged from branch '{branch}'.",
-        username_match=True,
-        task_results=[task_result],
-    )

--- a/api/services/verification/security_scanning.py
+++ b/api/services/verification/security_scanning.py
@@ -17,9 +17,9 @@ Verification is purely file-based.
 from __future__ import annotations
 
 import asyncio
-import logging
 
 import httpx
+from opentelemetry import trace
 from tenacity import (
     retry,
     retry_if_exception_type,
@@ -35,8 +35,6 @@ from services.verification.github_profile import (
     get_github_headers,
 )
 from services.verification.repo_utils import VerificationError
-
-logger = logging.getLogger(__name__)
 
 # CodeQL action identifier in workflow file content
 CODEQL_ACTION_PATTERN = "github/codeql-action"
@@ -141,9 +139,10 @@ async def _fetch_workflow_content(owner: str, repo: str, path: str) -> str | Non
         response.raise_for_status()
         return response.text
     except httpx.HTTPStatusError:
-        logger.warning(
-            "security_scanning.workflow_fetch_failed",
-            extra={"owner": owner, "repo": repo, "path": path},
+        span = trace.get_current_span()
+        span.add_event(
+            "workflow_fetch_failed",
+            {"owner": owner, "repo": repo, "path": path},
         )
         return None
 
@@ -224,17 +223,10 @@ async def _verify_security_scanning(
 
     passed_count = sum(1 for t in task_results if t.passed)
 
-    logger.info(
-        "security_scanning.checks_completed",
-        extra={
-            "owner": owner,
-            "repo": repo,
-            "dependabot": dependabot_result.passed,
-            "codeql": codeql_result.passed,
-            "passed": passed_count,
-            "total": len(task_results),
-        },
-    )
+    span = trace.get_current_span()
+    span.set_attribute("security.dependabot", dependabot_result.passed)
+    span.set_attribute("security.codeql", codeql_result.passed)
+    span.set_attribute("security.passed_count", passed_count)
 
     if all_passed:
         message = (

--- a/api/services/verification/token_base.py
+++ b/api/services/verification/token_base.py
@@ -11,14 +11,13 @@ import binascii
 import hashlib
 import hmac
 import json
-import logging
 from datetime import UTC, datetime
 from typing import Any
 
+from opentelemetry import trace
+
 from core.config import get_settings
 from schemas import ValidationResult
-
-logger = logging.getLogger(__name__)
 
 
 def _derive_secret(instance_id: str) -> str:
@@ -107,7 +106,8 @@ def verify_lab_token(
                     "Invalid token signature. The token may have been tampered with."
                 )
         except RuntimeError:
-            logger.exception("token.verification.misconfigured")
+            span = trace.get_current_span()
+            span.add_event("token_verification_misconfigured")
             return _fail(
                 f"{display_name} verification is not available right now.",
                 completed=False,
@@ -128,14 +128,10 @@ def verify_lab_token(
         if timestamp > datetime.now(UTC).timestamp() + 3600:
             return _fail("Invalid timestamp. The token appears to be from the future.")
 
-        logger.info(
-            "token.verification.passed",
-            extra={
-                "display_name": display_name,
-                "github_username": payload.get("github_username"),
-                "challenges": challenges,
-            },
-        )
+        span = trace.get_current_span()
+        span.set_attribute("token.verified", True)
+        span.set_attribute("token.display_name", display_name)
+        span.set_attribute("token.challenges", challenges)
 
         return ValidationResult(
             is_valid=True,
@@ -146,8 +142,9 @@ def verify_lab_token(
             cloud_provider=cloud_provider,
         )
 
-    except Exception:
-        logger.exception("token.verification.failed")
+    except Exception as e:
+        span = trace.get_current_span()
+        span.record_exception(e)
         return _fail(
             "Token verification failed. Please try again or contact support.",
             completed=False,

--- a/api/tests/test_logger.py
+++ b/api/tests/test_logger.py
@@ -2,7 +2,7 @@
 
 Tests the stdlib-based logging configuration:
 - configure_logging() sets up root logger handlers
-- _JSONFormatter produces valid JSON output
+- _JSONFormatter produces valid JSON output with CWE-117 sanitization
 - OTel handlers are preserved when present
 - Noisy third-party loggers are quieted
 """
@@ -16,8 +16,6 @@ import pytest
 
 from core.logger import (
     _JSONFormatter,
-    _LogSanitizationFilter,
-    _RequestContextFilter,
     configure_logging,
 )
 
@@ -96,6 +94,49 @@ class TestJSONFormatter:
         output = formatter.format(record)
         json.loads(output)  # Should not raise
 
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("linux\nFAKE LOG LINE", "linuxFAKE LOG LINE"),
+            ("hello\r\nworld", "helloworld"),
+            ("step\x00injected", "stepinjected"),
+        ],
+        ids=["newline", "carriage-return", "null-byte"],
+    )
+    def test_sanitizes_control_chars_in_extras(self, value, expected):
+        """CWE-117: control characters stripped from user-supplied extra fields."""
+        formatter = _JSONFormatter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="msg",
+            args=(),
+            exc_info=None,
+        )
+        record.field = value
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["field"] == expected
+
+    def test_preserves_tabs_in_extras(self):
+        """Tabs are intentionally preserved (only dangerous control chars removed)."""
+        formatter = _JSONFormatter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="msg",
+            args=(),
+            exc_info=None,
+        )
+        record.data = "col1\tcol2"
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["data"] == "col1\tcol2"
+
 
 @pytest.mark.unit
 class TestConfigureLogging:
@@ -135,98 +176,8 @@ class TestConfigureLogging:
 
         assert otel_handler in root.handlers
 
-    def test_registers_filters_in_correct_order(self):
-        """Context filter runs before sanitization so injected fields get cleaned."""
+    def test_no_filters_on_root_logger(self):
+        """Root logger filters were removed (dead code due to propagation bug)."""
         configure_logging()
         root = logging.getLogger()
-        filter_types = [type(f) for f in root.filters]
-        assert _RequestContextFilter in filter_types
-        assert _LogSanitizationFilter in filter_types
-        ctx_idx = filter_types.index(_RequestContextFilter)
-        san_idx = filter_types.index(_LogSanitizationFilter)
-        assert ctx_idx < san_idx, "Sanitization filter must run after context filter"
-
-
-@pytest.mark.unit
-class TestRequestContextFilter:
-    """Test _RequestContextFilter injects github_username from context var."""
-
-    def test_injects_username_from_context_var(self):
-        from core.middleware import request_github_username
-
-        token = request_github_username.set("testuser")
-        try:
-            f = _RequestContextFilter()
-            record = logging.LogRecord("test", logging.INFO, "", 0, "msg", (), None)
-            f.filter(record)
-            assert getattr(record, "github_username") == "testuser"
-        finally:
-            request_github_username.reset(token)
-
-    def test_does_not_overwrite_explicit_username(self):
-        from core.middleware import request_github_username
-
-        token = request_github_username.set("ctx-user")
-        try:
-            f = _RequestContextFilter()
-            record = logging.LogRecord("test", logging.INFO, "", 0, "msg", (), None)
-            record.github_username = "explicit-user"
-            f.filter(record)
-            assert getattr(record, "github_username") == "explicit-user"
-        finally:
-            request_github_username.reset(token)
-
-    def test_no_username_when_context_var_empty(self):
-        f = _RequestContextFilter()
-        record = logging.LogRecord("test", logging.INFO, "", 0, "msg", (), None)
-        f.filter(record)
-        assert not getattr(record, "github_username", None)
-
-
-@pytest.mark.unit
-class TestLogSanitizationFilter:
-    """Test _LogSanitizationFilter strips control chars from extra fields (CWE-117)."""
-
-    def _make_record(self, **extras: object) -> logging.LogRecord:
-        record = logging.LogRecord("test", logging.INFO, "", 0, "msg", (), None)
-        for key, value in extras.items():
-            setattr(record, key, value)
-        return record
-
-    @pytest.mark.parametrize(
-        "value,expected",
-        [
-            ("linux\nFAKE LOG LINE", "linuxFAKE LOG LINE"),
-            ("hello\r\nworld", "helloworld"),
-            ("step\x00injected", "stepinjected"),
-        ],
-        ids=["newline", "carriage-return", "null-byte"],
-    )
-    def test_strips_control_chars(self, value, expected):
-        f = _LogSanitizationFilter()
-        record = self._make_record(field=value)
-        f.filter(record)
-        assert getattr(record, "field") == expected
-
-    def test_preserves_tabs(self):
-        f = _LogSanitizationFilter()
-        record = self._make_record(data="col1\tcol2")
-        f.filter(record)
-        assert getattr(record, "data") == "col1\tcol2"
-
-    def test_leaves_non_string_extras_unchanged(self):
-        f = _LogSanitizationFilter()
-        record = self._make_record(user_id=42, active=True, ratio=3.14)
-        f.filter(record)
-        assert getattr(record, "user_id") == 42
-        assert getattr(record, "active") is True
-        assert getattr(record, "ratio") == 3.14
-
-    def test_does_not_modify_builtin_attributes(self):
-        f = _LogSanitizationFilter()
-        record = logging.LogRecord(
-            "test", logging.INFO, "/path/to\nfile.py", 0, "msg", (), None
-        )
-        original_pathname = record.pathname
-        f.filter(record)
-        assert record.pathname == original_pathname
+        assert len(root.filters) == 0


### PR DESCRIPTION
## What

Replace ~55 scattered log statements with OpenTelemetry custom spans, span attributes, and span events across the verification pipeline.

## Why

- Root logger filters (`_RequestContextFilter`, `_LogSanitizationFilter`) were **dead code** — Python's propagation rules skip parent logger filters, so `github_username` was never injected and CWE-117 sanitization never ran
- Logs had no user context (`github_username` in 0/24 statements) making production debugging painful
- OTel was fully configured but created zero custom spans — we had auto-instrumented HTTP spans with no business context

## Changes

### Verification modules (spans + attributes)
- `pull_request.py`, `ci_status.py`, `devops_analysis.py`: Wrapped core functions in custom spans with full context (user, requirement, PR, result, indicators)
- `indicator_engine.py`, `deployed_api.py`, `security_scanning.py`, `github_profile.py`, `token_base.py`, `errors.py`, `dispatcher.py`: Converted logs → span attributes/events on current span

### Service/route modules
- `submissions_service.py`: Added `submit_validation` span wrapping dispatch + DB write
- `steps_service.py`: Step complete/uncomplete → span attributes on current span
- `htmx_routes.py`: Warning logs → span events

### Core
- `logger.py`: Deleted dead filter classes, moved CWE-117 sanitization into `_JSONFormatter.format()`
- `observability.py`: Added `_configure_otlp()` for local dev (Aspire/Jaeger), restructured pipeline for Azure Monitor / OTLP / disabled paths
- `pyproject.toml`: Added `core/observability.py` to PLC0415 per-file-ignores

### Tests
- `test_logger.py`: Removed dead filter tests, added CWE-117 formatter tests, added no-filters assertion

## Result

Every verification now produces a span tree like:
```
POST /htmx/github/submit
  └─ submit_validation
       └─ pr_verification  (attrs: github.owner, requirement.id, verification.passed, indicator.matched, ...)
            ├─ HTTP GET 200  (auto: GitHub API call)
            └─ HTTP GET 200  (auto: GitHub API call)
```

**17 files changed, 624 insertions, 763 deletions, zero new dependencies.**