### PR TITLE
refactor: stop dual-writing Durable orchestration state to Postgres

### DIFF
--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -102,7 +102,6 @@ _TERMINAL_DURABLE_STATUSES = {"completed", "failed", "terminated", "canceled"}
 _DURABLE_FAILURE_STATUSES = {"failed", "terminated", "canceled"}
 _INITIAL_STATUS_DELAY_SECONDS = 2
 _RUNNING_STATUS_DELAY_SECONDS = 5
-_DURABLE_TERMINAL_FAILURE_MESSAGE = "Verification did not complete. Please try again."
 
 
 router = APIRouter(prefix="/htmx", tags=["htmx"], include_in_schema=False)
@@ -147,29 +146,34 @@ def _render_processing_card(
     )
 
 
-async def _mark_durable_terminal_failure(
+async def _delete_terminal_job(
     request: Request,
     token_data: VerificationStatusToken,
     status: str,
 ) -> None:
+    """Drop the verification_jobs row after Durable reaches terminal failure.
+
+    Replaces the older ``mark_server_error`` / ``mark_cancelled`` writes:
+    the user-facing failure message comes from Durable's runtime status
+    in the poller, not from a Postgres re-read, so we don't need to copy
+    Durable's terminal state back into Postgres. Deleting frees the
+    partial unique index so the user can retry.
+
+    The delete is guarded — if the persist activity won a race and
+    attached a Submission first, ``delete_active`` returns False and we
+    leave the row alone.
+    """
     session_maker = request.app.state.session_maker
     async with session_maker() as session:
         repository = VerificationJobRepository(session)
         job_id = UUID(token_data.job_id)
-        error_code = f"durable_{status}"
-        if status == "canceled":
-            await repository.mark_cancelled(
-                job_id,
-                error_code=error_code,
-                error_message=_DURABLE_TERMINAL_FAILURE_MESSAGE,
-            )
-        else:
-            await repository.mark_server_error(
-                job_id,
-                error_code=error_code,
-                error_message=_DURABLE_TERMINAL_FAILURE_MESSAGE,
-            )
+        deleted = await repository.delete_active(job_id)
         await session.commit()
+    if not deleted:
+        logger.info(
+            "verification.poller.delete_skipped",
+            extra={"job_id": str(job_id), "runtime_status": status},
+        )
 
 
 async def _render_step_toggle(
@@ -497,11 +501,12 @@ async def _start_async_job_and_render(
                 "error_type": type(exc).__name__,
             },
         )
+        # Delete the just-created row so the partial unique index doesn't
+        # block the user's retry. Durable owns terminal-state messaging
+        # now; we just need to free the in-flight slot.
         async with session_maker() as write_session:
-            await VerificationJobRepository(write_session).mark_server_error(
+            await VerificationJobRepository(write_session).delete_active(
                 job_submission.job.id,
-                error_code="durable_start_failed",
-                error_message=_DURABLE_START_ERROR_MESSAGE,
             )
             await write_session.commit()
         return render_card(
@@ -570,7 +575,7 @@ async def htmx_verification_job_status(
         )
 
     if status in _DURABLE_FAILURE_STATUSES:
-        await _mark_durable_terminal_failure(request, token_data, status)
+        await _delete_terminal_job(request, token_data, status)
         return HTMLResponse(_reload_verification_html())
 
     if status in _TERMINAL_DURABLE_STATUSES:

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -30,7 +30,10 @@ from learn_to_cloud.routes.htmx_routes import (
     htmx_uncomplete_step,
     htmx_verification_job_status,
 )
-from learn_to_cloud.services.durable_verification_client import DurableStatusResult
+from learn_to_cloud.services.durable_verification_client import (
+    DurableStatusResult,
+    DurableVerificationStartError,
+)
 from learn_to_cloud.services.steps_service import StepValidationError
 from learn_to_cloud.services.submissions_service import (
     SyncVerificationResult,
@@ -300,6 +303,61 @@ class TestHtmxSubmitVerification:
         # Should render a server error card, not crash
         assert result is not None
 
+    async def test_durable_start_failure_deletes_job(self):
+        """When Durable's start_new fails, the route deletes the just-
+        created job row instead of marking it server_error. Frees the
+        partial unique index so the user can retry immediately."""
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        job = SimpleNamespace(id=uuid4(), orchestration_instance_id=None)
+        async_result = VerificationJobSubmission(
+            job=cast(VerificationJob, job),
+            created=True,
+        )
+        write_session = AsyncMock()
+        request.app.state.session_maker.return_value.__aenter__.return_value = (
+            write_session
+        )
+        repo = MagicMock()
+        repo.delete_active = AsyncMock(return_value=True)
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_id",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.derive_submission_value",
+                autospec=True,
+                return_value="https://github.com/user/repo",
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                new_callable=AsyncMock,
+                return_value=async_result,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                new_callable=AsyncMock,
+                side_effect=DurableVerificationStartError("boom"),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                return_value=repo,
+            ),
+        ):
+            result = await htmx_submit_verification(
+                request,
+                current_user,
+                requirement_id="req-1",
+                submitted_value="https://github.com/user/repo",
+            )
+
+        assert isinstance(result, HTMLResponse)
+        repo.delete_active.assert_awaited_once_with(job.id)
+        repo.mark_server_error.assert_not_called()
+        write_session.commit.assert_awaited_once()
+
     async def test_sync_submit_returns_reload_trigger(self):
         """Sync submission types finish in-request and return a page-reload
         snippet so the next requirement re-renders with fresh server state."""
@@ -535,7 +593,10 @@ class TestHtmxVerificationJobStatus:
         assert isinstance(result, HTMLResponse)
         assert "location.reload()" in bytes(result.body).decode()
 
-    async def test_failed_status_marks_job_server_error(self):
+    async def test_failed_status_deletes_active_job(self):
+        """Durable terminal failure deletes the row instead of marking
+        a server-error status. Frees the partial unique index for retry
+        without copying Durable's terminal state into Postgres."""
         request = _mock_request()
         mock_session = AsyncMock()
         request.app.state.session_maker.return_value.__aenter__.return_value = (
@@ -565,6 +626,9 @@ class TestHtmxVerificationJobStatus:
                 autospec=True,
             ) as mock_repository_class,
         ):
+            mock_repository = mock_repository_class.return_value
+            mock_repository.delete_active = AsyncMock(return_value=True)
+
             result = await htmx_verification_job_status(
                 request,
                 token="signed-token",
@@ -572,10 +636,98 @@ class TestHtmxVerificationJobStatus:
             )
 
         assert isinstance(result, HTMLResponse)
-        mock_repository = mock_repository_class.return_value
-        mock_repository.mark_server_error.assert_awaited_once()
-        assert mock_repository.mark_server_error.await_args.args == (job_id,)
+        mock_repository.delete_active.assert_awaited_once_with(job_id)
+        mock_repository.mark_server_error.assert_not_called()
+        mock_repository.mark_cancelled.assert_not_called()
         mock_session.commit.assert_awaited_once()
+
+    async def test_canceled_status_also_deletes_active_job(self):
+        """``Canceled`` and ``Terminated`` are handled the same way as
+        ``Failed`` — delete the row, let the user retry."""
+        request = _mock_request()
+        mock_session = AsyncMock()
+        request.app.state.session_maker.return_value.__aenter__.return_value = (
+            mock_session
+        )
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        job_id = uuid4()
+        token_data = VerificationStatusToken(
+            user_id=1,
+            job_id=str(job_id),
+            instance_id=str(uuid4()),
+            requirement_id="req-1",
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.load_verification_status_token",
+                return_value=token_data,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_verification_orchestration_status",
+                new_callable=AsyncMock,
+                return_value=DurableStatusResult(runtime_status="Canceled"),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                autospec=True,
+            ) as mock_repository_class,
+        ):
+            mock_repository = mock_repository_class.return_value
+            mock_repository.delete_active = AsyncMock(return_value=True)
+
+            result = await htmx_verification_job_status(
+                request,
+                token="signed-token",
+                current_user=current_user,
+            )
+
+        assert isinstance(result, HTMLResponse)
+        mock_repository.delete_active.assert_awaited_once_with(job_id)
+
+    async def test_failed_status_delete_skipped_when_persist_won_race(self):
+        """If ``delete_active`` returns False (persist linked a
+        Submission first) the poller still responds with a reload — it
+        just logs and moves on."""
+        request = _mock_request()
+        mock_session = AsyncMock()
+        request.app.state.session_maker.return_value.__aenter__.return_value = (
+            mock_session
+        )
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        token_data = VerificationStatusToken(
+            user_id=1,
+            job_id=str(uuid4()),
+            instance_id=str(uuid4()),
+            requirement_id="req-1",
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.load_verification_status_token",
+                return_value=token_data,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_verification_orchestration_status",
+                new_callable=AsyncMock,
+                return_value=DurableStatusResult(runtime_status="Failed"),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                autospec=True,
+            ) as mock_repository_class,
+        ):
+            mock_repository = mock_repository_class.return_value
+            mock_repository.delete_active = AsyncMock(return_value=False)
+
+            result = await htmx_verification_job_status(
+                request,
+                token="signed-token",
+                current_user=current_user,
+            )
+
+        assert isinstance(result, HTMLResponse)
+        assert "location.reload()" in bytes(result.body).decode()
 
 
 @pytest.mark.unit

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID, uuid4
 
