### PR TITLE
fix: harden CSRF middleware with fail-closed and origin checks

### DIFF
--- a/api/core/csrf.py
+++ b/api/core/csrf.py
@@ -1,17 +1,25 @@
 """CSRF protection middleware — Synchronizer Token Pattern.
 
-Stores a random token in the server-side session and validates it on
+Stores a random token in the signed session cookie and validates it on
 unsafe requests (POST, PUT, PATCH, DELETE).  The token can be submitted
 via either:
 
 - **Header**: ``X-CSRFToken`` (used automatically by HTMX via a global
   ``htmx:configRequest`` listener in ``base.html``)
 - **Form field**: ``csrf_token`` (used by the logout ``<form>`` in the
-  navbar)
+  navbar — only parsed for ``application/x-www-form-urlencoded``; for
+  ``multipart/form-data`` uploads, use the header instead)
 
-This is stronger than the Double Submit Cookie pattern because the
-token lives in the signed session — an attacker who can set cookies
-on a subdomain still cannot forge requests.
+Defence-in-depth layers:
+
+1. **Synchronizer token** — the primary check.
+2. **Origin / Referer verification** — when ``trusted_origins`` are
+   configured, the middleware rejects unsafe requests whose ``Origin``
+   (or ``Referer``) does not match a trusted origin.  Requests with
+   neither header are allowed through to avoid breaking clients behind
+   privacy proxies, but a warning is logged.
+3. **Fail-closed** — if ``SessionMiddleware`` is not active, unsafe
+   requests are rejected instead of silently skipping CSRF enforcement.
 """
 
 from __future__ import annotations
@@ -19,6 +27,7 @@ from __future__ import annotations
 import logging
 import secrets
 from re import Pattern
+from urllib.parse import urlparse
 
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
@@ -32,6 +41,20 @@ _HEADER_NAME = "x-csrftoken"
 _FORM_FIELD = "csrf_token"
 
 
