### PR TITLE
fix: remove durable scheduler consumption capacity

### DIFF
--- a/infra/functions.tf
+++ b/infra/functions.tf
@@ -36,8 +36,7 @@ resource "azapi_resource" "verification_scheduler" {
     properties = {
       ipAllowlist = var.durable_task_scheduler_ip_allowlist
       sku = {
-        capacity = 1
-        name     = "Consumption"
+        name = "Consumption"
       }
     }
   }


### PR DESCRIPTION
## Summary
- remove invalid capacity from Durable Task Scheduler Consumption SKU
- granted the deploy service principal User Access Administrator on rg-ltc-dev so Terraform can manage declared RBAC assignments

## Validation
- terraform -chdir=infra fmt -check functions.tf
- terraform -chdir=infra validate
- uv run prek run --all-files