### PR TITLE
fix: poll durable verification status

### DIFF
--- a/api/src/learn_to_cloud/rendering/context.py
+++ b/api/src/learn_to_cloud/rendering/context.py
@@ -236,6 +236,8 @@ def build_requirement_card_context(
     server_error_message: str | None = None,
     error_banner: str | None = None,
     processing: bool = False,
+    verification_status_token: str | None = None,
+    verification_status_delay_seconds: int = 2,
 ) -> dict[str, Any]:
     """Build the template context for ``partials/requirement_card.html``.
 
@@ -259,6 +261,8 @@ def build_requirement_card_context(
         server_error_message: Optional server-error text.
         error_banner: Optional inline error banner text.
         processing: Whether the card is in the "analysing..." state.
+        verification_status_token: Signed token used by the HTMX polling card.
+        verification_status_delay_seconds: Delay before the next status poll.
     """
     derived_url: str | None = None
     pr_url_prefix: str | None = None
@@ -294,6 +298,8 @@ def build_requirement_card_context(
         "server_error_message": server_error_message,
         "error_banner": error_banner,
         "processing": processing,
+        "verification_status_token": verification_status_token,
+        "verification_status_delay_seconds": verification_status_delay_seconds,
         "derived_url": derived_url,
         "pr_url_prefix": pr_url_prefix,
     }

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -3,44 +3,35 @@
 These routes handle interactive HTMX requests (step toggles, form
 submissions, etc.) and return HTML partials instead of JSON.
 
-Async verifications use Durable Functions + SSE:
+Async verifications use Durable Functions + HTMX polling:
 1. POST /htmx/github/submit — pre-validates and returns a spinner card
     immediately (~100ms)
 2. Durable Functions runs verification and updates PostgreSQL job state
