### PR TITLE
refactor: switch active-job predicate to result_submission_id IS NULL (expand step)

### DIFF
--- a/api/alembic/versions/0020_add_result_submission_id_indexes.py
+++ b/api/alembic/versions/0020_add_result_submission_id_indexes.py
@@ -1,0 +1,55 @@
+"""Add active-job indexes keyed on result_submission_id.
+
+PR3 expand step. Application code switches to ``result_submission_id IS NULL``
+as the "active verification job" predicate; this revision adds the supporting
+indexes alongside the existing status-based ones so both old and new code
+paths work during the rolling deploy. A future migration will drop the old
+``status``-based index and column once all pods have moved to the new code.
+
+Revision ID: 0020_add_result_submission_id_indexes
+Revises: 0019_enforce_not_null_columns
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0020_add_result_submission_id_indexes"
+down_revision = "0019_enforce_not_null_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # New partial unique index: replaces the role of
+    # ``uq_verification_jobs_active_user_requirement`` (status-based) once
+    # all pods are on the new code. Kept additive in this revision so old
+    # pods running PR2 code can keep using the status-based predicate.
+    op.create_index(
+        "uq_verification_jobs_active_user_requirement_v2",
+        "verification_jobs",
+        ["user_id", "requirement_id"],
+        unique=True,
+        postgresql_where="result_submission_id IS NULL",
+    )
+    # Supporting (non-unique) index for ``get_active_for_phase`` queries
+    # under the new predicate.
+    op.create_index(
+        "ix_verification_jobs_user_phase_active",
+        "verification_jobs",
+        ["user_id", "phase_id"],
+        unique=False,
+        postgresql_where="result_submission_id IS NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_verification_jobs_user_phase_active",
+        table_name="verification_jobs",
+    )
+    op.drop_index(
+        "uq_verification_jobs_active_user_requirement_v2",
+        table_name="verification_jobs",
+    )

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -457,29 +457,28 @@ async def _start_async_job_and_render(
 ) -> HTMLResponse:
     """Start a Durable orchestration for an async job and render the spinner.
 
