### PR TITLE
fix: remove flex runtime app setting

### DIFF
--- a/infra/functions.tf
+++ b/infra/functions.tf
@@ -95,7 +95,6 @@ resource "azurerm_function_app_flex_consumption" "verification" {
     AZURE_CLIENT_ID                          = azurerm_user_assigned_identity.verification_functions.client_id
     DATABASE_URL                             = ""
     DURABLE_TASK_SCHEDULER_CONNECTION_STRING = "Endpoint=${azapi_resource.verification_scheduler.output.properties.endpoint};Authentication=ManagedIdentity;ClientID=${azurerm_user_assigned_identity.verification_functions.client_id}"
-    FUNCTIONS_WORKER_RUNTIME                 = "python"
     GITHUB_CLIENT_ID                         = var.github_client_id
     GITHUB_CLIENT_SECRET                     = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-client-secret)"
     GITHUB_TOKEN                             = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-token)"


### PR DESCRIPTION
## Summary
- remove FUNCTIONS_WORKER_RUNTIME from the Flex Consumption Function App app settings
- rely on azurerm_function_app_flex_consumption runtime_name/runtime_version for the runtime configuration

## Validation
- terraform -chdir=infra fmt -check functions.tf
- terraform -chdir=infra validate
- uv run prek run --all-files
- required Python/API/shared/Functions gates