### PR TITLE
Fix ACA migration job start command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -310,6 +310,8 @@ jobs:
               --resource-group "$RESOURCE_GROUP" \
               --container-name migrations \
               --image "$IMAGE" \
+              --command alembic \
+              --args upgrade head \
               --registry-identity "$MIGRATION_IDENTITY_ID" \
               --query name \
               --output tsv


### PR DESCRIPTION
## Summary
- pass the Alembic command/args when starting the ACA migration job with an image override
- prevents the job execution from falling back to the API image CMD

## Validation
- parsed .github/workflows/deploy.yml with PyYAML
- git diff --check