-3. GET /htmx/verification/{requirement_id}/stream polls PostgreSQL and
-   pushes the result HTML when the job reaches a terminal state
+3. Browser polls an API proxy that checks Durable orchestration status
+   without using PostgreSQL as the live status bus
 """
 
-import asyncio
-import json
 import logging
-from dataclasses import dataclass
 from typing import Annotated
+from uuid import UUID
 
-from fastapi import APIRouter, Form, Request
+from fastapi import APIRouter, Form, Query, Request
 from fastapi.responses import HTMLResponse
 from learn_to_cloud_shared.content_service import get_topic_by_id
-from learn_to_cloud_shared.core.config import get_settings
 from learn_to_cloud_shared.core.database import DbSession
-from learn_to_cloud_shared.models import SubmissionType, VerificationJobStatus
-from learn_to_cloud_shared.repositories.submission_repository import (
-    SubmissionRepository,
-)
+from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.repositories.verification_job_repository import (
-    ACTIVE_JOB_STATUSES,
     VerificationJobRepository,
 )
 from learn_to_cloud_shared.schemas import SubmissionData
-from learn_to_cloud_shared.verification.execution import to_submission_data
 from learn_to_cloud_shared.verification.requirements import get_requirement_by_id
 from learn_to_cloud_shared.verification.url_derivation import (
     derive_submission_value,
     is_derivable,
 )
 from opentelemetry import trace
-from starlette.responses import StreamingResponse
 
-from learn_to_cloud.core.auth import CurrentUser, UserId
+from learn_to_cloud.core.auth import AuthenticatedUser, CurrentUser, UserId
 from learn_to_cloud.core.ratelimit import limiter
 from learn_to_cloud.core.templates import templates
 from learn_to_cloud.rendering.context import (
@@ -51,6 +42,8 @@ from learn_to_cloud.rendering.steps import build_step_data
 from learn_to_cloud.services.durable_verification_client import (
     DurableVerificationConfigError,
     DurableVerificationStartError,
+    DurableVerificationStatusError,
+    get_verification_orchestration_status,
     start_verification_orchestration,
 )
 from learn_to_cloud.services.steps_service import (
@@ -74,6 +67,12 @@ from learn_to_cloud.services.users_service import (
     delete_user_account,
     get_user_by_id,
 )
+from learn_to_cloud.services.verification_status_tokens import (
+    VerificationStatusToken,
+    VerificationStatusTokenError,
+    create_verification_status_token,
+    load_verification_status_token,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -91,67 +90,79 @@ _DURABLE_START_ERROR_MESSAGE = (
     "please try again."
 )
 
-
-@dataclass(frozen=True, slots=True)
-class _VerificationStreamState:
-    status: VerificationJobStatus
-    error_message: str | None
-    submission: SubmissionData | None
-
-
-def _build_feedback_tasks_from_submission(
-    submission: SubmissionData | None,
-) -> tuple[list[dict[str, object]], int]:
-    if submission is None or not submission.feedback_json:
-        return [], 0
-
-    try:
-        raw_tasks = json.loads(submission.feedback_json)
-    except (json.JSONDecodeError, TypeError):
-        return [], 0
-
-    tasks = [
-        {
-            "name": task.get("task_name", ""),
-            "passed": task.get("passed", False),
-            "message": task.get("feedback", ""),
-            "next_steps": task.get("next_steps", ""),
-        }
-        for task in raw_tasks
-        if isinstance(task, dict)
-    ]
-    return tasks, sum(1 for task in tasks if task["passed"])
-
-
-async def _load_verification_stream_state(
-    session_maker,
-    user_id: int,
-    requirement_id: str,
-) -> _VerificationStreamState | None:
-    async with session_maker() as session:
-        job = await VerificationJobRepository(session).get_latest_for_requirement(
-            user_id,
-            requirement_id,
-        )
-        if job is None:
-            return None
-
-        submission = None
-        if job.result_submission_id is not None:
-            db_submission = await SubmissionRepository(session).get_by_id(
-                job.result_submission_id
-            )
-            if db_submission is not None:
-                submission = to_submission_data(db_submission)
-
-        return _VerificationStreamState(
-            status=job.status,
-            error_message=job.error_message,
-            submission=submission,
-        )
+_ACTIVE_DURABLE_STATUSES = {"pending", "running", "continuedasnew"}
+_TERMINAL_DURABLE_STATUSES = {"completed", "failed", "terminated", "canceled"}
+_DURABLE_FAILURE_STATUSES = {"failed", "terminated", "canceled"}
+_INITIAL_STATUS_DELAY_SECONDS = 2
+_RUNNING_STATUS_DELAY_SECONDS = 5
+_DURABLE_TERMINAL_FAILURE_MESSAGE = "Verification did not complete. Please try again."
 
 
 router = APIRouter(prefix="/htmx", tags=["htmx"], include_in_schema=False)
+
+
+def _reload_verification_html() -> str:
+    return (
+        "<div hx-trigger='load' "
+        "hx-on::load='setTimeout(()=>location.reload(),100)'></div>"
+    )
+
+
+def _status_error_response(message: str, *, status_code: int = 400) -> HTMLResponse:
+    return HTMLResponse(
+        f"<div class='text-red-600 text-sm p-2'>{message}</div>",
+        status_code=status_code,
+    )
+
+
+def _render_processing_card(
+    request: Request,
+    current_user: AuthenticatedUser,
+    token_data: VerificationStatusToken,
+    token: str,
+    *,
+    delay_seconds: int,
+) -> HTMLResponse:
+    requirement = get_requirement_by_id(token_data.requirement_id)
+    if requirement is None:
+        return HTMLResponse(_reload_verification_html())
+
+    return templates.TemplateResponse(
+        request,
+        "partials/requirement_card.html",
+        build_requirement_card_context(
+            requirement=requirement,
+            github_username=current_user.github_username,
+            processing=True,
+            verification_status_token=token,
+            verification_status_delay_seconds=delay_seconds,
+        ),
+    )
+
+
+async def _mark_durable_terminal_failure(
+    request: Request,
+    token_data: VerificationStatusToken,
+    status: str,
+) -> None:
+    session_maker = request.app.state.session_maker
+    async with session_maker() as session:
+        repository = VerificationJobRepository(session)
+        job_id = UUID(token_data.job_id)
+        error_code = f"durable_{status}"
+        if status == "canceled":
+            await repository.mark_cancelled(
+                job_id,
+                error_code=error_code,
+                error_message=_DURABLE_TERMINAL_FAILURE_MESSAGE,
+            )
+        else:
+            await repository.mark_server_error(
+                job_id,
+                error_code=error_code,
+                error_message=_DURABLE_TERMINAL_FAILURE_MESSAGE,
+            )
+        await session.commit()
 
 
 async def _render_step_toggle(
@@ -294,6 +305,8 @@ async def htmx_submit_verification(
         server_error_message: str | None = None,
         error_banner: str | None = None,
         processing: bool = False,
+        verification_status_token: str | None = None,
+        verification_status_delay_seconds: int = _INITIAL_STATUS_DELAY_SECONDS,
     ) -> HTMLResponse:
         """Render the requirement card partial with consistent context."""
         return templates.TemplateResponse(
@@ -309,6 +322,8 @@ async def htmx_submit_verification(
                 server_error_message=server_error_message,
                 error_banner=error_banner,
                 processing=processing,
+                verification_status_token=verification_status_token,
+                verification_status_delay_seconds=verification_status_delay_seconds,
             ),
         )
 
@@ -351,19 +366,30 @@ async def htmx_submit_verification(
             github_username=github_username,
         )
 
-        if (
-            job_submission.created
-            or job_submission.job.orchestration_instance_id is None
-        ):
+        existing_instance_id = job_submission.job.orchestration_instance_id
+        if job_submission.created or existing_instance_id is None:
             start_result = await start_verification_orchestration(job_submission.job.id)
+            instance_id = start_result.instance_id
             async with session_maker() as write_session:
                 await VerificationJobRepository(write_session).mark_starting(
                     job_submission.job.id,
                     start_result.instance_id,
                 )
                 await write_session.commit()
+        else:
+            instance_id = existing_instance_id
 
-        return _render_card(processing=True)
+        status_token = create_verification_status_token(
+            user_id=user_id,
+            job_id=job_submission.job.id,
+            instance_id=instance_id,
+            requirement_id=requirement_id,
+        )
+
+        return _render_card(
+            processing=True,
+            verification_status_token=status_token,
+        )
 
     except _USER_FACING_ERRORS as exc:
         return _render_card(error_banner=str(exc))
@@ -415,131 +441,83 @@ async def htmx_submit_verification(
         )
 
 
-@router.get("/verification/{requirement_id}/stream")
-async def htmx_verification_stream(
+@router.get("/verification/jobs/status", response_class=HTMLResponse)
+async def htmx_verification_job_status(
     request: Request,
-    requirement_id: str,
+    token: Annotated[str, Query(max_length=4096)],
     current_user: CurrentUser,
-) -> StreamingResponse:
-    """SSE stream that pushes the DB-backed verification result when ready."""
+) -> HTMLResponse:
+    """Return a polling card or reload trigger based on Durable job status."""
     user_id = current_user.user_id
-    stream_github_username = current_user.github_username
-    session_maker = request.app.state.session_maker
+    try:
+        token_data = load_verification_status_token(
+            token,
+            expected_user_id=user_id,
+        )
+    except VerificationStatusTokenError as exc:
+        span = trace.get_current_span()
+        span.add_event(
+            "verification_status_token_invalid",
+            {"user_id": user_id, "error": str(exc)},
+        )
+        return _status_error_response(
+            "Verification status expired. Refresh the page to check for results.",
+            status_code=400,
+        )
 
-    async def event_generator():
-        requirement = get_requirement_by_id(requirement_id)
-        if requirement is None:
-            yield (
-                "event: verification-result\n"
-                "data: <div hx-trigger='load'"
-                " hx-on::load='setTimeout(()=>location.reload(),100)'"
-                "></div>\n\n"
-            )
-            return
-        wait_timeout = get_settings().verification_wait_timeout
-        deadline = asyncio.get_running_loop().time() + wait_timeout
+    try:
+        durable_status = await get_verification_orchestration_status(
+            token_data.instance_id
+        )
+    except (DurableVerificationConfigError, DurableVerificationStatusError) as exc:
+        span = trace.get_current_span()
+        span.record_exception(exc)
+        span.set_attribute("error.type", type(exc).__name__)
+        span.set_attribute("user.id", user_id)
+        span.set_attribute("verification.job_id", token_data.job_id)
+        logger.warning(
+            "verification.status.durable_read_failed",
+            extra={
+                "user_id": user_id,
+                "job_id": token_data.job_id,
+                "error_type": type(exc).__name__,
+            },
+        )
+        return _status_error_response(
+            "Unable to load verification status. "
+            "Refresh the page to check for results.",
+            status_code=502,
+        )
 
-        while True:
-            try:
-                state = await _load_verification_stream_state(
-                    session_maker,
-                    user_id,
-                    requirement_id,
-                )
-            except Exception as exc:
-                span = trace.get_current_span()
-                span.record_exception(exc)
-                span.set_attribute("error.type", type(exc).__name__)
-                span.set_attribute("user.id", user_id)
-                span.set_attribute("requirement.id", requirement_id)
-                logger.exception(
-                    "verification.stream.db_read_failed",
-                    extra={
-                        "user_id": user_id,
-                        "requirement_id": requirement_id,
-                        "error_type": type(exc).__name__,
-                    },
-                )
-                yield (
-                    "event: verification-result\n"
-                    "data: <div class='text-red-600 text-sm p-2'>"
-                    "Unable to load verification status. Refresh the page "
-                    "to check for results.</div>\n\n"
-                )
-                return
+    status = durable_status.runtime_status.lower()
+    if status in _ACTIVE_DURABLE_STATUSES:
+        return _render_processing_card(
+            request,
+            current_user,
+            token_data,
+            token,
+            delay_seconds=_RUNNING_STATUS_DELAY_SECONDS,
+        )
 
-            if state is None:
-                yield (
-                    "event: verification-result\n"
-                    "data: <div hx-trigger='load'"
-                    " hx-on::load='setTimeout(()=>location.reload(),100)'"
-                    "></div>\n\n"
-                )
-                return
+    if status in _DURABLE_FAILURE_STATUSES:
+        await _mark_durable_terminal_failure(request, token_data, status)
+        return HTMLResponse(_reload_verification_html())
 
-            if state.status in ACTIVE_JOB_STATUSES:
-                if asyncio.get_running_loop().time() >= deadline:
-                    yield (
-                        "event: verification-result\n"
-                        "data: <div class='text-amber-600 text-sm p-2'>"
-                        "Verification is taking longer than expected. "
-                        "Refresh the page to check for results.</div>\n\n"
-                    )
-                    return
-                await asyncio.sleep(1)
-                continue
+    if status in _TERMINAL_DURABLE_STATUSES:
+        return HTMLResponse(_reload_verification_html())
 
-            if state.status == VerificationJobStatus.SUCCEEDED:
-                yield (
-                    "event: verification-result\n"
-                    "data: <div hx-trigger='load'"
-                    " hx-on::load='setTimeout(()=>location.reload(),100)'"
-                    "></div>\n\n"
-                )
-                return
-
-            feedback_tasks, feedback_passed = _build_feedback_tasks_from_submission(
-                state.submission
-            )
-            server_error = state.status == VerificationJobStatus.SERVER_ERROR
-            error_banner = None
-            if state.status == VerificationJobStatus.FAILED and not feedback_tasks:
-                error_banner = (
-                    state.submission.validation_message
-                    if state.submission and state.submission.validation_message
-                    else state.error_message
-                )
-            elif state.status == VerificationJobStatus.CANCELLED:
-                error_banner = state.error_message or "Verification was cancelled."
-
-            card_html = templates.get_template("partials/requirement_card.html").render(
-                request=request,
-                **build_requirement_card_context(
-                    requirement=requirement,
-                    github_username=stream_github_username,
-                    submission=state.submission,
-                    feedback_tasks=feedback_tasks,
-                    feedback_passed=feedback_passed,
-                    server_error=server_error,
-                    server_error_message=(
-                        state.error_message if server_error else None
-                    ),
-                    error_banner=error_banner,
-                    processing=False,
-                ),
-            )
-            data_lines = card_html.replace("\n", "\ndata: ")
-            yield f"event: verification-result\ndata: {data_lines}\n\n"
-            return
-
-    return StreamingResponse(
-        event_generator(),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",  # Disable nginx buffering
+    logger.warning(
+        "verification.status.unexpected_durable_status",
+        extra={
+            "user_id": user_id,
+            "job_id": token_data.job_id,
+            "runtime_status": durable_status.runtime_status,
         },
+    )
+    return _status_error_response(
+        "Verification is in an unexpected state. "
+        "Refresh the page to check for results.",
+        status_code=409,
     )
 
 

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -39,6 +39,9 @@ from learn_to_cloud.services.progress_service import fetch_phase_progress
 from learn_to_cloud.services.steps_service import get_valid_completed_steps
 from learn_to_cloud.services.submissions_service import get_phase_submission_context
 from learn_to_cloud.services.users_service import get_user_by_id
+from learn_to_cloud.services.verification_status_tokens import (
+    create_verification_status_token,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +138,16 @@ async def phase_page(
         phase_id,
     )
     active_jobs_by_req = {job.requirement_id: job for job in active_jobs}
+    verification_status_tokens_by_req = {
+        job.requirement_id: create_verification_status_token(
+            user_id=user_id,
+            job_id=job.id,
+            instance_id=job.orchestration_instance_id,
+            requirement_id=job.requirement_id,
+        )
+        for job in active_jobs
+        if job.orchestration_instance_id is not None
+    }
 
     # Pre-compute per-requirement derived URLs and PR-review prefixes so the
     # Jinja template never builds GitHub URLs.  Uses the same helper as the
@@ -167,6 +180,7 @@ async def phase_page(
             submissions_by_req=submissions_by_req,
             feedback_by_req=feedback_by_req,
             active_jobs_by_req=active_jobs_by_req,
+            verification_status_tokens_by_req=verification_status_tokens_by_req,
             derived_urls_by_req=derived_urls_by_req,
             pr_url_prefixes_by_req=pr_url_prefixes_by_req,
             progress=progress,

--- a/api/src/learn_to_cloud/services/durable_verification_client.py
+++ b/api/src/learn_to_cloud/services/durable_verification_client.py
@@ -17,9 +17,20 @@ class DurableVerificationStartError(Exception):
     """Raised when the Durable starter rejects or fails a start request."""
 
 
+class DurableVerificationStatusError(Exception):
+    """Raised when Durable status cannot be fetched or parsed."""
+
+
 @dataclass(frozen=True, slots=True)
 class DurableStartResult:
     instance_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class DurableStatusResult:
+    runtime_status: str
+    output: object | None = None
+    custom_status: object | None = None
 
 
 async def start_verification_orchestration(job_id: UUID) -> DurableStartResult:
@@ -61,3 +72,50 @@ async def start_verification_orchestration(job_id: UUID) -> DurableStartResult:
         )
 
     return DurableStartResult(instance_id=instance_id)
+
+
+async def get_verification_orchestration_status(
+    instance_id: str,
+) -> DurableStatusResult:
+    """Fetch Durable orchestration status through the Function app proxy."""
+    settings = get_settings()
+    base_url = settings.verification_functions_base_url.rstrip("/")
+    function_key = settings.verification_functions_key
+
+    if not base_url or not function_key:
+        raise DurableVerificationConfigError(
+            "Verification Functions endpoint is not configured."
+        )
+
+    url = f"{base_url}/api/verification/jobs/{instance_id}/status"
+    headers = {"x-functions-key": function_key}
+
+    try:
+        async with httpx.AsyncClient(timeout=settings.external_api_timeout) as client:
+            response = await client.get(url, headers=headers)
+    except httpx.HTTPError as exc:
+        raise DurableVerificationStatusError("Durable status request failed.") from exc
+
+    if response.status_code >= 400:
+        raise DurableVerificationStatusError(
+            f"Durable status returned HTTP {response.status_code}"
+        )
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise DurableVerificationStatusError(
+            "Durable status returned invalid JSON."
+        ) from exc
+
+    runtime_status = payload.get("runtimeStatus")
+    if not isinstance(runtime_status, str) or not runtime_status:
+        raise DurableVerificationStatusError(
+            "Durable status response did not include runtimeStatus."
+        )
+
+    return DurableStatusResult(
+        runtime_status=runtime_status,
+        output=payload.get("output"),
+        custom_status=payload.get("customStatus"),
+    )

--- a/api/src/learn_to_cloud/services/verification_status_tokens.py
+++ b/api/src/learn_to_cloud/services/verification_status_tokens.py
@@ -1,0 +1,107 @@
+"""Signed tokens for browser-visible verification status polling."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from itsdangerous import BadData, SignatureExpired, URLSafeTimedSerializer
+from learn_to_cloud_shared.core.config import get_settings
+
+_TOKEN_SALT = "verification-status-v1"
+
+
+class VerificationStatusTokenError(Exception):
+    """Raised when a verification status token is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationStatusToken:
+    user_id: int
+    job_id: str
+    instance_id: str
+    requirement_id: str
+
+
+def _serializer() -> URLSafeTimedSerializer:
+    return URLSafeTimedSerializer(get_settings().session_secret_key, salt=_TOKEN_SALT)
+
+
+def create_verification_status_token(
+    *,
+    user_id: int,
+    job_id: UUID,
+    instance_id: str,
+    requirement_id: str,
+) -> str:
+    payload = {
+        "user_id": user_id,
+        "job_id": str(job_id),
+        "instance_id": instance_id,
+        "requirement_id": requirement_id,
+    }
+    return _serializer().dumps(payload)
+
+
+def load_verification_status_token(
+    token: str,
+    *,
+    expected_user_id: int,
+) -> VerificationStatusToken:
+    max_age = get_settings().verification_wait_timeout + 120
+    try:
+        payload = _serializer().loads(token, max_age=max_age)
+    except SignatureExpired as exc:
+        raise VerificationStatusTokenError(
+            "Verification status token expired."
+        ) from exc
+    except BadData as exc:
+        raise VerificationStatusTokenError(
+            "Verification status token is invalid."
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise VerificationStatusTokenError(
+            "Verification status token payload is invalid."
+        )
+
+    user_id = _expect_int(payload, "user_id")
+    if user_id != expected_user_id:
+        raise VerificationStatusTokenError("Verification status token user mismatch.")
+
+    return VerificationStatusToken(
+        user_id=user_id,
+        job_id=_expect_uuid_str(payload, "job_id"),
+        instance_id=_expect_uuid_str(payload, "instance_id"),
+        requirement_id=_expect_str(payload, "requirement_id"),
+    )
+
+
+def _expect_str(payload: dict[Any, Any], field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value:
+        raise VerificationStatusTokenError(
+            f"Verification status token missing {field_name}."
+        )
+    return value
+
+
+def _expect_int(payload: dict[Any, Any], field_name: str) -> int:
+    value = payload.get(field_name)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise VerificationStatusTokenError(
+            f"Verification status token missing {field_name}."
+        )
+    return value
+
+
+def _expect_uuid_str(payload: dict[Any, Any], field_name: str) -> str:
+    value = _expect_str(payload, field_name)
+    try:
+        UUID(value)
+    except ValueError as exc:
+        raise VerificationStatusTokenError(
+            f"Verification status token has invalid {field_name}."
+        ) from exc
+    return value

--- a/api/src/learn_to_cloud/templates/pages/phase.html
+++ b/api/src/learn_to_cloud/templates/pages/phase.html
@@ -77,6 +77,7 @@
         {% set feedback_tasks = fb.get('tasks', []) if fb else [] %}
         {% set feedback_passed = fb.get('passed', 0) if fb else 0 %}
         {% set active_job = active_jobs_by_req.get(req.id) if active_jobs_by_req is defined else None %}
+        {% set verification_status_token = verification_status_tokens_by_req.get(req.id) if verification_status_tokens_by_req is defined else None %}
         {% set persisted_error = submission.validation_message if submission and not submission.is_validated and submission.validation_message else None %}
 
         {% if is_verified %}
@@ -88,7 +89,7 @@
         {% elif not ns.found_active %}
         {# First incomplete — show full card #}
         {% set ns.found_active = true %}
-        {% with requirement=req, submission=submission, feedback_tasks=feedback_tasks, feedback_passed=feedback_passed, phase_id=phase.order, error_banner=persisted_error, server_error=False, server_error_message=None, processing=active_job is not none, derived_url=derived_urls_by_req.get(req.id), pr_url_prefix=pr_url_prefixes_by_req.get(req.id) %}
+        {% with requirement=req, submission=submission, feedback_tasks=feedback_tasks, feedback_passed=feedback_passed, phase_id=phase.order, error_banner=persisted_error, server_error=False, server_error_message=None, processing=active_job is not none, verification_status_token=verification_status_token, verification_status_delay_seconds=2, derived_url=derived_urls_by_req.get(req.id), pr_url_prefix=pr_url_prefixes_by_req.get(req.id) %}
         {% include "partials/requirement_card.html" %}
         {% endwith %}
         {% else %}

--- a/api/src/learn_to_cloud/templates/partials/requirement_card.html
+++ b/api/src/learn_to_cloud/templates/partials/requirement_card.html
@@ -20,12 +20,11 @@
     <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">{{ requirement.description }}</p>
     {% endif %}
 
-    {% if processing %}
-    {# LLM verification in progress — connect to SSE stream for result #}
+    {% if processing and verification_status_token %}
+    {# Verification in progress — poll the Durable status proxy until terminal. #}
     <div
-        hx-ext="sse"
-        sse-connect="/htmx/verification/{{ requirement.id }}/stream"
-        sse-swap="verification-result"
+        hx-get="/htmx/verification/jobs/status?token={{ verification_status_token | urlencode }}"
+        hx-trigger="load delay:{{ verification_status_delay_seconds | default(2) }}s"
         hx-target="#requirement-{{ requirement.id }}"
         hx-swap="outerHTML"
         class="flex items-center gap-3 py-3"
@@ -34,6 +33,10 @@
         <span class="text-sm text-gray-600 dark:text-gray-400">
             Analyzing your code... this usually takes 30–60 seconds.
         </span>
+    </div>
+    {% elif processing %}
+    <div class="text-amber-600 dark:text-amber-400 text-sm p-2">
+        Verification is running. Refresh the page to check for results.
     </div>
     {% elif not submission or not submission.is_validated %}
     <form

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -25,9 +25,12 @@ from learn_to_cloud.routes.htmx_routes import (
     htmx_delete_account,
     htmx_submit_verification,
     htmx_uncomplete_step,
+    htmx_verification_job_status,
 )
+from learn_to_cloud.services.durable_verification_client import DurableStatusResult
 from learn_to_cloud.services.steps_service import StepValidationError
 from learn_to_cloud.services.users_service import UserNotFoundError
+from learn_to_cloud.services.verification_status_tokens import VerificationStatusToken
 
 
 def _mock_request(*, session: dict | None = None) -> MagicMock:
@@ -289,6 +292,121 @@ class TestHtmxSubmitVerification:
 
         # Should render a server error card, not crash
         assert result is not None
+
+
+@pytest.mark.unit
+class TestHtmxVerificationJobStatus:
+    """Tests for Durable-backed verification status polling."""
+
+    async def test_running_status_returns_next_poll_card(self):
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        token_data = VerificationStatusToken(
+            user_id=1,
+            job_id=str(uuid4()),
+            instance_id=str(uuid4()),
+            requirement_id="req-1",
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.load_verification_status_token",
+                return_value=token_data,
+            ) as mock_load_token,
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_verification_orchestration_status",
+                new_callable=AsyncMock,
+                return_value=DurableStatusResult(runtime_status="Running"),
+            ) as mock_get_status,
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_id",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = await htmx_verification_job_status(
+                request,
+                token="signed-token",
+                current_user=current_user,
+            )
+
+        assert isinstance(result, HTMLResponse)
+        mock_load_token.assert_called_once_with(
+            "signed-token",
+            expected_user_id=1,
+        )
+        mock_get_status.assert_awaited_once_with(token_data.instance_id)
+
+    async def test_completed_status_returns_reload_trigger(self):
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        token_data = VerificationStatusToken(
+            user_id=1,
+            job_id=str(uuid4()),
+            instance_id=str(uuid4()),
+            requirement_id="req-1",
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.load_verification_status_token",
+                return_value=token_data,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_verification_orchestration_status",
+                new_callable=AsyncMock,
+                return_value=DurableStatusResult(runtime_status="Completed"),
+            ),
+        ):
+            result = await htmx_verification_job_status(
+                request,
+                token="signed-token",
+                current_user=current_user,
+            )
+
+        assert isinstance(result, HTMLResponse)
+        assert "location.reload()" in bytes(result.body).decode()
+
+    async def test_failed_status_marks_job_server_error(self):
+        request = _mock_request()
+        mock_session = AsyncMock()
+        request.app.state.session_maker.return_value.__aenter__.return_value = (
+            mock_session
+        )
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        job_id = uuid4()
+        token_data = VerificationStatusToken(
+            user_id=1,
+            job_id=str(job_id),
+            instance_id=str(uuid4()),
+            requirement_id="req-1",
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.load_verification_status_token",
+                return_value=token_data,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_verification_orchestration_status",
+                new_callable=AsyncMock,
+                return_value=DurableStatusResult(runtime_status="Failed"),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                autospec=True,
+            ) as mock_repository_class,
+        ):
+            result = await htmx_verification_job_status(
+                request,
+                token="signed-token",
+                current_user=current_user,
+            )
+
+        assert isinstance(result, HTMLResponse)
+        mock_repository = mock_repository_class.return_value
+        mock_repository.mark_server_error.assert_awaited_once()
+        assert mock_repository.mark_server_error.await_args.args == (job_id,)
+        mock_session.commit.assert_awaited_once()
 
 
 @pytest.mark.unit

--- a/api/tests/services/test_durable_verification_client.py
+++ b/api/tests/services/test_durable_verification_client.py
@@ -10,6 +10,8 @@ import pytest
 from learn_to_cloud.services.durable_verification_client import (
     DurableVerificationConfigError,
     DurableVerificationStartError,
+    DurableVerificationStatusError,
+    get_verification_orchestration_status,
     start_verification_orchestration,
 )
 
@@ -32,8 +34,10 @@ def _async_client(response: httpx.Response | Exception):
     client = MagicMock()
     if isinstance(response, Exception):
         client.post = AsyncMock(side_effect=response)
+        client.get = AsyncMock(side_effect=response)
     else:
         client.post = AsyncMock(return_value=response)
+        client.get = AsyncMock(return_value=response)
 
     context_manager = MagicMock()
     context_manager.__aenter__ = AsyncMock(return_value=client)
@@ -114,3 +118,46 @@ async def test_transport_error_raises_start_error():
         pytest.raises(DurableVerificationStartError, match="request failed"),
     ):
         await start_verification_orchestration(uuid4())
+
+
+async def test_gets_orchestration_status_with_function_key_header():
+    instance_id = str(uuid4())
+    client, context_manager = _async_client(
+        httpx.Response(200, json={"runtimeStatus": "Running", "customStatus": None})
+    )
+
+    with (
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_settings",
+            return_value=_settings(),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.httpx.AsyncClient",
+            return_value=context_manager,
+        ) as async_client,
+    ):
+        result = await get_verification_orchestration_status(instance_id)
+
+    assert result.runtime_status == "Running"
+    async_client.assert_called_once_with(timeout=3.0)
+    client.get.assert_awaited_once_with(
+        f"http://localhost:7071/api/verification/jobs/{instance_id}/status",
+        headers={"x-functions-key": "function-key"},
+    )
+
+
+async def test_status_without_runtime_status_raises_status_error():
+    _, context_manager = _async_client(httpx.Response(200, json={"output": {}}))
+
+    with (
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_settings",
+            return_value=_settings(),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.httpx.AsyncClient",
+            return_value=context_manager,
+        ),
+        pytest.raises(DurableVerificationStatusError, match="runtimeStatus"),
+    ):
+        await get_verification_orchestration_status(str(uuid4()))

--- a/api/tests/services/test_verification_status_tokens.py
+++ b/api/tests/services/test_verification_status_tokens.py
@@ -1,0 +1,109 @@
+"""Unit tests for signed verification status tokens."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from learn_to_cloud.services.verification_status_tokens import (
+    VerificationStatusTokenError,
+    create_verification_status_token,
+    load_verification_status_token,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        session_secret_key="test-status-token-secret",
+        verification_wait_timeout=60,
+    )
+
+
+def test_token_round_trip_validates_expected_user():
+    job_id = uuid4()
+    instance_id = str(job_id)
+
+    with patch(
+        "learn_to_cloud.services.verification_status_tokens.get_settings",
+        return_value=_settings(),
+    ):
+        token = create_verification_status_token(
+            user_id=42,
+            job_id=job_id,
+            instance_id=instance_id,
+            requirement_id="journal-api",
+        )
+        result = load_verification_status_token(token, expected_user_id=42)
+
+    assert result.user_id == 42
+    assert result.job_id == str(job_id)
+    assert result.instance_id == instance_id
+    assert result.requirement_id == "journal-api"
+
+
+def test_tampered_token_is_rejected():
+    with (
+        patch(
+            "learn_to_cloud.services.verification_status_tokens.get_settings",
+            return_value=_settings(),
+        ),
+        pytest.raises(VerificationStatusTokenError, match="invalid"),
+    ):
+        load_verification_status_token("not-a-valid-token", expected_user_id=42)
+
+
+def test_user_mismatch_is_rejected():
+    with (
+        patch(
+            "learn_to_cloud.services.verification_status_tokens.get_settings",
+            return_value=_settings(),
+        ),
+        pytest.raises(VerificationStatusTokenError, match="user mismatch"),
+    ):
+        token = create_verification_status_token(
+            user_id=42,
+            job_id=uuid4(),
+            instance_id=str(uuid4()),
+            requirement_id="journal-api",
+        )
+        load_verification_status_token(token, expected_user_id=7)
+
+
+def test_invalid_uuid_fields_are_rejected():
+    with (
+        patch(
+            "learn_to_cloud.services.verification_status_tokens.get_settings",
+            return_value=_settings(),
+        ),
+        pytest.raises(VerificationStatusTokenError, match="invalid instance_id"),
+    ):
+        token = create_verification_status_token(
+            user_id=42,
+            job_id=uuid4(),
+            instance_id="not-a-uuid",
+            requirement_id="journal-api",
+        )
+        load_verification_status_token(token, expected_user_id=42)
+
+
+def test_expired_token_is_rejected():
+    settings = _settings()
+    settings.verification_wait_timeout = -121
+
+    with (
+        patch(
+            "learn_to_cloud.services.verification_status_tokens.get_settings",
+            return_value=settings,
+        ),
+        pytest.raises(VerificationStatusTokenError, match="expired"),
+    ):
+        token = create_verification_status_token(
+            user_id=42,
+            job_id=uuid4(),
+            instance_id=str(uuid4()),
+            requirement_id="journal-api",
+        )
+        load_verification_status_token(token, expected_user_id=42)

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -120,7 +120,7 @@ def _attached_invocation_context(context: func.Context | None) -> Iterator[None]
 
 def _json_response(payload: dict[str, object], status_code: int) -> func.HttpResponse:
     return func.HttpResponse(
-        json.dumps(payload),
+        json.dumps(payload, default=str),
         status_code=status_code,
         mimetype="application/json",
     )
