### PR TITLE
feat: run phase 0-2 verifications synchronously in FastAPI

### DIFF
--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -12,6 +12,7 @@ Async verifications use Durable Functions + HTMX polling:
 """
 
 import logging
+from collections.abc import Callable
 from typing import Annotated
 from uuid import UUID
 
@@ -23,12 +24,16 @@ from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
-from learn_to_cloud_shared.schemas import SubmissionData
+from learn_to_cloud_shared.schemas import SubmissionData, SubmissionResult
+from learn_to_cloud_shared.verification.execution import (
+    SubmissionAlreadyInFlightError,
+)
 from learn_to_cloud_shared.verification.requirements import get_requirement_by_id
 from learn_to_cloud_shared.verification.url_derivation import (
     derive_submission_value,
     is_derivable,
 )
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from learn_to_cloud.core.auth import AuthenticatedUser, CurrentUser, UserId
 from learn_to_cloud.core.ratelimit import limiter
@@ -59,6 +64,7 @@ from learn_to_cloud.services.submissions_service import (
     GitHubUsernameRequiredError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
+    SyncVerificationResult,
     VerificationJobSubmission,
     create_verification_job,
 )
@@ -83,6 +89,7 @@ _USER_FACING_ERRORS = (
     GitHubUsernameRequiredError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
+    SubmissionAlreadyInFlightError,
 )
 
 _DURABLE_START_ERROR_MESSAGE = (
@@ -285,7 +292,19 @@ async def htmx_submit_verification(
     submitted_value: Annotated[str, Form(max_length=2048)] = "",
     pr_number: Annotated[str, Form(max_length=16)] = "",
 ) -> HTMLResponse:
-    """Submit a hands-on verification and start its Durable orchestration."""
+    """Submit a hands-on verification.
+
+    Routes to one of two execution paths based on the requirement's
+    submission type:
+
+    * Sync (phases 0-2) — :func:`create_verification_job` runs validation
+      inside this request and persists the ``Submission`` row. The response
+      reloads the page so the just-updated card and any newly-unlocked
+      requirement render with fresh server-side state.
+    * Async (phases 3-6) — :func:`create_verification_job` returns a
+      ``VerificationJobSubmission`` and we start a Durable orchestration,
+      then return a spinner card that polls for status.
+    """
     user_id = current_user.user_id
     github_username = current_user.github_username
 
@@ -352,17 +371,94 @@ async def htmx_submit_verification(
     else:
         derived_value = submitted_value
 
-    # ── Persist job, then start Durable orchestration ──────────────────
-    job_submission: VerificationJobSubmission | None = None
+    # ── Dispatch to sync or async execution path ───────────────────────
     try:
-        job_submission = await create_verification_job(
+        dispatch_result = await create_verification_job(
             session_maker=session_maker,
             user_id=user_id,
             requirement_id=requirement_id,
             submitted_value=derived_value,
             github_username=github_username,
         )
+    except _USER_FACING_ERRORS as exc:
+        return _render_card(error_banner=str(exc))
+    except Exception as exc:
+        record_span_exception(exc)
+        logger.exception(
+            "htmx.submit.unexpected_error",
+            extra={
+                "user_id": user_id,
+                "requirement_id": requirement_id,
+                "error_type": type(exc).__name__,
+            },
+        )
+        return _render_card(
+            server_error=True,
+            server_error_message=(
+                "An unexpected error occurred during verification. "
+                "This attempt was not counted — please try again."
+            ),
+        )
 
+    if isinstance(dispatch_result, SyncVerificationResult):
+        return _render_sync_result(
+            user_id=user_id,
+            result=dispatch_result.submission_result,
+        )
+
+    return await _start_async_job_and_render(
+        session_maker=session_maker,
+        user_id=user_id,
+        requirement_id=requirement_id,
+        job_submission=dispatch_result,
+        render_card=_render_card,
+    )
+
+
+def _render_sync_result(
+    *,
+    user_id: int,
+    result: SubmissionResult,
+) -> HTMLResponse:
+    """Render the response for a sync verification that already finished.
+
+    The ``Submission`` row is already persisted; we reload the phase page
+    so the card, progress bar, and any newly-unlocked next requirement
+    all render from fresh server state. Reload trigger matches the
+    pattern used by :func:`_reload_verification_html` for async
+    completion so behavior is consistent across paths.
+    """
+    logger.info(
+        "htmx.submit.sync_completed",
+        extra={
+            "user_id": user_id,
+            "submission_id": result.submission.id,
+            "requirement_id": result.submission.requirement_id,
+            "submission_type": result.submission.submission_type.value,
+            "is_valid": result.is_valid,
+            "verification_completed": result.submission.verification_completed,
+            "is_server_error": result.is_server_error,
+        },
+    )
+    return HTMLResponse(_reload_verification_html())
+
+
+async def _start_async_job_and_render(
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+    user_id: int,
+    requirement_id: str,
+    job_submission: VerificationJobSubmission,
+    render_card: Callable[..., HTMLResponse],
+) -> HTMLResponse:
+    """Start a Durable orchestration for an async job and render the spinner.
+
+    On a successful start (or when a previous start is already known via
+    ``orchestration_instance_id``) returns the processing card with a
+    signed status token the browser polls. On Durable start failure marks
+    the job server-error and renders a banner.
+    """
+    try:
         existing_instance_id = job_submission.job.orchestration_instance_id
         if job_submission.created or existing_instance_id is None:
             start_result = await start_verification_orchestration(job_submission.job.id)
@@ -383,13 +479,11 @@ async def htmx_submit_verification(
             requirement_id=requirement_id,
         )
 
-        return _render_card(
+        return render_card(
             processing=True,
             verification_status_token=status_token,
         )
 
-    except _USER_FACING_ERRORS as exc:
-        return _render_card(error_banner=str(exc))
     except (
         DurableVerificationConfigError,
         DurableVerificationStartError,
@@ -403,34 +497,16 @@ async def htmx_submit_verification(
                 "error_type": type(exc).__name__,
             },
         )
-        if job_submission is not None:
-            async with session_maker() as write_session:
-                await VerificationJobRepository(write_session).mark_server_error(
-                    job_submission.job.id,
-                    error_code="durable_start_failed",
-                    error_message=_DURABLE_START_ERROR_MESSAGE,
-                )
-                await write_session.commit()
-        return _render_card(
+        async with session_maker() as write_session:
+            await VerificationJobRepository(write_session).mark_server_error(
+                job_submission.job.id,
+                error_code="durable_start_failed",
+                error_message=_DURABLE_START_ERROR_MESSAGE,
+            )
+            await write_session.commit()
+        return render_card(
             server_error=True,
             server_error_message=_DURABLE_START_ERROR_MESSAGE,
-        )
-    except Exception as exc:
-        record_span_exception(exc)
-        logger.exception(
-            "htmx.submit.unexpected_error",
-            extra={
-                "user_id": user_id,
-                "requirement_id": requirement_id,
-                "error_type": type(exc).__name__,
-            },
-        )
-        return _render_card(
-            server_error=True,
-            server_error_message=(
-                "An unexpected error occurred during verification. "
-                "This attempt was not counted — please try again."
-            ),
         )
 
 

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -24,8 +24,13 @@ from learn_to_cloud_shared.schemas import (
     HandsOnRequirement,
     PhaseSubmissionContext,
     SubmissionData,
+    SubmissionResult,
 )
-from learn_to_cloud_shared.verification.execution import to_submission_data
+from learn_to_cloud_shared.verification.dispatcher import is_sync_verifiable
+from learn_to_cloud_shared.verification.execution import (
+    execute_sync_submission_validation,
+    to_submission_data,
+)
 from learn_to_cloud_shared.verification.requirements import (
     get_phase_id_for_requirement,
     get_prerequisite_phase,
@@ -133,10 +138,28 @@ class _PreValidationContext:
 
 @dataclass(frozen=True, slots=True)
 class VerificationJobSubmission:
-    """Result of creating or reusing a verification job."""
+    """Result of creating or reusing a verification job (async Durable path)."""
 
     job: VerificationJob
     created: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SyncVerificationResult:
+    """Result of running a sync verification inside the FastAPI request.
+
+    Returned by :func:`create_verification_job` for submission types whose
+    validators finish in well under a second (phases 0-2). No Durable
+    Functions orchestration is started — the ``Submission`` row is already
+    persisted by the time this is returned.
+    """
+
+    submission_result: SubmissionResult
+
+
+# Tagged union returned by ``create_verification_job``. Callers use
+# ``isinstance`` to pick the rendering path.
+SubmissionDispatchResult = VerificationJobSubmission | SyncVerificationResult
 
 
 async def _check_submission_preconditions(
@@ -235,8 +258,14 @@ async def create_verification_job(
     requirement_id: str,
     submitted_value: str,
     github_username: str | None,
-) -> VerificationJobSubmission:
-    """Validate request preconditions and create or reuse an active job."""
+) -> SubmissionDispatchResult:
+    """Validate request preconditions and dispatch to the right execution path.
+
+    Returns a :class:`SyncVerificationResult` for submission types whose
+    validators run inside the FastAPI request (phases 0-2). Returns a
+    :class:`VerificationJobSubmission` for types that go through Durable
+    Functions (phases 3-6).
+    """
     ctx = await _check_submission_preconditions(
         session_maker,
         user_id,
@@ -244,6 +273,17 @@ async def create_verification_job(
         github_username,
         submitted_value,
     )
+
+    if is_sync_verifiable(ctx.requirement.submission_type):
+        submission_result = await execute_sync_submission_validation(
+            session_maker=session_maker,
+            user_id=user_id,
+            requirement=ctx.requirement,
+            phase_id=ctx.phase_id,
+            submitted_value=submitted_value,
+            github_username=github_username,
+        )
+        return SyncVerificationResult(submission_result=submission_result)
 
     async with session_maker() as write_session:
         repo = VerificationJobRepository(write_session)

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -13,11 +13,14 @@ Testing approach:
 """
 
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from fastapi.responses import HTMLResponse
+from learn_to_cloud_shared.models import VerificationJob
+from learn_to_cloud_shared.schemas import SubmissionResult
 
 from learn_to_cloud.core.auth import AuthenticatedUser
 from learn_to_cloud.routes.htmx_routes import (
@@ -29,6 +32,10 @@ from learn_to_cloud.routes.htmx_routes import (
 )
 from learn_to_cloud.services.durable_verification_client import DurableStatusResult
 from learn_to_cloud.services.steps_service import StepValidationError
+from learn_to_cloud.services.submissions_service import (
+    SyncVerificationResult,
+    VerificationJobSubmission,
+)
 from learn_to_cloud.services.users_service import UserNotFoundError
 from learn_to_cloud.services.verification_status_tokens import VerificationStatusToken
 
@@ -292,6 +299,168 @@ class TestHtmxSubmitVerification:
 
         # Should render a server error card, not crash
         assert result is not None
+
+    async def test_sync_submit_returns_reload_trigger(self):
+        """Sync submission types finish in-request and return a page-reload
+        snippet so the next requirement re-renders with fresh server state."""
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        submission = SimpleNamespace(
+            id=42,
+            requirement_id="req-1",
+            submission_type=SimpleNamespace(value="github_profile"),
+            verification_completed=True,
+        )
+        sync_result = SyncVerificationResult(
+            submission_result=cast(
+                SubmissionResult,
+                SimpleNamespace(
+                    submission=submission,
+                    is_valid=True,
+                    is_server_error=False,
+                ),
+            ),
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_id",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.derive_submission_value",
+                autospec=True,
+                return_value="https://github.com/user",
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                new_callable=AsyncMock,
+                return_value=sync_result,
+            ) as mock_create_job,
+            patch(
+                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                new_callable=AsyncMock,
+            ) as mock_start,
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+            ) as mock_repo_class,
+        ):
+            result = await htmx_submit_verification(
+                request,
+                current_user,
+                requirement_id="req-1",
+                submitted_value="https://github.com/user",
+            )
+
+        assert isinstance(result, HTMLResponse)
+        # Page reload trigger (matches the async terminal pattern).
+        assert "location.reload()" in bytes(result.body).decode()
+        # Critical: sync path must never touch Durable or VerificationJob.
+        mock_start.assert_not_awaited()
+        mock_repo_class.assert_not_called()
+        mock_create_job.assert_awaited_once()
+
+    async def test_sync_submit_failure_also_returns_reload_trigger(self):
+        """A failed sync verification still reloads so the failed card is
+        re-rendered from the persisted Submission state."""
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        submission = SimpleNamespace(
+            id=43,
+            requirement_id="req-1",
+            submission_type=SimpleNamespace(value="github_profile"),
+            verification_completed=True,
+        )
+        sync_result = SyncVerificationResult(
+            submission_result=cast(
+                SubmissionResult,
+                SimpleNamespace(
+                    submission=submission,
+                    is_valid=False,
+                    is_server_error=False,
+                ),
+            ),
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_id",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.derive_submission_value",
+                autospec=True,
+                return_value="https://github.com/user",
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                new_callable=AsyncMock,
+                return_value=sync_result,
+            ),
+        ):
+            result = await htmx_submit_verification(
+                request,
+                current_user,
+                requirement_id="req-1",
+                submitted_value="https://github.com/user",
+            )
+
+        assert isinstance(result, HTMLResponse)
+        assert "location.reload()" in bytes(result.body).decode()
+
+    async def test_async_submit_still_returns_processing_card(self):
+        """Regression: async submissions must keep using the
+        VerificationJobSubmission spinner-and-poll path."""
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        job = SimpleNamespace(id=uuid4(), orchestration_instance_id=None)
+        async_result = VerificationJobSubmission(
+            job=cast(VerificationJob, job),
+            created=True,
+        )
+        start_result = SimpleNamespace(instance_id=str(job.id))
+        write_session = AsyncMock()
+        request.app.state.session_maker.return_value.__aenter__.return_value = (
+            write_session
+        )
+        repo = MagicMock()
+        repo.mark_starting = AsyncMock()
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_id",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.derive_submission_value",
+                autospec=True,
+                return_value="https://github.com/user/repo",
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                new_callable=AsyncMock,
+                return_value=async_result,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                new_callable=AsyncMock,
+                return_value=start_result,
+            ) as mock_start,
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                return_value=repo,
+            ),
+        ):
+            result = await htmx_submit_verification(
+                request,
+                current_user,
+                requirement_id="req-1",
+                submitted_value="https://github.com/user/repo",
+            )
+
+        assert isinstance(result, HTMLResponse)
+        mock_start.assert_awaited_once_with(job.id)
+        repo.mark_starting.assert_awaited_once_with(job.id, start_result.instance_id)
 
 
 @pytest.mark.unit

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -18,6 +18,8 @@ from learn_to_cloud.services.submissions_service import (
     GitHubUsernameRequiredError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
+    SyncVerificationResult,
+    VerificationJobSubmission,
     create_verification_job,
     get_phase_submission_context,
 )
