### PR TITLE
Clean up legacy migration paths

### DIFF
--- a/.github/skills/debug-deploy/SKILL.md
+++ b/.github/skills/debug-deploy/SKILL.md
@@ -51,7 +51,7 @@ Look for these common patterns in the logs:
 #### Authentication Failures
 **Pattern:** `AuthorizationFailed`, `AADSTS`, `unauthorized`
 
-**Fix:** Check that `AZURE_CREDENTIALS` secret is valid. The service principal may need credential rotation.
+**Fix:** Check the OIDC deployment configuration: `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` secrets, plus the `AZURE_SUBSCRIPTION_ID` repository variable. The federated credential or Azure RBAC assignment may need updating.
 
 #### Resource Not Found
 **Pattern:** `ResourceNotFound` or `does not exist`
@@ -63,15 +63,16 @@ Look for these common patterns in the logs:
 
 **Fix:** Request quota increase in Azure portal or clean up unused resources.
 
-#### Migration Race Condition (Multi-Worker)
-**Pattern:** `/ready` returns 503 but `/health` returns 200, or `DuplicateTableError: relation already exists`
+#### Migration Job Failure
+**Pattern:** `Run database migrations` fails, `/ready` returns 503 after deploy, or Alembic reports a database error.
 
-**Cause:** Multiple uvicorn workers tried to run migrations simultaneously.
+**Cause:** The Azure Container Apps migration job failed before the API image was updated. Common causes are missing PostgreSQL role mapping, migration SQL errors, or job image/env override issues.
 
-**Fix:** This should be handled by `pg_advisory_lock` in `api/alembic/env.py`. If it recurs:
-1. Test locally: `docker compose down -v && docker compose up db api-multiworker`
-2. Check that `alembic/env.py` uses psycopg2 (sync driver) and acquires advisory lock before migrations
-3. Ensure the lock is committed before Alembic runs (so Alembic starts a clean transaction)
+**Fix:**
+1. Inspect the failed workflow step and the ACA Job logs.
+2. Verify `migration_identity_principal_id` is mapped to the Terraform `migration_postgres_role` output in PostgreSQL.
+3. Confirm `az containerapp job start` passes the SHA image, `alembic upgrade head`, DB env vars, `AZURE_CLIENT_ID`, and `--registry-identity`.
+4. Check that `alembic/env.py` still uses psycopg2 and acquires the advisory lock before migrations.
 
 #### Test Failures
 **Pattern:** `FAILED`, `pytest`, `AssertionError`

--- a/.github/skills/debug-deploy/debug-deploy.sh
+++ b/.github/skills/debug-deploy/debug-deploy.sh
@@ -116,8 +116,9 @@ cmd_logs() {
     if echo "$logs" | grep -q "AuthorizationFailed\|AADSTS\|authentication\|unauthorized"; then
         print_error "DETECTED: Authentication/Authorization Issue"
         echo ""
-        echo "Check that AZURE_CREDENTIALS secret is valid and not expired."
-        echo "The service principal may need its credentials rotated."
+        echo "Check the OIDC deployment configuration: AZURE_CLIENT_ID and AZURE_TENANT_ID secrets,"
+        echo "plus the AZURE_SUBSCRIPTION_ID repository variable."
+        echo "The federated credential or Azure RBAC assignment may need updating."
     fi
 
     # Check for resource not found
@@ -248,7 +249,7 @@ Examples:
 
 Common Issues Detected:
   • Terraform State Lock - Run 'unlock' command to fix
-  • Authentication Errors - Check AZURE_CREDENTIALS secret
+  • Authentication Errors - Check OIDC deployment secrets/variables and Azure RBAC
   • Resource Not Found - Resource may have been deleted outside Terraform
   • Quota Exceeded - Request quota increase or clean up resources
   • Test Failures - Run tests locally with 'pytest api/tests/'

--- a/.github/skills/ship-it/SKILL.md
+++ b/.github/skills/ship-it/SKILL.md
@@ -181,7 +181,7 @@ gh run view $run_id --log-failed
 | Pattern | Fix |
 |---------|-----|
 | `Error acquiring the state lock` | Extract Lock ID, `cd infra && terraform force-unlock -force <lock-id>`, re-run |
-| `AuthorizationFailed` | Check `AZURE_CREDENTIALS` secret — not fixable locally |
+| `AuthorizationFailed` | Check OIDC deployment secrets/variables and Azure RBAC — not fixable locally |
 | `ResourceNotFound` | `terraform refresh` or re-import |
 
 #### Build/Deploy Failures

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,6 +204,7 @@ jobs:
       migration_job_name: ${{ steps.tf-outputs.outputs.migration_job_name }}
       migration_identity_client_id: ${{ steps.tf-outputs.outputs.migration_identity_client_id }}
       migration_identity_id: ${{ steps.tf-outputs.outputs.migration_identity_id }}
+      migration_postgres_role: ${{ steps.tf-outputs.outputs.migration_postgres_role }}
       api_url: ${{ steps.tf-outputs.outputs.api_url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -239,7 +240,6 @@ jobs:
           TF_VAR_postgres_entra_admin_object_id: ${{ vars.POSTGRES_ENTRA_ADMIN_OBJECT_ID }}
           TF_VAR_postgres_entra_admin_principal_name: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME }}
           TF_VAR_postgres_entra_admin_principal_type: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE || 'Group' }}