-    On a successful start (or when a previous start is already known via
-    ``orchestration_instance_id``) returns the processing card with a
-    signed status token the browser polls. On Durable start failure marks
-    the job server-error and renders a banner.
+    The job's UUID *is* the Durable orchestration instance id (we always pass
+    ``instance_id=job.id`` to the starter), so we don't need to read it back
+    from ``VerificationJob.orchestration_instance_id`` — that column is dead
+    weight kept for old code mid-deploy and will be removed in PR4.
+
+    On the rare concurrent-submit case (``created=False``) the original submit
+    already kicked off Durable; we skip the start call and let the poller
+    discover the existing instance via ``job.id``. If that original start
+    never actually succeeded, the poller will see a 404 from Durable and
+    surface the error so the user can retry.
+
+    On Durable start failure deletes the just-created row so the partial
+    unique index doesn't block the user's retry.
     """
     try:
-        existing_instance_id = job_submission.job.orchestration_instance_id
-        if job_submission.created or existing_instance_id is None:
-            start_result = await start_verification_orchestration(job_submission.job.id)
-            instance_id = start_result.instance_id
-            async with session_maker() as write_session:
-                await VerificationJobRepository(write_session).mark_starting(
-                    job_submission.job.id,
-                    start_result.instance_id,
-                )
-                await write_session.commit()
-        else:
-            instance_id = existing_instance_id
+        if job_submission.created:
+            await start_verification_orchestration(job_submission.job.id)
 
         status_token = create_verification_status_token(
             user_id=user_id,
             job_id=job_submission.job.id,
-            instance_id=instance_id,
+            instance_id=str(job_submission.job.id),
             requirement_id=requirement_id,
         )
 

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -138,15 +138,17 @@ async def phase_page(
         phase_id,
     )
     active_jobs_by_req = {job.requirement_id: job for job in active_jobs}
+    # The Durable orchestration instance id IS the job UUID — we always
+    # pass ``instance_id=job.id`` to the starter, so we don't need to read
+    # back the now-dead ``orchestration_instance_id`` column.
     verification_status_tokens_by_req = {
         job.requirement_id: create_verification_status_token(
             user_id=user_id,
             job_id=job.id,
-            instance_id=job.orchestration_instance_id,
+            instance_id=str(job.id),
             requirement_id=job.requirement_id,
         )
         for job in active_jobs
-        if job.orchestration_instance_id is not None
     }
 
     # Pre-compute per-requirement derived URLs and PR-review prefixes so the

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -269,8 +269,10 @@ class TestHtmxSubmitVerification:
         assert result is not None
         mock_create_job.assert_awaited_once()
         mock_start.assert_awaited_once_with(job.id)
-        repo.mark_starting.assert_awaited_once_with(job.id, start_result.instance_id)
-        write_session.commit.assert_awaited_once()
+        # PR3: mark_starting is no longer called — the job UUID IS the
+        # Durable instance id, so we don't need to round-trip it back
+        # into Postgres.
+        repo.mark_starting.assert_not_called()
 
     async def test_submit_unexpected_error_renders_server_error(self):
         """Unexpected exceptions render a server error card."""
@@ -518,7 +520,53 @@ class TestHtmxSubmitVerification:
 
         assert isinstance(result, HTMLResponse)
         mock_start.assert_awaited_once_with(job.id)
-        repo.mark_starting.assert_awaited_once_with(job.id, start_result.instance_id)
+        # PR3: mark_starting is no longer called — the job UUID IS the
+        # Durable instance id, so we don't round-trip it back into Postgres.
+        repo.mark_starting.assert_not_called()
+
+    async def test_duplicate_submit_skips_durable_start(self):
+        """When ``create_verification_job`` returns ``created=False``
+        (concurrent submit raced into the same job row), the route does
+        NOT call ``start_verification_orchestration`` — the original
+        submit already kicked off Durable, and calling start_new again
+        with the same instance id would error."""
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        job = SimpleNamespace(id=uuid4(), orchestration_instance_id=None)
+        async_result = VerificationJobSubmission(
+            job=cast(VerificationJob, job),
+            created=False,
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_id",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.derive_submission_value",
+                autospec=True,
+                return_value="https://github.com/user/repo",
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                new_callable=AsyncMock,
+                return_value=async_result,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                new_callable=AsyncMock,
+            ) as mock_start,
+        ):
+            result = await htmx_submit_verification(
+                request,
+                current_user,
+                requirement_id="req-1",
+                submitted_value="https://github.com/user/repo",
+            )
+
+        assert isinstance(result, HTMLResponse)
+        mock_start.assert_not_awaited()
 
 
 @pytest.mark.unit

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -243,6 +243,22 @@ class VerificationJob(TimestampMixin, Base):
             unique=True,
             postgresql_where=text("status IN ('queued', 'starting', 'running')"),
         ),
+        # PR3 expand step: result_submission_id-keyed predicates replace
+        # the status-based "active job" index. Kept alongside the legacy
+        # index until PR4 drops the status column.
+        Index(
+            "uq_verification_jobs_active_user_requirement_v2",
+            "user_id",
+            "requirement_id",
+            unique=True,
+            postgresql_where=text("result_submission_id IS NULL"),
+        ),
+        Index(
+            "ix_verification_jobs_user_phase_active",
+            "user_id",
+            "phase_id",
+            postgresql_where=text("result_submission_id IS NULL"),
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
@@ -20,6 +20,14 @@ ACTIVE_JOB_STATUSES = (
 )
 ACTIVE_JOB_STATUS_PREDICATE = "status IN ('queued', 'starting', 'running')"
 
+# PR3 expand step: new "active job" predicate keyed on the absence of a
+# linked Submission rather than on the status enum. Matches the partial
+# unique index ``uq_verification_jobs_active_user_requirement_v2`` and the
+# supporting non-unique index ``ix_verification_jobs_user_phase_active``
+# added by migration 0020. New code uses this predicate; old code mid-deploy
+# keeps using the status-based one.
+ACTIVE_JOB_UNLINKED_PREDICATE = "result_submission_id IS NULL"
+
 TERMINAL_JOB_STATUSES = (
     VerificationJobStatus.SUCCEEDED,
     VerificationJobStatus.FAILED,
@@ -99,9 +107,15 @@ class VerificationJobRepository:
                     created_at=now,
                     updated_at=now,
                 )
+                # Use the new ``result_submission_id IS NULL`` partial unique
+                # index. A brand-new row has ``result_submission_id=NULL``
+                # so it lands in the index and dedupes any concurrent
+                # submit for the same (user_id, requirement_id). Once the
+                # persist activity links a Submission the row exits the
+                # index and a follow-up submit succeeds.
                 .on_conflict_do_nothing(
                     index_elements=["user_id", "requirement_id"],
-                    index_where=text(ACTIVE_JOB_STATUS_PREDICATE),
+                    index_where=text(ACTIVE_JOB_UNLINKED_PREDICATE),
                 )
                 .returning(VerificationJob)
             )
@@ -128,13 +142,18 @@ class VerificationJobRepository:
         user_id: int,
         requirement_id: str,
     ) -> VerificationJob | None:
-        """Get the active job for a user and requirement, if one exists."""
+        """Get the active job for a user and requirement, if one exists.
+
+        "Active" means a row exists with no linked Submission yet — the
+        ``delete_active`` poller path and the persist activity both
+        flip rows out of this predicate when work completes.
+        """
         result = await self.db.execute(
             select(VerificationJob)
             .where(
                 VerificationJob.user_id == user_id,
                 VerificationJob.requirement_id == requirement_id,
-                VerificationJob.status.in_(ACTIVE_JOB_STATUSES),
+                VerificationJob.result_submission_id.is_(None),
             )
             .order_by(VerificationJob.created_at.desc())
             .limit(1)
@@ -146,13 +165,17 @@ class VerificationJobRepository:
         user_id: int,
         phase_id: int,
     ) -> list[VerificationJob]:
-        """Get active jobs for a user in a phase."""
+        """Get active jobs for a user in a phase.
+
+        "Active" means a row exists with no linked Submission yet —
+        see :meth:`get_active_for_requirement`.
+        """
         result = await self.db.execute(
             select(VerificationJob)
             .where(
                 VerificationJob.user_id == user_id,
                 VerificationJob.phase_id == phase_id,
-                VerificationJob.status.in_(ACTIVE_JOB_STATUSES),
+                VerificationJob.result_submission_id.is_(None),
             )
             .order_by(VerificationJob.created_at.desc())
         )

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
@@ -102,6 +102,10 @@ class TestCreate:
         db_session: AsyncSession,
         user,
     ):
+        """After PR3 the "active" predicate is ``result_submission_id IS NULL``,
+        so a terminal-but-unlinked row would still block. Real production
+        terminal calls always link a Submission (executor) or delete the
+        row (poller); the test reflects the executor path."""
         repo = VerificationJobRepository(db_session)
 
         first, first_created = await repo.create_or_get_active(
@@ -111,10 +115,21 @@ class TestCreate:
             phase_id=1,
             submitted_value="token-1",
         )
+        submission = await SubmissionRepository(db_session).create(
+            user_id=USER_ID,
+            requirement_id="req-retry",
+            submission_type=SubmissionType.CTF_TOKEN,
+            phase_id=1,
+            submitted_value="token-1",
+            extracted_username=None,
+            is_validated=False,
+            verification_completed=True,
+        )
         await repo.mark_failed(
             first.id,
             error_code="validation_failed",
             error_message="Try again",
+            result_submission_id=submission.id,
         )
         second, second_created = await repo.create_or_get_active(
             user_id=USER_ID,
@@ -136,9 +151,14 @@ class TestFind:
         db_session: AsyncSession,
         user,
     ):
+        """After PR3, ``get_active_for_requirement`` keys on
+        ``result_submission_id IS NULL`` rather than the status enum.
+        Use ``delete_active`` (the actual poller path post-PR2) to release
+        the first row, then create the second."""
         repo = VerificationJobRepository(db_session)
         first = await _create_job(repo, requirement_id="req-latest")
-        await repo.mark_cancelled(first.id, error_code="user_cancelled")
+        deleted = await repo.delete_active(first.id)
+        assert deleted is True
         second = await _create_job(repo, requirement_id="req-latest")
 
         active = await repo.get_active_for_requirement(USER_ID, "req-latest")


### PR DESCRIPTION
**Expand step of the verification_jobs slim-down. PR4 will be the contract step.**

## Why split into expand + contract

To stay rolling-deploy safe. The deploy pipeline updates ACA pods and Verification Functions independently, and Alembic runs *before* the new ACA revision goes live. If a single PR both removed model columns and dropped the underlying DB columns, the old PR2 pods left running during the rolling window would crash on every `SELECT verification_jobs.*` (4-6 min outage).

Splitting into expand (this PR) + contract (future PR4) means:
- This PR adds new indexes alongside the old ones, switches code to use the new predicate, but leaves all columns + the old index intact. Old PR2 pods keep working.
- PR4 ships only the Alembic migration that drops columns + the old index. By then all pods are on PR3 code which doesn't reference those columns.

## What changed

| File | Summary |
|------|---------|
| `alembic/versions/0020_add_result_submission_id_indexes.py` | New partial unique index `uq_verification_jobs_active_user_requirement_v2` ON `(user_id, requirement_id) WHERE result_submission_id IS NULL`. New supporting non-unique index `ix_verification_jobs_user_phase_active` ON `(user_id, phase_id) WHERE result_submission_id IS NULL`. Old indexes untouched. |
| `models.py` | `VerificationJob.__table_args__` gets the two new indexes (keeps SQLAlchemy `create_all` for test fixtures in sync with the live migration). |
| `verification_job_repository.py` | `create_or_get_active` ON CONFLICT now targets the new index. `get_active_for_requirement` and `get_active_for_phase` switch to `result_submission_id.is_(None)`. Old `mark_*` methods kept for old-code compat. New `ACTIVE_JOB_UNLINKED_PREDICATE` constant. |
| `htmx_routes._start_async_job_and_render` | Drops the `orchestration_instance_id` read and the `mark_starting` write. The job UUID IS the Durable instance id; passes `instance_id=job.id` directly. On duplicate-submit (`created=False`) skips `start_new` entirely. |
| `pages_routes.py` | `verification_status_tokens_by_req` uses `job.id` as `instance_id`; drops the `orchestration_instance_id IS NOT NULL` filter. |
| Tests | Updated two repo tests that exercised the legacy "mark terminal without linking Submission" path (no production callers post-PR2). New test: `test_duplicate_submit_skips_durable_start`. |

## Why each change is rolling-deploy safe

- **New code uses new index** for ON CONFLICT and queries. Old code (PR2 version) keeps using the status-based index. Both indexes coexist in the DB.
- **INSERT still defaults `status='queued'`** (model column unchanged), so old code's status-based queries still see new rows as active during the rolling deploy. No cross-version "ghost row" issues.
- **`delete_active` keeps its dual guard** (`result_submission_id IS NULL AND status IN ACTIVE_JOB_STATUSES`) — defense in depth so the poller never deletes a row that either has a Submission linked or has had `mark_*` called.
- **Duplicate-submit handling**: under PR3 the route skips `start_new` when `created=False` rather than trying to read `orchestration_instance_id`. The original submit already kicked Durable; the new submit just renders the spinner. If the original start actually failed, the poller will discover a 404 from Durable and surface the error — same observable behavior as PR2.

## Quality gates

- `ruff check` ✓
- `ruff format --check` ✓
- `ty check` (api / shared / verification-functions including tests) ✓
- `pytest` — **687 passed**
- `alembic upgrade head` + `alembic downgrade -1` + `alembic upgrade head` round-trip verified locally
- `import function_app` ✓

## Deferred to PR4

- Drop `VerificationJob.status`, `orchestration_instance_id`, `error_code`, `error_message`, `started_at`, `completed_at`.
- Drop the legacy `uq_verification_jobs_active_user_requirement` partial unique index and `ix_verification_jobs_status_updated`.
- Drop the `verification_job_status` enum type and the `VerificationJobStatus` Python enum.
- Drop `mark_starting`, `mark_running`, `mark_succeeded`, `mark_failed`, `mark_server_error`, `mark_cancelled`, `update_status` from the repository.
- Simplify the executor's persist activity to set `result_submission_id` directly (instead of via `mark_succeeded` / `mark_failed` / `mark_server_error`).
- Remove `_terminal_result` / `_result_code` / `_result_message` machinery that derives terminal state from `status`.