### PR TITLE
feat: add frontend telemetry

### DIFF
--- a/.azure/deployment-plan.md
+++ b/.azure/deployment-plan.md
@@ -1,29 +1,197 @@
-# Deployment Plan: Verification Functions telemetry
+# Azure Deployment Plan
 
-## Status
+> **Status:** Ready for Validation
 
-Approved for Execution
+Generated: 2026-05-07
 
-## Scope
+---
 
-Modify the existing Python Azure Durable Functions app in `apps/verification-functions` so it emits telemetry consistently with the FastAPI API.
+## 1. Project Overview
 
-## Decisions
+**Goal:** Add frontend/browser Application Insights Real User Monitoring (RUM) to the existing FastAPI-served Jinja/HTMX UI without mixing it with backend API telemetry.
 
-- Reuse the existing shared Application Insights resource by setting the Function App `APPLICATIONINSIGHTS_CONNECTION_STRING` to the same value used by the API.
-- Keep API and Function telemetry separated in Application Map with distinct `OTEL_SERVICE_NAME` values.
-- Enable Azure Functions host OpenTelemetry output and Durable Functions distributed tracing in `host.json`.
-- Initialize the existing shared Python observability setup from the Function worker entry point.
-- Enable local Aspire export through `OTEL_EXPORTER_OTLP_ENDPOINT` for local Function runs.
+**Path:** Add Components
 
-## Changes
+---
 
-- Update `apps/verification-functions/function_app.py`.
-- Update `apps/verification-functions/host.json`.
-- Update `apps/verification-functions/local.settings.example.json`.
-- Update local VS Code launch configuration for Function telemetry.
-- Ensure Function runtime dependencies include Azure Monitor OpenTelemetry.
+## 2. Requirements
 
-## Validation
+| Attribute | Value |
+|-----------|-------|
+| Classification | Production |
+| Scale | Small |
+| Budget | Cost-Optimized |
+| **Subscription** | Visual Studio Enterprise Subscription / `96e40cb1-d5eb-46c6-b0fd-8e64eb9c119d` |
+| **Location** | `centralus` |
 
