### PR TITLE
move to aca job for migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -201,6 +201,8 @@ jobs:
       container_registry_endpoint: ${{ steps.tf-outputs.outputs.container_registry_endpoint }}
       database_host: ${{ steps.tf-outputs.outputs.database_host }}
       database_name: ${{ steps.tf-outputs.outputs.database_name }}
+      migration_job_name: ${{ steps.tf-outputs.outputs.migration_job_name }}
+      migration_identity_id: ${{ steps.tf-outputs.outputs.migration_identity_id }}
       api_url: ${{ steps.tf-outputs.outputs.api_url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -236,6 +238,7 @@ jobs:
           TF_VAR_postgres_entra_admin_object_id: ${{ vars.POSTGRES_ENTRA_ADMIN_OBJECT_ID }}
           TF_VAR_postgres_entra_admin_principal_name: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME }}
           TF_VAR_postgres_entra_admin_principal_type: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE || 'Group' }}
+          TF_VAR_postgres_migration_role: ${{ vars.POSTGRES_MIGRATION_USER }}
 
       - name: Terraform Apply
         run: terraform apply -auto-approve -lock-timeout=120s tfplan
@@ -249,6 +252,8 @@ jobs:
           echo "container_registry_endpoint=$(terraform output -raw AZURE_CONTAINER_REGISTRY_ENDPOINT)" >> "$GITHUB_OUTPUT"
           echo "database_host=$(terraform output -raw database_host)" >> "$GITHUB_OUTPUT"
           echo "database_name=$(terraform output -raw postgres_database_name)" >> "$GITHUB_OUTPUT"
+          echo "migration_job_name=$(terraform output -raw migration_job_name)" >> "$GITHUB_OUTPUT"
+          echo "migration_identity_id=$(terraform output -raw migration_identity_id)" >> "$GITHUB_OUTPUT"
           echo "api_url=$(terraform output -raw api_url)" >> "$GITHUB_OUTPUT"
 
   # -----------------------------------------------------------------------
@@ -258,7 +263,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy == 'true')
     needs: [terraform, changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -268,17 +273,6 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version-file: "api/pyproject.toml"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          version: "0.9.26"
-          enable-cache: true
 
       - name: Log in to ACR
         run: az acr login --name ${{ needs.terraform.outputs.container_registry_name }}
@@ -301,31 +295,64 @@ jobs:
           docker push ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }}
           docker push ${{ needs.terraform.outputs.container_registry_endpoint }}/api:latest
 
-      - name: Azure CLI Login for migrations
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
-        with:
-          client-id: ${{ secrets.AZURE_MIGRATION_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          allow-no-subscriptions: true
-
       - name: Run database migrations
-        working-directory: api
         env:
-          DEBUG: "true"
-          POSTGRES_HOST: ${{ needs.terraform.outputs.database_host }}
-          POSTGRES_DATABASE: ${{ needs.terraform.outputs.database_name }}
-          POSTGRES_USER: ${{ vars.POSTGRES_MIGRATION_USER }}
+          MIGRATION_JOB_NAME: ${{ needs.terraform.outputs.migration_job_name }}
+          MIGRATION_IDENTITY_ID: ${{ needs.terraform.outputs.migration_identity_id }}
+          RESOURCE_GROUP: ${{ needs.terraform.outputs.resource_group_name }}
+          IMAGE: ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }}
         run: |
-          : "${POSTGRES_USER:?Set repository variable POSTGRES_MIGRATION_USER to the mapped PostgreSQL migration principal name.}"
-          uv sync --locked
-          uv run alembic upgrade head
+          az config set extension.use_dynamic_install=yes_without_prompt
 
