### PR TITLE
fix: restore Foundry verification grading

### DIFF
--- a/infra/functions.tf
+++ b/infra/functions.tf
@@ -86,7 +86,7 @@ resource "azurerm_role_assignment" "verification_task_hub_dashboard_readers" {
 
 resource "azurerm_role_assignment" "verification_functions_foundry" {
   scope                            = azapi_resource.foundry_project.id
-  role_definition_name             = "Azure AI User"
+  role_definition_name             = "Foundry User"
   principal_id                     = azurerm_user_assigned_identity.verification_functions.principal_id
   principal_type                   = "ServicePrincipal"
   skip_service_principal_aad_check = true

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
@@ -29,6 +29,14 @@ SubmissionPersistHook = Callable[
     [AsyncSession, Submission, ValidationResult],
     Awaitable[None],
 ]
+MAX_VALIDATION_MESSAGE_LENGTH = 1024
+
+
+def persisted_validation_message(message: str | None) -> str | None:
+    """Return a validation message that fits persisted status columns."""
+    if message is None or len(message) <= MAX_VALIDATION_MESSAGE_LENGTH:
+        return message
+    return f"{message[: MAX_VALIDATION_MESSAGE_LENGTH - 3]}..."
 
 
 def to_submission_data(submission: Submission) -> SubmissionData:
@@ -98,7 +106,9 @@ async def persist_validation_result(
         verification_completed=validation_result.verification_completed,
         feedback_json=_feedback_json(validation_result),
         validation_message=(
-            validation_result.message if not validation_result.is_valid else None
+            persisted_validation_message(validation_result.message)
+            if not validation_result.is_valid
+            else None
         ),
         cloud_provider=validation_result.cloud_provider,
     )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -110,7 +110,7 @@ def llm_grading_unavailable_result(
     validation_result = run_result.validation_result.model_copy(
         update={
             "is_valid": False,
-            "message": f"LLM verification grading failed: {detail}",
+            "message": "LLM verification grading failed. Please try again later.",
             "verification_completed": False,
         }
     )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -21,7 +21,10 @@ from learn_to_cloud_shared.repositories.verification_job_repository import (
 )
 from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
 from learn_to_cloud_shared.verification.dispatcher import validate_submission
-from learn_to_cloud_shared.verification.execution import persist_validation_result
+from learn_to_cloud_shared.verification.execution import (
+    persist_validation_result,
+    persisted_validation_message,
+)
 from learn_to_cloud_shared.verification.requirements import get_requirement_by_id
 
 tracer = trace.get_tracer(__name__)
@@ -411,7 +414,9 @@ async def persist_verification_result(
                 updated_job = await job_repo.mark_failed(
                     job.id,
                     error_code=VALIDATION_FAILED_ERROR_CODE,
-                    error_message=validation_result.message,
+                    error_message=(
+                        persisted_validation_message(validation_result.message) or ""
+                    ),
                     result_submission_id=submission.id,
                 )
                 status = VerificationJobStatus.FAILED
@@ -419,7 +424,9 @@ async def persist_verification_result(
                 updated_job = await job_repo.mark_server_error(
                     job.id,
                     error_code=VERIFICATION_INCOMPLETE_ERROR_CODE,
-                    error_message=validation_result.message,
+                    error_message=(
+                        persisted_validation_message(validation_result.message) or ""
+                    ),
                     result_submission_id=submission.id,
                 )
                 status = VerificationJobStatus.SERVER_ERROR

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -20,6 +20,7 @@ from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
 from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
+from learn_to_cloud_shared.verification.execution import MAX_VALIDATION_MESSAGE_LENGTH
 from learn_to_cloud_shared.verification_job_executor import (
     REQUIREMENT_NOT_FOUND_ERROR_CODE,
     VALIDATION_FAILED_ERROR_CODE,
@@ -306,6 +307,51 @@ async def test_execute_verification_job_marks_server_error(
     assert submission.is_validated is False
     assert submission.verification_completed is False
     assert submission.validation_message == "GitHub API unavailable."
+
+
+async def test_execute_verification_job_truncates_persisted_error_messages(
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    job_id = await _create_job(session_maker)
+    long_message = "LLM verification grading failed: " + ("permission denied " * 200)
+    validation = AsyncMock(
+        return_value=ValidationResult(
+            is_valid=False,
+            message=long_message,
+            verification_completed=False,
+        )
+    )
+
+    with (
+        patch(
+            "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
+            return_value=_requirement(),
+        ),
+        patch(
+            "learn_to_cloud_shared.verification_job_executor.validate_submission",
+            validation,
+        ),
+    ):
+        result = await execute_verification_job(job_id, session_maker=session_maker)
+
+    assert result.status == VerificationJobStatus.SERVER_ERROR
+    assert result.detail == long_message
+
+    status, result_submission_id, error_code, error_message = await _get_job_status(
+        session_maker,
+        job_id,
+    )
+    assert status == VerificationJobStatus.SERVER_ERROR
+    assert result_submission_id == result.submission_id
+    assert error_code == VERIFICATION_INCOMPLETE_ERROR_CODE
+    assert error_message is not None
+    assert len(error_message) == MAX_VALIDATION_MESSAGE_LENGTH
+    assert error_message.endswith("...")
+
+    submission = await _get_submission(session_maker, result.submission_id)
+    assert submission.validation_message is not None
+    assert len(submission.validation_message) == MAX_VALIDATION_MESSAGE_LENGTH
+    assert submission.validation_message == error_message
 
 
 async def test_execute_verification_job_is_idempotent_for_terminal_jobs(

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -181,5 +181,5 @@ def test_llm_grading_unavailable_result_marks_server_error():
     assert updated.validation_result.is_valid is False
     assert updated.validation_result.verification_completed is False
     assert updated.validation_result.message == (
-        "LLM verification grading failed: structured output missing"
+        "LLM verification grading failed. Please try again later."
     )


### PR DESCRIPTION
## Summary
- Assign the verification Functions identity the renamed Foundry User role at the Foundry project scope.
- Use a generic persisted LLM grading failure message.
- Truncate persisted validation messages to fit existing database columns.

## Validation
- Terraform targeted plan/apply for Foundry RBAC succeeded locally.
- Retest telemetry showed run_llm_grading succeeded and persist_verification_result succeeded.
- Ruff, format, ty, API smoke tests, full API/shared tests, and Functions import passed.