### PR TITLE
switch to managed identity from username/pass for ACR -> ACA

### DIFF
--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -3,8 +3,15 @@ resource "azurerm_container_registry" "main" {
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
   sku                 = "Basic"
-  admin_enabled       = true
+  admin_enabled       = false
   tags                = local.tags
+}
+
+resource "azurerm_role_assignment" "api_acr_pull" {
+  scope                = azurerm_container_registry.main.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.api.principal_id
+  principal_type       = "ServicePrincipal"
 }
 
 resource "azurerm_container_app_environment" "main" {
@@ -28,14 +35,8 @@ resource "azurerm_container_app" "api" {
   }
 
   registry {
-    server               = azurerm_container_registry.main.login_server
-    username             = azurerm_container_registry.main.admin_username
-    password_secret_name = "acr-password"
-  }
-
-  secret {
-    name  = "acr-password"
-    value = azurerm_container_registry.main.admin_password
+    server   = azurerm_container_registry.main.login_server
+    identity = azurerm_user_assigned_identity.api.id
   }
 
   secret {
@@ -179,6 +180,7 @@ resource "azurerm_container_app" "api" {
   }
 
   depends_on = [
+    azurerm_role_assignment.api_acr_pull,
     azurerm_postgresql_flexible_server_database.main,
   ]
 }


### PR DESCRIPTION
Summary

Switch Azure Container Apps image pulls from ACR admin username/password authentication to managed identity
authentication.

Changes

 - Disable the ACR admin user with admin_enabled = false
 - Grant the API user-assigned managed identity AcrPull on the ACR
 - Configure the Container App registry block to use the API managed identity
 - Remove the acr-password Container App secret and username/password registry config
 - Add an explicit Container App dependency on the ACR pull role assignment

Why

The Container App currently pulls images from ACR using the registry-wide admin username/password. This replaces
that shared credential path with Azure RBAC and the existing API managed identity, limiting access to AcrPull on
this registry only.

Validation

 terraform -chdir=infra fmt -check
 terraform -chdir=infra validate

Terraform validation passes, and there are no remaining infra references to the old ACR password path.
