### PR TITLE
fix: run migrations through python wrapper

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -384,8 +384,8 @@ jobs:
               --resource-group "$RESOURCE_GROUP" \
               --container-name migrations \
               --image "$IMAGE" \
-              --command alembic \
-              --args upgrade head \
+              --command python \
+              --args scripts/run_migrations.py \
               --env-vars \
                 POSTGRES_HOST="$POSTGRES_HOST" \
                 POSTGRES_USER="$POSTGRES_USER" \

--- a/api/scripts/run_migrations.py
+++ b/api/scripts/run_migrations.py
@@ -1,0 +1,11 @@
+import alembic.command
+import alembic.config
+
+
+def main() -> None:
+    """Run all Alembic migrations."""
+    alembic.command.upgrade(alembic.config.Config("alembic.ini"), "head")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/migrations.tf
+++ b/infra/migrations.tf
@@ -26,8 +26,8 @@ resource "azurerm_container_app_job" "migrations" {
     container {
       name    = "migrations"
       image   = "${azurerm_container_registry.main.login_server}/api:latest"
-      command = ["alembic"]
-      args    = ["upgrade", "head"]
+      command = ["python"]
+      args    = ["scripts/run_migrations.py"]
       cpu     = 0.5
       memory  = "1Gi"
 


### PR DESCRIPTION
## Summary\n- add a small Python migration runner that invokes Alembic directly\n- run Container Apps migration jobs with `python scripts/run_migrations.py` instead of the missing `alembic` console script\n- keep Terraform migration job defaults and deploy workflow overrides aligned\n\n## Validation\n- full local quality gates passed\n- CI-equivalent Terraform plan is clean\n- Azure Container Apps migration job succeeded with a temporary ACR image using the new runner