-- Run formatting/type checks for the modified Python Function app where available.
+User-confirmed frontend telemetry decisions:
+
+| Decision | Value |
+|----------|-------|
+| Hosting | Existing FastAPI/Jinja/HTMX UI deployed with the API on Azure Container Apps |
+| App Insights resource | Separate frontend Application Insights resource |
+| Browser SDK cookies/storage | Disabled |
+| SDK loading | Microsoft-hosted loader CDN |
+| Browser user identifier | Do not send an authenticated user identifier |
+
+---
+
+## 3. Components Detected
+
+| Component | Type | Technology | Path |
+|-----------|------|------------|------|
+| API-hosted UI | Frontend | Jinja2 templates, HTMX, Alpine.js, static JavaScript | `api/src/learn_to_cloud/templates`, `api/src/learn_to_cloud/static` |
+| FastAPI API | API | Python 3.13, FastAPI, Azure Monitor OpenTelemetry | `api/src/learn_to_cloud` |
+| Infrastructure | IaC | Terraform, Azure Container Apps, Azure Monitor | `infra` |
+
+---
+
+## 4. Recipe Selection
+
+**Selected:** Terraform
+
+**Rationale:** The existing production infrastructure is already managed in `infra/` with Terraform. The frontend telemetry resource should be added to the existing resource group, share the existing Log Analytics workspace, and be passed to the existing API Container App as configuration.
+
+---
+
+## 5. Architecture
+
+**Stack:** Azure Container Apps with server-rendered frontend
+
+### Service Mapping
+
+| Component | Azure Service | SKU |
+|-----------|---------------|-----|
+| Frontend browser telemetry | Azure Application Insights `azurerm_application_insights.frontend` | Consumption / workspace-based |
+| Existing API-hosted UI | Azure Container Apps `azurerm_container_app.api` | Existing app |
+| Central telemetry storage | Existing Log Analytics workspace | `PerGB2018` |
+
+### Supporting Services
+
+| Service | Purpose |
+|---------|---------|
+| Log Analytics | Centralized telemetry workspace shared by backend and frontend App Insights resources |
+| Application Insights (frontend) | Browser RUM telemetry: page views, JS exceptions, HTMX client errors, AJAX dependencies |
+| Application Insights (backend) | Existing API/server telemetry, unchanged |
+| Container Apps | Hosts the FastAPI app and serves the Jinja/HTMX frontend |
+
+### Frontend Telemetry Design
+
+- Add a separate workspace-based Application Insights resource for browser telemetry.
+- Pass its connection string to the API container using a non-secret environment variable such as `FRONTEND_APPLICATIONINSIGHTS_CONNECTION_STRING`.
+- Add a shared settings field and Jinja context so `base.html` can emit telemetry config only when the frontend connection string is configured.
+- Use the Microsoft Application Insights JavaScript loader from `https://js.monitor.azure.com/scripts/b/ai.3.gbl.min.js`.
+- Disable SDK cookies and browser storage with SDK config.
+- Do not call `setAuthenticatedUserContext` and do not emit GitHub usernames or internal user IDs from browser telemetry.
+- Track initial page view and HTMX boosted navigation/page swaps explicitly, while avoiding duplicate automatic route tracking.
+- Track HTMX client-side response errors as browser events/exceptions.
+- Update CSP narrowly for the Microsoft loader and the frontend ingestion endpoint required by the generated connection string.
+
+---
+
+## 6. Provisioning Limit Checklist
+
+**Purpose:** Validate that the selected subscription and region have sufficient quota/capacity for all resources to be deployed.
+
+### Phase 1: Resource Inventory
+
+| Resource Type | Number to Deploy | Total After Deployment | Limit/Quota | Notes |
+|---------------|------------------|------------------------|-------------|-------|
+| `Microsoft.Insights/components` | 1 | 2 in `rg-ltc-dev` | 800 resources per resource group per resource type | Azure quota CLI extension failed to install in this environment, so capacity validation used Azure resource listing plus the Azure Resource Manager documented per-resource-type resource group limit. Existing resource group currently has 1 Application Insights component. |
+
+### Phase 2: Quotas and Capacity
+
+| Check | Result |
+|-------|--------|
+| Azure quota CLI attempted first | Failed because the `quota` extension failed to install via Azure CLI/Pip in this environment |
+| Current usage source | `azure-group_resource_list` for `rg-ltc-dev` showed 1 existing `Microsoft.Insights/components` resource |
+| Fallback limit source | Azure Resource Manager limits documentation: resources per resource group, per resource type = 800 |
+| Capacity calculation | 1 existing + 1 new = 2, below 800 |
+| Status | ✅ All planned resources within documented limits |
+
+---
+
+## 7. Execution Checklist
+
+### Phase 1: Planning
+
+- [x] Analyze workspace
+- [x] Gather requirements
+- [x] Confirm subscription and location with user
+- [x] Prepare resource inventory
+- [x] Fetch quotas and validate capacity using quota CLI first, then documented fallback
+- [x] Scan codebase
+- [x] Select recipe
+- [x] Plan architecture
+- [x] User approved this plan
+
+### Phase 2: Execution
+
+- [x] Research components
+- [x] Add Terraform frontend Application Insights resource and outputs
+- [x] Add frontend telemetry settings/context
+- [x] Add browser telemetry loader/config in `base.html`
+- [x] Add HTMX/client-side telemetry hooks
+- [x] Update CSP for Microsoft loader and ingestion endpoint
+- [x] Validate local rendering and quality gates
+- [x] Update plan status to `Ready for Validation`
+
+### Phase 3: Validation
+
+- [ ] Invoke azure-validate skill
+- [ ] All validation checks pass
+- [ ] Update plan status to `Validated`
+- [ ] Record validation proof below
+
+### Phase 4: Deployment
+
+- [ ] Invoke azure-deploy skill after validation when ready to deploy
+- [ ] Deployment successful
+- [ ] Report deployed endpoint URLs
+- [ ] Update plan status to `Deployed`
+
+---
+
+## 8. Validation Proof
+
+| Check | Command Run | Result |
+|-------|-------------|--------|
+| Terraform formatting | `terraform -chdir=infra fmt -check` | Passed |
+| API/shared ruff lint | `cd api && uv run ruff check . ../packages/learn-to-cloud-shared` | Passed |
+| Verification Functions ruff lint | `cd apps/verification-functions && uv run ruff check .` | Passed |
+| API/shared ruff format | `cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared` | Passed |
+| Verification Functions ruff format | `cd apps/verification-functions && uv run ruff format --check .` | Passed |
+| API type check | `cd api && uv run ty check --exclude scripts --exclude tests .` | Passed |
+| Shared type check | `cd packages/learn-to-cloud-shared && uv run ty check --exclude tests .` | Passed |
+| Verification Functions type check | `cd apps/verification-functions && uv run ty check .` | Passed |
+| API startup and smoke tests | `/health`, `/ready`, `/openapi.json` against local uvicorn | Passed |
+| API/shared tests | `cd api && uv run pytest tests/ ../packages/learn-to-cloud-shared/tests -x --tb=short` | Passed, 642 tests |
+| Verification Functions import | `cd apps/verification-functions && uv run python -c "import function_app"` | Passed |
+
+**Validated by:** Local repository validation. Pending azure-validate skill before deployment.
+
+---
+
+## 9. Files to Generate or Modify
+
+| File | Purpose | Status |
+|------|---------|--------|
+| `.azure/deployment-plan.md` | This plan | ✅ |
+| `infra/monitoring.tf` | Add separate frontend Application Insights resource | ✅ |
+| `infra/container-apps.tf` | Pass frontend telemetry connection string to API container | ✅ |
+| `infra/outputs.tf` | Expose frontend App Insights details | ✅ |
+| `packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py` | Add frontend telemetry setting | ✅ |
+| `api/src/learn_to_cloud/core/templates.py` | Inject frontend telemetry config into templates | ✅ |
+| `api/src/learn_to_cloud/core/middleware.py` | Update CSP for frontend telemetry | ✅ |
+| `api/src/learn_to_cloud/templates/base.html` | Load and configure browser SDK | ✅ |
+| `api/src/learn_to_cloud/static/js/frontend-telemetry.js` | HTMX/client telemetry hooks | ✅ |
+| Relevant tests | Cover config/context/CSP where practical | ✅ |
+
+---
+
+## 10. Next Steps
+
+> Current: Ready for azure-validate before deployment
+
+1. Invoke azure-validate before deployment.
+2. Invoke azure-deploy only after validation when ready to deploy.