-from sqlalchemy import select, text
+from sqlalchemy import delete, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -288,3 +288,25 @@ class VerificationJobRepository:
             error_code=error_code,
             error_message=error_message,
         )
+
+    async def delete_active(self, job_id: UUID) -> bool:
+        """Delete an active, unlinked verification job by id.
+
+        Guards against racing the persist activity: deletion only runs
+        when the row is still active AND has no linked Submission. If
+        persist won the race and attached a Submission (or already
+        flipped the row to a terminal status), the delete is a no-op
+        and the caller learns by the returned ``False``.
+
+        Returns:
+            True if the row was deleted, False otherwise (already
+            terminal, already linked to a Submission, or never existed).
+        """
+        stmt = delete(VerificationJob).where(
+            VerificationJob.id == job_id,
+            VerificationJob.result_submission_id.is_(None),
+            VerificationJob.status.in_(ACTIVE_JOB_STATUSES),
+        )
+        result = await self.db.execute(stmt)
+        rowcount = getattr(result, "rowcount", 0) or 0
+        return rowcount > 0

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -11,6 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.models import (
+    Submission,
     User,
     VerificationJob,
     VerificationJobStatus,
@@ -374,12 +375,63 @@ async def run_verification(
         return VerificationRunResult(job=job, validation_result=validation_result)
 
 
+async def _result_from_existing_submission(
+    db: AsyncSession,
+    *,
+    job: PreparedVerificationJob,
+    submission_id: int,
+) -> VerificationJobExecutionResult:
+    """Build the persist-activity result from an already-written Submission.
+
+    Used when an activity retry runs against a job that's already been
+    persisted. The original Submission and job state are the source of
+    truth; we just rebuild the durable-safe execution result.
+    """
+    existing = await db.get(Submission, submission_id)
+    if existing is None:
+        # Job points to a submission that vanished. Treat as a hard
+        # integrity error; do not silently persist a duplicate row.
+        raise VerificationJobNotFoundError(
+            f"job {job.id} references missing submission {submission_id}",
+        )
+
+    is_valid = existing.is_validated
+    verification_completed = existing.verification_completed
+    if is_valid:
+        status = VerificationJobStatus.SUCCEEDED
+    elif verification_completed:
+        status = VerificationJobStatus.FAILED
+    else:
+        status = VerificationJobStatus.SERVER_ERROR
+
+    return VerificationJobExecutionResult(
+        job_id=job.id,
+        status=status,
+        code=_result_code(status),
+        requirement_id=job.requirement.id,
+        requirement_name=job.requirement.name,
+        submission_type=job.requirement.submission_type.value,
+        submission_id=existing.id,
+        is_valid=is_valid,
+        verification_completed=verification_completed,
+        message=_result_message(status),
+        detail=existing.validation_message,
+    )
+
+
 async def persist_verification_result(
     run_result: VerificationRunResult,
     *,
     session_maker: async_sessionmaker[AsyncSession],
 ) -> VerificationJobExecutionResult:
-    """Persist a validation result and mark the verification job terminal."""
+    """Persist a validation result and mark the verification job terminal.
+
+    Idempotent on Durable activity retry: if the job already references
+    a persisted ``Submission`` we return the same result without writing
+    a duplicate row. Falls back to the legacy ``status``-based terminal
+    short-circuit so this stays correct during a rolling deploy where
+    older code paths still set ``status``.
+    """
     job = run_result.job
     validation_result = run_result.validation_result
 
@@ -391,6 +443,22 @@ async def persist_verification_result(
             payload = await _load_job_payload(db, job.id)
             if payload is None:
                 raise VerificationJobNotFoundError(str(job.id))
+
+            # Replay-safety guard: a prior successful run of this
+            # activity already attached a Submission. Return the same
+            # result instead of writing another row. Preferred over the
+            # status-based guard below because it survives the schema
+            # slim-down planned for PR3.
+            if payload.result_submission_id is not None:
+                result = await _result_from_existing_submission(
+                    db,
+                    job=job,
+                    submission_id=payload.result_submission_id,
+                )
+                span.set_attribute("verification.status", result.status.value)
+                span.set_attribute("verification.replay", True)
+                return result
+
             if payload.status in TERMINAL_JOB_STATUSES:
                 result = _terminal_result(payload)
                 span.set_attribute("verification.status", result.status.value)

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
@@ -228,3 +228,91 @@ class TestStatusTransitions:
         assert updated.error_code == "github_unavailable"
         assert updated.error_message == "GitHub API unavailable"
         assert updated.completed_at is not None
+
+
+class TestDeleteActive:
+    """``delete_active`` guards against racing the persist activity."""
+
+    async def test_deletes_active_unlinked_row(
+        self,
+        db_session: AsyncSession,
+        user,
+    ):
+        repo = VerificationJobRepository(db_session)
+        job = await _create_job(repo)
+
+        deleted = await repo.delete_active(job.id)
+        await db_session.commit()
+
+        assert deleted is True
+        remaining = await db_session.execute(
+            select(func.count()).select_from(VerificationJob)
+        )
+        assert remaining.scalar() == 0
+
+    async def test_refuses_when_result_submission_linked(
+        self,
+        db_session: AsyncSession,
+        user,
+    ):
+        repo = VerificationJobRepository(db_session)
+        job = await _create_job(repo)
+
+        submission = await SubmissionRepository(db_session).create(
+            user_id=USER_ID,
+            requirement_id="req-1",
+            submission_type=SubmissionType.GITHUB_PROFILE,
+            phase_id=0,
+            submitted_value="https://github.com/testuser",
+            extracted_username="testuser",
+            is_validated=False,
+            verification_completed=True,
+        )
+        await repo.mark_failed(
+            job.id,
+            error_code="validation_failed",
+            error_message="nope",
+            result_submission_id=submission.id,
+        )
+
+        deleted = await repo.delete_active(job.id)
+
+        assert deleted is False
+        loaded = await repo.get_by_id(job.id)
+        assert loaded is not None
+        assert loaded.result_submission_id == submission.id
+
+    async def test_refuses_when_status_already_terminal(
+        self,
+        db_session: AsyncSession,
+        user,
+    ):
+        repo = VerificationJobRepository(db_session)
+        job = await _create_job(repo)
+
+        # Move the job to a terminal status WITHOUT setting
+        # result_submission_id. This is the "Durable failed and persist
+        # already marked it terminal" race window.
+        await repo.mark_server_error(
+            job.id,
+            error_code="durable_failed",
+            error_message="durable failed",
+        )
+
+        deleted = await repo.delete_active(job.id)
+
+        assert deleted is False
+        loaded = await repo.get_by_id(job.id)
+        assert loaded is not None
+        assert loaded.status == VerificationJobStatus.SERVER_ERROR
+
+    async def test_unknown_id_returns_false(
+        self,
+        db_session: AsyncSession,
+        user,
+    ):
+        repo = VerificationJobRepository(db_session)
+
+        deleted = await repo.delete_active(UUID("00000000-0000-0000-0000-000000000000"))
+
+        assert deleted is False

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.models import (
@@ -425,3 +425,89 @@ async def test_execute_verification_job_marks_missing_requirement_server_error(
     assert error_message == f"Requirement not found: {REQUIREMENT_ID}"
     assert await _count_submissions(session_maker) == 0
     validation.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Replay safety: persist_verification_result is idempotent on activity retry
+# ---------------------------------------------------------------------------
+
+
+async def test_persist_is_idempotent_via_result_submission_id_guard(
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    """A Durable activity retry must NOT write a second Submission row.
+
+    Simulates the race where the persist activity's DB commit succeeds
+    but the activity's response is lost in transit, so Durable retries
+    the activity. The job row has ``result_submission_id`` already set;
+    the second call must short-circuit on that and return the same
+    result without inserting another Submission.
+
+    This test specifically exercises the new ``result_submission_id``
+    guard rather than the older ``status in TERMINAL_JOB_STATUSES``
+    guard: status is reset to RUNNING so only the new guard can rescue
+    us. That matches the post-PR3 schema where ``status`` is gone.
+    """
+    from learn_to_cloud_shared.verification_job_executor import (
+        PreparedVerificationJob,
+        VerificationRunResult,
+    )
+
+    job_id = await _create_job(session_maker)
+
+    # Build the prepared job + run result that the activity would
+    # receive — no DB needed for these objects.
+    prepared = PreparedVerificationJob(
+        id=job_id,
+        user_id=USER_ID,
+        github_username="executoruser",
+        requirement=_requirement(),
+        phase_id=3,
+        submitted_value="https://github.com/executoruser/repo",
+    )
+    run_result = VerificationRunResult(
+        job=prepared,
+        validation_result=ValidationResult(is_valid=True, message="Verified"),
+    )
+
+    first = await persist_verification_result(
+        run_result,
+        session_maker=session_maker,
+    )
+    assert first.status == VerificationJobStatus.SUCCEEDED
+    assert first.submission_id is not None
+    assert await _count_submissions(session_maker) == 1
+
+    # Reset job.status to RUNNING but keep result_submission_id linked.
+    # This isolates the new replay guard: the old TERMINAL guard would
+    # not fire here.
+    async with session_maker() as db:
+        await db.execute(
+            text(
+                "UPDATE verification_jobs SET status='running', "
+                "completed_at=NULL WHERE id=:id"
+            ),
+            {"id": str(job_id)},
+        )
+        await db.commit()
+
+    # Activity retry: same run_result, second call.
+    second = await persist_verification_result(
+        run_result,
+        session_maker=session_maker,
+    )
+
+    # Same outcome, same submission_id, no second Submission row.
+    assert second.status == VerificationJobStatus.SUCCEEDED
+    assert second.submission_id == first.submission_id
+    assert second.is_valid is True
+    assert second.requirement_id == REQUIREMENT_ID
+    assert await _count_submissions(session_maker) == 1
+
+
+# Note: a "result_submission_id points at a missing Submission" guard
+# exists in _result_from_existing_submission for defense in depth, but
+# the FK ``verification_jobs_result_submission_id_fkey`` with
+# ON DELETE SET NULL makes that state unreachable at the database
+# level — deleting the Submission nulls the link before the activity
+# could see the dangling id. So there's no realistic state to test.


### PR DESCRIPTION
**Stacked on top of #419 — should merge after that lands.**

Once #419 merges, GitHub will automatically retarget this PR to `main`.

## Why

The verification poller used to read Durable runtime status, then write back to Postgres via `mark_server_error` / `mark_cancelled` to "release" the partial unique index for retry. That dual-write is the smell that motivated this whole refactor: Durable already owns the runtime state, and copying it back into a Postgres status column just to free an index is overkill.

This PR replaces the write-back with a guarded delete and makes the persist activity idempotent against Durable retries. **Schema is unchanged.** A follow-up PR3 will drop the now-redundant `status` / `error_code` / `error_message` / `started_at` / `completed_at` / `orchestration_instance_id` columns and redefine the partial unique index on `result_submission_id IS NULL`.

## What changed

| File | Summary |
|------|---------|
| `repositories/verification_job_repository.py` | New `delete_active(job_id)` — DELETE guarded by `result_submission_id IS NULL AND status IN ACTIVE_JOB_STATUSES`. Returns bool so callers learn when the persist activity won a race. |
| `routes/htmx_routes.py` | `_mark_durable_terminal_failure` → `_delete_terminal_job`. Poller deletes on Durable `Failed`/`Canceled`/`Terminated` instead of marking. Durable start-failure branch also deletes. |
| `verification_job_executor.py` | `persist_verification_result` short-circuits on `payload.result_submission_id is not None` and reconstructs the same `VerificationJobExecutionResult` from the existing `Submission` without writing a duplicate row. Keeps the legacy `status in TERMINAL_JOB_STATUSES` guard for rolling-deploy safety; the new guard is defense in depth that survives PR3 dropping `status`. |

## Concurrency & replay safety

Per the rubber-duck review:

- **Race between poller and persist**: deletion is guarded by `result_submission_id IS NULL AND status IN ACTIVE_JOB_STATUSES`. If persist already linked a Submission or already marked the row terminal, `delete_active` is a no-op and returns `False`. The poller logs and moves on.
- **Durable activity retry after a lost response**: `result_submission_id` is the idempotency key. The activity loads the existing Submission and returns the same result; no duplicate row.
- **Submission deleted out from under the job**: `_result_from_existing_submission` raises `VerificationJobNotFoundError`. The FK `verification_jobs_result_submission_id_fkey` with `ON DELETE SET NULL` makes that state structurally unreachable at the DB level, but the safety net stays as defense in depth.

## Tests added

- `test_verification_job_repository.TestDeleteActive` — 4 integration tests for the new guarded delete (active+unlinked deletes; refuses when linked; refuses when terminal; returns False for unknown id).
- `test_htmx_routes` — poller `Failed` and `Canceled` both call `delete_active`; delete-skipped path still reloads; Durable start failure deletes instead of `mark_server_error`.
- `test_verification_job_executor.test_persist_is_idempotent_via_result_submission_id_guard` — resets status to RUNNING with `result_submission_id` still linked, calls persist twice, asserts only one `Submission` row exists. This specifically isolates the new guard from the older TERMINAL_JOB_STATUSES short-circuit.

## Quality gates

- `ruff check` ✓
- `ruff format --check` ✓
- `ty check` (api / shared / verification-functions / tests) ✓
- `pytest` — **686 passed**
- `import function_app` ✓

## Rollout / safety

- **No schema change.** Old code paths can still read/write the columns.
- **`mark_*` methods retained** on the repository — callers may exist on the older Durable-side code mid-deploy.
- **`prepare_verification_job` still calls `mark_running`** — PR3 deals with this.
- **Rollback**: revert the merge commit. No migrations to undo.

## Deferred to PR3

- Drop `VerificationJob.status`, `orchestration_instance_id`, `error_code`, `error_message`, `started_at`, `completed_at`.
- Redefine the partial unique index on `result_submission_id IS NULL`.
- Switch `pages_routes.get_active_for_phase` query to `result_submission_id IS NULL`.
- Switch `_start_async_job_and_render` from `orchestration_instance_id` to Durable lookup.
- Remove the drain-only orchestrator triggers from #419.
- This needs the 2-step rolling-deploy-safe migration design we discussed.