-      - name: Azure CLI Login for app update
-        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          execution_name=$(
+            az containerapp job start \
+              --name "$MIGRATION_JOB_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
+              --container-name migrations \
+              --image "$IMAGE" \
+              --registry-identity "$MIGRATION_IDENTITY_ID" \
+              --query name \
+              --output tsv
+          )
+          echo "Started migration job execution: $execution_name"
+
+          for i in {1..180}; do
+            status=$(
+              az containerapp job execution show \
+                --name "$MIGRATION_JOB_NAME" \
+                --resource-group "$RESOURCE_GROUP" \
+                --job-execution-name "$execution_name" \
+                --query "properties.status" \
+                --output tsv
+            )
+            echo "Migration job status: $status"
+
+            if [[ "$status" == "Succeeded" ]]; then
+              exit 0
+            fi
+            if [[ "$status" =~ ^(Failed|Canceled|Cancelled)$ ]]; then
+              az containerapp job logs show \
+                --name "$MIGRATION_JOB_NAME" \
+                --resource-group "$RESOURCE_GROUP" \
+                --container migrations \
+                --execution "$execution_name" \
+                --tail 100 \
+                --format text || true
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Migration job did not complete before timeout."
+          az containerapp job logs show \
+            --name "$MIGRATION_JOB_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            --container migrations \
+            --execution "$execution_name" \
+            --tail 100 \
+            --format text || true
+          exit 1
 
       - name: Deploy to Container App
         run: |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -105,4 +105,4 @@ Routes (HTTP) → Services (Business Logic) → Repositories (Database)
 - Database models use `TimestampMixin` for `created_at`/`updated_at`
 - Enums: `class MyEnum(str, PyEnum)` with `native_enum=False` in columns
 - Config via `pydantic-settings` (`Settings` class in `core/config.py`)