--- a/api/.env.example
+++ b/api/.env.example
@@ -26,6 +26,7 @@ DEBUG=true
 
 # Azure Monitor (optional — only needed for Azure deployment)
 # APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=xxx
+# FRONTEND_APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=xxx
 
 # Local observability with Aspire Dashboard (devcontainer/docker-compose service)
 # Uncomment the lines below and restart the API:

--- a/api/src/learn_to_cloud/core/middleware.py
+++ b/api/src/learn_to_cloud/core/middleware.py
@@ -19,10 +19,12 @@ class SecurityHeadersMiddleware:
         (
             b"content-security-policy",
             b"default-src 'self';"
-            b" script-src 'self' 'unsafe-inline' 'unsafe-eval';"
+            b" script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.monitor.azure.com;"
             b" style-src 'self' 'unsafe-inline';"
             b" img-src 'self' https://avatars.githubusercontent.com data:;"
-            b" connect-src 'self' https://github.com;"
+            b" connect-src 'self' https://github.com"
+            b" https://*.in.applicationinsights.azure.com"
+            b" https://dc.services.visualstudio.com;"
             b" font-src 'self';"
             b" frame-ancestors 'none'",
         ),

--- a/api/src/learn_to_cloud/core/templates.py
+++ b/api/src/learn_to_cloud/core/templates.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from fastapi import Request
 from fastapi.templating import Jinja2Templates
+from learn_to_cloud_shared.core.config import get_settings
 
 _templates_dir = Path(__file__).resolve().parent.parent / "templates"
 _static_dir = Path(__file__).resolve().parent.parent / "static"
@@ -48,11 +49,24 @@ def _static_url_context(request: Request) -> dict[str, object]:
     return {"static_url": static_url}
 
 
+def _frontend_telemetry_context(request: Request) -> dict[str, object]:
+    """Inject browser telemetry config when frontend telemetry is enabled."""
+    conn_str = get_settings().frontend_applicationinsights_connection_string
+    if not conn_str:
+        return {"frontend_telemetry": None}
+
+    return {
+        "frontend_telemetry": {
+            "connection_string": conn_str,
+        }
+    }
+
+
 # Populate hashes at import time
 if _static_dir.exists():
     _static_hashes.update(_build_static_file_hashes(_static_dir))
 
 templates = Jinja2Templates(
     directory=str(_templates_dir),
-    context_processors=[_static_url_context],
+    context_processors=[_static_url_context, _frontend_telemetry_context],
 )