@@ -237,6 +239,7 @@ class TestAlreadyValidatedShortCircuit:
                 github_username="user",
             )
 
+            assert isinstance(result, VerificationJobSubmission)
             assert result.job is mock_job
             assert result.created is True
 
@@ -352,9 +355,198 @@ class TestSequentialPhaseGating:
                 github_username="user",
             )
 
+            assert isinstance(result, VerificationJobSubmission)
             assert result.job is mock_job
             assert result.created is True
             mock_job_repo.create_or_get_active.assert_awaited_once()
+
+
+@pytest.mark.unit
+class TestSyncDispatchBranch:
+    """Tests for the sync (phase 0-2) execution branch in create_verification_job."""
+
+    @pytest.mark.asyncio
+    async def test_sync_type_runs_in_process_and_returns_sync_result(self):
+        """A sync submission type calls execute_sync_submission_validation
+        and never touches VerificationJobRepository."""
+        mock_session_maker = _mock_session_maker()
+        mock_requirement = _make_mock_requirement(
+            submission_type=SubmissionType.GITHUB_PROFILE,
+        )
+        sentinel_result = MagicMock(name="SubmissionResult")
+
+        with (
+            patch(
+                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
+                autospec=True,
+                return_value=mock_requirement,
+            ),
+            patch(
+                "learn_to_cloud.services.submissions_service.SubmissionRepository",
+                autospec=True,
+            ) as mock_repo_class,
+            patch(
+                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
+                autospec=True,
+            ) as mock_job_repo_class,
+            patch(
+                "learn_to_cloud.services.submissions_service.execute_sync_submission_validation",
+                new_callable=AsyncMock,
+                return_value=sentinel_result,
+            ) as mock_sync_execute,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
+            mock_repo_class.return_value = mock_repo
+
+            result = await create_verification_job(
+                session_maker=mock_session_maker,
+                user_id=123,
+                requirement_id="test-requirement",
+                submitted_value="https://github.com/user",
+                github_username="user",
+            )
+
+        assert isinstance(result, SyncVerificationResult)
+        assert result.submission_result is sentinel_result
+        mock_sync_execute.assert_awaited_once()
+        # Critical: sync path must not create or look up VerificationJob rows.
+        mock_job_repo_class.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_type_returns_verification_job_submission(self):
+        """A phase 3+ submission type still goes through the Durable
+        VerificationJob path and returns VerificationJobSubmission."""
+        mock_session_maker = _mock_session_maker()
+        mock_requirement = _make_mock_requirement(
+            submission_type=SubmissionType.CI_STATUS,
+        )
+        mock_job = MagicMock()
+
+        with (
+            patch(
+                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
+                autospec=True,
+                return_value=mock_requirement,
+            ),
+            patch(
+                "learn_to_cloud.services.submissions_service.SubmissionRepository",
+                autospec=True,
+            ) as mock_repo_class,
+            patch(
+                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
+                autospec=True,
+            ) as mock_job_repo_class,
+            patch(
+                "learn_to_cloud.services.submissions_service.execute_sync_submission_validation",
+                new_callable=AsyncMock,
+            ) as mock_sync_execute,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
+            mock_repo_class.return_value = mock_repo
+
+            mock_job_repo = MagicMock()
+            mock_job_repo.create_or_get_active = AsyncMock(
+                return_value=(mock_job, True)
+            )
+            mock_job_repo_class.return_value = mock_job_repo
+
+            result = await create_verification_job(
+                session_maker=mock_session_maker,
+                user_id=123,
+                requirement_id="test-requirement",
+                submitted_value="https://github.com/user/repo",
+                github_username="user",
+            )
+
+        assert isinstance(result, VerificationJobSubmission)
+        assert result.job is mock_job
+        assert result.created is True
+        # Critical: async path must not run the in-request sync validator.
+        mock_sync_execute.assert_not_awaited()
+        mock_job_repo.create_or_get_active.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sync_preconditions_still_enforced(self):
+        """Sync path still rejects already-validated requirements before
+        running the validator. Guards against regression where the branch
+        skips _check_submission_preconditions."""
+        mock_session_maker = _mock_session_maker()
+        mock_requirement = _make_mock_requirement(
+            submission_type=SubmissionType.CTF_TOKEN,
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
+                autospec=True,
+                return_value=mock_requirement,
+            ),
+            patch(
+                "learn_to_cloud.services.submissions_service.SubmissionRepository",
+                autospec=True,
+            ) as mock_repo_class,
+            patch(
+                "learn_to_cloud.services.submissions_service.execute_sync_submission_validation",
+                new_callable=AsyncMock,
+            ) as mock_sync_execute,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_and_requirement = AsyncMock(
+                return_value=MagicMock(is_validated=True)
+            )
+            mock_repo_class.return_value = mock_repo
+
+            with pytest.raises(AlreadyValidatedError):
+                await create_verification_job(
+                    session_maker=mock_session_maker,
+                    user_id=123,
+                    requirement_id="test-requirement",
+                    submitted_value="some-token",
+                    github_username="user",
+                )
+
+        mock_sync_execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sync_path_requires_github_username_for_ctf_token(self):
+        """CTF_TOKEN without github_username must still raise even on the
+        sync path, since the validator can't run anonymously."""
+        mock_session_maker = _mock_session_maker()
+        mock_requirement = _make_mock_requirement(
+            submission_type=SubmissionType.CTF_TOKEN,
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
+                autospec=True,
+                return_value=mock_requirement,
+            ),
+            patch(
+                "learn_to_cloud.services.submissions_service.SubmissionRepository",
+                autospec=True,
+            ) as mock_repo_class,
+            patch(
+                "learn_to_cloud.services.submissions_service.execute_sync_submission_validation",
+                new_callable=AsyncMock,
+            ) as mock_sync_execute,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
+            mock_repo_class.return_value = mock_repo
+
+            with pytest.raises(GitHubUsernameRequiredError):
+                await create_verification_job(
+                    session_maker=mock_session_maker,
+                    user_id=123,
+                    requirement_id="test-requirement",
+                    submitted_value="some-token",
+                    github_username=None,
+                )
+
+        mock_sync_execute.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -71,12 +71,12 @@ configure_observability()
 app = df.DFApp(http_auth_level=func.AuthLevel.FUNCTION)
 
 _DEFAULT_ORCHESTRATOR_NAME = "verification_orchestrator"
+# Async-only submission types: phase 3+ verifications that involve LLM
+# grading, multi-task fan-out, or external probes with retries and stay on
+# the Durable Functions path. Phase 0-2 sync types (github_profile,
+# profile_readme, repo_fork, ctf_token, networking_token) run inside the
+# FastAPI request instead and are intentionally absent.
 _ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE = {
-    SubmissionType.GITHUB_PROFILE: "verify_github_profile_orchestrator",
-    SubmissionType.PROFILE_README: "verify_profile_readme_orchestrator",
-    SubmissionType.REPO_FORK: "verify_repo_fork_orchestrator",
-    SubmissionType.CTF_TOKEN: "verify_ctf_token_orchestrator",
-    SubmissionType.NETWORKING_TOKEN: "verify_networking_token_orchestrator",
     SubmissionType.JOURNAL_API_RESPONSE: "verify_phase3_journal_api_orchestrator",
     SubmissionType.CODE_ANALYSIS: "verify_phase3_journal_api_orchestrator",
     SubmissionType.PR_REVIEW: "verify_phase3_pr_review_orchestrator",
@@ -387,31 +387,49 @@ def verification_orchestrator(context: df.DurableOrchestrationContext):
 
 @app.orchestration_trigger(context_name="context")
 def verify_github_profile_orchestrator(context: df.DurableOrchestrationContext):
-    """Run GitHub profile verification."""
+    """Drain-only orchestrator for in-flight phase 0 GitHub profile jobs.
+
+    Phase 0-2 verifications now run synchronously in FastAPI (see
+    ``api/src/learn_to_cloud/routes/htmx_routes.py``). This trigger stays
+    registered so any orchestration started before the cutover can still
+    complete cleanly. Safe to remove after Durable retention expires.
+    """
     return (yield from _run_verification_orchestration(context))
 
 
 @app.orchestration_trigger(context_name="context")
 def verify_profile_readme_orchestrator(context: df.DurableOrchestrationContext):
-    """Run profile README verification."""
+    """Drain-only orchestrator for in-flight phase 0 profile README jobs.
+
+    See :func:`verify_github_profile_orchestrator` for rationale.
+    """
     return (yield from _run_verification_orchestration(context))
 
 
 @app.orchestration_trigger(context_name="context")
 def verify_repo_fork_orchestrator(context: df.DurableOrchestrationContext):
-    """Run repository fork verification."""
+    """Drain-only orchestrator for in-flight phase 0 repo fork jobs.
+
+    See :func:`verify_github_profile_orchestrator` for rationale.
+    """
     return (yield from _run_verification_orchestration(context))
 
 
 @app.orchestration_trigger(context_name="context")
 def verify_ctf_token_orchestrator(context: df.DurableOrchestrationContext):
-    """Run CTF token verification."""
+    """Drain-only orchestrator for in-flight phase 1 CTF token jobs.
+
+    See :func:`verify_github_profile_orchestrator` for rationale.
+    """
     return (yield from _run_verification_orchestration(context))
 
 
 @app.orchestration_trigger(context_name="context")
 def verify_networking_token_orchestrator(context: df.DurableOrchestrationContext):
-    """Run networking token verification."""
+    """Drain-only orchestrator for in-flight phase 2 networking token jobs.
+
+    See :func:`verify_github_profile_orchestrator` for rationale.
+    """
     return (yield from _run_verification_orchestration(context))
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
@@ -132,6 +132,27 @@ _USERNAME_NOT_REQUIRED: frozenset[SubmissionType] = frozenset(
 )
 
 
+# Submission types that finish in well under a second (one GitHub API call
+# or a constant-time token compare) and can run inside the FastAPI request
+# instead of going through Durable Functions.  Phase 3+ types involve LLM
+# grading, fan-out, or external probes with retries and stay on the async
+# Durable path.
+SYNC_VERIFIABLE_SUBMISSION_TYPES: frozenset[SubmissionType] = frozenset(
+    {
+        SubmissionType.GITHUB_PROFILE,
+        SubmissionType.PROFILE_README,
+        SubmissionType.REPO_FORK,
+        SubmissionType.CTF_TOKEN,
+        SubmissionType.NETWORKING_TOKEN,
+    }
+)
+
+
+def is_sync_verifiable(submission_type: SubmissionType) -> bool:
+    """Return True if the submission type runs synchronously in FastAPI."""
+    return submission_type in SYNC_VERIFIABLE_SUBMISSION_TYPES
+
+
 async def _dispatch_validation(
     requirement: HandsOnRequirement,
     submitted_value: str,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
@@ -7,6 +7,7 @@ import logging
 from collections.abc import Awaitable, Callable
 
 from opentelemetry import trace
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.models import Submission, SubmissionType
@@ -30,6 +31,16 @@ SubmissionPersistHook = Callable[
     Awaitable[None],
 ]
 MAX_VALIDATION_MESSAGE_LENGTH = 1024
+
+
+class SubmissionAlreadyInFlightError(Exception):
+    """Raised when a sync verification is already running for the same requirement.
+
+    Used as a dedupe signal when two concurrent submits (e.g. a double-click)
+    arrive for the same ``(user_id, requirement_id)``. The first one holds a
+    Postgres transactional advisory lock; the second one sees the lock is
+    busy and bails out so the user can wait for the first to finish.
+    """
 
 
 def persisted_validation_message(message: str | None) -> str | None:
@@ -187,6 +198,106 @@ async def execute_submission_validation(
                     if not validation_result.is_valid
                     else None
                 ),
+            },
+        )
+
+        return build_submission_result(db_submission, validation_result)
+
+
+def _advisory_lock_key(user_id: int, requirement_id: str) -> str:
+    """Stable Postgres advisory-lock key for one (user, requirement) pair.
+
+    Namespaced so it can't collide with any other advisory locks the app
+    may take in the future.
+    """
+    return f"verification-sub:{user_id}:{requirement_id}"
+
+
+async def execute_sync_submission_validation(
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+    user_id: int,
+    requirement: HandsOnRequirement,
+    phase_id: int,
+    submitted_value: str,
+    github_username: str | None,
+) -> SubmissionResult:
+    """Run a sync (sub-second) verification in one DB transaction.
+
+    Used for submission types that finish quickly enough to answer from
+    the same HTTP request — no Durable Functions, no spinner, no polling.
+
+    Concurrency: takes a Postgres transactional advisory lock keyed on
+    ``(user_id, requirement_id)`` so two parallel submits (e.g. a
+    double-click) can't both run validation and race
+    ``Submission.attempt_number`` into a duplicate-key crash. If the lock
+    is already held, raises :class:`SubmissionAlreadyInFlightError`.
+
+    The DB connection is held across the validator call (typically a
+    single GitHub API request, ~200-500ms). Lock contention is bounded to
+    the same user submitting the same requirement, so pool pressure
+    stays negligible.
+    """
+    lock_key = _advisory_lock_key(user_id, requirement.id)
+
+    with tracer.start_as_current_span(
+        "execute_sync_submission_validation",
+        attributes={
+            "user.id": user_id,
+            "requirement.id": requirement.id,
+            "submission.type": requirement.submission_type.value,
+        },
+    ) as span:
+        async with session_maker() as session, session.begin():
+            acquired = await session.scalar(
+                text("SELECT pg_try_advisory_xact_lock(hashtext(:key))"),
+                {"key": lock_key},
+            )
+            if not acquired:
+                span.set_attribute("submission.lock_acquired", False)
+                raise SubmissionAlreadyInFlightError(
+                    "A verification for this requirement is already in progress. "
+                    "Please wait a moment and try again."
+                )
+            span.set_attribute("submission.lock_acquired", True)
+
+            validation_result = await validate_submission(
+                requirement=requirement,
+                submitted_value=submitted_value,
+                expected_username=github_username,
+            )
+
+            db_submission = await persist_validation_result(
+                session,
+                user_id=user_id,
+                requirement=requirement,
+                phase_id=phase_id,
+                submitted_value=submitted_value,
+                github_username=github_username,
+                validation_result=validation_result,
+            )
+
+        span.set_attribute("submission.is_valid", validation_result.is_valid)
+        span.set_attribute(
+            "submission.verification_completed",
+            validation_result.verification_completed,
+        )
+
+        logger.info(
+            "submission.completed",
+            extra={
+                "user_id": user_id,
+                "requirement_id": requirement.id,
+                "phase_id": phase_id,
+                "submission_type": requirement.submission_type,
+                "is_valid": validation_result.is_valid,
+                "verification_completed": validation_result.verification_completed,
+                "validation_message": (
+                    validation_result.message
+                    if not validation_result.is_valid
+                    else None
+                ),
+                "execution_path": "sync",
             },
         )
 

--- a/packages/learn-to-cloud-shared/tests/verification/test_dispatcher.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_dispatcher.py
@@ -1,0 +1,41 @@
+"""Tests for the sync/async dispatch helper in the verification dispatcher."""
+
+import pytest
+
+from learn_to_cloud_shared.models import SubmissionType
+from learn_to_cloud_shared.verification.dispatcher import (
+    SYNC_VERIFIABLE_SUBMISSION_TYPES,
+    is_sync_verifiable,
+)
+
+_EXPECTED_SYNC = {
+    SubmissionType.GITHUB_PROFILE,
+    SubmissionType.PROFILE_README,
+    SubmissionType.REPO_FORK,
+    SubmissionType.CTF_TOKEN,
+    SubmissionType.NETWORKING_TOKEN,
+}
+
+
+def test_sync_verifiable_set_is_exactly_the_phase_0_to_2_types():
+    """Guard rail: any new sync type must be added intentionally.
+
+    Keeping this assertion concrete protects against silently routing a
+    new phase 3+ verification through the in-request path.
+    """
+    assert SYNC_VERIFIABLE_SUBMISSION_TYPES == _EXPECTED_SYNC
+
+
+@pytest.mark.parametrize(
+    "submission_type", sorted(_EXPECTED_SYNC, key=lambda t: t.value)
+)
+def test_is_sync_verifiable_true_for_phase_0_to_2_types(submission_type):
+    assert is_sync_verifiable(submission_type) is True
+
+
+@pytest.mark.parametrize(
+    "submission_type",
+    sorted(set(SubmissionType) - _EXPECTED_SYNC, key=lambda t: t.value),
+)
+def test_is_sync_verifiable_false_for_async_types(submission_type):
+    assert is_sync_verifiable(submission_type) is False

--- a/packages/learn-to-cloud-shared/tests/verification/test_sync_execution.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_sync_execution.py
@@ -1,0 +1,346 @@
+"""Integration tests for the sync verification execution path.
+
+Exercises ``execute_sync_submission_validation`` against a real Postgres
+test database so the ``pg_try_advisory_xact_lock``-based dedupe contract
+is verified end-to-end (mocking the lock would only assert that the
+mock is called).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from learn_to_cloud_shared.models import Submission, SubmissionType
+from learn_to_cloud_shared.repositories.user_repository import UserRepository
+from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
+from learn_to_cloud_shared.verification.execution import (
+    SubmissionAlreadyInFlightError,
+    execute_sync_submission_validation,
+)
+
+pytestmark = pytest.mark.integration
+
+USER_ID = 92001
+REQUIREMENT_ID = "sync-execution-test"
+PHASE_ID = 0
+
+
+@pytest.fixture()
+def session_maker(test_engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(
+        bind=test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+
+def _requirement(
+    submission_type: SubmissionType = SubmissionType.GITHUB_PROFILE,
+) -> HandsOnRequirement:
+    return HandsOnRequirement(
+        id=REQUIREMENT_ID,
+        submission_type=submission_type,
+        name="Sync Execution Test",
+        description="Test requirement",
+    )
+
+
+async def _seed_user(session_maker: async_sessionmaker[AsyncSession]) -> None:
+    async with session_maker() as db:
+        await UserRepository(db).upsert(USER_ID, github_username="syncuser")
+        await db.commit()
+
+
+async def _count_submissions(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> int:
+    async with session_maker() as db:
+        result = await db.execute(
+            select(Submission).where(Submission.user_id == USER_ID)
+        )
+        return len(list(result.scalars().all()))
+
+
+async def test_sync_validation_persists_submission(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Happy path: validator returns success, ``Submission`` row is written."""
+    await _seed_user(session_maker)
+
+    with patch(
+        "learn_to_cloud_shared.verification.execution.validate_submission",
+        new=AsyncMock(
+            return_value=ValidationResult(
+                is_valid=True,
+                message="ok",
+                verification_completed=True,
+            )
+        ),
+    ):
+        result = await execute_sync_submission_validation(
+            session_maker=session_maker,
+            user_id=USER_ID,
+            requirement=_requirement(),
+            phase_id=PHASE_ID,
+            submitted_value="https://github.com/syncuser",
+            github_username="syncuser",
+        )
+
+    assert result.is_valid is True
+    assert result.submission.is_validated is True
+    assert await _count_submissions(session_maker) == 1
+
+
+async def test_sync_validation_persists_failure(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """User-correctable failure path: row is written with is_validated=False."""
+    await _seed_user(session_maker)
+
+    with patch(
+        "learn_to_cloud_shared.verification.execution.validate_submission",
+        new=AsyncMock(
+            return_value=ValidationResult(
+                is_valid=False,
+                message="GitHub username does not match",
+                verification_completed=True,
+            )
+        ),
+    ):
+        result = await execute_sync_submission_validation(
+            session_maker=session_maker,
+            user_id=USER_ID,
+            requirement=_requirement(),
+            phase_id=PHASE_ID,
+            submitted_value="https://github.com/wronguser",
+            github_username="syncuser",
+        )
+
+    assert result.is_valid is False
+    assert result.submission.is_validated is False
+    assert result.submission.verification_completed is True
+    assert await _count_submissions(session_maker) == 1
+
+
+async def test_sync_validation_rolls_back_on_validator_exception(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """A crash inside the validator must not leave a half-written Submission.
+
+    The transaction wraps lock + validate + persist, so a raised exception
+    rolls back the whole thing and the advisory lock is released.
+    """
+    await _seed_user(session_maker)
+
+    with patch(
+        "learn_to_cloud_shared.verification.execution.validate_submission",
+        new=AsyncMock(side_effect=RuntimeError("validator crashed")),
+    ):
+        with pytest.raises(RuntimeError, match="validator crashed"):
+            await execute_sync_submission_validation(
+                session_maker=session_maker,
+                user_id=USER_ID,
+                requirement=_requirement(),
+                phase_id=PHASE_ID,
+                submitted_value="https://github.com/syncuser",
+                github_username="syncuser",
+            )
+
+    assert await _count_submissions(session_maker) == 0
+
+    # Lock was released, so a follow-up submit succeeds.
+    with patch(
+        "learn_to_cloud_shared.verification.execution.validate_submission",
+        new=AsyncMock(
+            return_value=ValidationResult(
+                is_valid=True,
+                message="ok",
+                verification_completed=True,
+            )
+        ),
+    ):
+        await execute_sync_submission_validation(
+            session_maker=session_maker,
+            user_id=USER_ID,
+            requirement=_requirement(),
+            phase_id=PHASE_ID,
+            submitted_value="https://github.com/syncuser",
+            github_username="syncuser",
+        )
+
+    assert await _count_submissions(session_maker) == 1
+
+
+async def test_concurrent_submits_for_same_requirement_dedupe(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Two concurrent submits for the same (user, requirement) must not
+    both run the validator and persist duplicate Submission rows.
+
+    Uses an asyncio.Event to keep the first request inside the validator
+    long enough for the second request to race past the lock check.
+    """
+    await _seed_user(session_maker)
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_validator(*_args, **_kwargs):
+        started.set()
+        await release.wait()
+        return ValidationResult(
+            is_valid=True,
+            message="ok",
+            verification_completed=True,
+        )
+
+    with patch(
+        "learn_to_cloud_shared.verification.execution.validate_submission",
+        new=_slow_validator,
+    ):
+        first = asyncio.create_task(
+            execute_sync_submission_validation(
+                session_maker=session_maker,
+                user_id=USER_ID,
+                requirement=_requirement(),
+                phase_id=PHASE_ID,
+                submitted_value="https://github.com/syncuser",
+                github_username="syncuser",
+            )
+        )
+
+        # Wait until the first request is past the lock and inside the validator.
+        await asyncio.wait_for(started.wait(), timeout=5.0)
+
+        # The second request must immediately bail out with
+        # SubmissionAlreadyInFlightError — not block, not race-write a row.
+        with pytest.raises(SubmissionAlreadyInFlightError):
+            await execute_sync_submission_validation(
+                session_maker=session_maker,
+                user_id=USER_ID,
+                requirement=_requirement(),
+                phase_id=PHASE_ID,
+                submitted_value="https://github.com/syncuser",
+                github_username="syncuser",
+            )
+
+        # Let the first request complete; it should succeed and write a row.
+        release.set()
+        first_result = await asyncio.wait_for(first, timeout=5.0)
+        assert first_result.is_valid is True
+
+    assert await _count_submissions(session_maker) == 1
+
+
+async def test_advisory_lock_keyed_per_requirement(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """The lock is per ``(user_id, requirement_id)``, so a concurrent
+    submit for a *different* requirement must NOT be blocked."""
+    other_requirement_id = f"{REQUIREMENT_ID}-other"
+    await _seed_user(session_maker)
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_validator(*_args, **_kwargs):
+        started.set()
+        await release.wait()
+        return ValidationResult(
+            is_valid=True,
+            message="ok",
+            verification_completed=True,
+        )
+
+    async def _fast_validator(*_args, **_kwargs):
+        return ValidationResult(
+            is_valid=True,
+            message="ok",
+            verification_completed=True,
+        )
+
+    # First submit holds the lock for REQUIREMENT_ID.
+    with patch(
+        "learn_to_cloud_shared.verification.execution.validate_submission",
+        new=_slow_validator,
+    ):
+        first = asyncio.create_task(
+            execute_sync_submission_validation(
+                session_maker=session_maker,
+                user_id=USER_ID,
+                requirement=_requirement(),
+                phase_id=PHASE_ID,
+                submitted_value="https://github.com/syncuser",
+                github_username="syncuser",
+            )
+        )
+        await asyncio.wait_for(started.wait(), timeout=5.0)
+
+        # Different requirement → different lock key → must proceed immediately.
+        other_requirement = HandsOnRequirement(
+            id=other_requirement_id,
+            submission_type=SubmissionType.GITHUB_PROFILE,
+            name="Other",
+            description="Other",
+        )
+        with patch(
+            "learn_to_cloud_shared.verification.execution.validate_submission",
+            new=_fast_validator,
+        ):
+            second_result = await execute_sync_submission_validation(
+                session_maker=session_maker,
+                user_id=USER_ID,
+                requirement=other_requirement,
+                phase_id=PHASE_ID,
+                submitted_value="https://github.com/syncuser",
+                github_username="syncuser",
+            )
+        assert second_result.is_valid is True
+
+        release.set()
+        await asyncio.wait_for(first, timeout=5.0)
+
+    assert await _count_submissions(session_maker) == 2
+
+
+async def test_advisory_lock_uses_pg_try_advisory_xact_lock(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """The lock helper uses Postgres' transactional advisory lock — the
+    test also reaches into pg_locks to confirm zero advisory locks remain
+    after the function returns. Catches regressions where someone swaps
+    in pg_advisory_lock (session-level) by mistake."""
+    await _seed_user(session_maker)
+
+    with patch(
+        "learn_to_cloud_shared.verification.execution.validate_submission",
+        new=AsyncMock(
+            return_value=ValidationResult(
+                is_valid=True,
+                message="ok",
+                verification_completed=True,
+            )
+        ),
+    ):
+        await execute_sync_submission_validation(
+            session_maker=session_maker,
+            user_id=USER_ID,
+            requirement=_requirement(),
+            phase_id=PHASE_ID,
+            submitted_value="https://github.com/syncuser",
+            github_username="syncuser",
+        )
+
+    async with session_maker() as db:
+        held = await db.scalar(
+            text(
+                "SELECT COUNT(*) FROM pg_locks WHERE locktype = 'advisory' AND granted"
+            )
+        )
+        assert held == 0


### PR DESCRIPTION
## Why

Phase 0-2 hands-on checks (`github_profile`, `profile_readme`, `repo_fork`, `ctf_token`, `networking_token`) are sub-second: a single GitHub API call or a constant-time token compare. Today every submission flows through Durable Functions with a spinner card and HTMX polling. That's pure overhead for these types — they finish faster than the first poll interval.

This PR routes the fast types through the FastAPI request directly. **No `VerificationJob` row, no Durable, no polling.** Phase 3-6 keeps the Durable path unchanged.

## What changed

| File | Summary |
|------|---------|
| `verification/dispatcher.py` | `SYNC_VERIFIABLE_SUBMISSION_TYPES` + `is_sync_verifiable()` helper |
| `verification/execution.py` | New `execute_sync_submission_validation()` using `pg_try_advisory_xact_lock` for dedupe + `SubmissionAlreadyInFlightError` |
| `services/submissions_service.py` | `create_verification_job` branches on type after `_check_submission_preconditions`; returns `SyncVerificationResult \| VerificationJobSubmission` |
| `routes/htmx_routes.py` | Submit handler dispatches on the union; sync path reloads the page (matching async terminal behavior) so next requirement unlocks |
| `apps/verification-functions/function_app.py` | Removed 5 sync types from orchestrator map; kept trigger functions as drain-only so in-flight Durable histories complete cleanly |

## Concurrency safety

The sync path uses a **Postgres transactional advisory lock** keyed on `(user_id, requirement_id)`. Without this, two parallel submits (double-click) would both run the validator and race `Submission.attempt_number` into a duplicate-key conflict. The lock is released at transaction end, so crashes can't leak it.

This was the blocking issue surfaced by an early rubber-duck review. The advisory-lock approach is verified end-to-end in `test_sync_execution.py::test_concurrent_submits_for_same_requirement_dedupe` using `asyncio.Event` to hold the first request inside the validator while the second races past.

## Tests

- `tests/verification/test_dispatcher.py` — full truth table for `is_sync_verifiable` (13 tests)
- `tests/verification/test_sync_execution.py` — integration tests against real Postgres (6 tests):
  - happy-path persistence
  - failure-path persistence (`is_validated=False`)
  - rollback on validator exception + lock released
  - concurrent-submit dedupe via `SubmissionAlreadyInFlightError`
  - per-requirement lock keying (different requirements don't block each other)
  - `pg_locks` check that no advisory locks leak after the request
- `api/tests/services/test_submissions_service.py` — sync branch persists `Submission` without touching `VerificationJobRepository`; async branch return type unchanged; preconditions still enforced
- `api/tests/routes/test_htmx_routes.py` — sync success and failure both return the reload trigger; async path still returns the spinner card

## Quality gates

- `ruff check` ✓
- `ruff format --check` ✓
- `ty check` (api, shared, verification-functions, tests included) ✓
- `pytest` — **678 passed**
- `import function_app` ✓

## Rollout / safety

- **Existing in-flight Durable jobs for sync types**: still serviced. The 5 per-type orchestrator triggers are kept registered (drain-only with updated docstrings). New sync-type submissions never enter that path because `create_verification_job` returns `SyncVerificationResult` before any `VerificationJob` row is created.
- **Schema**: no schema change in this PR.
- **Rollback**: revert the merge commit — no migrations to undo.

## Deferred to a follow-up PR

Slimming `VerificationJob` to a pure work-queue marker (dropping `status`, `orchestration_instance_id`, `error_code`, `error_message`, `started_at`, `completed_at`) is in scope for `refactor/slim-verification-job`. That work needs a 2-step rolling-deploy-safe migration and an explicit stale-row lifecycle, and is intentionally not part of this PR.