### PR TITLE
Fix deploy job gate after skipped CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -260,7 +260,7 @@ jobs:
   # Deploy — build image, push, update container app (push to main only)
   # -----------------------------------------------------------------------
   deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy == 'true')
+    if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy == 'true') && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     needs: [terraform, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 45


### PR DESCRIPTION
## Summary
- add an explicit always() deploy job gate so workflow_dispatch and deploy-relevant non-code pushes can run after intentionally skipped CI
- keep failure/cancelled protection for direct dependencies

## Validation
- parsed .github/workflows/deploy.yml with PyYAML
- git diff --check