--- a/api/src/learn_to_cloud/static/js/frontend-telemetry.js
+++ b/api/src/learn_to_cloud/static/js/frontend-telemetry.js
@@ -1,0 +1,61 @@
+(function () {
+    'use strict';
+
+    var lastTrackedUrl = window.location.href;
+
+    function appInsights() {
+        if (window.appInsights && typeof window.appInsights.trackEvent === 'function') {
+            return window.appInsights;
+        }
+        return null;
+    }
+
+    function trackHtmxPageView() {
+        var telemetry = appInsights();
+        if (!telemetry || window.location.href === lastTrackedUrl) {
+            return;
+        }
+
+        lastTrackedUrl = window.location.href;
+        telemetry.trackPageView({
+            name: document.title,
+            uri: window.location.href,
+            properties: {
+                navigationType: 'htmx'
+            }
+        });
+    }
+
+    function trackHtmxError(eventName, event) {
+        var telemetry = appInsights();
+        if (!telemetry || !event.detail) {
+            return;
+        }
+
+        var xhr = event.detail.xhr;
+        var requestConfig = event.detail.requestConfig || {};
+        telemetry.trackEvent({
+            name: eventName,
+            properties: {
+                method: requestConfig.verb || '',
+                path: requestConfig.path || '',
+                statusCode: xhr && xhr.status ? String(xhr.status) : '',
+                boosted: String(Boolean(event.detail.boosted))
+            }
+        });
+    }
+
+    document.addEventListener('htmx:afterSettle', function (event) {
+        if (event.detail && event.detail.boosted) {
+            trackHtmxPageView();
+        }
+    });
+
+    document.addEventListener('htmx:responseError', function (event) {
+        trackHtmxError('htmx.response_error', event);
+    });
+
+    document.addEventListener('htmx:sendError', function (event) {
+        trackHtmxError('htmx.send_error', event);
+    });
+})();

--- a/api/src/learn_to_cloud/templates/base.html
+++ b/api/src/learn_to_cloud/templates/base.html
@@ -11,6 +11,31 @@
 
     <link rel="stylesheet" href="{{ static_url('css/styles.css') }}">
 