+def _normalize_origin(origin: str) -> str:
+    """Normalize an origin to ``scheme://host[:port]`` (lower-cased)."""
+    parsed = urlparse(origin if "://" in origin else f"https://{origin}")
+    scheme = (parsed.scheme or "https").lower()
+    host = (parsed.hostname or "").lower()
+    port = parsed.port
+    # Omit default ports for cleaner comparison.
+    if port and not (
+        (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    ):
+        return f"{scheme}://{host}:{port}"
+    return f"{scheme}://{host}"
+
+
 class CSRFMiddleware:
     """Synchronizer Token CSRF middleware.
 
@@ -39,6 +62,9 @@ class CSRFMiddleware:
         app: The ASGI application.
         exempt_urls: Optional regex patterns for paths that skip CSRF
             checks (e.g. OAuth callbacks that receive external redirects).
+        trusted_origins: Origins (``scheme://host[:port]``) that are
+            allowed to make unsafe requests.  When set, the ``Origin``
+            or ``Referer`` header is verified before token validation.
     """
 
     def __init__(
@@ -46,9 +72,13 @@ class CSRFMiddleware:
         app: ASGIApp,
         *,
         exempt_urls: list[Pattern[str]] | None = None,
+        trusted_origins: list[str] | None = None,
     ) -> None:
         self.app = app
         self.exempt_urls = exempt_urls or []
+        self.trusted_origins = frozenset(
+            _normalize_origin(o) for o in (trusted_origins or []) if o
+        )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -60,7 +90,20 @@ class CSRFMiddleware:
         # Ensure a CSRF token exists in the session.
         session = scope.get("session")
         if session is None:
-            # SessionMiddleware not active — skip CSRF enforcement.
+            # Fail-closed: reject unsafe requests when session is unavailable.
+            if request.method not in _SAFE_METHODS:
+                logger.error(
+                    "csrf.no_session",
+                    extra={
+                        "path": request.url.path,
+                        "method": request.method,
+                    },
+                )
+                response = PlainTextResponse(
+                    "CSRF check failed — session unavailable", status_code=403
+                )
+                await response(scope, receive, send)
+                return
             await self.app(scope, receive, send)
             return
 
@@ -78,7 +121,22 @@ class CSRFMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # Validate: check header first, then form body.
+        # --- Defence-in-depth: Origin / Referer verification ---
+        if self.trusted_origins and not self._check_origin(request):
+            logger.warning(
+                "csrf.origin_rejected",
+                extra={
+                    "path": request.url.path,
+                    "method": request.method,
+                    "origin": request.headers.get("origin", ""),
+                    "referer": request.headers.get("referer", ""),
+                },
+            )
+            response = self._error_response(request)
+            await response(scope, receive, send)
+            return
+
+        # --- Primary check: Synchronizer token ---
         submitted: str | None = request.headers.get(_HEADER_NAME)
         if not submitted:
             content_type = request.headers.get("content-type", "")
@@ -105,6 +163,34 @@ class CSRFMiddleware:
             return
 
         await self.app(scope, receive, send)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _check_origin(self, request: Request) -> bool:
+        """Verify that Origin or Referer matches a trusted origin."""
+        origin = request.headers.get("origin")
+        if origin:
+            return _normalize_origin(origin) in self.trusted_origins
+
+        referer = request.headers.get("referer")
+        if referer:
+            parsed = urlparse(referer)
+            referer_origin = f"{parsed.scheme}://{parsed.netloc}"
+            return _normalize_origin(referer_origin) in self.trusted_origins
+
+        # Neither header present — allow through but log for visibility.
+        # Privacy proxies and extensions may strip these headers; the
+        # synchronizer token still protects against CSRF in this case.
+        logger.info(
+            "csrf.no_origin_header",
+            extra={
+                "path": request.url.path,
+                "method": request.method,
+            },
+        )
+        return True
 
     def _url_is_exempt(self, path: str) -> bool:
         return any(pattern.match(path) for pattern in self.exempt_urls)

--- a/api/main.py
+++ b/api/main.py
@@ -244,6 +244,7 @@ app.add_middleware(UserTrackingMiddleware)
 app.add_middleware(
     CSRFMiddleware,
     exempt_urls=[re.compile(r"^/auth/callback$")],
+    trusted_origins=_settings.allowed_origins,
 )
 app.add_middleware(
     SessionMiddleware,

--- a/api/tests/core/test_csrf.py
+++ b/api/tests/core/test_csrf.py
@@ -9,7 +9,8 @@ Tests the Synchronizer Token Pattern:
 - 403 on missing or wrong token
 - Exempt URLs skip checks
 - Non-HTTP scopes pass through
-- No session → middleware is a no-op
+- No session → fail-closed on unsafe methods, pass-through on safe methods
+- Origin / Referer verification (defence-in-depth)
 """
 
 import re
@@ -24,6 +25,7 @@ from core.csrf import CSRFMiddleware
 # ---------------------------------------------------------------------------
 
 _TOKEN = "test-csrf-token-value"
+_TRUSTED_ORIGIN = "https://example.com"
 
 
 async def _noop_receive():
@@ -203,11 +205,19 @@ class TestCSRFMiddleware:
         await middleware(scope, _noop_receive, _noop_send)
         assert called
 
-    async def test_no_session_passes_through(self):
-        """If no session is available, middleware should not enforce CSRF."""
+    async def test_no_session_rejects_unsafe_method(self):
+        """Unsafe methods without a session should be rejected (fail-closed)."""
         middleware = CSRFMiddleware(_make_app_that_sends_response)
         scope = _http_scope(method="POST")
-        # No "session" key in scope.
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 403 for m in sent)
+
+    async def test_no_session_allows_safe_method(self):
+        """Safe methods without a session should still pass through."""
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(method="GET")
         sent = []
 
         await middleware(scope, _noop_receive, _collect_send(sent))
@@ -239,3 +249,163 @@ class TestCSRFMiddleware:
         assert any(m.get("status") == 403 for m in sent)
         body_msg = next((m for m in sent if m.get("type") == "http.response.body"), {})
         assert b"refresh" in body_msg.get("body", b"").lower()
+
+
+@pytest.mark.unit
+class TestCSRFOriginVerification:
+    """Test Origin / Referer defence-in-depth checks."""
+
+    async def test_valid_origin_header_accepted(self):
+        """POST with matching Origin header should pass."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(
+            _make_app_that_sends_response,
+            trusted_origins=[_TRUSTED_ORIGIN],
+        )
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[
+                (b"x-csrftoken", _TOKEN.encode()),
+                (b"origin", b"https://example.com"),
+            ],
+        )
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 200 for m in sent)
+
+    async def test_invalid_origin_header_rejected(self):
+        """POST with non-matching Origin header should return 403."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(
+            _make_app_that_sends_response,
+            trusted_origins=[_TRUSTED_ORIGIN],
+        )
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[
+                (b"x-csrftoken", _TOKEN.encode()),
+                (b"origin", b"https://evil.com"),
+            ],
+        )
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 403 for m in sent)
+
+    async def test_valid_referer_accepted(self):
+        """POST with matching Referer (no Origin) should pass."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(
+            _make_app_that_sends_response,
+            trusted_origins=[_TRUSTED_ORIGIN],
+        )
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[
+                (b"x-csrftoken", _TOKEN.encode()),
+                (b"referer", b"https://example.com/some/page"),
+            ],
+        )
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 200 for m in sent)
+
+    async def test_invalid_referer_rejected(self):
+        """POST with non-matching Referer (no Origin) should return 403."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(
+            _make_app_that_sends_response,
+            trusted_origins=[_TRUSTED_ORIGIN],
+        )
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[
+                (b"x-csrftoken", _TOKEN.encode()),
+                (b"referer", b"https://evil.com/attack"),
+            ],
+        )
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 403 for m in sent)
+
+    async def test_no_origin_or_referer_falls_through_to_token_check(self):
+        """Missing both Origin and Referer should fall through to token check."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(
+            _make_app_that_sends_response,
+            trusted_origins=[_TRUSTED_ORIGIN],
+        )
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[(b"x-csrftoken", _TOKEN.encode())],
+        )
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 200 for m in sent)
+
+    async def test_origin_check_skipped_when_no_trusted_origins(self):
+        """Without trusted_origins configured, origin check is skipped."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(_make_app_that_sends_response)
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[
+                (b"x-csrftoken", _TOKEN.encode()),
+                (b"origin", b"https://evil.com"),
+            ],
+        )
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        # Should pass because origin check is not enforced.
+        assert any(m.get("status") == 200 for m in sent)
+
+    async def test_origin_normalization_strips_default_port(self):
+        """Origin with default port should match the same origin without port."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(
+            _make_app_that_sends_response,
+            trusted_origins=["https://example.com"],
+        )
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[
+                (b"x-csrftoken", _TOKEN.encode()),
+                (b"origin", b"https://example.com:443"),
+            ],
+        )
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 200 for m in sent)
+
+    async def test_origin_normalization_preserves_non_default_port(self):
+        """Origin with non-default port should require exact match."""
+        session = {"_csrf_token": _TOKEN}
+        middleware = CSRFMiddleware(
+            _make_app_that_sends_response,
+            trusted_origins=["http://localhost:4280"],
+        )
+        scope = _http_scope(
+            method="POST",
+            session=session,
+            headers=[
+                (b"x-csrftoken", _TOKEN.encode()),
+                (b"origin", b"http://localhost:4280"),
+            ],
+        )
+        sent = []
+
+        await middleware(scope, _noop_receive, _collect_send(sent))
+        assert any(m.get("status") == 200 for m in sent)