-- Migrations run as subprocess in lifespan to avoid asyncio/psycopg2 deadlock
+- Production migrations run through an Azure Container Apps Job before API deployment

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -4,20 +4,25 @@ This project uses [Alembic](https://alembic.sqlalchemy.org/) for database schema
 
 ## How Migrations Run in Production
 
-Migrations run in GitHub Actions before the Container App image is updated. The
-workflow:
+Migrations run in an Azure Container Apps manual Job before the API Container
+App image is updated. The workflow:
 
-1. Authenticates to Azure with the deploy service principal.
-2. Runs `uv run alembic upgrade head` with `POSTGRES_USER` set to the mapped migration principal.
-3. Stops the deployment before `az containerapp update` if the migration fails.
+1. Builds and pushes the new API image to Azure Container Registry.
+2. Starts the migration job with that image tag.
+3. The job runs `alembic upgrade head` with `POSTGRES_USER` set to the mapped
+   migration PostgreSQL role.
+4. The workflow polls the job execution until it succeeds or fails.
+5. Stops the deployment before `az containerapp update` if the migration job
+   fails.
 
 The API container sets `RUN_MIGRATIONS_ON_STARTUP=false` in
 [`infra/container-apps.tf`](../infra/container-apps.tf). This keeps the runtime
 managed identity from needing schema owner or PostgreSQL administrator
 privileges.
 
-> **Note:** Because Container Apps may have multiple replicas, Alembic uses a PostgreSQL advisory lock
-> (defined in `alembic/env.py`) to ensure only one replica runs migrations at a time.
+> **Note:** The migration job runs with one replica, and Alembic also uses a
+> PostgreSQL advisory lock (defined in `alembic/env.py`) to guard against
+> accidental concurrent executions.
 
 ## Production Database Identities
 
@@ -28,9 +33,10 @@ state, not a bootstrap procedure.
 | Principal | Purpose |
 | --- | --- |
 | PostgreSQL Entra admin group | Break-glass administration and role management. Configured with `postgres_entra_admin_*` Terraform variables. Do not use this principal for app runtime or normal migrations. |
-| API managed identity | Runtime application identity attached to the Container App. It gets the Entra token used for PostgreSQL login. |
+| API managed identity | Runtime application identity attached to the API Container App. It gets the Entra token used for runtime PostgreSQL login. |
 | API PostgreSQL role | Runtime database role, `ltc_api_runtime_<environment>` by default. It is mapped to the API managed identity object ID, has DML and sequence privileges, and must not own schema objects. |
-| Migration principal | Deploy-time Alembic migrations. It owns application schema objects and runs schema changes. This principal does not need Azure RBAC beyond acquiring a PostgreSQL Entra token. |
+| Migration job managed identity | User-assigned identity attached to the Container Apps migration job. It pulls the API image from ACR and gets the Entra token used by Alembic. |
+| Migration PostgreSQL role | Deploy-time Alembic migration role. It owns application schema objects and runs schema changes. Its name is provided by `POSTGRES_MIGRATION_USER` in GitHub Actions and by `postgres_migration_role` in Terraform. |
 
 Do not make the API managed identity a PostgreSQL Flexible Server Entra admin.
 Azure removes a PostgreSQL Entra admin by attempting to drop the mapped database
@@ -47,19 +53,22 @@ Required repository variables for deployment:
 | `POSTGRES_ENTRA_ADMIN_OBJECT_ID` | Object ID for the dedicated PostgreSQL Entra admin group/principal. |
 | `POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME` | Display name for the PostgreSQL Entra admin principal. |
 | `POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE` | `Group`, `User`, or `ServicePrincipal`; defaults to `Group` in the workflow. |
-| `POSTGRES_MIGRATION_USER` | PostgreSQL role name for the mapped migration principal used by Alembic. |
+| `POSTGRES_MIGRATION_USER` | PostgreSQL role name for the mapped migration job identity used by Alembic. The deploy workflow passes this into Terraform as `postgres_migration_role`. |
 
-Optional Terraform variable:
+Terraform variables:
 
 | Variable | Purpose |
 | --- | --- |
+| `postgres_migration_role` | PostgreSQL migration role used by the Azure Container Apps migration job. Required; set from `POSTGRES_MIGRATION_USER` in GitHub Actions. |
 | `postgres_api_runtime_role` | PostgreSQL runtime role used by the API. Defaults to `ltc_api_runtime_<environment>`. |
 
-Required repository secret for migrations:
+No GitHub secret is needed for PostgreSQL migration authentication. GitHub only
+starts the Azure Container Apps Job; the job uses its own managed identity to
+acquire the PostgreSQL Entra token inside Azure.
 
-| Secret | Purpose |
-| --- | --- |
-| `AZURE_MIGRATION_CLIENT_ID` | Client ID of the migration service principal or managed identity. It is used only to acquire a PostgreSQL Entra token. |
+The migration job identity must be mapped to the migration PostgreSQL role before
+the job can connect. Use the Terraform output
+`migration_identity_principal_id` when creating or verifying that mapping.
 
 ## Running Migrations Locally
 

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -14,6 +14,13 @@ resource "azurerm_role_assignment" "api_acr_pull" {
   principal_type       = "ServicePrincipal"
 }
 
+resource "azurerm_role_assignment" "migrations_acr_pull" {
+  scope                = azurerm_container_registry.main.id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.migrations.principal_id
+  principal_type       = "ServicePrincipal"
+}
+
 resource "azurerm_container_app_environment" "main" {
   name                       = "cae-ltc-${var.environment}"
   location                   = azurerm_resource_group.main.location

--- a/infra/identity.tf
+++ b/infra/identity.tf
@@ -6,3 +6,10 @@ resource "azurerm_user_assigned_identity" "api" {
   location            = azurerm_resource_group.main.location
   tags                = local.tags
 }
+
+resource "azurerm_user_assigned_identity" "migrations" {
+  name                = "id-ltc-migrations-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  tags                = local.tags
+}

--- a/infra/migrations.tf
+++ b/infra/migrations.tf
@@ -1,0 +1,65 @@
+resource "azurerm_container_app_job" "migrations" {
+  name                         = "job-ltc-migrations-${var.environment}"
+  location                     = azurerm_resource_group.main.location
+  resource_group_name          = azurerm_resource_group.main.name
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  replica_timeout_in_seconds   = 1800
+  replica_retry_limit          = 0
+  tags                         = local.tags
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.migrations.id]
+  }
+
+  registry {
+    server   = azurerm_container_registry.main.login_server
+    identity = azurerm_user_assigned_identity.migrations.id
+  }
+
+  manual_trigger_config {
+    parallelism              = 1
+    replica_completion_count = 1
+  }
+
+  template {
+    container {
+      name    = "migrations"
+      image   = "${azurerm_container_registry.main.login_server}/api:latest"
+      command = ["alembic"]
+      args    = ["upgrade", "head"]
+      cpu     = 0.5
+      memory  = "1Gi"
+
+      env {
+        name  = "POSTGRES_HOST"
+        value = azurerm_postgresql_flexible_server.main.fqdn
+      }
+
+      env {
+        name  = "POSTGRES_USER"
+        value = local.migration_postgres_role
+      }
+
+      env {
+        name  = "POSTGRES_DATABASE"
+        value = azurerm_postgresql_flexible_server_database.main.name
+      }
+
+      env {
+        name  = "AZURE_CLIENT_ID"
+        value = azurerm_user_assigned_identity.migrations.client_id
+      }
+
+      env {
+        name  = "DEBUG"
+        value = "true"
+      }
+    }
+  }
+
+  depends_on = [
+    azurerm_role_assignment.migrations_acr_pull,
+    azurerm_postgresql_flexible_server_database.main,
+  ]
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -48,3 +48,23 @@ output "api_url" {
   description = "API URL (for CI/CD)"
   value       = "https://${azurerm_container_app.api.ingress[0].fqdn}"
 }
+
+output "migration_job_name" {
+  description = "Container Apps Job name used to run database migrations"
+  value       = azurerm_container_app_job.migrations.name
+}
+
+output "migration_identity_client_id" {
+  description = "Client ID for the migration job managed identity"
+  value       = azurerm_user_assigned_identity.migrations.client_id
+}
+
+output "migration_identity_id" {
+  description = "Resource ID for the migration job managed identity"
+  value       = azurerm_user_assigned_identity.migrations.id
+}
+
+output "migration_identity_principal_id" {
+  description = "Principal ID for mapping the migration job identity to PostgreSQL"
+  value       = azurerm_user_assigned_identity.migrations.principal_id
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -46,9 +46,10 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  api_postgres_role   = coalesce(var.postgres_api_runtime_role, "ltc_api_runtime_${var.environment}")
-  suffix              = random_string.suffix.result
-  resource_group_name = "rg-ltc-${var.environment}"
+  api_postgres_role       = coalesce(var.postgres_api_runtime_role, "ltc_api_runtime_${var.environment}")
+  migration_postgres_role = var.postgres_migration_role
+  suffix                  = random_string.suffix.result
+  resource_group_name     = "rg-ltc-${var.environment}"
   tags = {
     environment = var.environment
     project     = "learntocloud"

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -18,6 +18,11 @@ subscription_id = "your-azure-subscription-id"
 postgres_entra_admin_object_id      = "00000000-0000-0000-0000-000000000000"
 postgres_entra_admin_principal_name = "Learn to Cloud PostgreSQL Admins"
 # postgres_entra_admin_principal_type = "Group"
+
+# Required - PostgreSQL migration role mapped to the migration job identity
+postgres_migration_role = "ltc_migrations_dev"
+
+# Optional - PostgreSQL runtime role mapped to the API managed identity
 # postgres_api_runtime_role = "ltc_api_runtime_dev"
 
 # Required - GitHub OAuth App (create at https://github.com/settings/developers)

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -45,6 +45,16 @@ variable "postgres_api_runtime_role" {
   }
 }
 
+variable "postgres_migration_role" {
+  description = "PostgreSQL role used by the Azure Container Apps migration job. It must be mapped to the migration managed identity and own/manage schema objects."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[A-Za-z_][A-Za-z0-9_]*$", var.postgres_migration_role))
+    error_message = "postgres_migration_role must be a valid PostgreSQL role identifier using letters, numbers, and underscores, and must not start with a number."
+  }
+}
+
 variable "github_client_id" {
   description = "GitHub OAuth App client ID"
   type        = string


### PR DESCRIPTION
- Added a dedicated migration user-assigned identity: 
id-ltc-migrations-${environment}.
 - Granted that identity AcrPull on the existing ACR.
 - Added azurerm_container_app_job.migrations to run alembic upgrade head 
from the API image.
 - Updated deploy workflow to:
  - build/push the API image,
  - start the ACA migration job with the SHA-tagged image,
  - poll the job execution,
  - block API deployment if the job fails,
  - then update the API Container App.
 - Removed the GitHub runner-side migration auth/uv run alembic upgrade head
 path from deploy.
 - Removed deploy-job Python/uv setup because migrations no longer run on 
the runner.
 - Added Terraform outputs for migration job/identity details.
 - Updated migration docs and Terraform example vars.