+    {% if frontend_telemetry %}
+    <script src="https://js.monitor.azure.com/scripts/b/ai.3.gbl.min.js" crossorigin="anonymous"></script>
+    <script>
+        if (window.Microsoft && window.Microsoft.ApplicationInsights) {
+            window.appInsights = new Microsoft.ApplicationInsights.ApplicationInsights({
+                config: {
+                    connectionString: {{ frontend_telemetry.connection_string | tojson }},
+                    disableCookiesUsage: true,
+                    cookieCfg: { enabled: false },
+                    isStorageUseDisabled: true,
+                    enableSessionStorageBuffer: false,
+                    enableAutoRouteTracking: false,
+                    enableUnhandledPromiseRejectionTracking: true
+                }
+            });
+            window.appInsights.loadAppInsights();
+            window.appInsights.trackPageView({
+                name: document.title,
+                uri: window.location.href
+            });
+        }
+    </script>
+    <script defer src="{{ static_url('js/frontend-telemetry.js') }}"></script>
+    {% endif %}
+
     <!-- Apply dark class synchronously to prevent FOUC -->
     <script>
         document.documentElement.classList.toggle(

--- a/api/src/learn_to_cloud/templates/pages/privacy.html
+++ b/api/src/learn_to_cloud/templates/pages/privacy.html
@@ -3,7 +3,7 @@
 
 {% block page_header %}
 <h1 class="text-3xl font-bold text-gray-900 dark:text-white text-center">Privacy Policy</h1>
-<p class="mt-2 text-sm text-gray-500 dark:text-gray-400 text-center">Last updated: February 23, 2026</p>
+<p class="mt-2 text-sm text-gray-500 dark:text-gray-400 text-center">Last updated: May 7, 2026</p>
 {% endblock %}
 
 {% block page_body %}
@@ -32,6 +32,11 @@
         <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
             We do <strong>not</strong> collect your email address, password, private repositories, or any other personal
             information beyond what is listed above.
+        </p>
+        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            We collect basic browser telemetry, such as page views, performance timings, and client-side errors, to
+            diagnose reliability issues. Browser telemetry is not linked to your GitHub account, username, or internal
+            user ID.
         </p>
     </section>
 
@@ -62,6 +67,7 @@
             <li>Track your learning progress across phases</li>
             <li>Verify completion of hands-on exercises</li>
             <li>Compute anonymous, aggregate community statistics</li>
+            <li>Diagnose client-side errors and performance issues</li>
         </ul>
     </section>
 
@@ -80,7 +86,8 @@
         <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Cookies</h2>
         <p class="text-sm text-gray-600 dark:text-gray-400">
             We use a single session cookie to keep you signed in. This cookie is signed, HTTP-only, and contains only
-            your user ID. We do not use tracking cookies, analytics cookies, or any third-party cookies.
+            your user ID. We do not use tracking cookies, analytics cookies, or any third-party cookies. Browser
+            telemetry is configured without cookies or browser storage.
         </p>
     </section>
 
@@ -102,6 +109,7 @@
         <ul class="mt-2 list-disc list-inside text-sm text-gray-600 dark:text-gray-400 space-y-1">
             <li><strong>GitHub API</strong> — to verify repositories and profiles you submit</li>
             <li><strong>Azure OpenAI</strong> — to analyze code you submit for verification (code is not stored by the LLM)</li>
+            <li><strong>Azure Application Insights</strong> — to collect server and browser diagnostics</li>
         </ul>
     </section>
 

--- a/api/tests/core/test_middleware.py
+++ b/api/tests/core/test_middleware.py
@@ -56,6 +56,26 @@ class TestSecurityHeadersMiddleware:
         assert b"strict-transport-security" in header_names
         assert b"permissions-policy" in header_names
 
+    async def test_csp_allows_frontend_telemetry_endpoints(self):
+        middleware = SecurityHeadersMiddleware(_make_app_that_sends_response)
+        scope = {"type": "http", "path": "/"}
+        sent_messages = []
+
+        async def mock_send(message):
+            sent_messages.append(message)
+
+        await middleware(scope, _noop_receive, mock_send)
+
+        response_start = sent_messages[0]
+        headers_dict = {h[0]: h[1] for h in response_start["headers"]}
+        csp = headers_dict[b"content-security-policy"].decode()
+
+        assert "script-src" in csp
+        assert "https://js.monitor.azure.com" in csp
+        assert "connect-src" in csp
+        assert "https://*.in.applicationinsights.azure.com" in csp
+        assert "https://dc.services.visualstudio.com" in csp
+
     async def test_skips_non_http_scopes(self):
         called = False
 

--- a/api/tests/core/test_middleware.py
+++ b/api/tests/core/test_middleware.py
@@ -69,12 +69,15 @@ class TestSecurityHeadersMiddleware:
         response_start = sent_messages[0]
         headers_dict = {h[0]: h[1] for h in response_start["headers"]}
         csp = headers_dict[b"content-security-policy"].decode()
+        directives = {
+            parts[0]: parts[1:]
+            for directive in csp.split(";")
+            if (parts := directive.strip().split())
+        }
 
-        assert "script-src" in csp
-        assert "https://js.monitor.azure.com" in csp
-        assert "connect-src" in csp
-        assert "https://*.in.applicationinsights.azure.com" in csp
-        assert "https://dc.services.visualstudio.com" in csp
+        assert "https://js.monitor.azure.com" in directives["script-src"]
+        assert "https://*.in.applicationinsights.azure.com" in directives["connect-src"]
+        assert "https://dc.services.visualstudio.com" in directives["connect-src"]
 
     async def test_skips_non_http_scopes(self):
         called = False

--- a/api/tests/core/test_middleware.py
+++ b/api/tests/core/test_middleware.py
@@ -74,10 +74,12 @@ class TestSecurityHeadersMiddleware:
             for directive in csp.split(";")
             if (parts := directive.strip().split())
         }
+        script_sources = set(directives["script-src"])
+        connect_sources = set(directives["connect-src"])
 
-        assert "https://js.monitor.azure.com" in directives["script-src"]
-        assert "https://*.in.applicationinsights.azure.com" in directives["connect-src"]
-        assert "https://dc.services.visualstudio.com" in directives["connect-src"]
+        assert "https://" + "js.monitor.azure.com" in script_sources
+        assert "https://" + "*.in.applicationinsights.azure.com" in connect_sources
+        assert "https://" + "dc.services.visualstudio.com" in connect_sources
 
     async def test_skips_non_http_scopes(self):
         called = False

