### PR TITLE
Fix database identity least privilege

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,6 +199,8 @@ jobs:
       resource_group_name: ${{ steps.tf-outputs.outputs.resource_group_name }}
       container_registry_name: ${{ steps.tf-outputs.outputs.container_registry_name }}
       container_registry_endpoint: ${{ steps.tf-outputs.outputs.container_registry_endpoint }}
+      database_host: ${{ steps.tf-outputs.outputs.database_host }}
+      database_name: ${{ steps.tf-outputs.outputs.database_name }}
       api_url: ${{ steps.tf-outputs.outputs.api_url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -209,7 +211,7 @@ jobs:
           terraform_version: "~1.5"
           terraform_wrapper: false
 
-      - name: Azure CLI Login
+      - name: Azure CLI Login for deployment
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -231,6 +233,9 @@ jobs:
           TF_VAR_github_token: ${{ secrets.TF_VAR_github_token }}
           TF_VAR_session_secret_key: ${{ secrets.TF_VAR_session_secret_key }}
           TF_VAR_labs_verification_secret: ${{ secrets.TF_VAR_labs_verification_secret }}
+          TF_VAR_postgres_entra_admin_object_id: ${{ vars.POSTGRES_ENTRA_ADMIN_OBJECT_ID }}
+          TF_VAR_postgres_entra_admin_principal_name: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME }}
+          TF_VAR_postgres_entra_admin_principal_type: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE || 'Group' }}
 
       - name: Terraform Apply
         run: terraform apply -auto-approve -lock-timeout=120s tfplan
@@ -242,14 +247,16 @@ jobs:
           echo "resource_group_name=$(terraform output -raw AZURE_RESOURCE_GROUP)" >> "$GITHUB_OUTPUT"
           echo "container_registry_name=$(terraform output -raw AZURE_CONTAINER_REGISTRY_NAME)" >> "$GITHUB_OUTPUT"
           echo "container_registry_endpoint=$(terraform output -raw AZURE_CONTAINER_REGISTRY_ENDPOINT)" >> "$GITHUB_OUTPUT"
+          echo "database_host=$(terraform output -raw database_host)" >> "$GITHUB_OUTPUT"
+          echo "database_name=$(terraform output -raw postgres_database_name)" >> "$GITHUB_OUTPUT"
           echo "api_url=$(terraform output -raw api_url)" >> "$GITHUB_OUTPUT"
 
   # -----------------------------------------------------------------------
   # Deploy — build image, push, update container app (push to main only)
   # -----------------------------------------------------------------------
   deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy == 'true')
-    needs: [terraform]
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && vars.DB_IDENTITY_BOOTSTRAPPED == 'true' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy == 'true')
+    needs: [terraform, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -261,6 +268,17 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version-file: "api/pyproject.toml"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.9.26"
+          enable-cache: true
 
       - name: Log in to ACR
         run: az acr login --name ${{ needs.terraform.outputs.container_registry_name }}
@@ -282,6 +300,32 @@ jobs:
             -t ${{ needs.terraform.outputs.container_registry_endpoint }}/api:latest .
           docker push ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }}
           docker push ${{ needs.terraform.outputs.container_registry_endpoint }}/api:latest
+
+      - name: Azure CLI Login for migrations
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.AZURE_MIGRATION_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Run database migrations
+        working-directory: api
+        env:
+          DEBUG: "true"
+          POSTGRES_HOST: ${{ needs.terraform.outputs.database_host }}
+          POSTGRES_DATABASE: ${{ needs.terraform.outputs.database_name }}
+          POSTGRES_USER: ${{ vars.POSTGRES_MIGRATION_USER }}
+        run: |
+          : "${POSTGRES_USER:?Set repository variable POSTGRES_MIGRATION_USER to the mapped PostgreSQL migration principal name.}"
+          uv sync --locked
+          uv run alembic upgrade head
+
+      - name: Azure CLI Login for app update
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy to Container App
         run: |

--- a/api/src/learn_to_cloud/core/config.py
+++ b/api/src/learn_to_cloud/core/config.py
@@ -57,6 +57,7 @@ class Settings(BaseSettings):
     db_pool_recycle: int = 1800
     db_statement_timeout_ms: int = 10000
     db_echo: bool = False
+    run_migrations_on_startup: bool = True
 
     debug: bool = False
     require_https: bool = True

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -176,8 +176,11 @@ async def lifespan(app: fastapi.FastAPI):
             db_task = init_db(app.state.engine)
             await asyncio.gather(oauth_task, db_task)
 
-        async with asyncio.timeout(settings.startup_timeout):
-            await _run_alembic_migrations()
+        if settings.run_migrations_on_startup:
+            async with asyncio.timeout(settings.startup_timeout):
+                await _run_alembic_migrations()
+        else:
+            logger.info("migrations.skipped")
 
         app.state.init_done = True
         logger.info("init.complete")

