### PR TITLE
chore: improve terraform validation

### DIFF
--- a/.github/skills/debug-deploy/debug-deploy.sh
+++ b/.github/skills/debug-deploy/debug-deploy.sh
@@ -3,7 +3,7 @@
 # Debug Deploy Workflow Script
 # =============================================================================
 # This script helps diagnose and fix issues with the GitHub Actions deploy workflow.
-# Usage: ./scripts/debug-deploy.sh [command]
+# Usage: .github/skills/debug-deploy/debug-deploy.sh [command]
 #
 # Commands:
 #   status    - Show recent workflow runs and their status (default)
@@ -26,7 +26,8 @@ NC='\033[0m' # No Color
 
 # Navigate to repo root
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SCRIPT_RELATIVE_PATH=".github/skills/debug-deploy/debug-deploy.sh"
 cd "$REPO_ROOT"
 
 print_header() {
@@ -67,7 +68,7 @@ cmd_status() {
     gh run list --workflow=deploy.yml --limit 10
 
     echo ""
-    print_info "Use './scripts/debug-deploy.sh logs <run-id>' to view logs for a specific run"
+    print_info "Use '$SCRIPT_RELATIVE_PATH logs <run-id>' to view logs for a specific run"
 }
 
 # View failed logs
@@ -102,7 +103,7 @@ cmd_logs() {
         echo "The Terraform state file is locked by another process."
         echo ""
         echo "To fix this, run:"
-        echo -e "  ${GREEN}./scripts/debug-deploy.sh unlock${NC}"
+        echo -e "  ${GREEN}$SCRIPT_RELATIVE_PATH unlock${NC}"
         echo ""
 
         # Extract lock ID if present
@@ -148,7 +149,7 @@ cmd_logs() {
     if echo "$logs" | grep -q "ruff\|lint error\|E501\|F401"; then
         print_warning "DETECTED: Linting Issues"
         echo ""
-        echo "Code linting failed. Run 'ruff check api/' locally to see issues."
+        echo "Code linting failed. Run '(cd api && uv run ruff check . ../packages/learn-to-cloud-shared)' locally to see issues."
     fi
 }
 
@@ -209,7 +210,7 @@ cmd_rerun() {
     print_success "Workflow re-run requested!"
 
     echo ""
-    print_info "Watch the run with: ./scripts/debug-deploy.sh watch"
+    print_info "Watch the run with: $SCRIPT_RELATIVE_PATH watch"
 }
 
 # Watch a workflow run
@@ -230,7 +231,7 @@ cmd_help() {
     cat << EOF
 Debug Deploy Workflow Script
 
-Usage: ./scripts/debug-deploy.sh [command] [args]
+Usage: .github/skills/debug-deploy/debug-deploy.sh [command] [args]
 
 Commands:
   status          Show recent workflow runs and their status (default)
@@ -241,19 +242,19 @@ Commands:
   help            Show this help message
 
 Examples:
-  ./scripts/debug-deploy.sh                    # Show status
-  ./scripts/debug-deploy.sh logs               # View most recent failure
-  ./scripts/debug-deploy.sh logs 12345678      # View specific run
-  ./scripts/debug-deploy.sh unlock             # Fix Terraform lock
-  ./scripts/debug-deploy.sh rerun              # Re-run latest failed
+  .github/skills/debug-deploy/debug-deploy.sh                    # Show status
+  .github/skills/debug-deploy/debug-deploy.sh logs               # View most recent failure
+  .github/skills/debug-deploy/debug-deploy.sh logs 12345678      # View specific run
+  .github/skills/debug-deploy/debug-deploy.sh unlock             # Fix Terraform lock
+  .github/skills/debug-deploy/debug-deploy.sh rerun              # Re-run latest failed
 
 Common Issues Detected:
   • Terraform State Lock - Run 'unlock' command to fix
   • Authentication Errors - Check OIDC deployment secrets/variables and Azure RBAC
   • Resource Not Found - Resource may have been deleted outside Terraform
   • Quota Exceeded - Request quota increase or clean up resources
-  • Test Failures - Run tests locally with 'pytest api/tests/'
-  • Lint Failures - Run 'ruff check api/' locally
+  • Test Failures - Run tests locally with 'cd api && uv run pytest tests/ ../packages/learn-to-cloud-shared/tests -x'
+  • Lint Failures - Run 'cd api && uv run ruff check . ../packages/learn-to-cloud-shared' locally
 
 EOF
 }

--- a/.github/skills/ship-it/SKILL.md
+++ b/.github/skills/ship-it/SKILL.md
@@ -37,7 +37,7 @@ Reply with "LFG 🚀 I'll ship it" to acknowledge the user's intent.
 ## Step 1: Run Prek
 
 ```bash
-cd <workspace> && uv run prek run --all-files
+cd <workspace> && prek run --all-files
 ```
 
 ### Handling Failures
@@ -48,7 +48,7 @@ Prek hooks may auto-fix issues (ruff lint `--fix`, ruff format, trailing whitesp
 
 1. **Check if hooks auto-fixed files** — many hooks modify files in place. Re-run prek:
    ```bash
-   uv run prek run --all-files
+   prek run --all-files
    ```
 
 2. **If the second run passes** — the auto-fixes resolved everything. Proceed to Step 2.

--- a/.github/skills/validate/SKILL.md
+++ b/.github/skills/validate/SKILL.md
@@ -146,11 +146,11 @@ cd <workspace>/apps/verification-functions && uv run python -c "import function_
 | Task | Command |
 |------|---------|
 | Kill API | `lsof -ti:8000 \| xargs kill -9 2>/dev/null \|\| true` |
-| Lint | `cd api && uv run ruff check . ../packages/learn-to-cloud-shared` |
+| Lint | `cd api && uv run ruff check . ../packages/learn-to-cloud-shared && cd ../apps/verification-functions && uv run ruff check .` |
 | Lint + fix | `uv run ruff check --fix <file>` |
-| Format check | `cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared` |
+| Format check | `cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared && cd ../apps/verification-functions && uv run ruff format --check .` |
 | Format fix | `uv run ruff format <file>` |
-| Type check | `cd api && uv run ty check --exclude scripts --exclude tests .` |
+| Type check | `cd api && uv run ty check --exclude scripts --exclude tests . && cd ../packages/learn-to-cloud-shared && uv run ty check --exclude tests . && cd ../../apps/verification-functions && uv run ty check .` |
 | Health check | `curl -s http://localhost:8000/health` |
 
 ---

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,37 @@ jobs:
           fail-on-severity: moderate
 
   # -----------------------------------------------------------------------
+  # Terraform CI — fast PR checks without Azure credentials or remote state
+  # -----------------------------------------------------------------------
+  terraform-ci:
+    needs: [changes]
+    if: needs.changes.outputs.deploy == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
+        with:
+          terraform_version: "~1.5"
+          terraform_wrapper: false
+
+      - name: Terraform format check
+        run: terraform fmt -check -recursive
+
+      - name: Terraform init without backend
+        run: terraform init -backend=false
+
+      - name: Terraform validate
+        run: terraform validate
+
+      - name: Terraform tests
+        run: terraform test -no-color
+
+  # -----------------------------------------------------------------------
   # CI — lint, type-check, test (runs on push AND PR)
   # -----------------------------------------------------------------------
   ci:
@@ -210,11 +241,25 @@ jobs:
             exit 1
           fi
 
+  terraform-ci-status:
+    if: always()
+    needs: [terraform-ci]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Terraform CI result
+        run: |
+          if [[ "${{ needs.terraform-ci.result }}" =~ ^(success|skipped)$ ]]; then
+            echo "Terraform CI passed or was skipped (no deploy changes)"
+          else
+            echo "Terraform CI failed: ${{ needs.terraform-ci.result }}"
+            exit 1
+          fi
+
   # -----------------------------------------------------------------------
-  # Terraform — plan + apply (push to main only)
+  # Terraform — validate/plan on manual branch runs, apply only on main
   # -----------------------------------------------------------------------
   terraform:
-    if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy == 'true') && !contains(needs.*.result, 'failure')
+    if: always() && github.event_name != 'pull_request' && (github.event_name == 'workflow_dispatch' || (github.ref == 'refs/heads/main' && needs.changes.outputs.deploy == 'true')) && !contains(needs.*.result, 'failure')
     needs: [ci, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -255,7 +300,7 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Terraform Init
-        run: terraform init
+        run: terraform init -backend-config="key=learn-to-cloud-${AZURE_ENV_NAME:-dev}.tfstate"
 
       - name: Terraform Validate
         run: terraform validate
@@ -270,12 +315,14 @@ jobs:
           TF_VAR_postgres_entra_admin_principal_type: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE || 'Group' }}
 
       - name: Terraform Apply
+        if: github.ref == 'refs/heads/main'
         run: terraform apply -auto-approve -lock-timeout=120s tfplan
 
       - name: Get Terraform Outputs
+        if: github.ref == 'refs/heads/main'
         id: tf-outputs
         run: |
-          echo "api_container_app_name=ca-ltc-api-${{ vars.AZURE_ENV_NAME }}" >> "$GITHUB_OUTPUT"
+          echo "api_container_app_name=$(terraform output -raw api_container_app_name)" >> "$GITHUB_OUTPUT"
           echo "resource_group_name=$(terraform output -raw AZURE_RESOURCE_GROUP)" >> "$GITHUB_OUTPUT"
           echo "container_registry_name=$(terraform output -raw AZURE_CONTAINER_REGISTRY_NAME)" >> "$GITHUB_OUTPUT"
           echo "container_registry_endpoint=$(terraform output -raw AZURE_CONTAINER_REGISTRY_ENDPOINT)" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,6 @@ obj/
 *.tfvars
 *.tfvars.local
 !terraform.tfvars.example
-.terraform.lock.hcl
 crash.log
 crash.*.log
 override.tf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 repos:
   # Ruff - Python linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.15.12
     hooks:
       - id: ruff
         name: ruff lint

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,65 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/azure/azapi" {
+  version     = "2.9.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:HjiC0LNLnJ8/HNGVWJl7Vh80Iiuxskocz16osUmuuZw=",
+    "h1:tF2SjvM2Vj+7MTbFXhssLYu1Uc9uK/cVWBYIH8heDqM=",
+    "zh:0a4eee8c9362db6ca19d371eccf38701c8306be761182da87b624294f7e8f867",
+    "zh:4df87bee5b8f4cce27461ae26132a599542583cdf035942b42b0259a514ab46e",
+    "zh:57dc1f4227f1d0eab630fcf868d6c9a1b4dc4c165608ce5a4d7028a482770547",
+    "zh:5c500e42c419c324ea8f41c40e4cc8af187323cebc9f70543749b6c0e59c0fe9",
+    "zh:6c7dca31242e27d2f215b1a9370b65579b3a988282a3609564ea96866f86f0ca",
+    "zh:74dada7351b25d01e61aa70aa8cf1f1fb96d09c514be4b66d12816c5e61f9e01",
+    "zh:9c67c0727ab8be15879793f929f3d71f0f149ae1daaf577d0bd4d57b2e61c408",
+    "zh:a0266da16db14b635a61d6766efc28468056bac91ed6662fc9f2a0aad923b063",
+    "zh:a4a555627f40fa797b34ddede599812cddb1e0e9be105ccfcf1f293451b97cd7",
+    "zh:a6a1c4a46f4f01e4420a456adefe8bcf3bff3c9d09a8dfeedeea5b94c866dfd8",
+    "zh:c64fc4067a8276d4405d9359990e0c45e66dba07433a1f3ab1e6c32f6ef3b048",
+    "zh:ee77a881d071b3a0ad8a64f9c1158e3aee9b37e9063de5dd8fa9d238dbe70ba1",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.71.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:ltQBUN5VCzE7AXfRievOnIL9ZC40v3Af7R9qfz8XoCQ=",
+    "h1:tvzoYA+qZ5ZIVK3/xrOlBbT/Ua/V2AqpNFYecLw1Fj8=",
+    "zh:01cc81ba9951d84757321918fdca7fe69ceed3570c57b8243c446fd8e2566ec4",
+    "zh:0cf2e5e039b772f3eeaaeadc53828b07c0bb861562915bfcbc5c884871075c1c",
+    "zh:22c53af5beddc85c66b28f1892ac043bcce8efb578d89c03256e69aed98629b5",
+    "zh:2e1c3b917ae247b2d23a48e38870f27f12a4e196d50f19f2b3fe0e78223e499b",
+    "zh:380e908e885673605c26c1ea2181a94eac99600b2c3126f3ae8b99323ddd9cd6",
+    "zh:386e15eb9c9538486334a543b662701905151dc34db73c5e1849d3814f5484ac",
+    "zh:5e4a8bf18c649940b59c5cf6cd6e53cf901014aad9bc995987a4c4cb1352f100",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7c1d971aa318240ce6f81131803a495da8a095a1ab260a3f670090487b542834",
+    "zh:8ed8d8d1074cc6fcc2f39efd84de8eaaf565d15fdbf52ed16ac9adb2d397a4b6",
+    "zh:9cd754daa817c60688695e58da3a118686ff79a7c7f29446d3f74056319fe0fb",
+    "zh:fd6f9b6b3276809c0674c46e25e97df281f136d4c25d3d7820cacd2f04a1c664",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "h1:m2y2fw9SBQ6+e7pNhi3+qsh8bYNmqkL89BulzH7uK3U=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -40,6 +40,12 @@ resource "azurerm_container_app" "api" {
     ignore_changes = [
       template[0].container[0].image,
     ]
+
+    precondition {
+      condition     = local.api_min_replicas <= local.api_max_replicas
+      error_message = "api_min_replicas must be less than or equal to api_max_replicas."
+    }
+
   }
 
   identity {
@@ -93,12 +99,12 @@ resource "azurerm_container_app" "api" {
   }
 
   template {
-    min_replicas = 0
+    min_replicas = local.api_min_replicas
     # PostgreSQL max connections vary by SKU.
     # Each replica uses up to 10 (pool_size=5 + max_overflow=5).
     # 2 replicas × 10 = 20 connections — well under typical SKU limits.
     # Scaling uses the default HTTP rule (10 concurrent requests per replica).
-    max_replicas = 2
+    max_replicas = local.api_max_replicas
 
     container {
       name   = "api"

--- a/infra/database.tf
+++ b/infra/database.tf
@@ -3,12 +3,12 @@ resource "azurerm_postgresql_flexible_server" "main" {
   resource_group_name           = azurerm_resource_group.main.name
   location                      = azurerm_resource_group.main.location
   version                       = "16"
-  storage_mb                    = 32768
-  sku_name                      = "B_Standard_B1ms"
-  backup_retention_days         = 7
-  geo_redundant_backup_enabled  = false
+  storage_mb                    = local.postgres_storage_mb
+  sku_name                      = local.postgres_sku_name
+  backup_retention_days         = local.postgres_backup_retention_days
+  geo_redundant_backup_enabled  = local.postgres_geo_redundant_backup_enabled
   public_network_access_enabled = true
-  zone                          = "3"
+  zone                          = local.postgres_zone
   tags                          = local.tags
 
   authentication {

--- a/infra/functions.tf
+++ b/infra/functions.tf
@@ -43,6 +43,16 @@ resource "azapi_resource" "verification_scheduler" {
 
   response_export_values    = ["properties.endpoint"]
   schema_validation_enabled = false
+
+  lifecycle {
+    precondition {
+      condition = var.environment != "prod" || (
+        !contains(var.durable_task_scheduler_ip_allowlist, "0.0.0.0/0") &&
+        !contains(var.durable_task_scheduler_ip_allowlist, "::/0")
+      )
+      error_message = "durable_task_scheduler_ip_allowlist must not allow all IPv4 or IPv6 addresses in prod."
+    }
+  }
 }
 
 resource "azapi_resource" "verification_task_hub" {

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -53,10 +53,14 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "api_5xx_errors" {
   criteria {
     query                   = <<-QUERY
       requests
+      | where cloud_RoleName in ("learn-to-cloud-api", "ca-ltc-api-${var.environment}")
+          or cloud_RoleName has "learn-to-cloud-api"
+          or cloud_RoleName has "ca-ltc-api"
       | where resultCode startswith "5"
       | summarize ErrorCount = count() by bin(timestamp, 5m)
     QUERY
-    time_aggregation_method = "Count"
+    time_aggregation_method = "Maximum"
+    metric_measure_column   = "ErrorCount"
     operator                = "GreaterThanOrEqual"
     threshold               = 3
 

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -59,6 +59,11 @@ output "api_url" {
   value       = "https://${azurerm_container_app.api.ingress[0].fqdn}"
 }
 
+output "api_container_app_name" {
+  description = "API Container App name (for CI/CD)"
+  value       = azurerm_container_app.api.name
+}
+
 output "migration_job_name" {
   description = "Container Apps Job name used to run database migrations"
   value       = azurerm_container_app_job.migrations.name

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -46,9 +46,16 @@ resource "random_string" "suffix" {
 }
 
 locals {
+  api_max_replicas                              = coalesce(var.api_max_replicas, 2)
+  api_min_replicas                              = coalesce(var.api_min_replicas, 0)
   api_postgres_role                             = coalesce(var.postgres_api_runtime_role, "ltc_api_runtime_${var.environment}")
   key_vault_name                                = "kv-ltc-${var.environment}-${local.suffix}"
   migration_postgres_role                       = coalesce(var.postgres_migration_role, "ltc-postgres-migrations-${var.environment}")
+  postgres_backup_retention_days                = coalesce(var.postgres_backup_retention_days, 7)
+  postgres_geo_redundant_backup_enabled         = coalesce(var.postgres_geo_redundant_backup_enabled, false)
+  postgres_sku_name                             = coalesce(var.postgres_sku_name, "B_Standard_B1ms")
+  postgres_storage_mb                           = coalesce(var.postgres_storage_mb, 32768)
+  postgres_zone                                 = coalesce(var.postgres_zone, "3")
   verification_functions_postgres_role          = coalesce(var.postgres_verification_functions_role, "ltc_verification_functions_${var.environment}")
   verification_functions_storage_account_prefix = substr(replace("stltcfunc${lower(var.environment)}", "-", ""), 0, 18)
   verification_functions_storage_account_name   = "${local.verification_functions_storage_account_prefix}${local.suffix}"

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -30,6 +30,7 @@ postgres_entra_admin_principal_name = "Learn to Cloud PostgreSQL Admins"
 # postgres_verification_functions_role = "ltc_verification_functions_dev"
 
 # Optional - CIDR ranges allowed to connect to Durable Task Scheduler.
+# For prod, use trusted CIDRs only; Terraform rejects 0.0.0.0/0 and ::/0.
 # durable_task_scheduler_ip_allowlist = ["0.0.0.0/0"]
 
 # Optional - Durable Task Scheduler dashboard readers by environment.
@@ -51,3 +52,14 @@ github_client_id = "Ov23xxx"
 # location    = "centralus"
 # environment = "dev"
 # alert_emails = ["learntocloud@gmail.com"]
+# api_min_replicas = 0
+# api_max_replicas = 2
+#
+# PostgreSQL defaults use the cheapest configured deployment shape. Override
+# only if you intentionally want a larger SKU, more retention, or geo-redundant
+# backups.
+# postgres_sku_name                      = "B_Standard_B1ms"
+# postgres_storage_mb                    = 32768
+# postgres_backup_retention_days         = 35
+# postgres_geo_redundant_backup_enabled  = true
+# postgres_zone                          = "3"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -103,6 +103,11 @@ variable "environment" {
   description = "Environment name (dev, staging, prod)"
   type        = string
   default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "environment must be dev, staging, or prod."
+  }
 }
 
 variable "location" {
@@ -115,4 +120,76 @@ variable "alert_emails" {
   description = "Email addresses to receive monitoring alerts"
   type        = list(string)
   default     = ["learntocloudguide@gmail.com"]
+}
+
+variable "api_min_replicas" {
+  description = "Minimum API Container App replicas. Defaults to 0 so the API can scale to zero."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.api_min_replicas == null || var.api_min_replicas >= 0
+    error_message = "api_min_replicas must be zero or greater."
+  }
+}
+
+variable "api_max_replicas" {
+  description = "Maximum API Container App replicas."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.api_max_replicas == null || var.api_max_replicas >= 1
+    error_message = "api_max_replicas must be at least 1."
+  }
+}
+
+variable "postgres_sku_name" {
+  description = "PostgreSQL Flexible Server SKU. Defaults to the cheapest configured burstable SKU."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.postgres_sku_name == null || length(trimspace(var.postgres_sku_name)) > 0
+    error_message = "postgres_sku_name must be non-empty when set."
+  }
+}
+
+variable "postgres_storage_mb" {
+  description = "PostgreSQL Flexible Server storage size in MB."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.postgres_storage_mb == null || var.postgres_storage_mb >= 32768
+    error_message = "postgres_storage_mb must be at least 32768 MB when set."
+  }
+}
+
+variable "postgres_backup_retention_days" {
+  description = "PostgreSQL Flexible Server backup retention in days."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.postgres_backup_retention_days == null || (var.postgres_backup_retention_days >= 7 && var.postgres_backup_retention_days <= 35)
+    error_message = "postgres_backup_retention_days must be between 7 and 35 when set."
+  }
+}
+
+variable "postgres_geo_redundant_backup_enabled" {
+  description = "Whether PostgreSQL geo-redundant backup is enabled. Decide before initial production creation."
+  type        = bool
+  default     = null
+}
+
+variable "postgres_zone" {
+  description = "PostgreSQL Flexible Server availability zone. Set to null only when the target region/SKU supports zone omission."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.postgres_zone == null || can(regex("^[1-9][0-9]*$", var.postgres_zone))
+    error_message = "postgres_zone must be a positive zone number string when set."
+  }
 }

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -39,20 +39,30 @@ class VerificationJobNotFoundError(Exception):
 class VerificationJobExecutionResult:
     job_id: UUID
     status: VerificationJobStatus
+    code: str
+    requirement_id: str
+    requirement_name: str | None
+    submission_type: str | None
     submission_id: int | None
     is_valid: bool
     verification_completed: bool
     message: str
+    detail: str | None = None
 
     def to_payload(self) -> dict[str, object]:
         """Return a JSON-serializable Durable activity result."""
         return {
             "job_id": str(self.job_id),
             "status": self.status.value,
+            "code": self.code,
+            "requirement_id": self.requirement_id,
+            "requirement_name": self.requirement_name,
+            "submission_type": self.submission_type,
             "submission_id": self.submission_id,
             "is_valid": self.is_valid,
             "verification_completed": self.verification_completed,
             "message": self.message,
+            "detail": self.detail,
         }
 
 
@@ -149,7 +159,9 @@ class _VerificationJobPayload:
     phase_id: int
     submitted_value: str
     status: VerificationJobStatus
+    submission_type: str
     result_submission_id: int | None
+    error_code: str | None
     error_message: str | None
 
 
@@ -204,21 +216,53 @@ async def _load_job_payload(
         phase_id=job.phase_id,
         submitted_value=job.submitted_value,
         status=job.status,
+        submission_type=job.submission_type.value,
         result_submission_id=job.result_submission_id,
+        error_code=job.error_code,
         error_message=job.error_message,
     )
+
+
+def _result_code(status: VerificationJobStatus, error_code: str | None = None) -> str:
+    if status == VerificationJobStatus.SUCCEEDED:
+        return "verification_succeeded"
+    if status == VerificationJobStatus.FAILED:
+        return error_code or VALIDATION_FAILED_ERROR_CODE
+    if status == VerificationJobStatus.SERVER_ERROR:
+        return error_code or VERIFICATION_INCOMPLETE_ERROR_CODE
+    if status == VerificationJobStatus.CANCELLED:
+        return error_code or "verification_cancelled"
+    return status.value
+
+
+def _result_message(status: VerificationJobStatus) -> str:
+    if status == VerificationJobStatus.SUCCEEDED:
+        return "Verification succeeded."
+    if status == VerificationJobStatus.FAILED:
+        return "Verification failed."
+    if status == VerificationJobStatus.SERVER_ERROR:
+        return "Verification could not be completed."
+    if status == VerificationJobStatus.CANCELLED:
+        return "Verification was cancelled."
+    return "Verification job is not complete."
 
 
 def _terminal_result(
     payload: _VerificationJobPayload,
 ) -> VerificationJobExecutionResult:
+    requirement = get_requirement_by_id(payload.requirement_id)
     return VerificationJobExecutionResult(
         job_id=payload.id,
         status=payload.status,
+        code=_result_code(payload.status, payload.error_code),
+        requirement_id=payload.requirement_id,
+        requirement_name=requirement.name if requirement is not None else None,
+        submission_type=payload.submission_type,
         submission_id=payload.result_submission_id,
         is_valid=payload.status == VerificationJobStatus.SUCCEEDED,
         verification_completed=payload.status != VerificationJobStatus.SERVER_ERROR,
-        message=payload.error_message or "Verification job already completed.",
+        message=_result_message(payload.status),
+        detail=payload.error_message,
     )
 
 
@@ -227,13 +271,14 @@ async def _mark_missing_requirement(
     session_maker: async_sessionmaker[AsyncSession],
     job_id: UUID,
     requirement_id: str,
+    submission_type: str,
 ) -> VerificationJobExecutionResult:
-    message = f"Requirement not found: {requirement_id}"
+    detail = f"Requirement not found: {requirement_id}"
     async with session_maker() as db:
         job = await VerificationJobRepository(db).mark_server_error(
             job_id,
             error_code=REQUIREMENT_NOT_FOUND_ERROR_CODE,
-            error_message=message,
+            error_message=detail,
         )
         if job is None:
             raise VerificationJobNotFoundError(str(job_id))
@@ -242,10 +287,15 @@ async def _mark_missing_requirement(
     return VerificationJobExecutionResult(
         job_id=job_id,
         status=VerificationJobStatus.SERVER_ERROR,
+        code=REQUIREMENT_NOT_FOUND_ERROR_CODE,
+        requirement_id=requirement_id,
+        requirement_name=None,
+        submission_type=submission_type,
         submission_id=None,
         is_valid=False,
         verification_completed=False,
-        message=message,
+        message=_result_message(VerificationJobStatus.SERVER_ERROR),
+        detail=detail,
     )
 
 
@@ -279,6 +329,7 @@ async def prepare_verification_job(
                 session_maker=session_maker,
                 job_id=normalized_job_id,
                 requirement_id=payload.requirement_id,
+                submission_type=payload.submission_type,
             )
             span.set_attribute("verification.status", result.status.value)
             return VerificationJobPreparation(terminal_result=result)
@@ -382,10 +433,15 @@ async def persist_verification_result(
         return VerificationJobExecutionResult(
             job_id=job.id,
             status=status,
+            code=_result_code(status),
+            requirement_id=job.requirement.id,
+            requirement_name=job.requirement.name,
+            submission_type=job.requirement.submission_type.value,
             submission_id=submission.id,
             is_valid=validation_result.is_valid,
             verification_completed=validation_result.verification_completed,
-            message=validation_result.message,
+            message=_result_message(status),
+            detail=validation_result.message,
         )
 
 


### PR DESCRIPTION
## Summary
- add Terraform PR CI checks and branch plan-only workflow support
- parameterize low-cost API/PostgreSQL Terraform settings without changing defaults
- fix API 5xx alert query aggregation and expose API Container App name as output
- commit Terraform provider lockfile for reproducible provider selection

## Validation
- prek run --all-files
- cd api && uv run pytest tests/ ../packages/learn-to-cloud-shared/tests -x --tb=short
- cd api && uv run ruff check . ../packages/learn-to-cloud-shared && uv run ruff format --check . ../packages/learn-to-cloud-shared && uv run ty check --exclude scripts --exclude tests .
- cd packages/learn-to-cloud-shared && uv run ty check --exclude tests .
- cd apps/verification-functions && uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run python -c "import function_app"
- terraform -chdir=infra fmt -check -recursive && terraform -chdir=infra init -backend=false && terraform -chdir=infra validate && terraform -chdir=infra test -no-color
- terraform -chdir=infra plan -input=false -lock-timeout=120s