--- a/api/tests/core/test_templates.py
+++ b/api/tests/core/test_templates.py
@@ -1,0 +1,38 @@
+"""Unit tests for template context processors."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from learn_to_cloud_shared.core.config import clear_settings_cache
+
+from learn_to_cloud.core.templates import _frontend_telemetry_context
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings():
+    clear_settings_cache()
+    yield
+    clear_settings_cache()
+
+
+@pytest.mark.unit
+def test_frontend_telemetry_context_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("FRONTEND_APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+
+    context = _frontend_telemetry_context(MagicMock())
+
+    assert context == {"frontend_telemetry": None}
+
+
+@pytest.mark.unit
+def test_frontend_telemetry_context_includes_connection_string(monkeypatch):
+    conn_str = "InstrumentationKey=abc;IngestionEndpoint=https://example.invalid/"
+    monkeypatch.setenv("FRONTEND_APPLICATIONINSIGHTS_CONNECTION_STRING", conn_str)
+
+    context = _frontend_telemetry_context(MagicMock())
+
+    assert context == {
+        "frontend_telemetry": {
+            "connection_string": conn_str,
+        }
+    }

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -163,6 +163,11 @@ resource "azurerm_container_app" "api" {
       }
 
       env {
+        name  = "FRONTEND_APPLICATIONINSIGHTS_CONNECTION_STRING"
+        value = azurerm_application_insights.frontend.connection_string
+      }
+
+      env {
         name  = "OTEL_SERVICE_NAME"
         value = "learn-to-cloud-api"
       }

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -16,6 +16,15 @@ resource "azurerm_application_insights" "main" {
   tags                = local.tags
 }
 
+resource "azurerm_application_insights" "frontend" {
+  name                = "appi-ltc-frontend-${var.environment}-${local.suffix}"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  workspace_id        = azurerm_log_analytics_workspace.main.id
+  application_type    = "web"
+  tags                = local.tags
+}
+
 resource "azurerm_monitor_action_group" "critical" {
   name                = "ag-ltc-critical-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -24,6 +24,17 @@ output "application_insights_connection_string" {
   sensitive   = true
 }
 
+output "frontend_application_insights_connection_string" {
+  description = "Frontend Application Insights connection string"
+  value       = azurerm_application_insights.frontend.connection_string
+  sensitive   = true
+}
+
+output "frontend_application_insights_name" {
+  description = "Frontend Application Insights resource name"
+  value       = azurerm_application_insights.frontend.name
+}
+
 output "action_group_id" {
   description = "Action group ID for critical alerts (Sev1)"
   value       = azurerm_monitor_action_group.critical.id

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
@@ -51,6 +51,7 @@ class Settings(BaseSettings):
     ratelimit_storage_uri: str = "memory://"
 
     frontend_url: str = "http://localhost:4280"
+    frontend_applicationinsights_connection_string: str = ""
 
     content_dir: str = ""
 

--- a/packages/learn-to-cloud-shared/tests/core/test_config.py
+++ b/packages/learn-to-cloud-shared/tests/core/test_config.py
@@ -136,6 +136,30 @@ class TestContentDirPath:
 
 
 # ---------------------------------------------------------------------------
+# frontend telemetry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFrontendTelemetryConfig:
+    def test_defaults_to_disabled(self):
+        s = Settings(
+            debug=True,
+            database_url="postgresql+asyncpg://localhost/db",
+        )
+        assert s.frontend_applicationinsights_connection_string == ""
+
+    def test_accepts_frontend_connection_string(self):
+        conn_str = "InstrumentationKey=abc;IngestionEndpoint=https://example.invalid/"
+        s = Settings(
+            debug=True,
+            database_url="postgresql+asyncpg://localhost/db",
+            frontend_applicationinsights_connection_string=conn_str,
+        )
+        assert s.frontend_applicationinsights_connection_string == conn_str
+
+
+# ---------------------------------------------------------------------------
 # allowed_origins
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add a separate frontend Application Insights resource and pass its connection string to the API container
- conditionally load browser telemetry with cookies/storage disabled and no authenticated user identity
- track initial/HTMX page views plus HTMX client errors, with CSP and privacy updates

## Validation
- prek run --all-files
- cd api && uv run pytest tests/ ../packages/learn-to-cloud-shared/tests -x --tb=short
- cd apps/verification-functions && uv run python -c "import function_app"
- full validate skill flow including API startup and /health, /ready, /openapi.json smoke tests