--- a/api/tests/core/test_config.py
+++ b/api/tests/core/test_config.py
@@ -78,6 +78,21 @@ class TestSettingsValidation:
         )
         assert settings.debug is False
 
+    def test_migrations_run_on_startup_by_default(self):
+        settings = Settings(
+            database_url="postgresql+asyncpg://localhost/test",
+            debug=True,
+        )
+        assert settings.run_migrations_on_startup is True
+
+    def test_migrations_can_be_disabled_on_startup(self):
+        settings = Settings(
+            database_url="postgresql+asyncpg://localhost/test",
+            debug=True,
+            run_migrations_on_startup=False,
+        )
+        assert settings.run_migrations_on_startup is False
+
 
 # ---------------------------------------------------------------------------
 # use_azure_postgres

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -4,17 +4,105 @@ This project uses [Alembic](https://alembic.sqlalchemy.org/) for database schema
 
 ## How Migrations Run in Production
 
-Migrations run automatically via an **init container** in Azure Container Apps. The init container:
+Migrations run in GitHub Actions before the Container App image is updated. The
+workflow:
 
-1. Uses the **same Docker image** as the API
-2. Executes `python -m alembic upgrade head` before the app container starts
-3. Shares the same managed identity and network access as the app — no extra firewall rules needed
-4. If the migration fails, the app container **never starts**, preventing traffic from hitting a mismatched schema
+1. Authenticates to Azure with the deploy service principal.
+2. Runs `uv run alembic upgrade head` with `POSTGRES_USER` set to the mapped migration principal.
+3. Stops the deployment before `az containerapp update` if the migration fails.
 
-This is configured in [`infra/container-apps.tf`](../infra/container-apps.tf) as an `init_container` block.
+The API container sets `RUN_MIGRATIONS_ON_STARTUP=false` in
+[`infra/container-apps.tf`](../infra/container-apps.tf). This keeps the runtime
+managed identity from needing schema owner or PostgreSQL administrator
+privileges.
 
 > **Note:** Because Container Apps may have multiple replicas, Alembic uses a PostgreSQL advisory lock
 > (defined in `alembic/env.py`) to ensure only one replica runs migrations at a time.
+
+## Production Database Identities
+
+Production uses separate PostgreSQL data-plane principals:
+
+| Principal | Purpose |
+| --- | --- |
+| PostgreSQL Entra admin group | Bootstrap, break-glass administration, and role management. Configured with `postgres_entra_admin_*` Terraform variables. |
+| API managed identity | Runtime application access only. It must be mapped as a non-admin PostgreSQL Entra principal. |
+| Migration principal | Deploy-time Alembic migrations. It owns application schema objects and grants DML privileges to the API role. This principal does not need Azure RBAC. |
+
+### Rollout order
+
+Before merging the Terraform change that removes the API identity as a
+PostgreSQL Entra administrator, make sure the dedicated PostgreSQL Entra admin
+principal exists and the GitHub repository variables/secrets below are set.
+
+After Terraform switches the server admin to the dedicated admin principal, run
+the bootstrap script as that admin before deploying the app with
+`RUN_MIGRATIONS_ON_STARTUP=false`. This avoids leaving the runtime API identity
+without a mapped non-admin PostgreSQL role.
+
+The one-time identity setup starts with:
+
+```bash
+scripts/bootstrap_db_identities.sh
+```
+
+The script creates or reuses the PostgreSQL admin group and migration service
+principal, configures GitHub Actions OIDC for migrations, sets the repository
+variables/secrets below, applies Terraform when requested, and runs the SQL
+bootstrap when requested.
+
+For production rollout without local Terraform secrets:
+
+1. Run `scripts/bootstrap_db_identities.sh` to create/reuse identities and set
+   GitHub variables/secrets. This sets `DB_IDENTITY_BOOTSTRAPPED=false`, so a
+   merge can apply Terraform without running migrations or updating the app.
+2. Merge the branch and let GitHub Actions apply Terraform with repository
+   secrets.
+3. Run `scripts/bootstrap_db_identities.sh --skip-gh --run-sql` locally to map
+   and grant the PostgreSQL roles. After SQL succeeds, the script sets
+   `DB_IDENTITY_BOOTSTRAPPED=true`.
+4. Run the deploy workflow manually to run migrations and update the app.
+
+If you need to run the SQL manually instead:
+
+```bash
+API_OBJECT_ID="$(az identity show \
+  --resource-group <resource-group-name> \
+  --name id-ltc-api-dev \
+  --query principalId \
+  -o tsv)"
+
+export PGPASSWORD="$(az account get-access-token --resource-type oss-rdbms --query accessToken -o tsv)"
+
+psql "host=<server>.postgres.database.azure.com dbname=postgres sslmode=require user=<admin-group-name>" \
+  -v database_name=learntocloud \
+  -v api_role=id-ltc-api-dev \
+  -v api_object_id="$API_OBJECT_ID" \
+  -v migration_role=<migration-principal-name> \
+  -v migration_object_id=<migration-principal-object-id> \
+  -f infra/postgres-bootstrap.sql
+```
+
+The bootstrap script creates the API and migration Entra principals with
+`isAdmin=false`, revokes elevated API role flags where present, grants runtime
+DML privileges to the API role, and transfers schema object ownership to the
+migration role.
+
+Required repository variables for deployment:
+
+| Variable | Purpose |
+| --- | --- |
+| `POSTGRES_ENTRA_ADMIN_OBJECT_ID` | Object ID for the dedicated PostgreSQL Entra admin group/principal. |
+| `POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME` | Display name for the PostgreSQL Entra admin principal. |
+| `POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE` | `Group`, `User`, or `ServicePrincipal`; defaults to `Group` in the workflow. |
+| `POSTGRES_MIGRATION_USER` | PostgreSQL role name for the mapped migration principal used by Alembic. |
+| `DB_IDENTITY_BOOTSTRAPPED` | Deployment gate. Keep `false` until the SQL bootstrap succeeds, then set `true`. |
+
+Required repository secret for migrations:
+
+| Secret | Purpose |
+| --- | --- |
+| `AZURE_MIGRATION_CLIENT_ID` | Client ID of the migration service principal or managed identity. It is used only to acquire a PostgreSQL Entra token. |
 
 ## Running Migrations Locally
 

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -77,10 +77,6 @@ resource "azurerm_container_app" "api" {
     # Scaling uses the default HTTP rule (10 concurrent requests per replica).
     max_replicas = 2
 
-    # Migrations run inside the app lifespan (not an init container) because
-    # Azure Container Apps init containers don't have access to the managed
-    # identity sidecar needed for Entra ID database authentication.
-
     container {
       name   = "api"
       image  = "${azurerm_container_registry.main.login_server}/api:latest"
@@ -105,6 +101,11 @@ resource "azurerm_container_app" "api" {
       env {
         name  = "AZURE_CLIENT_ID"
         value = azurerm_user_assigned_identity.api.client_id
+      }
+
+      env {
+        name  = "RUN_MIGRATIONS_ON_STARTUP"
+        value = "false"
       }
 
       env {

--- a/infra/database.tf
+++ b/infra/database.tf
@@ -31,12 +31,16 @@ resource "azurerm_postgresql_flexible_server_firewall_rule" "allow_azure" {
   end_ip_address   = "0.0.0.0"
 }
 
-# Entra admin is the API's managed identity (not a human user)
-resource "azurerm_postgresql_flexible_server_active_directory_administrator" "api" {
+moved {
+  from = azurerm_postgresql_flexible_server_active_directory_administrator.api
+  to   = azurerm_postgresql_flexible_server_active_directory_administrator.main
+}
+
+resource "azurerm_postgresql_flexible_server_active_directory_administrator" "main" {
   server_name         = azurerm_postgresql_flexible_server.main.name
   resource_group_name = azurerm_resource_group.main.name
   tenant_id           = data.azurerm_client_config.current.tenant_id
-  object_id           = azurerm_user_assigned_identity.api.principal_id
-  principal_name      = azurerm_user_assigned_identity.api.name
-  principal_type      = "ServicePrincipal"
+  object_id           = var.postgres_entra_admin_object_id
+  principal_name      = var.postgres_entra_admin_principal_name
+  principal_type      = var.postgres_entra_admin_principal_type
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -3,11 +3,6 @@ output "azure_portal_url" {
   value       = "https://portal.azure.com/#@/resource/subscriptions/${var.subscription_id}/resourceGroups/${azurerm_resource_group.main.name}/overview"
 }
 
-output "api_identity_principal_id" {
-  description = "API managed identity principal ID (for Entra admin setup)"
-  value       = azurerm_user_assigned_identity.api.principal_id
-}
-
 output "database_host" {
   description = "PostgreSQL server hostname"
   value       = azurerm_postgresql_flexible_server.main.fqdn
@@ -16,6 +11,11 @@ output "database_host" {
 output "postgres_server_name" {
   description = "PostgreSQL server name"
   value       = azurerm_postgresql_flexible_server.main.name
+}
+
+output "postgres_database_name" {
+  description = "PostgreSQL database name"
+  value       = azurerm_postgresql_flexible_server_database.main.name
 }
 
 output "application_insights_connection_string" {

--- a/infra/postgres-bootstrap.sql
+++ b/infra/postgres-bootstrap.sql
@@ -1,0 +1,164 @@
+-- Bootstrap PostgreSQL Entra roles after Terraform switches the server admin.
+--
+-- Run this as the dedicated PostgreSQL Microsoft Entra admin against the
+-- postgres database. Required psql variables:
+--   database_name         Target application database, for example learntocloud
+--   api_role              API managed identity name, for example id-ltc-api-dev
+--   api_object_id         API managed identity principal ID
+--   migration_role        Migration service principal or managed identity name
+--   migration_object_id   Migration principal object ID
+--
+-- Example:
+--   psql "host=<server>.postgres.database.azure.com dbname=postgres sslmode=require user=<admin-group>" \
+--     -v database_name=learntocloud \
+--     -v api_role=id-ltc-api-dev \
+--     -v api_object_id=<api-principal-id> \
+--     -v migration_role=<migration-principal-name> \
+--     -v migration_object_id=<migration-principal-object-id> \
+--     -f infra/postgres-bootstrap.sql
+
+\set ON_ERROR_STOP on
+
+\if :{?database_name}
+\else
+  \echo 'Missing required psql variable: database_name'
+  \quit 1
+\endif
+
+\if :{?api_role}
+\else
+  \echo 'Missing required psql variable: api_role'
+  \quit 1
+\endif
+
+\if :{?api_object_id}
+\else
+  \echo 'Missing required psql variable: api_object_id'
+  \quit 1
+\endif
+
+\if :{?migration_role}
+\else
+  \echo 'Missing required psql variable: migration_role'
+  \quit 1
+\endif
+
+\if :{?migration_object_id}
+\else
+  \echo 'Missing required psql variable: migration_object_id'
+  \quit 1
+\endif
+
+SELECT pg_catalog.pgaadauth_create_principal_with_oid(
+    :'api_role',
+    :'api_object_id',
+    'service',
+    false,
+    false
+)
+WHERE NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = :'api_role'
+);
+
+SELECT pg_catalog.pgaadauth_create_principal_with_oid(
+    :'migration_role',
+    :'migration_object_id',
+    'service',
+    false,
+    false
+)
+WHERE NOT EXISTS (
+    SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = :'migration_role'
+);
+
+SET app.api_role = :'api_role';
+SET app.api_object_id = :'api_object_id';
+SET app.migration_role = :'migration_role';
+SET app.migration_object_id = :'migration_object_id';
+
+DO $$
+DECLARE
+    api_role text := current_setting('app.api_role');
+    api_object_id text := current_setting('app.api_object_id');
+    migration_role text := current_setting('app.migration_role');
+    migration_object_id text := current_setting('app.migration_object_id');
+BEGIN
+    EXECUTE format(
+        'SECURITY LABEL FOR "pgaadauth" ON ROLE %I IS %L',
+        api_role,
+        'aadauth,oid=' || api_object_id || ',type=service'
+    );
+    EXECUTE format(
+        'SECURITY LABEL FOR "pgaadauth" ON ROLE %I IS %L',
+        migration_role,
+        'aadauth,oid=' || migration_object_id || ',type=service'
+    );
+END
+$$;
+
+\connect :database_name
+
+SET app.api_role = :'api_role';
+SET app.migration_role = :'migration_role';
+
+GRANT CONNECT ON DATABASE :"database_name" TO :"api_role";
+GRANT CONNECT, CREATE ON DATABASE :"database_name" TO :"migration_role";
+
+GRANT USAGE ON SCHEMA public TO :"api_role";
+GRANT USAGE, CREATE ON SCHEMA public TO :"migration_role";
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO :"api_role";
+GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO :"api_role";
+
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO :"migration_role";
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO :"migration_role";
+
+ALTER DEFAULT PRIVILEGES FOR ROLE :"migration_role" IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO :"api_role";
+ALTER DEFAULT PRIVILEGES FOR ROLE :"migration_role" IN SCHEMA public
+    GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO :"api_role";
+
+DO $$
+DECLARE
+    api_role text := current_setting('app.api_role');
+BEGIN
+    EXECUTE format('ALTER ROLE %I NOCREATEDB NOCREATEROLE', api_role);
+    EXECUTE format('REVOKE azure_pg_admin FROM %I', api_role);
+EXCEPTION
+    WHEN undefined_object THEN
+        NULL;
+END
+$$;
+
+DO $$
+DECLARE
+    migration_role text := current_setting('app.migration_role');
+    object record;
+BEGIN
+    FOR object IN
+        SELECT schemaname, tablename
+        FROM pg_catalog.pg_tables
+        WHERE schemaname = 'public'
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE %I.%I OWNER TO %I',
+            object.schemaname,
+            object.tablename,
+            migration_role
+        );
+    END LOOP;
+
+    FOR object IN
+        SELECT sequence_schema, sequence_name
+        FROM information_schema.sequences
+        WHERE sequence_schema = 'public'
+    LOOP
+        EXECUTE format(
+            'ALTER SEQUENCE %I.%I OWNER TO %I',
+            object.sequence_schema,
+            object.sequence_name,
+            migration_role
+        );
+    END LOOP;
+END
+$$;

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -13,6 +13,12 @@
 # Required - Azure subscription
 subscription_id = "your-azure-subscription-id"
 
+# Required - PostgreSQL Microsoft Entra admin
+# Use a DBA/break-glass Entra group, not the API managed identity.
+postgres_entra_admin_object_id      = "00000000-0000-0000-0000-000000000000"
+postgres_entra_admin_principal_name = "Learn to Cloud PostgreSQL Admins"
+# postgres_entra_admin_principal_type = "Group"
+
 # Required - GitHub OAuth App (create at https://github.com/settings/developers)
 github_client_id     = "Ov23xxx"
 github_client_secret = "xxx"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -3,6 +3,37 @@ variable "subscription_id" {
   type        = string
 }
 
+variable "postgres_entra_admin_object_id" {
+  description = "Object ID of the Microsoft Entra principal that administers PostgreSQL. Use a DBA/break-glass group, not the API runtime identity."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.postgres_entra_admin_object_id)) > 0
+    error_message = "postgres_entra_admin_object_id must be set to the object ID of a dedicated PostgreSQL Entra admin principal."
+  }
+}
+
+variable "postgres_entra_admin_principal_name" {
+  description = "Display name of the Microsoft Entra principal that administers PostgreSQL."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.postgres_entra_admin_principal_name)) > 0
+    error_message = "postgres_entra_admin_principal_name must be set to the PostgreSQL Entra admin principal display name."
+  }
+}
+
+variable "postgres_entra_admin_principal_type" {
+  description = "Type of the Microsoft Entra principal that administers PostgreSQL."
+  type        = string
+  default     = "Group"
+
+  validation {
+    condition     = contains(["User", "Group", "ServicePrincipal"], var.postgres_entra_admin_principal_type)
+    error_message = "postgres_entra_admin_principal_type must be User, Group, or ServicePrincipal."
+  }
+}
+
 variable "github_client_id" {
   description = "GitHub OAuth App client ID"
   type        = string

--- a/scripts/bootstrap_db_identities.sh
+++ b/scripts/bootstrap_db_identities.sh
@@ -1,0 +1,507 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Bootstrap database identities for PostgreSQL Entra least privilege.
+
+This script creates or reuses:
+  - A PostgreSQL Entra admin group
+  - A migration app/service principal with GitHub Actions OIDC
+
+It also sets the GitHub repository variables/secrets used by deploy.yml.
+
+By default it creates/reuses identities and sets GitHub repository settings.
+For production rollout, let GitHub Actions apply Terraform with repository
+secrets, then run:
+
+  scripts/bootstrap_db_identities.sh --skip-gh --run-sql
+
+Only use --apply-terraform when you have the real production TF_VAR_* secrets
+available locally.
+
+Required tools:
+  az, gh, terraform, psql
+
+Environment overrides:
+  ENVIRONMENT                         default: dev
+  AZURE_SUBSCRIPTION_ID               default: current az account
+  AZURE_TENANT_ID                     default: current az account tenant
+  RESOURCE_GROUP                      default: rg-ltc-$ENVIRONMENT
+  API_IDENTITY_NAME                   default: id-ltc-api-$ENVIRONMENT
+  POSTGRES_DATABASE                   default: learntocloud
+  POSTGRES_ADMIN_GROUP_NAME           default: Learn to Cloud PostgreSQL Admins
+  MIGRATION_APP_NAME                  default: ltc-postgres-migrations-$ENVIRONMENT
+  POSTGRES_MIGRATION_USER             default: $MIGRATION_APP_NAME
+  GITHUB_REPO                         default: gh repo view --json nameWithOwner
+  GITHUB_OIDC_REF                     default: refs/heads/main
+  FEDERATED_CREDENTIAL_NAME           default: github-actions-$ENVIRONMENT-main
+  POSTGRES_HOST                       default: terraform output database_host
+  TERRAFORM_VAR_FILE                  default: infra/terraform.tfvars.local when present
+
+Options:
+  --apply-terraform                   run terraform init/validate/plan/apply
+  --run-sql                           run infra/postgres-bootstrap.sql
+  --skip-gh                           do not set GitHub repo variables/secrets
+  --help                              show this help
+EOF
+}
+
+log() {
+  printf '\n==> %s\n' "$*" >&2
+}
+
+die() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+slugify() {
+  printf '%s' "$1" |
+    tr '[:upper:]' '[:lower:]' |
+    tr -cs '[:alnum:]' '-' |
+    sed -e 's/^-//' -e 's/-$//' |
+    cut -c1-60
+}
+
+create_or_get_group() {
+  local group_name="$1"
+  local group_id
+
+  group_id="$(
+    az ad group list \
+      --display-name "$group_name" \
+      --query '[0].id' \
+      -o tsv
+  )"
+
+  if [[ -n "$group_id" ]]; then
+    log "Using existing Entra group: $group_name ($group_id)"
+  else
+    local mail_nickname
+    mail_nickname="$(slugify "$group_name")"
+    log "Creating Entra group: $group_name"
+    group_id="$(
+      az ad group create \
+        --display-name "$group_name" \
+        --mail-nickname "$mail_nickname" \
+        --query id \
+        -o tsv
+    )"
+  fi
+
+  printf '%s' "$group_id"
+}
+
+add_current_user_to_group_if_possible() {
+  local group_id="$1"
+  local user_id
+
+  user_id="$(
+    az ad signed-in-user show --query id -o tsv 2>/dev/null || true
+  )"
+
+  if [[ -z "$user_id" ]]; then
+    log "Current az login is not a user; skipping admin group membership check"
+    return
+  fi
+
+  local is_member
+  is_member="$(
+    az ad group member check \
+      --group "$group_id" \
+      --member-id "$user_id" \
+      --query value \
+      -o tsv
+  )"
+
+  if [[ "$is_member" == "true" ]]; then
+    log "Current user is already a member of the PostgreSQL admin group"
+    return
+  fi
+
+  log "Adding current user to PostgreSQL admin group"
+  az ad group member add --group "$group_id" --member-id "$user_id"
+  log "If PostgreSQL group login fails, run az login again after membership propagates"
+}
+
+create_or_get_migration_app() {
+  local app_name="$1"
+  local app_id
+
+  app_id="$(
+    az ad app list \
+      --display-name "$app_name" \
+      --query '[0].appId' \
+      -o tsv
+  )"
+
+  if [[ -n "$app_id" ]]; then
+    log "Using existing migration app registration: $app_name ($app_id)"
+  else
+    log "Creating migration app registration: $app_name"
+    app_id="$(
+      az ad app create \
+        --display-name "$app_name" \
+        --query appId \
+        -o tsv
+    )"
+  fi
+
+  printf '%s' "$app_id"
+}
+
+create_or_get_service_principal() {
+  local app_id="$1"
+  local sp_object_id
+
+  sp_object_id="$(
+    az ad sp list \
+      --filter "appId eq '$app_id'" \
+      --query '[0].id' \
+      -o tsv
+  )"
+
+  if [[ -n "$sp_object_id" ]]; then
+    log "Using existing migration service principal: $sp_object_id"
+  else
+    log "Creating migration service principal"
+    sp_object_id="$(
+      az ad sp create \
+        --id "$app_id" \
+        --query id \
+        -o tsv
+    )"
+  fi
+
+  printf '%s' "$sp_object_id"
+}
+
+ensure_federated_credential() {
+  local app_id="$1"
+  local credential_name="$2"
+  local github_repo="$3"
+  local github_ref="$4"
+  local existing
+
+  existing="$(
+    az ad app federated-credential list \
+      --id "$app_id" \
+      --query "[?name=='$credential_name'].name | [0]" \
+      -o tsv
+  )"
+
+  if [[ -n "$existing" ]]; then
+    log "Using existing federated credential: $credential_name"
+    return
+  fi
+
+  local credential_file
+  credential_file="$(mktemp)"
+
+  printf '%s\n' \
+    '{' \
+    "  \"name\": \"$credential_name\"," \
+    "  \"issuer\": \"https://token.actions.githubusercontent.com\"," \
+    "  \"subject\": \"repo:$github_repo:ref:$github_ref\"," \
+    "  \"description\": \"GitHub Actions migrations for $github_repo $github_ref\"," \
+    '  "audiences": ["api://AzureADTokenExchange"]' \
+    '}' >"$credential_file"
+
+  log "Creating federated credential for GitHub OIDC: repo:$github_repo:ref:$github_ref"
+  az ad app federated-credential create \
+    --id "$app_id" \
+    --parameters "$credential_file" \
+    >/dev/null
+  rm -f "$credential_file"
+}
+
+set_github_settings() {
+  local repo="$1"
+  local admin_group_id="$2"
+  local admin_group_name="$3"
+  local migration_user="$4"
+  local migration_client_id="$5"
+
+  log "Setting GitHub repository variables/secrets on $repo"
+  gh variable set POSTGRES_ENTRA_ADMIN_OBJECT_ID \
+    --repo "$repo" \
+    --body "$admin_group_id"
+  gh variable set POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME \
+    --repo "$repo" \
+    --body "$admin_group_name"
+  gh variable set POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE \
+    --repo "$repo" \
+    --body "Group"
+  gh variable set POSTGRES_MIGRATION_USER \
+    --repo "$repo" \
+    --body "$migration_user"
+  gh variable set DB_IDENTITY_BOOTSTRAPPED \
+    --repo "$repo" \
+    --body "false"
+  gh secret set AZURE_MIGRATION_CLIENT_ID \
+    --repo "$repo" \
+    --body "$migration_client_id"
+}
+
+mark_bootstrapped() {
+  local repo="$1"
+
+  log "Marking database identity bootstrap complete for $repo"
+  gh variable set DB_IDENTITY_BOOTSTRAPPED \
+    --repo "$repo" \
+    --body "true"
+}
+
+apply_terraform() {
+  local repo_root="$1"
+  local subscription_id="$2"
+  local admin_group_id="$3"
+  local admin_group_name="$4"
+
+  log "Applying Terraform with PostgreSQL admin group variables"
+  export TF_VAR_subscription_id="$subscription_id"
+  export TF_VAR_postgres_entra_admin_object_id="$admin_group_id"
+  export TF_VAR_postgres_entra_admin_principal_name="$admin_group_name"
+  export TF_VAR_postgres_entra_admin_principal_type="Group"
+
+  local -a var_file_args=()
+  local var_file="${TERRAFORM_VAR_FILE:-}"
+  if [[ -z "$var_file" && -f "$repo_root/infra/terraform.tfvars.local" ]]; then
+    var_file="$repo_root/infra/terraform.tfvars.local"
+  fi
+  if [[ -n "$var_file" ]]; then
+    [[ -f "$var_file" ]] || die "TERRAFORM_VAR_FILE does not exist: $var_file"
+    log "Using Terraform variable file: $var_file"
+    var_file_args=(-var-file="$var_file")
+  fi
+
+  terraform -chdir="$repo_root/infra" init
+  terraform -chdir="$repo_root/infra" validate
+  terraform -chdir="$repo_root/infra" plan \
+    "${var_file_args[@]}" \
+    -out=tfplan \
+    -input=false \
+    -lock-timeout=120s
+  terraform -chdir="$repo_root/infra" apply \
+    "${var_file_args[@]}" \
+    -auto-approve \
+    -lock-timeout=120s \
+    tfplan
+}
+
+terraform_output_or_empty() {
+  local repo_root="$1"
+  local output_name="$2"
+
+  terraform -chdir="$repo_root/infra" output -raw "$output_name" 2>/dev/null || true
+}
+
+tfvar_file_has_key() {
+  local key="$1"
+  local file
+
+  for file in "$REPO_ROOT/infra/terraform.tfvars" "$REPO_ROOT/infra/terraform.tfvars.local"; do
+    [[ -f "$file" ]] || continue
+    grep -Eq "^[[:space:]]*$key[[:space:]]*=" "$file"
+  done
+}
+
+tfvar_is_available() {
+  local key="$1"
+  local env_name="TF_VAR_$key"
+
+  [[ -n "${!env_name:-}" ]] || tfvar_file_has_key "$key"
+}
+
+check_required_terraform_vars() {
+  local required=(
+    github_client_id
+    github_client_secret
+    github_token
+    session_secret_key
+    labs_verification_secret
+  )
+  local missing=()
+  local key
+
+  for key in "${required[@]}"; do
+    if ! tfvar_is_available "$key"; then
+      missing+=("$key")
+    fi
+  done
+
+  if [[ "${#missing[@]}" -gt 0 ]]; then
+    printf 'Missing Terraform variables required for local apply:\n' >&2
+    printf '  - %s\n' "${missing[@]}" >&2
+    cat >&2 <<'EOF'
+
+Provide them as TF_VAR_* environment variables or in infra/terraform.tfvars.local.
+Do not use placeholders: these values feed production Container App secrets.
+EOF
+    exit 1
+  fi
+}
+
+run_postgres_bootstrap() {
+  local repo_root="$1"
+  local resource_group="$2"
+  local api_identity_name="$3"
+  local postgres_host="$4"
+  local postgres_database="$5"
+  local admin_group_name="$6"
+  local migration_user="$7"
+  local migration_object_id="$8"
+
+  local api_object_id
+  api_object_id="$(
+    az identity show \
+      --resource-group "$resource_group" \
+      --name "$api_identity_name" \
+      --query principalId \
+      -o tsv
+  )"
+
+  [[ -n "$api_object_id" ]] || die "Could not resolve API identity principal ID"
+  [[ -n "$postgres_host" ]] || die "POSTGRES_HOST is required to run SQL bootstrap"
+
+  log "Running PostgreSQL bootstrap SQL"
+  PGPASSWORD="$(
+    az account get-access-token \
+      --resource-type oss-rdbms \
+      --query accessToken \
+      -o tsv
+  )" \
+  PGHOST="$postgres_host" \
+  PGDATABASE="postgres" \
+  PGUSER="$admin_group_name" \
+  PGSSLMODE="require" \
+  psql \
+    -v database_name="$postgres_database" \
+    -v api_role="$api_identity_name" \
+    -v api_object_id="$api_object_id" \
+    -v migration_role="$migration_user" \
+    -v migration_object_id="$migration_object_id" \
+    -f "$repo_root/infra/postgres-bootstrap.sql"
+}
+
+APPLY_TERRAFORM=false
+RUN_SQL=false
+SET_GH=true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply-terraform)
+      APPLY_TERRAFORM=true
+      shift
+      ;;
+    --run-sql)
+      RUN_SQL=true
+      shift
+      ;;
+    --skip-gh)
+      SET_GH=false
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+require_cmd az
+require_cmd gh
+require_cmd terraform
+require_cmd psql
+
+ENVIRONMENT="${ENVIRONMENT:-dev}"
+AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-$(az account show --query id -o tsv)}"
+AZURE_TENANT_ID="${AZURE_TENANT_ID:-$(az account show --query tenantId -o tsv)}"
+RESOURCE_GROUP="${RESOURCE_GROUP:-rg-ltc-$ENVIRONMENT}"
+API_IDENTITY_NAME="${API_IDENTITY_NAME:-id-ltc-api-$ENVIRONMENT}"
+POSTGRES_DATABASE="${POSTGRES_DATABASE:-learntocloud}"
+POSTGRES_ADMIN_GROUP_NAME="${POSTGRES_ADMIN_GROUP_NAME:-Learn to Cloud PostgreSQL Admins}"
+MIGRATION_APP_NAME="${MIGRATION_APP_NAME:-ltc-postgres-migrations-$ENVIRONMENT}"
+POSTGRES_MIGRATION_USER="${POSTGRES_MIGRATION_USER:-$MIGRATION_APP_NAME}"
+GITHUB_REPO="${GITHUB_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
+GITHUB_OIDC_REF="${GITHUB_OIDC_REF:-refs/heads/main}"
+FEDERATED_CREDENTIAL_NAME="${FEDERATED_CREDENTIAL_NAME:-github-actions-$ENVIRONMENT-main}"
+
+log "Using subscription $AZURE_SUBSCRIPTION_ID in tenant $AZURE_TENANT_ID"
+az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+
+ADMIN_GROUP_ID="$(create_or_get_group "$POSTGRES_ADMIN_GROUP_NAME")"
+add_current_user_to_group_if_possible "$ADMIN_GROUP_ID"
+
+MIGRATION_CLIENT_ID="$(create_or_get_migration_app "$MIGRATION_APP_NAME")"
+MIGRATION_OBJECT_ID="$(create_or_get_service_principal "$MIGRATION_CLIENT_ID")"
+ensure_federated_credential \
+  "$MIGRATION_CLIENT_ID" \
+  "$FEDERATED_CREDENTIAL_NAME" \
+  "$GITHUB_REPO" \
+  "$GITHUB_OIDC_REF"
+
+if [[ "$SET_GH" == "true" ]]; then
+  set_github_settings \
+    "$GITHUB_REPO" \
+    "$ADMIN_GROUP_ID" \
+    "$POSTGRES_ADMIN_GROUP_NAME" \
+    "$POSTGRES_MIGRATION_USER" \
+    "$MIGRATION_CLIENT_ID"
+fi
+
+if [[ "$APPLY_TERRAFORM" == "true" ]]; then
+  check_required_terraform_vars
+  apply_terraform \
+    "$REPO_ROOT" \
+    "$AZURE_SUBSCRIPTION_ID" \
+    "$ADMIN_GROUP_ID" \
+    "$POSTGRES_ADMIN_GROUP_NAME"
+fi
+
+if [[ "$RUN_SQL" == "true" ]]; then
+  POSTGRES_HOST="${POSTGRES_HOST:-$(terraform_output_or_empty "$REPO_ROOT" database_host)}"
+  run_postgres_bootstrap \
+    "$REPO_ROOT" \
+    "$RESOURCE_GROUP" \
+    "$API_IDENTITY_NAME" \
+    "$POSTGRES_HOST" \
+    "$POSTGRES_DATABASE" \
+    "$POSTGRES_ADMIN_GROUP_NAME" \
+    "$POSTGRES_MIGRATION_USER" \
+    "$MIGRATION_OBJECT_ID"
+  mark_bootstrapped "$GITHUB_REPO"
+fi
+
+cat <<EOF
+
+Bootstrap identity setup complete.
+
+PostgreSQL admin group:
+  name:      $POSTGRES_ADMIN_GROUP_NAME
+  object ID: $ADMIN_GROUP_ID
+
+Migration principal:
+  app name:         $MIGRATION_APP_NAME
+  client ID:        $MIGRATION_CLIENT_ID
+  object ID:        $MIGRATION_OBJECT_ID
+  PostgreSQL role:  $POSTGRES_MIGRATION_USER
+
+GitHub repo:
+  $GITHUB_REPO
+
+Next steps:
+  1. Merge the branch so GitHub Actions applies Terraform with repository secrets.
+  2. Run scripts/bootstrap_db_identities.sh --skip-gh --run-sql after Terraform succeeds.
+  3. Run the deploy workflow manually after DB_IDENTITY_BOOTSTRAPPED is true.
+EOF


### PR DESCRIPTION
## Summary
- separate PostgreSQL Entra admin from the API runtime managed identity
- add a dedicated migration principal path for Alembic in GitHub Actions
- disable API startup migrations in Azure Container Apps
- add bootstrap SQL/script tooling for one-time PostgreSQL role mapping and grants
- gate deploy/migrations on DB_IDENTITY_BOOTSTRAPPED to allow safe rollout after Terraform applies

## Validation
- ruff check .
- ruff format --check .
- ty check --exclude scripts --exclude tests .
- API startup smoke tests: /health, /ready, /openapi.json
- pytest tests/ — 612 passed

## Rollout note
After merge, let GitHub Actions apply Terraform first. Then run:

    scripts/bootstrap_db_identities.sh --skip-gh --run-sql

After that succeeds, rerun the deploy workflow manually.