-          TF_VAR_postgres_migration_role: ${{ vars.POSTGRES_MIGRATION_USER }}
 
       - name: Terraform Apply
         run: terraform apply -auto-approve -lock-timeout=120s tfplan
@@ -256,6 +256,7 @@ jobs:
           echo "migration_job_name=$(terraform output -raw migration_job_name)" >> "$GITHUB_OUTPUT"
           echo "migration_identity_client_id=$(terraform output -raw migration_identity_client_id)" >> "$GITHUB_OUTPUT"
           echo "migration_identity_id=$(terraform output -raw migration_identity_id)" >> "$GITHUB_OUTPUT"
+          echo "migration_postgres_role=$(terraform output -raw migration_postgres_role)" >> "$GITHUB_OUTPUT"
           echo "api_url=$(terraform output -raw api_url)" >> "$GITHUB_OUTPUT"
 
   # -----------------------------------------------------------------------
@@ -304,7 +305,7 @@ jobs:
           MIGRATION_IDENTITY_ID: ${{ needs.terraform.outputs.migration_identity_id }}
           POSTGRES_DATABASE: ${{ needs.terraform.outputs.database_name }}
           POSTGRES_HOST: ${{ needs.terraform.outputs.database_host }}
-          POSTGRES_USER: ${{ vars.POSTGRES_MIGRATION_USER }}
+          POSTGRES_USER: ${{ needs.terraform.outputs.migration_postgres_role }}
           RESOURCE_GROUP: ${{ needs.terraform.outputs.resource_group_name }}
           IMAGE: ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }}
         run: |

--- a/api/src/learn_to_cloud/core/config.py
+++ b/api/src/learn_to_cloud/core/config.py
@@ -57,7 +57,6 @@ class Settings(BaseSettings):
     db_pool_recycle: int = 1800
     db_statement_timeout_ms: int = 10000
     db_echo: bool = False
-    run_migrations_on_startup: bool = True
 
     debug: bool = False
     require_https: bool = True

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -2,8 +2,6 @@
 
 import asyncio
 import logging
-import subprocess
-import sys
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
@@ -124,42 +122,6 @@ async def _background_warmup(app: fastapi.FastAPI) -> None:
         logger.warning("content.preload.failed", exc_info=True)
 
 
-async def _run_alembic_migrations() -> None:
-    """Run Alembic migrations in a subprocess.
-
-    psycopg2's connection pool cleanup deadlocks inside
-    asyncio.to_thread when uvloop is the event loop.  Running
-    migrations as a subprocess avoids the issue entirely.
-    """
-    cmd = [
-        sys.executable,
-        "-c",
-        (
-            "from alembic import command; "
-            "from alembic.config import Config; "
-            "command.upgrade(Config('alembic.ini'), 'head')"
-        ),
-    ]
-    cwd = Path(__file__).resolve().parents[2]
-
-    result = await asyncio.to_thread(
-        lambda: subprocess.run(
-            cmd,
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            timeout=get_settings().startup_timeout,
-        )
-    )
-
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        logger.error("migrations.failed", extra={"stderr": stderr})
-        raise RuntimeError(f"Alembic migration failed:\n{stderr}")
-
-    logger.info("migrations.complete")
-
-
 @asynccontextmanager
 async def lifespan(app: fastapi.FastAPI):
     """Create DB engine at startup, dispose on shutdown."""
