### PR TITLE
fix: reconcile alembic drift

### DIFF
--- a/api/alembic/versions/0018_drop_analytics_snapshot.py
+++ b/api/alembic/versions/0018_drop_analytics_snapshot.py
@@ -1,0 +1,37 @@
+"""drop orphaned analytics_snapshot table
+
+Revision ID: 0018_drop_analytics_snapshot
+Revises: 0017_add_verification_jobs
+Create Date: 2026-05-08
+
+The AnalyticsSnapshot model was removed from the codebase, but the table was
+never dropped from the database. No code references the table anymore.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0018_drop_analytics_snapshot"
+down_revision = "0017_add_verification_jobs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_table("analytics_snapshot")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "analytics_snapshot",
+        sa.Column("id", sa.Integer, primary_key=True, default=1),
+        sa.Column("data", sa.Text, nullable=False),
+        sa.Column(
+            "computed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint("id = 1", name="ck_analytics_snapshot_single_row"),
+    )

--- a/api/alembic/versions/0019_enforce_not_null_columns.py
+++ b/api/alembic/versions/0019_enforce_not_null_columns.py
@@ -1,0 +1,78 @@
+"""backfill nulls and enforce NOT NULL on audit + flag columns
+
+Revision ID: 0019_enforce_not_null_columns
+Revises: 0018_drop_analytics_snapshot
+Create Date: 2026-05-08
+
+Models declare these columns as non-Optional ``Mapped[...]`` (which implies
+``NOT NULL``), but the database still allows ``NULL``. Backfill any existing
+``NULL`` rows with safe defaults, then enforce the constraint so the schema
+matches the model declarations.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0019_enforce_not_null_columns"
+down_revision = "0018_drop_analytics_snapshot"
+branch_labels = None
+depends_on = None
+
+
+_NULLABLE_TIMESTAMPS = (
+    ("users", "created_at"),
+    ("users", "updated_at"),
+    ("submissions", "created_at"),
+    ("submissions", "updated_at"),
+    ("verification_jobs", "created_at"),
+    ("verification_jobs", "updated_at"),
+    ("step_progress", "completed_at"),
+)
+
+_NULLABLE_BOOLEANS = (
+    ("users", "is_admin"),
+    ("submissions", "is_validated"),
+    ("submissions", "verification_completed"),
+)
+
+
+def upgrade() -> None:
+    for table, column in _NULLABLE_TIMESTAMPS:
+        op.execute(
+            f"UPDATE {table} SET {column} = NOW() WHERE {column} IS NULL"  # noqa: S608
+        )
+        op.alter_column(
+            table,
+            column,
+            existing_type=sa.DateTime(timezone=True),
+            nullable=False,
+        )
+
+    for table, column in _NULLABLE_BOOLEANS:
+        op.execute(
+            f"UPDATE {table} SET {column} = false WHERE {column} IS NULL"  # noqa: S608
+        )
+        op.alter_column(
+            table,
+            column,
+            existing_type=sa.Boolean(),
+            nullable=False,
+        )
+
+
+def downgrade() -> None:
+    for table, column in _NULLABLE_BOOLEANS:
+        op.alter_column(
+            table,
+            column,
+            existing_type=sa.Boolean(),
+            nullable=True,
+        )
+    for table, column in _NULLABLE_TIMESTAMPS:
+        op.alter_column(
+            table,
+            column,
+            existing_type=sa.DateTime(timezone=True),
+            nullable=True,
+        )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -166,7 +166,7 @@ class Submission(TimestampMixin, Base):
             "ix_submissions_user_req_latest",
             "user_id",
             "requirement_id",
-            "created_at",
+            text("created_at DESC"),
         ),
     )
 


### PR DESCRIPTION
## Summary

Brings the live DB schema back in sync with the SQLAlchemy models. Three drift items resolved:

### 1. Orphaned `analytics_snapshot` table → migration 0018
The `AnalyticsSnapshot` model was removed previously without a migration. No code references the table (verified with grep across `api/src` and `packages/learn-to-cloud-shared/src`). Migration drops it; downgrade recreates it.

### 2. NOT NULL drift on 10 columns → migration 0019
Models declare these as non-`Optional` `Mapped[...]` (which implies NOT NULL), but the DB still allows NULL:

| Table | Columns |
|---|---|
| `users` | `is_admin`, `created_at`, `updated_at` |
| `submissions` | `is_validated`, `verification_completed`, `created_at`, `updated_at` |
| `verification_jobs` | `created_at`, `updated_at` |
| `step_progress` | `completed_at` |

Migration backfills nulls (`NOW()` for timestamps, `false` for booleans) **before** `ALTER … SET NOT NULL` so the constraint can be applied without errors.

### 3. `ix_submissions_user_req_latest` index direction
DB has the index with `created_at DESC`; the model declared plain `created_at`. Updated the model to use `text(\"created_at DESC\")` so the existing DB index is preserved (no rebuild cost).

## Validation
- `alembic upgrade head` → both migrations applied cleanly to local DB
- `alembic check` → **No new upgrade operations detected** ✅
- `prek run --all-files` ✅
- `pytest tests/ ../packages/learn-to-cloud-shared/tests` → 642 passed