--- a/api/tests/core/test_csrf_middleware_order.py
+++ b/api/tests/core/test_csrf_middleware_order.py
@@ -5,7 +5,8 @@ directly and therefore can't catch wiring mistakes in `main.py`.
 
 This test proves the expected behavior:
 - Session wraps CSRF (correct) -> POST without token is rejected (403)
-- CSRF wraps Session (wrong) -> CSRF becomes a no-op and POST succeeds (200)
+- CSRF wraps Session (wrong) -> CSRF can't read session, so unsafe
+  requests are also rejected (403) thanks to fail-closed behaviour.
 """
 
 from __future__ import annotations
@@ -34,7 +35,7 @@ def _build_app(*, correct_order: bool) -> FastAPI:
         app.add_middleware(CSRFMiddleware)
         app.add_middleware(SessionMiddleware, secret_key="test-secret")
     else:
-        # Wrong: CSRF runs before Session at runtime and becomes a silent no-op.
+        # Wrong: CSRF runs before Session at runtime — session is unavailable.
         app.add_middleware(SessionMiddleware, secret_key="test-secret")
         app.add_middleware(CSRFMiddleware)
 
@@ -58,7 +59,8 @@ class TestCSRFMiddlewareOrdering:
             r = await client.post("/protected", headers={"X-CSRFToken": token})
             assert r.status_code == 200
 
-    async def test_wrong_order_disables_csrf(self) -> None:
+    async def test_wrong_order_rejects_unsafe_requests(self) -> None:
+        """Wrong middleware order means no session — fail-closed returns 403."""
         app = _build_app(correct_order=False)
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app),
@@ -68,4 +70,4 @@ class TestCSRFMiddlewareOrdering:
             assert token == ""
 
             r = await client.post("/protected")
-            assert r.status_code == 200
+            assert r.status_code == 403


### PR DESCRIPTION
- Fail-closed: reject unsafe requests when session is unavailable instead of silently skipping CSRF enforcement
- Origin/Referer verification: defence-in-depth layer that validates the Origin (or Referer) header against trusted_origins before token check
- Normalize origins to scheme://host[:port] for robust comparison
- Update docstring to accurately describe signed cookie session
- Add 8 new tests for origin verification and fail-closed behaviour
- Update middleware order test to reflect new fail-closed semantics