@@ -175,12 +137,6 @@ async def lifespan(app: fastapi.FastAPI):
             oauth_task = asyncio.to_thread(init_oauth)
             db_task = init_db(app.state.engine)
             await asyncio.gather(oauth_task, db_task)
-
-        if settings.run_migrations_on_startup:
-            async with asyncio.timeout(settings.startup_timeout):
-                await _run_alembic_migrations()
-        else:
-            logger.info("migrations.skipped")
 
         app.state.init_done = True
         logger.info("init.complete")

--- a/api/tests/core/test_config.py
+++ b/api/tests/core/test_config.py
@@ -78,21 +78,6 @@ class TestSettingsValidation:
         )
         assert settings.debug is False
 
-    def test_migrations_run_on_startup_by_default(self):
-        settings = Settings(
-            database_url="postgresql+asyncpg://localhost/test",
-            debug=True,
-        )
-        assert settings.run_migrations_on_startup is True
-
-    def test_migrations_can_be_disabled_on_startup(self):
-        settings = Settings(
-            database_url="postgresql+asyncpg://localhost/test",
-            debug=True,
-            run_migrations_on_startup=False,
-        )
-        assert settings.run_migrations_on_startup is False
-
 
 # ---------------------------------------------------------------------------
 # use_azure_postgres

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -15,8 +15,7 @@ App image is updated. The workflow:
 5. Stops the deployment before `az containerapp update` if the migration job
    fails.
 
-The API container sets `RUN_MIGRATIONS_ON_STARTUP=false` in
-[`infra/container-apps.tf`](../infra/container-apps.tf). This keeps the runtime
+The API container does not run migrations on startup. This keeps the runtime
 managed identity from needing schema owner or PostgreSQL administrator
 privileges.
 
@@ -36,7 +35,7 @@ state, not a bootstrap procedure.
 | API managed identity | Runtime application identity attached to the API Container App. It gets the Entra token used for runtime PostgreSQL login. |
 | API PostgreSQL role | Runtime database role, `ltc_api_runtime_<environment>` by default. It is mapped to the API managed identity object ID, has DML and sequence privileges, and must not own schema objects. |
 | Migration job managed identity | User-assigned identity attached to the Container Apps migration job. It pulls the API image from ACR and gets the Entra token used by Alembic. |
-| Migration PostgreSQL role | Deploy-time Alembic migration role. It owns application schema objects and runs schema changes. Its name is provided by `POSTGRES_MIGRATION_USER` in GitHub Actions and by `postgres_migration_role` in Terraform. |
+| Migration PostgreSQL role | Deploy-time Alembic migration role. It owns application schema objects and runs schema changes. Terraform defaults the name to `ltc-postgres-migrations-<environment>` and exposes the effective name as `migration_postgres_role`. |
 
 Do not make the API managed identity a PostgreSQL Flexible Server Entra admin.
 Azure removes a PostgreSQL Entra admin by attempting to drop the mapped database
@@ -53,22 +52,22 @@ Required repository variables for deployment:
 | `POSTGRES_ENTRA_ADMIN_OBJECT_ID` | Object ID for the dedicated PostgreSQL Entra admin group/principal. |
 | `POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME` | Display name for the PostgreSQL Entra admin principal. |
 | `POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE` | `Group`, `User`, or `ServicePrincipal`; defaults to `Group` in the workflow. |
-| `POSTGRES_MIGRATION_USER` | PostgreSQL role name for the mapped migration job identity used by Alembic. The deploy workflow passes this into Terraform as `postgres_migration_role`. |
 
 Terraform variables:
 
 | Variable | Purpose |
 | --- | --- |