@@ -241,3 +241,68 @@ async def start_verification_job(
             extra={"job_id": job_id, "instance_id": instance_id},
         )
         return client.create_check_status_response(req, instance_id)
+
+
+@app.route(route="verification/jobs/{instance_id}/status", methods=["GET"])
+@app.durable_client_input(client_name="client")
+async def get_verification_job_status(
+    req: func.HttpRequest,
+    client: df.DurableOrchestrationClient,
+    context: func.Context,
+) -> func.HttpResponse:
+    """Return minimal Durable status for a verification orchestration."""
+    _ensure_observability()
+    with _attached_invocation_context(context):
+        raw_instance_id = req.route_params.get("instance_id")
+        if raw_instance_id is None:
+            return _json_response({"error": "missing_instance_id"}, status_code=400)
+
+        try:
+            instance_id = str(UUID(raw_instance_id))
+        except ValueError:
+            return _json_response({"error": "invalid_instance_id"}, status_code=400)
+
+        status = await client.get_status(
+            instance_id,
+            show_history=False,
+            show_history_output=False,
+            show_input=False,
+        )
+        if status is None:
+            return _json_response({"error": "instance_not_found"}, status_code=404)
+
+        return _json_response(
+            {
+                "instanceId": _status_attr(status, "instance_id", "instanceId")
+                or instance_id,
+                "runtimeStatus": _status_value(
+                    _status_attr(status, "runtime_status", "runtimeStatus")
+                ),
+                "customStatus": _status_attr(status, "custom_status", "customStatus"),
+                "output": _status_attr(status, "output"),
+                "createdTime": _status_attr(status, "created_time", "createdTime"),
+                "lastUpdatedTime": _status_attr(
+                    status,
+                    "last_updated_time",
+                    "lastUpdatedTime",
+                ),
+            },
+            status_code=200,
+        )
+
+
+def _status_attr(value: object, *names: str) -> object | None:
+    for name in names:
+        attr = getattr(value, name, None)
+        if attr is not None:
+            return attr
+    return None
+
+
+def _status_value(value: object | None) -> str | None:
+    if value is None:
+        return None
+    enum_value = getattr(value, "value", None)
+    if isinstance(enum_value, str):
+        return enum_value
+    return str(value)


### PR DESCRIPTION
## Summary
- replace DB-backed SSE verification waiting with HTMX polling through an authenticated Durable status proxy
- add signed verification status tokens so active browser polling avoids per-poll DB reads
- add Durable Functions status endpoint and tests for status/token behavior

## Validation
- prek run --all-files
- cd api && uv run pytest tests/ ../packages/learn-to-cloud-shared/tests -x --tb=short
- cd apps/verification-functions && uv run python -c "import function_app"