### PR TITLE
fix: use function host keys data source

### DIFF
--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -78,7 +78,7 @@ resource "azurerm_container_app" "api" {
 
   secret {
     name  = "verification-functions-key"
-    value = random_password.verification_functions_key.result
+    value = data.azurerm_function_app_host_keys.verification.default_function_key
   }
 
   ingress {
@@ -209,7 +209,6 @@ resource "azurerm_container_app" "api" {
   depends_on = [
     azurerm_role_assignment.api_acr_pull,
     azurerm_role_assignment.api_key_vault_secrets_user,
-    azapi_resource.verification_functions_host_key,
     azurerm_postgresql_flexible_server_database.main,
   ]
 }

--- a/infra/database.tf
+++ b/infra/database.tf
@@ -14,6 +14,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
   authentication {
     active_directory_auth_enabled = true
     password_auth_enabled         = false
+    tenant_id                     = data.azurerm_client_config.current.tenant_id
   }
 }
 

--- a/infra/functions.tf
+++ b/infra/functions.tf
@@ -65,11 +65,6 @@ resource "azurerm_role_assignment" "verification_functions_durable_task" {
   skip_service_principal_aad_check = true
 }
 
-resource "random_password" "verification_functions_key" {
-  length  = 64
-  special = false
-}
-
 resource "azurerm_function_app_flex_consumption" "verification" {
   name                = "func-ltc-verification-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name
@@ -91,7 +86,6 @@ resource "azurerm_function_app_flex_consumption" "verification" {
   }
 
   app_settings = {
-    APPLICATIONINSIGHTS_CONNECTION_STRING    = azurerm_application_insights.main.connection_string
     AZURE_CLIENT_ID                          = azurerm_user_assigned_identity.verification_functions.client_id
     DATABASE_URL                             = ""
     DURABLE_TASK_SCHEDULER_CONNECTION_STRING = "Endpoint=${azapi_resource.verification_scheduler.output.properties.endpoint};Authentication=ManagedIdentity;ClientID=${azurerm_user_assigned_identity.verification_functions.client_id}"
@@ -118,17 +112,9 @@ resource "azurerm_function_app_flex_consumption" "verification" {
   ]
 }
 
-resource "azapi_resource" "verification_functions_host_key" {
-  type      = "Microsoft.Web/sites/host/functionKeys@2022-09-01"
-  name      = "default/verification-api"
-  parent_id = azurerm_function_app_flex_consumption.verification.id
+data "azurerm_function_app_host_keys" "verification" {
+  name                = azurerm_function_app_flex_consumption.verification.name
+  resource_group_name = azurerm_resource_group.main.name
 
-  body = {
-    properties = {
-      name  = "verification-api"
-      value = random_password.verification_functions_key.result
-    }
-  }
-
-  schema_validation_enabled = false
+  depends_on = [azurerm_function_app_flex_consumption.verification]
 }


### PR DESCRIPTION
## Summary
- use the native azurerm_function_app_host_keys data source for the verification Function host key
- remove the AzAPI host/functionKeys resource, which cannot be managed because the endpoint rejects GET
- set PostgreSQL Entra tenant_id explicitly to match AzureRM requirements and avoid repeated drift
- remove duplicate Function App App Insights app setting managed by site_config

## Validation
- terraform -chdir=infra fmt -check database.tf functions.tf container-apps.tf
- terraform -chdir=infra validate
- terraform -chdir=infra plan/apply against dev Azure backend
- terraform -chdir=infra plan -detailed-exitcode returned clean
- uv run prek run --all-files
- required Python/API/shared/Functions gates