-| `postgres_migration_role` | PostgreSQL migration role used by the Azure Container Apps migration job. Required; set from `POSTGRES_MIGRATION_USER` in GitHub Actions. |
+| `postgres_migration_role` | Optional PostgreSQL migration role override. Defaults to `ltc-postgres-migrations-<environment>`. |
 | `postgres_api_runtime_role` | PostgreSQL runtime role used by the API. Defaults to `ltc_api_runtime_<environment>`. |
 
 No GitHub secret is needed for PostgreSQL migration authentication. GitHub only
 starts the Azure Container Apps Job; the job uses its own managed identity to
 acquire the PostgreSQL Entra token inside Azure.
 
-The migration job identity must be mapped to the migration PostgreSQL role before
-the job can connect. Use the Terraform output
-`migration_identity_principal_id` when creating or verifying that mapping.
+The migration job identity must be mapped to the effective migration PostgreSQL
+role before the job can connect. Use Terraform outputs
+`migration_identity_principal_id` and `migration_postgres_role` when creating or
+verifying that mapping.
 
 ## Running Migrations Locally
 

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -112,11 +112,6 @@ resource "azurerm_container_app" "api" {
       }
 
       env {
-        name  = "RUN_MIGRATIONS_ON_STARTUP"
-        value = "false"
-      }
-
-      env {
         name  = "GITHUB_CLIENT_ID"
         value = var.github_client_id
       }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -68,3 +68,8 @@ output "migration_identity_principal_id" {
   description = "Principal ID for mapping the migration job identity to PostgreSQL"
   value       = azurerm_user_assigned_identity.migrations.principal_id
 }
+
+output "migration_postgres_role" {
+  description = "PostgreSQL role used by the Azure Container Apps migration job"
+  value       = local.migration_postgres_role
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -47,7 +47,7 @@ resource "random_string" "suffix" {
 
 locals {
   api_postgres_role       = coalesce(var.postgres_api_runtime_role, "ltc_api_runtime_${var.environment}")
-  migration_postgres_role = var.postgres_migration_role
+  migration_postgres_role = coalesce(var.postgres_migration_role, "ltc-postgres-migrations-${var.environment}")
   suffix                  = random_string.suffix.result
   resource_group_name     = "rg-ltc-${var.environment}"
   tags = {

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -19,8 +19,9 @@ postgres_entra_admin_object_id      = "00000000-0000-0000-0000-000000000000"
 postgres_entra_admin_principal_name = "Learn to Cloud PostgreSQL Admins"
 # postgres_entra_admin_principal_type = "Group"
 
-# Required - PostgreSQL migration role mapped to the migration job identity
-postgres_migration_role = "ltc-postgres-migrations-dev"
+# Optional - PostgreSQL migration role mapped to the migration job identity.
+# Defaults to "ltc-postgres-migrations-<environment>".
+# postgres_migration_role = "ltc-postgres-migrations-dev"
 
 # Optional - PostgreSQL runtime role mapped to the API managed identity
 # postgres_api_runtime_role = "ltc_api_runtime_dev"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -46,12 +46,13 @@ variable "postgres_api_runtime_role" {
 }
 
 variable "postgres_migration_role" {
-  description = "PostgreSQL role used by the Azure Container Apps migration job. It must be mapped to the migration managed identity and own/manage schema objects."
+  description = "PostgreSQL role used by the Azure Container Apps migration job. Defaults to ltc-postgres-migrations-<environment>."
   type        = string
+  default     = null
 
   validation {
-    condition     = length(trimspace(var.postgres_migration_role)) > 0 && length(var.postgres_migration_role) <= 63
-    error_message = "postgres_migration_role must be a non-empty PostgreSQL role name no longer than 63 characters."
+    condition     = var.postgres_migration_role == null ? true : length(trimspace(var.postgres_migration_role)) > 0 && length(var.postgres_migration_role) <= 63
+    error_message = "postgres_migration_role must be a non-empty PostgreSQL role name no longer than 63 characters when set."
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the API startup Alembic migration fallback and related config/tests
- move the migration PostgreSQL role default/output into Terraform
- update the deploy workflow to stop depending on POSTGRES_MIGRATION_USER
- refresh migration/deploy docs for the ACA Job steady state

## Validation
- terraform fmt -check
- terraform validate
- cd api && uv run ruff check .
- cd api && uv run ruff format --check .
- cd api && uv run ty check --exclude scripts --exclude tests .
- cd api && uv run pytest tests/

Do not merge yet.