### PR TITLE
Fix Terraform validation for migration role names

### DIFF
--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -20,7 +20,7 @@ postgres_entra_admin_principal_name = "Learn to Cloud PostgreSQL Admins"
 # postgres_entra_admin_principal_type = "Group"
 
 # Required - PostgreSQL migration role mapped to the migration job identity
-postgres_migration_role = "ltc_migrations_dev"
+postgres_migration_role = "ltc-postgres-migrations-dev"
 
 # Optional - PostgreSQL runtime role mapped to the API managed identity
 # postgres_api_runtime_role = "ltc_api_runtime_dev"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -50,8 +50,8 @@ variable "postgres_migration_role" {
   type        = string
 
   validation {
-    condition     = can(regex("^[A-Za-z_][A-Za-z0-9_]*$", var.postgres_migration_role))
-    error_message = "postgres_migration_role must be a valid PostgreSQL role identifier using letters, numbers, and underscores, and must not start with a number."
+    condition     = length(trimspace(var.postgres_migration_role)) > 0 && length(var.postgres_migration_role) <= 63
+    error_message = "postgres_migration_role must be a non-empty PostgreSQL role name no longer than 63 characters."
   }
 }
 


### PR DESCRIPTION
## Summary
- allow hyphenated PostgreSQL migration role names in Terraform validation
- update the example value to match the configured GitHub Actions variable

## Validation
- terraform fmt -check
- terraform validate
- git diff --check