### PR TITLE
refactor: drop legacy status enum + mark_* methods (PR4 contract step)

### DIFF
--- a/api/alembic/versions/0021_decouple_verification_jobs_from_status.py
+++ b/api/alembic/versions/0021_decouple_verification_jobs_from_status.py
@@ -1,0 +1,77 @@
+"""Decouple verification_jobs from the legacy status columns.
+
+PR4 of the verification-job slim-down: application code stops referencing
+``status`` and the other lifecycle columns. The columns themselves stay in
+the DB so PR3 pods can still ``SELECT *`` them during the rolling deploy;
+a future PR5 will drop them along with the ``verification_job_status``
+enum type.
+
+This revision performs three small additive changes:
+
+1. Add a server-side DEFAULT of ``'queued'`` to ``status``. After PR4 the
+   SQLAlchemy model no longer includes ``status`` so INSERTs would
+   otherwise violate the ``NOT NULL`` constraint.
+2. Drop two now-unused legacy indexes:
+
+   - ``ix_verification_jobs_status_updated`` (no PR3+ code queries by
+     ``status``).
+   - ``uq_verification_jobs_active_user_requirement`` (PR3+ code uses
+     the ``result_submission_id IS NULL`` partial unique index instead).
+
+3. One-off cleanup: delete any "ghost" rows where the legacy status is
+   terminal but no ``Submission`` was linked. The only pre-PR2 path that
+   could create such a row was ``_mark_missing_requirement`` in the
+   executor; PR2 removed that pattern. The DELETE is defensive and
+   keeps the new ``result_submission_id IS NULL`` partial unique index
+   from refusing legitimate submits because of a stale leftover.
+
+Revision ID: 0021_decouple_verification_jobs_from_status
+Revises: 0020_add_result_submission_id_indexes
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0021_decouple_verification_jobs_from_status"
+down_revision = "0020_add_result_submission_id_indexes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE verification_jobs ALTER COLUMN status SET DEFAULT 'queued'")
+    op.drop_index(
+        "ix_verification_jobs_status_updated",
+        table_name="verification_jobs",
+    )
+    op.drop_index(
+        "uq_verification_jobs_active_user_requirement",
+        table_name="verification_jobs",
+    )
+    op.execute(
+        sa.text(
+            "DELETE FROM verification_jobs "
+            "WHERE result_submission_id IS NULL "
+            "AND status IN ('succeeded', 'failed', 'server_error', 'cancelled')"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.create_index(
+        "uq_verification_jobs_active_user_requirement",
+        "verification_jobs",
+        ["user_id", "requirement_id"],
+        unique=True,
+        postgresql_where="status IN ('queued', 'starting', 'running')",
+    )
+    op.create_index(
+        "ix_verification_jobs_status_updated",
+        "verification_jobs",
+        ["status", "updated_at"],
+    )
+    op.execute("ALTER TABLE verification_jobs ALTER COLUMN status DROP DEFAULT")

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -231,7 +231,6 @@ class TestHtmxSubmitVerification:
             write_session
         )
         repo = MagicMock()
-        repo.mark_starting = AsyncMock()
 
         with (
             patch(
@@ -269,10 +268,6 @@ class TestHtmxSubmitVerification:
         assert result is not None
         mock_create_job.assert_awaited_once()
         mock_start.assert_awaited_once_with(job.id)
-        # PR3: mark_starting is no longer called — the job UUID IS the
-        # Durable instance id, so we don't need to round-trip it back
-        # into Postgres.
-        repo.mark_starting.assert_not_called()
 
     async def test_submit_unexpected_error_renders_server_error(self):
         """Unexpected exceptions render a server error card."""
@@ -357,7 +352,6 @@ class TestHtmxSubmitVerification:
 
         assert isinstance(result, HTMLResponse)
         repo.delete_active.assert_awaited_once_with(job.id)
-        repo.mark_server_error.assert_not_called()
         write_session.commit.assert_awaited_once()
 
     async def test_sync_submit_returns_reload_trigger(self):
@@ -484,7 +478,6 @@ class TestHtmxSubmitVerification:
             write_session
         )
         repo = MagicMock()
-        repo.mark_starting = AsyncMock()
 
         with (
             patch(
@@ -520,9 +513,6 @@ class TestHtmxSubmitVerification:
 
         assert isinstance(result, HTMLResponse)
         mock_start.assert_awaited_once_with(job.id)
-        # PR3: mark_starting is no longer called — the job UUID IS the
-        # Durable instance id, so we don't round-trip it back into Postgres.
-        repo.mark_starting.assert_not_called()
 
     async def test_duplicate_submit_skips_durable_start(self):
         """When ``create_verification_job`` returns ``created=False``
@@ -685,8 +675,6 @@ class TestHtmxVerificationJobStatus:
 
         assert isinstance(result, HTMLResponse)
         mock_repository.delete_active.assert_awaited_once_with(job_id)
-        mock_repository.mark_server_error.assert_not_called()
-        mock_repository.mark_cancelled.assert_not_called()
         mock_session.commit.assert_awaited_once()
 
     async def test_canceled_status_also_deletes_active_job(self):

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -123,18 +123,6 @@ class SubmissionType(StrEnum):
     SECURITY_SCANNING = "security_scanning"
 
 
-class VerificationJobStatus(StrEnum):
-    """Lifecycle status for an asynchronous verification job."""
-
-    QUEUED = "queued"
-    STARTING = "starting"
-    RUNNING = "running"
-    SUCCEEDED = "succeeded"
-    FAILED = "failed"
-    SERVER_ERROR = "server_error"
-    CANCELLED = "cancelled"
-
-
 class Submission(TimestampMixin, Base):
     """Tracks validated submissions for hands-on verification.
 
@@ -225,7 +213,16 @@ class Submission(TimestampMixin, Base):
 
 
 class VerificationJob(TimestampMixin, Base):
-    """App-facing status record for asynchronous verification execution."""
+    """Work-queue marker for asynchronous verification execution.
+
+    A row exists during in-flight Durable orchestration. The persist
+    activity links a ``Submission`` via ``result_submission_id`` when
+    work completes; the poller deletes the row if Durable reports
+    terminal failure. PR4 dropped the legacy ``status`` enum, the
+    ``mark_*`` lifecycle methods, and the Postgres-side error /
+    timestamp columns — Durable owns runtime state, ``Submission``
+    owns the outcome.
+    """
 
     __tablename__ = "verification_jobs"
     __table_args__ = (
@@ -235,17 +232,6 @@ class VerificationJob(TimestampMixin, Base):
             "requirement_id",
             "created_at",
         ),
-        Index("ix_verification_jobs_status_updated", "status", "updated_at"),
-        Index(
-            "uq_verification_jobs_active_user_requirement",
-            "user_id",
-            "requirement_id",
-            unique=True,
-            postgresql_where=text("status IN ('queued', 'starting', 'running')"),
-        ),
-        # PR3 expand step: result_submission_id-keyed predicates replace
-        # the status-based "active job" index. Kept alongside the legacy
-        # index until PR4 drops the status column.
         Index(
             "uq_verification_jobs_active_user_requirement_v2",
             "user_id",
@@ -285,36 +271,12 @@ class VerificationJob(TimestampMixin, Base):
     submitted_value: Mapped[str] = mapped_column(Text, nullable=False)
     extracted_username: Mapped[str | None] = mapped_column(String(255), nullable=True)
     cloud_provider: Mapped[str | None] = mapped_column(String(16), nullable=True)
-    status: Mapped[VerificationJobStatus] = mapped_column(
-        Enum(
-            VerificationJobStatus,
-            name="verification_job_status",
-            native_enum=False,
-            create_constraint=True,
-            values_callable=lambda x: [e.value for e in x],
-        ),
-        nullable=False,
-        default=VerificationJobStatus.QUEUED,
-    )
-    orchestration_instance_id: Mapped[str | None] = mapped_column(
-        String(255), nullable=True
-    )
     result_submission_id: Mapped[int | None] = mapped_column(
         Integer,
         ForeignKey("submissions.id", ondelete="SET NULL"),
         nullable=True,
     )
-    error_code: Mapped[str | None] = mapped_column(String(100), nullable=True)
-    error_message: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     traceparent: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    started_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True),
-        nullable=True,
-    )
-    completed_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True),
-        nullable=True,
-    )
 
     user: Mapped["User"] = relationship(back_populates="verification_jobs")
     result_submission: Mapped["Submission | None"] = relationship(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
@@ -1,43 +1,41 @@
-"""Repository for verification job status records."""
+"""Repository for verification job records.
 
+PR4 stripped the legacy status enum and the ``mark_*`` lifecycle methods.
+``VerificationJob`` is now a thin work-queue marker: a row exists during
+in-flight verification work, gets linked to a ``Submission`` via
+:meth:`VerificationJobRepository.link_submission` when the persist
+activity completes, and is deleted by the poller on Durable terminal
+failure via :meth:`VerificationJobRepository.delete_active`.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
 from uuid import UUID, uuid4
 
-from sqlalchemy import delete, select, text
+from sqlalchemy import delete, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from learn_to_cloud_shared.models import (
     SubmissionType,
     VerificationJob,
-    VerificationJobStatus,
     utcnow,
 )
 
-ACTIVE_JOB_STATUSES = (
-    VerificationJobStatus.QUEUED,
-    VerificationJobStatus.STARTING,
-    VerificationJobStatus.RUNNING,
-)
-ACTIVE_JOB_STATUS_PREDICATE = "status IN ('queued', 'starting', 'running')"
-
-# PR3 expand step: new "active job" predicate keyed on the absence of a
-# linked Submission rather than on the status enum. Matches the partial
-# unique index ``uq_verification_jobs_active_user_requirement_v2`` and the
-# supporting non-unique index ``ix_verification_jobs_user_phase_active``
-# added by migration 0020. New code uses this predicate; old code mid-deploy
-# keeps using the status-based one.
 ACTIVE_JOB_UNLINKED_PREDICATE = "result_submission_id IS NULL"
 
-TERMINAL_JOB_STATUSES = (
-    VerificationJobStatus.SUCCEEDED,
-    VerificationJobStatus.FAILED,
-    VerificationJobStatus.SERVER_ERROR,
-    VerificationJobStatus.CANCELLED,
-)
+
+class LinkResult(StrEnum):
+    """Outcome of :meth:`VerificationJobRepository.link_submission`."""
+
+    LINKED = "linked"
+    ALREADY_LINKED = "already_linked"
+    MISSING = "missing"
 
 
 class VerificationJobRepository:
-    """Repository for verification job status records."""
+    """Repository for verification job records."""
 
     def __init__(self, db: AsyncSession) -> None:
         self.db = db
@@ -52,8 +50,6 @@ class VerificationJobRepository:
         submitted_value: str,
         extracted_username: str | None = None,
         cloud_provider: str | None = None,
-        status: VerificationJobStatus = VerificationJobStatus.QUEUED,
-        orchestration_instance_id: str | None = None,
         traceparent: str | None = None,
     ) -> VerificationJob:
         """Create a verification job and let DB constraints enforce uniqueness."""
@@ -66,8 +62,6 @@ class VerificationJobRepository:
             submitted_value=submitted_value,
             extracted_username=extracted_username,
             cloud_provider=cloud_provider,
-            status=status,
-            orchestration_instance_id=orchestration_instance_id,
             traceparent=traceparent,
         )
         self.db.add(job)
@@ -84,10 +78,17 @@ class VerificationJobRepository:
         submitted_value: str,
         extracted_username: str | None = None,
         cloud_provider: str | None = None,
-        orchestration_instance_id: str | None = None,
         traceparent: str | None = None,
     ) -> tuple[VerificationJob, bool]:
-        """Create a queued job, or return the active one for the requirement."""
+        """Create a queued job, or return the active one for the requirement.
+
+        The partial unique index
+        ``uq_verification_jobs_active_user_requirement_v2`` ensures only
+        one row per ``(user_id, requirement_id)`` may be unlinked at a
+        time. A brand-new row has ``result_submission_id=NULL`` so it
+        falls under the predicate; once the persist activity links a
+        Submission the row exits and a follow-up submit succeeds.
+        """
         for _ in range(2):
             now = utcnow()
             stmt = (
@@ -101,18 +102,10 @@ class VerificationJobRepository:
                     submitted_value=submitted_value,
                     extracted_username=extracted_username,
                     cloud_provider=cloud_provider,
-                    status=VerificationJobStatus.QUEUED,
-                    orchestration_instance_id=orchestration_instance_id,
                     traceparent=traceparent,
                     created_at=now,
                     updated_at=now,
                 )
-                # Use the new ``result_submission_id IS NULL`` partial unique
-                # index. A brand-new row has ``result_submission_id=NULL``
-                # so it lands in the index and dedupes any concurrent
-                # submit for the same (user_id, requirement_id). Once the
-                # persist activity links a Submission the row exits the
-                # index and a follow-up submit succeeds.
                 .on_conflict_do_nothing(
                     index_elements=["user_id", "requirement_id"],
                     index_where=text(ACTIVE_JOB_UNLINKED_PREDICATE),
@@ -142,12 +135,7 @@ class VerificationJobRepository:
         user_id: int,
         requirement_id: str,
     ) -> VerificationJob | None:
-        """Get the active job for a user and requirement, if one exists.
-
-        "Active" means a row exists with no linked Submission yet — the
-        ``delete_active`` poller path and the persist activity both
-        flip rows out of this predicate when work completes.
-        """
+        """Get the active (unlinked) job for a user and requirement, if any."""
         result = await self.db.execute(
             select(VerificationJob)
             .where(
@@ -165,11 +153,7 @@ class VerificationJobRepository:
         user_id: int,
         phase_id: int,
     ) -> list[VerificationJob]:
-        """Get active jobs for a user in a phase.
-
-        "Active" means a row exists with no linked Submission yet —
-        see :meth:`get_active_for_requirement`.
-        """
+        """Get active (unlinked) jobs for a user in a phase."""
         result = await self.db.execute(
             select(VerificationJob)
             .where(
@@ -198,137 +182,50 @@ class VerificationJobRepository:
         )
         return result.scalar_one_or_none()
 
-    async def update_status(
+    async def link_submission(
         self,
         job_id: UUID,
-        status: VerificationJobStatus,
-        *,
-        orchestration_instance_id: str | None = None,
-        result_submission_id: int | None = None,
-        error_code: str | None = None,
-        error_message: str | None = None,
-    ) -> VerificationJob | None:
-        """Update a verification job status and lifecycle metadata."""
-        job = await self.get_by_id(job_id)
-        if job is None:
-            return None
+        submission_id: int,
+    ) -> LinkResult:
+        """Link a persisted ``Submission`` to this verification job.
 
-        now = utcnow()
-        job.status = status
-        job.updated_at = now
-        if status in (VerificationJobStatus.STARTING, VerificationJobStatus.RUNNING):
-            job.started_at = job.started_at or now
-        if status in TERMINAL_JOB_STATUSES:
-            job.completed_at = now
-        if orchestration_instance_id is not None:
-            job.orchestration_instance_id = orchestration_instance_id
-        if result_submission_id is not None:
-            job.result_submission_id = result_submission_id
-        if error_code is not None:
-            job.error_code = error_code
-        if error_message is not None:
-            job.error_message = error_message
-        if status == VerificationJobStatus.SUCCEEDED:
-            job.error_code = None
-            job.error_message = None
-
-        await self.db.flush()
-        return job
-
-    async def mark_starting(
-        self,
-        job_id: UUID,
-        orchestration_instance_id: str,
-    ) -> VerificationJob | None:
-        """Mark a job as starting under an execution backend."""
-        return await self.update_status(
-            job_id,
-            VerificationJobStatus.STARTING,
-            orchestration_instance_id=orchestration_instance_id,
+        Idempotent against Durable activity retries: only links when the
+        row is still unlinked. On rowcount=0 re-reads to distinguish the
+        "another activity attempt linked it first" case from the
+        "poller already deleted the row" case.
+        """
+        stmt = (
+            update(VerificationJob)
+            .where(
+                VerificationJob.id == job_id,
+                VerificationJob.result_submission_id.is_(None),
+            )
+            .values(
+                result_submission_id=submission_id,
+                updated_at=utcnow(),
+            )
         )
+        result = await self.db.execute(stmt)
+        rowcount = getattr(result, "rowcount", 0) or 0
+        if rowcount > 0:
+            return LinkResult.LINKED
 
-    async def mark_running(self, job_id: UUID) -> VerificationJob | None:
-        """Mark a job as running."""
-        return await self.update_status(job_id, VerificationJobStatus.RUNNING)
-
-    async def mark_succeeded(
-        self,
-        job_id: UUID,
-        result_submission_id: int,
-    ) -> VerificationJob | None:
-        """Mark a job as succeeded with its persisted submission result."""
-        return await self.update_status(
-            job_id,
-            VerificationJobStatus.SUCCEEDED,
-            result_submission_id=result_submission_id,
-        )
-
-    async def mark_failed(
-        self,
-        job_id: UUID,
-        *,
-        error_code: str,
-        error_message: str,
-        result_submission_id: int | None = None,
-    ) -> VerificationJob | None:
-        """Mark a job as failed due to user-correctable validation failure."""
-        return await self.update_status(
-            job_id,
-            VerificationJobStatus.FAILED,
-            error_code=error_code,
-            error_message=error_message,
-            result_submission_id=result_submission_id,
-        )
-
-    async def mark_server_error(
-        self,
-        job_id: UUID,
-        *,
-        error_code: str,
-        error_message: str,
-        result_submission_id: int | None = None,
-    ) -> VerificationJob | None:
-        """Mark a job as failed due to verifier infrastructure or server error."""
-        return await self.update_status(
-            job_id,
-            VerificationJobStatus.SERVER_ERROR,
-            error_code=error_code,
-            error_message=error_message,
-            result_submission_id=result_submission_id,
-        )
-
-    async def mark_cancelled(
-        self,
-        job_id: UUID,
-        *,
-        error_code: str | None = None,
-        error_message: str | None = None,
-    ) -> VerificationJob | None:
-        """Mark a job as cancelled."""
-        return await self.update_status(
-            job_id,
-            VerificationJobStatus.CANCELLED,
-            error_code=error_code,
-            error_message=error_message,
-        )
+        existing = await self.get_by_id(job_id)
+        if existing is None:
+            return LinkResult.MISSING
+        return LinkResult.ALREADY_LINKED
 
     async def delete_active(self, job_id: UUID) -> bool:
         """Delete an active, unlinked verification job by id.
 
         Guards against racing the persist activity: deletion only runs
-        when the row is still active AND has no linked Submission. If
-        persist won the race and attached a Submission (or already
-        flipped the row to a terminal status), the delete is a no-op
-        and the caller learns by the returned ``False``.
-
-        Returns:
-            True if the row was deleted, False otherwise (already
-            terminal, already linked to a Submission, or never existed).
+        when the row still has no linked Submission. If persist won the
+        race the delete is a no-op and the caller learns via the
+        returned ``False``.
         """
         stmt = delete(VerificationJob).where(
             VerificationJob.id == job_id,
             VerificationJob.result_submission_id.is_(None),
-            VerificationJob.status.in_(ACTIVE_JOB_STATUSES),
         )
         result = await self.db.execute(stmt)
         rowcount = getattr(result, "rowcount", 0) or 0

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -1,4 +1,23 @@
-"""Execute persisted verification jobs outside the FastAPI request path."""
+"""Execute persisted verification jobs outside the FastAPI request path.
+
+PR4 removed the legacy ``status`` enum and the ``mark_*`` lifecycle
+writes. A verification job is now identified by the presence of its row
+in ``verification_jobs``; the outcome lives entirely in the linked
+``Submission``. The executor:
+
+1. ``prepare_verification_job`` loads the job and, if it already has a
+   linked Submission (Durable replay after a successful prior run),
+   returns the same execution result without doing more work.
+2. ``run_verification`` runs the validator (no DB writes).
+3. ``persist_verification_result`` writes the ``Submission`` and links
+   it to the job via ``VerificationJobRepository.link_submission``.
+   Idempotent against retries via the ``ALREADY_LINKED`` short-circuit.
+
+The missing-requirement edge case writes a server-error ``Submission``
+and links it, so ``prepare`` stays idempotent on retry — the row exists,
+the link exists, and ``preparation.terminal_result`` is reconstructed
+from the linked Submission.
+"""
 
 from __future__ import annotations
 
@@ -12,12 +31,15 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.models import (
     Submission,
+    SubmissionType,
     User,
     VerificationJob,
-    VerificationJobStatus,
+)
+from learn_to_cloud_shared.repositories.submission_repository import (
+    SubmissionRepository,
 )
 from learn_to_cloud_shared.repositories.verification_job_repository import (
-    TERMINAL_JOB_STATUSES,
+    LinkResult,
     VerificationJobRepository,
 )
 from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
@@ -33,6 +55,20 @@ tracer = trace.get_tracer(__name__)
 VALIDATION_FAILED_ERROR_CODE = "validation_failed"
 VERIFICATION_INCOMPLETE_ERROR_CODE = "verification_incomplete"
 REQUIREMENT_NOT_FOUND_ERROR_CODE = "requirement_not_found"
+VERIFICATION_SUCCEEDED_CODE = "verification_succeeded"
+
+# Plain string outcomes kept for Durable activity payload compatibility
+# with deployed pre-PR4 readers. ``status`` consumers expect one of these
+# literals.
+_OUTCOME_SUCCEEDED = "succeeded"
+_OUTCOME_FAILED = "failed"
+_OUTCOME_SERVER_ERROR = "server_error"
+
+_MESSAGE_BY_OUTCOME = {
+    _OUTCOME_SUCCEEDED: "Verification succeeded.",
+    _OUTCOME_FAILED: "Verification failed.",
+    _OUTCOME_SERVER_ERROR: "Verification could not be completed.",
+}
 
 
 class VerificationJobNotFoundError(Exception):
@@ -41,8 +77,16 @@ class VerificationJobNotFoundError(Exception):
 
 @dataclass(frozen=True, slots=True)
 class VerificationJobExecutionResult:
+    """Result of running one persisted verification job.
+
+    ``status`` is a plain string (``"succeeded"`` / ``"failed"`` /
+    ``"server_error"``) rather than the legacy ``VerificationJobStatus``
+    enum so Durable activity payloads stay compatible with any pre-PR4
+    readers still in flight.
+    """
+
     job_id: UUID
-    status: VerificationJobStatus
+    status: str
     code: str
     requirement_id: str
     requirement_name: str | None
@@ -57,7 +101,7 @@ class VerificationJobExecutionResult:
         """Return a JSON-serializable Durable activity result."""
         return {
             "job_id": str(self.job_id),
-            "status": self.status.value,
+            "status": self.status,
             "code": self.code,
             "requirement_id": self.requirement_id,
             "requirement_name": self.requirement_name,
@@ -162,11 +206,8 @@ class _VerificationJobPayload:
     requirement_id: str
     phase_id: int
     submitted_value: str
-    status: VerificationJobStatus
     submission_type: str
     result_submission_id: int | None
-    error_code: str | None
-    error_message: str | None
 
 
 def _expect_mapping(value: object) -> Mapping[str, object]:
@@ -219,86 +260,112 @@ async def _load_job_payload(
         requirement_id=job.requirement_id,
         phase_id=job.phase_id,
         submitted_value=job.submitted_value,
-        status=job.status,
         submission_type=job.submission_type.value,
         result_submission_id=job.result_submission_id,
-        error_code=job.error_code,
-        error_message=job.error_message,
     )
 
 
-def _result_code(status: VerificationJobStatus, error_code: str | None = None) -> str:
-    if status == VerificationJobStatus.SUCCEEDED:
-        return "verification_succeeded"
-    if status == VerificationJobStatus.FAILED:
-        return error_code or VALIDATION_FAILED_ERROR_CODE
-    if status == VerificationJobStatus.SERVER_ERROR:
-        return error_code or VERIFICATION_INCOMPLETE_ERROR_CODE
-    if status == VerificationJobStatus.CANCELLED:
-        return error_code or "verification_cancelled"
-    return status.value
+def _outcome_for(validation_result: ValidationResult) -> str:
+    if validation_result.is_valid:
+        return _OUTCOME_SUCCEEDED
+    if validation_result.verification_completed:
+        return _OUTCOME_FAILED
+    return _OUTCOME_SERVER_ERROR
 
 
-def _result_message(status: VerificationJobStatus) -> str:
-    if status == VerificationJobStatus.SUCCEEDED:
-        return "Verification succeeded."
-    if status == VerificationJobStatus.FAILED:
-        return "Verification failed."
-    if status == VerificationJobStatus.SERVER_ERROR:
-        return "Verification could not be completed."
-    if status == VerificationJobStatus.CANCELLED:
-        return "Verification was cancelled."
-    return "Verification job is not complete."
+def _code_for_outcome(outcome: str, fallback: str | None = None) -> str:
+    if outcome == _OUTCOME_SUCCEEDED:
+        return VERIFICATION_SUCCEEDED_CODE
+    if outcome == _OUTCOME_FAILED:
+        return fallback or VALIDATION_FAILED_ERROR_CODE
+    return fallback or VERIFICATION_INCOMPLETE_ERROR_CODE
 
 
-def _terminal_result(
-    payload: _VerificationJobPayload,
+def _outcome_from_submission(submission: Submission) -> str:
+    if submission.is_validated:
+        return _OUTCOME_SUCCEEDED
+    if submission.verification_completed:
+        return _OUTCOME_FAILED
+    return _OUTCOME_SERVER_ERROR
+
+
+def _build_result_from_submission(
+    *,
+    job_id: UUID,
+    submission: Submission,
+    requirement: HandsOnRequirement | None,
 ) -> VerificationJobExecutionResult:
-    requirement = get_requirement_by_id(payload.requirement_id)
+    """Build a ``VerificationJobExecutionResult`` from an already-persisted
+    ``Submission``. Used by the replay short-circuit in
+    :func:`prepare_verification_job` and :func:`persist_verification_result`.
+    """
+    outcome = _outcome_from_submission(submission)
     return VerificationJobExecutionResult(
-        job_id=payload.id,
-        status=payload.status,
-        code=_result_code(payload.status, payload.error_code),
-        requirement_id=payload.requirement_id,
+        job_id=job_id,
+        status=outcome,
+        code=_code_for_outcome(outcome),
+        requirement_id=submission.requirement_id,
         requirement_name=requirement.name if requirement is not None else None,
-        submission_type=payload.submission_type,
-        submission_id=payload.result_submission_id,
-        is_valid=payload.status == VerificationJobStatus.SUCCEEDED,
-        verification_completed=payload.status != VerificationJobStatus.SERVER_ERROR,
-        message=_result_message(payload.status),
-        detail=payload.error_message,
+        submission_type=submission.submission_type.value,
+        submission_id=submission.id,
+        is_valid=submission.is_validated,
+        verification_completed=submission.verification_completed,
+        message=_MESSAGE_BY_OUTCOME[outcome],
+        detail=submission.validation_message,
     )
 
 
-async def _mark_missing_requirement(
+async def _handle_missing_requirement(
     *,
     session_maker: async_sessionmaker[AsyncSession],
-    job_id: UUID,
-    requirement_id: str,
-    submission_type: str,
+    payload: _VerificationJobPayload,
 ) -> VerificationJobExecutionResult:
-    detail = f"Requirement not found: {requirement_id}"
+    """Record a server-error ``Submission`` for a job whose requirement was
+    removed from content, link the job to it, and return the resulting
+    execution result.
+
+    Linking the Submission (rather than deleting the job row) keeps
+    ``prepare_verification_job`` idempotent: a retry sees the linked row
+    and short-circuits via the replay path.
+    """
+    detail = f"Requirement not found: {payload.requirement_id}"
+    try:
+        submission_type = SubmissionType(payload.submission_type)
+    except ValueError:
+        submission_type = SubmissionType.GITHUB_PROFILE
+
     async with session_maker() as db:
-        job = await VerificationJobRepository(db).mark_server_error(
-            job_id,
-            error_code=REQUIREMENT_NOT_FOUND_ERROR_CODE,
-            error_message=detail,
+        submission_repo = SubmissionRepository(db)
+        submission = await submission_repo.create(
+            user_id=payload.user_id,
+            requirement_id=payload.requirement_id,
+            submission_type=submission_type,
+            phase_id=payload.phase_id,
+            submitted_value=payload.submitted_value,
+            extracted_username=None,
+            is_validated=False,
+            verification_completed=False,
+            validation_message=detail,
         )
-        if job is None:
-            raise VerificationJobNotFoundError(str(job_id))
+        link = await VerificationJobRepository(db).link_submission(
+            payload.id,
+            submission.id,
+        )
+        if link is LinkResult.MISSING:
+            raise VerificationJobNotFoundError(str(payload.id))
         await db.commit()
 
     return VerificationJobExecutionResult(
-        job_id=job_id,
-        status=VerificationJobStatus.SERVER_ERROR,
+        job_id=payload.id,
+        status=_OUTCOME_SERVER_ERROR,
         code=REQUIREMENT_NOT_FOUND_ERROR_CODE,
-        requirement_id=requirement_id,
+        requirement_id=payload.requirement_id,
         requirement_name=None,
-        submission_type=submission_type,
-        submission_id=None,
+        submission_type=payload.submission_type,
+        submission_id=submission.id,
         is_valid=False,
         verification_completed=False,
-        message=_result_message(VerificationJobStatus.SERVER_ERROR),
+        message=_MESSAGE_BY_OUTCOME[_OUTCOME_SERVER_ERROR],
         detail=detail,
     )
 
@@ -308,7 +375,15 @@ async def prepare_verification_job(
     *,
     session_maker: async_sessionmaker[AsyncSession],
 ) -> VerificationJobPreparation:
-    """Load and mark a verification job as running before validation."""
+    """Load a verification job and dispatch to the right execution path.
+
+    Replay-safe short-circuits:
+    1. If the job is already linked to a ``Submission`` (Durable retried
+       prepare after the persist activity already finished), return the
+       same execution result from the linked Submission.
+    2. If the requirement was removed from content between submit and
+       execute, record a server-error Submission and short-circuit.
+    """
     normalized_job_id = _coerce_job_id(job_id)
 
     with tracer.start_as_current_span(
@@ -319,23 +394,31 @@ async def prepare_verification_job(
             payload = await _load_job_payload(db, normalized_job_id)
             if payload is None:
                 raise VerificationJobNotFoundError(str(normalized_job_id))
-            if payload.status in TERMINAL_JOB_STATUSES:
-                result = _terminal_result(payload)
-                span.set_attribute("verification.status", result.status.value)
-                return VerificationJobPreparation(terminal_result=result)
 
-            await VerificationJobRepository(db).mark_running(normalized_job_id)
-            await db.commit()
+            if payload.result_submission_id is not None:
+                submission = await db.get(Submission, payload.result_submission_id)
+                if submission is None:
+                    raise VerificationJobNotFoundError(
+                        f"job {normalized_job_id} references missing submission "
+                        f"{payload.result_submission_id}"
+                    )
+                requirement = get_requirement_by_id(payload.requirement_id)
+                result = _build_result_from_submission(
+                    job_id=normalized_job_id,
+                    submission=submission,
+                    requirement=requirement,
+                )
+                span.set_attribute("verification.status", result.status)
+                span.set_attribute("verification.replay", True)
+                return VerificationJobPreparation(terminal_result=result)
 
         requirement = get_requirement_by_id(payload.requirement_id)
         if requirement is None:
-            result = await _mark_missing_requirement(
+            result = await _handle_missing_requirement(
                 session_maker=session_maker,
-                job_id=normalized_job_id,
-                requirement_id=payload.requirement_id,
-                submission_type=payload.submission_type,
+                payload=payload,
             )
-            span.set_attribute("verification.status", result.status.value)
+            span.set_attribute("verification.status", result.status)
             return VerificationJobPreparation(terminal_result=result)
 
         return VerificationJobPreparation(
@@ -375,62 +458,17 @@ async def run_verification(
         return VerificationRunResult(job=job, validation_result=validation_result)
 
 
-async def _result_from_existing_submission(
-    db: AsyncSession,
-    *,
-    job: PreparedVerificationJob,
-    submission_id: int,
-) -> VerificationJobExecutionResult:
-    """Build the persist-activity result from an already-written Submission.
-
-    Used when an activity retry runs against a job that's already been
-    persisted. The original Submission and job state are the source of
-    truth; we just rebuild the durable-safe execution result.
-    """
-    existing = await db.get(Submission, submission_id)
-    if existing is None:
-        # Job points to a submission that vanished. Treat as a hard
-        # integrity error; do not silently persist a duplicate row.
-        raise VerificationJobNotFoundError(
-            f"job {job.id} references missing submission {submission_id}",
-        )
-
-    is_valid = existing.is_validated
-    verification_completed = existing.verification_completed
-    if is_valid:
-        status = VerificationJobStatus.SUCCEEDED
-    elif verification_completed:
-        status = VerificationJobStatus.FAILED
-    else:
-        status = VerificationJobStatus.SERVER_ERROR
-
-    return VerificationJobExecutionResult(
-        job_id=job.id,
-        status=status,
-        code=_result_code(status),
-        requirement_id=job.requirement.id,
-        requirement_name=job.requirement.name,
-        submission_type=job.requirement.submission_type.value,
-        submission_id=existing.id,
-        is_valid=is_valid,
-        verification_completed=verification_completed,
-        message=_result_message(status),
-        detail=existing.validation_message,
-    )
-
-
 async def persist_verification_result(
     run_result: VerificationRunResult,
     *,
     session_maker: async_sessionmaker[AsyncSession],
 ) -> VerificationJobExecutionResult:
-    """Persist a validation result and mark the verification job terminal.
+    """Persist a validation result and link it to the verification job.
 
-    Idempotent on Durable activity retry: if the job already references
-    a persisted ``Submission`` we return the same result without writing
-    a duplicate row. Falls back to the legacy ``status``-based terminal
-    short-circuit so this stays correct during a rolling deploy where
-    older code paths still set ``status``.
+    Idempotent against Durable activity retries via the
+    ``result_submission_id`` short-circuit and the
+    :class:`~learn_to_cloud_shared.repositories.verification_job_repository.LinkResult.ALREADY_LINKED`
+    case from ``link_submission``.
     """
     job = run_result.job
     validation_result = run_result.validation_result
@@ -444,24 +482,20 @@ async def persist_verification_result(
             if payload is None:
                 raise VerificationJobNotFoundError(str(job.id))
 
-            # Replay-safety guard: a prior successful run of this
-            # activity already attached a Submission. Return the same
-            # result instead of writing another row. Preferred over the
-            # status-based guard below because it survives the schema
-            # slim-down planned for PR3.
             if payload.result_submission_id is not None:
-                result = await _result_from_existing_submission(
-                    db,
-                    job=job,
-                    submission_id=payload.result_submission_id,
+                submission = await db.get(Submission, payload.result_submission_id)
+                if submission is None:
+                    raise VerificationJobNotFoundError(
+                        f"job {job.id} references missing submission "
+                        f"{payload.result_submission_id}"
+                    )
+                result = _build_result_from_submission(
+                    job_id=job.id,
+                    submission=submission,
+                    requirement=job.requirement,
                 )
-                span.set_attribute("verification.status", result.status.value)
+                span.set_attribute("verification.status", result.status)
                 span.set_attribute("verification.replay", True)
-                return result
-
-            if payload.status in TERMINAL_JOB_STATUSES:
-                result = _terminal_result(payload)
-                span.set_attribute("verification.status", result.status.value)
                 return result
 
             submission = await persist_validation_result(
@@ -474,49 +508,56 @@ async def persist_verification_result(
                 validation_result=validation_result,
             )
 
-            job_repo = VerificationJobRepository(db)
-            if validation_result.is_valid:
-                updated_job = await job_repo.mark_succeeded(job.id, submission.id)
-                status = VerificationJobStatus.SUCCEEDED
-            elif validation_result.verification_completed:
-                updated_job = await job_repo.mark_failed(
-                    job.id,
-                    error_code=VALIDATION_FAILED_ERROR_CODE,
-                    error_message=(
-                        persisted_validation_message(validation_result.message) or ""
-                    ),
-                    result_submission_id=submission.id,
-                )
-                status = VerificationJobStatus.FAILED
-            else:
-                updated_job = await job_repo.mark_server_error(
-                    job.id,
-                    error_code=VERIFICATION_INCOMPLETE_ERROR_CODE,
-                    error_message=(
-                        persisted_validation_message(validation_result.message) or ""
-                    ),
-                    result_submission_id=submission.id,
-                )
-                status = VerificationJobStatus.SERVER_ERROR
-
-            if updated_job is None:
+            link = await VerificationJobRepository(db).link_submission(
+                job.id,
+                submission.id,
+            )
+            if link is LinkResult.MISSING:
                 raise VerificationJobNotFoundError(str(job.id))
+            if link is LinkResult.ALREADY_LINKED:
+                # Another activity attempt linked a Submission between our
+                # _load_job_payload and the link_submission UPDATE. Roll
+                # back our duplicate insert by aborting the transaction;
+                # reload the canonical Submission and return its result.
+                await db.rollback()
+                async with session_maker() as fresh_db:
+                    canonical = await _load_job_payload(fresh_db, job.id)
+                    if canonical is None or canonical.result_submission_id is None:
+                        raise VerificationJobNotFoundError(str(job.id))
+                    canonical_submission = await fresh_db.get(
+                        Submission,
+                        canonical.result_submission_id,
+                    )
+                    if canonical_submission is None:
+                        raise VerificationJobNotFoundError(str(job.id))
+                    result = _build_result_from_submission(
+                        job_id=job.id,
+                        submission=canonical_submission,
+                        requirement=job.requirement,
+                    )
+                span.set_attribute("verification.status", result.status)
+                span.set_attribute("verification.replay", True)
+                return result
 
             await db.commit()
 
-        span.set_attribute("verification.status", status.value)
+        outcome = _outcome_for(validation_result)
+        code = _code_for_outcome(outcome)
+        span.set_attribute("verification.status", outcome)
         return VerificationJobExecutionResult(
             job_id=job.id,
-            status=status,
-            code=_result_code(status),
+            status=outcome,
+            code=code,
             requirement_id=job.requirement.id,
             requirement_name=job.requirement.name,
             submission_type=job.requirement.submission_type.value,
             submission_id=submission.id,
             is_valid=validation_result.is_valid,
             verification_completed=validation_result.verification_completed,
-            message=_result_message(status),
-            detail=validation_result.message,
+            message=_MESSAGE_BY_OUTCOME[outcome],
+            detail=persisted_validation_message(validation_result.message)
+            if not validation_result.is_valid
+            else None,
         )
 
 
@@ -525,7 +566,7 @@ async def execute_verification_job(
     *,
     session_maker: async_sessionmaker[AsyncSession],
 ) -> VerificationJobExecutionResult:
-    """Run one persisted verification job and update its DB status."""
+    """Run one persisted verification job end-to-end."""
     normalized_job_id = _coerce_job_id(job_id)
 
     with tracer.start_as_current_span(
@@ -539,7 +580,7 @@ async def execute_verification_job(
         if preparation.terminal_result is not None:
             span.set_attribute(
                 "verification.status",
-                preparation.terminal_result.status.value,
+                preparation.terminal_result.status,
             )
             return preparation.terminal_result
         if preparation.job is None:
@@ -550,5 +591,5 @@ async def execute_verification_job(
             run_result,
             session_maker=session_maker,
         )
-        span.set_attribute("verification.status", result.status.value)
+        span.set_attribute("verification.status", result.status)
         return result

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
@@ -6,16 +6,13 @@ import pytest
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from learn_to_cloud_shared.models import (
-    SubmissionType,
-    VerificationJob,
-    VerificationJobStatus,
-)
+from learn_to_cloud_shared.models import SubmissionType, VerificationJob
 from learn_to_cloud_shared.repositories.submission_repository import (
     SubmissionRepository,
 )
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
 from learn_to_cloud_shared.repositories.verification_job_repository import (
+    LinkResult,
     VerificationJobRepository,
 )
 
@@ -47,6 +44,25 @@ async def _create_job(
     )
 
 
+async def _create_submission(
+    db_session: AsyncSession,
+    *,
+    requirement_id: str = "req-1",
+    is_validated: bool = True,
+    verification_completed: bool = True,
+):
+    return await SubmissionRepository(db_session).create(
+        user_id=USER_ID,
+        requirement_id=requirement_id,
+        submission_type=SubmissionType.GITHUB_PROFILE,
+        phase_id=0,
+        submitted_value="https://github.com/testuser",
+        extracted_username="testuser",
+        is_validated=is_validated,
+        verification_completed=verification_completed,
+    )
+
+
 class TestCreate:
     async def test_creates_verification_job(
         self,
@@ -58,12 +74,12 @@ class TestCreate:
         job = await _create_job(repo)
 
         assert isinstance(job.id, UUID)
-        assert job.status == VerificationJobStatus.QUEUED
         assert job.user_id == USER_ID
         assert job.requirement_id == "req-1"
         assert job.submission_type == SubmissionType.GITHUB_PROFILE
         assert job.traceparent is not None
         assert job.created_at is not None
+        assert job.result_submission_id is None
 
     async def test_create_or_get_active_returns_existing_active_job(
         self,
@@ -97,15 +113,15 @@ class TestCreate:
         )
         assert count == 1
 
-    async def test_terminal_job_allows_new_active_job(
+    async def test_linked_job_allows_new_active_job(
         self,
         db_session: AsyncSession,
         user,
     ):
-        """After PR3 the "active" predicate is ``result_submission_id IS NULL``,
-        so a terminal-but-unlinked row would still block. Real production
-        terminal calls always link a Submission (executor) or delete the
-        row (poller); the test reflects the executor path."""
+        """After ``link_submission`` flips a job out of the unlinked
+        partial unique index, a follow-up submit must succeed.
+        Mirrors the failure-retry path: persist a Submission and link
+        it, then submit again."""
         repo = VerificationJobRepository(db_session)
 
         first, first_created = await repo.create_or_get_active(
@@ -115,22 +131,15 @@ class TestCreate:
             phase_id=1,
             submitted_value="token-1",
         )
-        submission = await SubmissionRepository(db_session).create(
-            user_id=USER_ID,
+        submission = await _create_submission(
+            db_session,
             requirement_id="req-retry",
-            submission_type=SubmissionType.CTF_TOKEN,
-            phase_id=1,
-            submitted_value="token-1",
-            extracted_username=None,
             is_validated=False,
             verification_completed=True,
         )
-        await repo.mark_failed(
-            first.id,
-            error_code="validation_failed",
-            error_message="Try again",
-            result_submission_id=submission.id,
-        )
+        link = await repo.link_submission(first.id, submission.id)
+        assert link is LinkResult.LINKED
+
         second, second_created = await repo.create_or_get_active(
             user_id=USER_ID,
             requirement_id="req-retry",
@@ -151,10 +160,6 @@ class TestFind:
         db_session: AsyncSession,
         user,
     ):
-        """After PR3, ``get_active_for_requirement`` keys on
-        ``result_submission_id IS NULL`` rather than the status enum.
-        Use ``delete_active`` (the actual poller path post-PR2) to release
-        the first row, then create the second."""
         repo = VerificationJobRepository(db_session)
         first = await _create_job(repo, requirement_id="req-latest")
         deleted = await repo.delete_active(first.id)
@@ -181,73 +186,62 @@ class TestFind:
         assert result is None
 
 
-class TestStatusTransitions:
-    async def test_marks_starting_and_running(
+class TestLinkSubmission:
+    """``link_submission`` is the executor's terminal write."""
+
+    async def test_links_unlinked_job(
         self,
         db_session: AsyncSession,
         user,
     ):
         repo = VerificationJobRepository(db_session)
         job = await _create_job(repo)
+        submission = await _create_submission(db_session)
 
-        starting = await repo.mark_starting(job.id, "durable-instance-1")
-        assert starting is not None
-        assert starting.status == VerificationJobStatus.STARTING
-        assert starting.orchestration_instance_id == "durable-instance-1"
-        assert starting.started_at is not None
+        before = job.updated_at
+        result = await repo.link_submission(job.id, submission.id)
+        await db_session.commit()
 
-        running = await repo.mark_running(job.id)
+        assert result is LinkResult.LINKED
+        loaded = await repo.get_by_id(job.id)
+        assert loaded is not None
+        assert loaded.result_submission_id == submission.id
+        assert loaded.updated_at >= before
 
-        assert running is not None
-        assert running.status == VerificationJobStatus.RUNNING
-        assert running.started_at == starting.started_at
-
-    async def test_marks_succeeded_with_submission_result(
+    async def test_second_call_returns_already_linked(
         self,
         db_session: AsyncSession,
         user,
     ):
-        job_repo = VerificationJobRepository(db_session)
-        submission_repo = SubmissionRepository(db_session)
-        job = await _create_job(job_repo)
-        submission = await submission_repo.create(
-            user_id=USER_ID,
-            requirement_id="req-1",
-            submission_type=SubmissionType.GITHUB_PROFILE,
-            phase_id=0,
-            submitted_value="https://github.com/testuser",
-            extracted_username="testuser",
-            is_validated=True,
-        )
+        """Idempotency check: a Durable activity retry that re-runs
+        ``link_submission`` sees ``ALREADY_LINKED`` instead of writing
+        again."""
+        repo = VerificationJobRepository(db_session)
+        job = await _create_job(repo)
+        submission = await _create_submission(db_session)
 
-        updated = await job_repo.mark_succeeded(job.id, submission.id)
+        first = await repo.link_submission(job.id, submission.id)
+        # Even if the retry passes a different submission id, the row's
+        # existing link wins. Reuse the same id for simplicity.
+        second = await repo.link_submission(job.id, submission.id)
 
-        assert updated is not None
-        assert updated.status == VerificationJobStatus.SUCCEEDED
-        assert updated.result_submission_id == submission.id
-        assert updated.error_code is None
-        assert updated.error_message is None
-        assert updated.completed_at is not None
+        assert first is LinkResult.LINKED
+        assert second is LinkResult.ALREADY_LINKED
 
-    async def test_marks_server_error_with_error_details(
+    async def test_missing_job_returns_missing(
         self,
         db_session: AsyncSession,
         user,
     ):
         repo = VerificationJobRepository(db_session)
-        job = await _create_job(repo)
+        submission = await _create_submission(db_session)
 
-        updated = await repo.mark_server_error(
-            job.id,
-            error_code="github_unavailable",
-            error_message="GitHub API unavailable",
+        result = await repo.link_submission(
+            UUID("00000000-0000-0000-0000-000000000000"),
+            submission.id,
         )
 
-        assert updated is not None
-        assert updated.status == VerificationJobStatus.SERVER_ERROR
-        assert updated.error_code == "github_unavailable"
-        assert updated.error_message == "GitHub API unavailable"
-        assert updated.completed_at is not None
+        assert result is LinkResult.MISSING
 
 
 class TestDeleteActive:
@@ -277,23 +271,8 @@ class TestDeleteActive:
     ):
         repo = VerificationJobRepository(db_session)
         job = await _create_job(repo)
-
-        submission = await SubmissionRepository(db_session).create(
-            user_id=USER_ID,
-            requirement_id="req-1",
-            submission_type=SubmissionType.GITHUB_PROFILE,
-            phase_id=0,
-            submitted_value="https://github.com/testuser",
-            extracted_username="testuser",
-            is_validated=False,
-            verification_completed=True,
-        )
-        await repo.mark_failed(
-            job.id,
-            error_code="validation_failed",
-            error_message="nope",
-            result_submission_id=submission.id,
-        )
+        submission = await _create_submission(db_session)
+        await repo.link_submission(job.id, submission.id)
 
         deleted = await repo.delete_active(job.id)
 
@@ -301,30 +280,6 @@ class TestDeleteActive:
         loaded = await repo.get_by_id(job.id)
         assert loaded is not None
         assert loaded.result_submission_id == submission.id
-
-    async def test_refuses_when_status_already_terminal(
-        self,
-        db_session: AsyncSession,
-        user,
-    ):
-        repo = VerificationJobRepository(db_session)
-        job = await _create_job(repo)
-
-        # Move the job to a terminal status WITHOUT setting
-        # result_submission_id. This is the "Durable failed and persist
-        # already marked it terminal" race window.
-        await repo.mark_server_error(
-            job.id,
-            error_code="durable_failed",
-            error_message="durable failed",
-        )
-
-        deleted = await repo.delete_active(job.id)
-
-        assert deleted is False
-        loaded = await repo.get_by_id(job.id)
-        assert loaded is not None
-        assert loaded.status == VerificationJobStatus.SERVER_ERROR
 
     async def test_unknown_id_returns_false(
         self,

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -4,17 +4,10 @@ from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 import pytest
-from sqlalchemy import func, select, text
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
-from learn_to_cloud_shared.models import (
-    Submission,
-    SubmissionType,
-    VerificationJobStatus,
-)
-from learn_to_cloud_shared.repositories.submission_repository import (
-    SubmissionRepository,
-)
+from learn_to_cloud_shared.models import Submission, SubmissionType, VerificationJob
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
@@ -25,6 +18,10 @@ from learn_to_cloud_shared.verification_job_executor import (
     REQUIREMENT_NOT_FOUND_ERROR_CODE,
     VALIDATION_FAILED_ERROR_CODE,
     VERIFICATION_INCOMPLETE_ERROR_CODE,
+    VERIFICATION_SUCCEEDED_CODE,
+    PreparedVerificationJob,
+    VerificationJobNotFoundError,
+    VerificationRunResult,
     execute_verification_job,
     persist_verification_result,
     prepare_verification_job,
@@ -79,33 +76,26 @@ async def _create_job(
         return job.id
 
 
-async def _get_job_status(
+async def _get_job_link(
     session_maker: async_sessionmaker[AsyncSession],
     job_id: UUID,
-) -> tuple[VerificationJobStatus, int | None, str | None, str | None]:
+) -> int | None:
+    """Return ``result_submission_id`` for the job, or ``None`` if missing.
+
+    Asserts the row exists; tests for "row deleted" outcomes should query
+    differently.
+    """
     async with session_maker() as db:
         job = await VerificationJobRepository(db).get_by_id(job_id)
         assert job is not None
-        return (
-            job.status,
-            job.result_submission_id,
-            job.error_code,
-            job.error_message,
-        )
+        return job.result_submission_id
 
 
-async def _get_submission(
+async def _count_jobs(
     session_maker: async_sessionmaker[AsyncSession],
-    submission_id: int,
-) -> Submission:
+) -> int:
     async with session_maker() as db:
-        submission = await SubmissionRepository(db).get_by_user_and_requirement(
-            USER_ID,
-            REQUIREMENT_ID,
-        )
-        assert submission is not None
-        assert submission.id == submission_id
-        return submission
+        return await db.scalar(select(func.count()).select_from(VerificationJob)) or 0
 
 
 async def _count_submissions(
@@ -113,6 +103,16 @@ async def _count_submissions(
 ) -> int:
     async with session_maker() as db:
         return await db.scalar(select(func.count()).select_from(Submission)) or 0
+
+
+async def _get_submission(
+    session_maker: async_sessionmaker[AsyncSession],
+    submission_id: int,
+) -> Submission:
+    async with session_maker() as db:
+        submission = await db.get(Submission, submission_id)
+        assert submission is not None
+        return submission
 
 
 async def test_split_verification_primitives_prepare_run_and_persist(
@@ -136,15 +136,6 @@ async def test_split_verification_primitives_prepare_run_and_persist(
     assert preparation.job is not None
     assert preparation.job.to_payload()["id"] == str(job_id)
 
-    status, result_submission_id, error_code, error_message = await _get_job_status(
-        session_maker,
-        job_id,
-    )
-    assert status == VerificationJobStatus.RUNNING
-    assert result_submission_id is None
-    assert error_code is None
-    assert error_message is None
-
     with patch(
         "learn_to_cloud_shared.verification_job_executor.validate_submission",
         validation,
@@ -159,9 +150,11 @@ async def test_split_verification_primitives_prepare_run_and_persist(
         session_maker=session_maker,
     )
 
-    assert result.status == VerificationJobStatus.SUCCEEDED
+    assert result.status == "succeeded"
+    assert result.code == VERIFICATION_SUCCEEDED_CODE
     assert result.submission_id is not None
     assert await _count_submissions(session_maker) == 1
+    assert await _get_job_link(session_maker, job_id) == result.submission_id
 
 
 async def test_execute_verification_job_marks_success_and_links_submission(
@@ -184,35 +177,23 @@ async def test_execute_verification_job_marks_success_and_links_submission(
     ):
         result = await execute_verification_job(job_id, session_maker=session_maker)
 
-    assert result.status == VerificationJobStatus.SUCCEEDED
+    assert result.status == "succeeded"
     assert result.submission_id is not None
     assert result.is_valid is True
     assert result.verification_completed is True
     payload = result.to_payload()
     assert payload["status"] == "succeeded"
-    assert payload["code"] == "verification_succeeded"
+    assert payload["code"] == VERIFICATION_SUCCEEDED_CODE
     assert payload["requirement_id"] == REQUIREMENT_ID
     assert payload["requirement_name"] == "Verification Executor Test"
     assert payload["submission_type"] == SubmissionType.CI_STATUS.value
     assert payload["message"] == "Verification succeeded."
-    assert payload["detail"] == "Verified"
+    # On success there is no validation message; ``detail`` is None.
+    assert payload["detail"] is None
 
-    status, result_submission_id, error_code, error_message = await _get_job_status(
-        session_maker,
-        job_id,
-    )
-    assert status == VerificationJobStatus.SUCCEEDED
-    assert result_submission_id == result.submission_id
-    assert error_code is None
-    assert error_message is None
-
+    assert await _get_job_link(session_maker, job_id) == result.submission_id
     submission = await _get_submission(session_maker, result.submission_id)
     assert submission.is_validated is True
-    assert submission.verification_completed is True
-    assert submission.extracted_username == "executoruser"
-
-    validation.assert_awaited_once()
-    assert validation.await_args.kwargs["expected_username"] == "executoruser"
 
 
 async def test_execute_verification_job_marks_user_validation_failure(
@@ -222,7 +203,7 @@ async def test_execute_verification_job_marks_user_validation_failure(
     validation = AsyncMock(
         return_value=ValidationResult(
             is_valid=False,
-            message="Fix your repository settings.",
+            message="GitHub username does not match",
             verification_completed=True,
         )
     )
@@ -239,37 +220,26 @@ async def test_execute_verification_job_marks_user_validation_failure(
     ):
         result = await execute_verification_job(job_id, session_maker=session_maker)
 
-    assert result.status == VerificationJobStatus.FAILED
-    assert result.submission_id is not None
+    assert result.status == "failed"
+    assert result.code == VALIDATION_FAILED_ERROR_CODE
     assert result.is_valid is False
     assert result.verification_completed is True
-    assert result.code == VALIDATION_FAILED_ERROR_CODE
-    assert result.message == "Verification failed."
-    assert result.detail == "Fix your repository settings."
+    assert result.detail == "GitHub username does not match"
 
-    status, result_submission_id, error_code, error_message = await _get_job_status(
-        session_maker,
-        job_id,
-    )
-    assert status == VerificationJobStatus.FAILED
-    assert result_submission_id == result.submission_id
-    assert error_code == VALIDATION_FAILED_ERROR_CODE
-    assert error_message == "Fix your repository settings."
-
-    submission = await _get_submission(session_maker, result.submission_id)
-    assert submission.is_validated is False
-    assert submission.verification_completed is True
-    assert submission.validation_message == "Fix your repository settings."
+    assert await _get_job_link(session_maker, job_id) == result.submission_id
 
 
 async def test_execute_verification_job_marks_server_error(
     session_maker: async_sessionmaker[AsyncSession],
 ):
+    """A validator returning ``verification_completed=False`` records a
+    server-error result. The Submission row exists and is linked but
+    is_validated=False / verification_completed=False."""
     job_id = await _create_job(session_maker)
     validation = AsyncMock(
         return_value=ValidationResult(
             is_valid=False,
-            message="GitHub API unavailable.",
+            message="GitHub API unavailable",
             verification_completed=False,
         )
     )
@@ -286,39 +256,29 @@ async def test_execute_verification_job_marks_server_error(
     ):
         result = await execute_verification_job(job_id, session_maker=session_maker)
 
-    assert result.status == VerificationJobStatus.SERVER_ERROR
-    assert result.submission_id is not None
-    assert result.is_valid is False
-    assert result.verification_completed is False
+    assert result.status == "server_error"
     assert result.code == VERIFICATION_INCOMPLETE_ERROR_CODE
-    assert result.message == "Verification could not be completed."
-    assert result.detail == "GitHub API unavailable."
-
-    status, result_submission_id, error_code, error_message = await _get_job_status(
-        session_maker,
-        job_id,
-    )
-    assert status == VerificationJobStatus.SERVER_ERROR
-    assert result_submission_id == result.submission_id
-    assert error_code == VERIFICATION_INCOMPLETE_ERROR_CODE
-    assert error_message == "GitHub API unavailable."
+    assert result.verification_completed is False
+    assert result.detail == "GitHub API unavailable"
 
     submission = await _get_submission(session_maker, result.submission_id)
     assert submission.is_validated is False
     assert submission.verification_completed is False
-    assert submission.validation_message == "GitHub API unavailable."
 
 
 async def test_execute_verification_job_truncates_persisted_error_messages(
     session_maker: async_sessionmaker[AsyncSession],
 ):
+    """Validation messages over the persisted limit are truncated for
+    storage; the ``detail`` in the activity result follows the same
+    rule."""
     job_id = await _create_job(session_maker)
-    long_message = "LLM verification grading failed: " + ("permission denied " * 200)
+    long_message = "x" * (MAX_VALIDATION_MESSAGE_LENGTH + 64)
     validation = AsyncMock(
         return_value=ValidationResult(
             is_valid=False,
             message=long_message,
-            verification_completed=False,
+            verification_completed=True,
         )
     )
 
@@ -334,65 +294,21 @@ async def test_execute_verification_job_truncates_persisted_error_messages(
     ):
         result = await execute_verification_job(job_id, session_maker=session_maker)
 
-    assert result.status == VerificationJobStatus.SERVER_ERROR
-    assert result.detail == long_message
-
-    status, result_submission_id, error_code, error_message = await _get_job_status(
-        session_maker,
-        job_id,
-    )
-    assert status == VerificationJobStatus.SERVER_ERROR
-    assert result_submission_id == result.submission_id
-    assert error_code == VERIFICATION_INCOMPLETE_ERROR_CODE
-    assert error_message is not None
-    assert len(error_message) == MAX_VALIDATION_MESSAGE_LENGTH
-    assert error_message.endswith("...")
-
-    submission = await _get_submission(session_maker, result.submission_id)
-    assert submission.validation_message is not None
-    assert len(submission.validation_message) == MAX_VALIDATION_MESSAGE_LENGTH
-    assert submission.validation_message == error_message
-
-
-async def test_execute_verification_job_is_idempotent_for_terminal_jobs(
-    session_maker: async_sessionmaker[AsyncSession],
-):
-    job_id = await _create_job(session_maker)
-    async with session_maker() as db:
-        submission = await SubmissionRepository(db).create(
-            user_id=USER_ID,
-            requirement_id=REQUIREMENT_ID,
-            submission_type=SubmissionType.CI_STATUS,
-            phase_id=3,
-            submitted_value="https://github.com/executoruser/repo",
-            extracted_username="executoruser",
-            is_validated=True,
-        )
-        updated = await VerificationJobRepository(db).mark_succeeded(
-            job_id,
-            submission.id,
-        )
-        assert updated is not None
-        await db.commit()
-
-    validation = AsyncMock()
-    with patch(
-        "learn_to_cloud_shared.verification_job_executor.validate_submission",
-        validation,
-    ):
-        result = await execute_verification_job(job_id, session_maker=session_maker)
-
-    assert result.status == VerificationJobStatus.SUCCEEDED
-    assert result.submission_id == submission.id
-    assert result.code == "verification_succeeded"
-    assert result.message == "Verification succeeded."
-    assert await _count_submissions(session_maker) == 1
-    validation.assert_not_awaited()
+    assert result.status == "failed"
+    assert result.detail is not None
+    assert len(result.detail) <= MAX_VALIDATION_MESSAGE_LENGTH
 
 
 async def test_execute_verification_job_marks_missing_requirement_server_error(
     session_maker: async_sessionmaker[AsyncSession],
 ):
+    """When the requirement vanishes from content between submit and
+    execute, the executor writes a server-error Submission, links it,
+    and short-circuits via the terminal_result path.
+
+    Linking (rather than deleting the job row) keeps the executor
+    idempotent on Durable activity retry — the second attempt sees the
+    linked row and returns the same result."""
     job_id = await _create_job(session_maker)
     validation = AsyncMock()
 
@@ -408,55 +324,65 @@ async def test_execute_verification_job_marks_missing_requirement_server_error(
     ):
         result = await execute_verification_job(job_id, session_maker=session_maker)
 
-    assert result.status == VerificationJobStatus.SERVER_ERROR
-    assert result.submission_id is None
+    assert result.status == "server_error"
+    assert result.submission_id is not None
     assert result.verification_completed is False
     assert result.code == REQUIREMENT_NOT_FOUND_ERROR_CODE
     assert result.message == "Verification could not be completed."
     assert result.detail == f"Requirement not found: {REQUIREMENT_ID}"
 
-    status, result_submission_id, error_code, error_message = await _get_job_status(
-        session_maker,
-        job_id,
-    )
-    assert status == VerificationJobStatus.SERVER_ERROR
-    assert result_submission_id is None
-    assert error_code == REQUIREMENT_NOT_FOUND_ERROR_CODE
-    assert error_message == f"Requirement not found: {REQUIREMENT_ID}"
-    assert await _count_submissions(session_maker) == 0
+    # Row stays linked so a retry is idempotent.
+    assert await _get_job_link(session_maker, job_id) == result.submission_id
+    submission = await _get_submission(session_maker, result.submission_id)
+    assert submission.is_validated is False
+    assert submission.verification_completed is False
+    assert submission.validation_message == f"Requirement not found: {REQUIREMENT_ID}"
+
     validation.assert_not_awaited()
 
 
-# ---------------------------------------------------------------------------
-# Replay safety: persist_verification_result is idempotent on activity retry
-# ---------------------------------------------------------------------------
+async def test_execute_verification_job_is_idempotent_for_terminal_jobs(
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    """The replay short-circuit fires when the job already has a linked
+    Submission; the result is reconstructed from that Submission rather
+    than running the validator again."""
+    job_id = await _create_job(session_maker)
+    validation = AsyncMock(
+        return_value=ValidationResult(is_valid=True, message="Verified")
+    )
+
+    with (
+        patch(
+            "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
+            return_value=_requirement(),
+        ),
+        patch(
+            "learn_to_cloud_shared.verification_job_executor.validate_submission",
+            validation,
+        ),
+    ):
+        first = await execute_verification_job(job_id, session_maker=session_maker)
+        # Reset the validator so the retry would clearly be observable
+        # if the short-circuit weren't in place.
+        validation.reset_mock()
+        second = await execute_verification_job(job_id, session_maker=session_maker)
+
+    assert first.status == "succeeded"
+    assert second.status == "succeeded"
+    assert second.submission_id == first.submission_id
+    assert await _count_submissions(session_maker) == 1
+    validation.assert_not_awaited()
 
 
 async def test_persist_is_idempotent_via_result_submission_id_guard(
     session_maker: async_sessionmaker[AsyncSession],
 ):
-    """A Durable activity retry must NOT write a second Submission row.
-
-    Simulates the race where the persist activity's DB commit succeeds
-    but the activity's response is lost in transit, so Durable retries
-    the activity. The job row has ``result_submission_id`` already set;
-    the second call must short-circuit on that and return the same
-    result without inserting another Submission.
-
-    This test specifically exercises the new ``result_submission_id``
-    guard rather than the older ``status in TERMINAL_JOB_STATUSES``
-    guard: status is reset to RUNNING so only the new guard can rescue
-    us. That matches the post-PR3 schema where ``status`` is gone.
-    """
-    from learn_to_cloud_shared.verification_job_executor import (
-        PreparedVerificationJob,
-        VerificationRunResult,
-    )
-
+    """A second ``persist_verification_result`` call after the first one
+    linked a Submission must short-circuit on the result_submission_id
+    guard, not write a duplicate row."""
     job_id = await _create_job(session_maker)
 
-    # Build the prepared job + run result that the activity would
-    # receive — no DB needed for these objects.
     prepared = PreparedVerificationJob(
         id=job_id,
         user_id=USER_ID,
@@ -474,40 +400,49 @@ async def test_persist_is_idempotent_via_result_submission_id_guard(
         run_result,
         session_maker=session_maker,
     )
-    assert first.status == VerificationJobStatus.SUCCEEDED
-    assert first.submission_id is not None
-    assert await _count_submissions(session_maker) == 1
-
-    # Reset job.status to RUNNING but keep result_submission_id linked.
-    # This isolates the new replay guard: the old TERMINAL guard would
-    # not fire here.
-    async with session_maker() as db:
-        await db.execute(
-            text(
-                "UPDATE verification_jobs SET status='running', "
-                "completed_at=NULL WHERE id=:id"
-            ),
-            {"id": str(job_id)},
-        )
-        await db.commit()
-
-    # Activity retry: same run_result, second call.
     second = await persist_verification_result(
         run_result,
         session_maker=session_maker,
     )
 
-    # Same outcome, same submission_id, no second Submission row.
-    assert second.status == VerificationJobStatus.SUCCEEDED
+    assert first.status == "succeeded"
+    assert second.status == "succeeded"
     assert second.submission_id == first.submission_id
-    assert second.is_valid is True
-    assert second.requirement_id == REQUIREMENT_ID
     assert await _count_submissions(session_maker) == 1
 
 
-# Note: a "result_submission_id points at a missing Submission" guard
-# exists in _result_from_existing_submission for defense in depth, but
-# the FK ``verification_jobs_result_submission_id_fkey`` with
-# ON DELETE SET NULL makes that state unreachable at the database
-# level — deleting the Submission nulls the link before the activity
-# could see the dangling id. So there's no realistic state to test.
+async def test_persist_raises_when_job_row_was_deleted(
+    session_maker: async_sessionmaker[AsyncSession],
+):
+    """If the poller's ``delete_active`` won the race the persist
+    activity raises ``VerificationJobNotFoundError`` rather than
+    creating an orphan Submission."""
+    job_id = await _create_job(session_maker)
+
+    # Simulate the poller having deleted the row mid-flight.
+    async with session_maker() as db:
+        deleted = await VerificationJobRepository(db).delete_active(job_id)
+        await db.commit()
+        assert deleted is True
+
+    prepared = PreparedVerificationJob(
+        id=job_id,
+        user_id=USER_ID,
+        github_username="executoruser",
+        requirement=_requirement(),
+        phase_id=3,
+        submitted_value="https://github.com/executoruser/repo",
+    )
+    run_result = VerificationRunResult(
+        job=prepared,
+        validation_result=ValidationResult(is_valid=True, message="Verified"),
+    )
+
+    with pytest.raises(VerificationJobNotFoundError):
+        await persist_verification_result(
+            run_result,
+            session_maker=session_maker,
+        )
+
+    assert await _count_submissions(session_maker) == 0
+    assert await _count_jobs(session_maker) == 0


### PR DESCRIPTION
**PR4 is the code-only contract step of the verification_jobs slim-down.** Schema unchanged in this PR. A trailing PR5 will physically drop the legacy columns + the ``verification_job_status`` enum type — that has to be a separate PR because dropping columns during a rolling deploy would crash any old pods whose SQLAlchemy model still references them.

## Why split into PR4 (code) + PR5 (schema)

The deploy pipeline runs Alembic *before* the new ACA revision goes live. If a single PR removed model fields AND dropped the DB columns, PR3 pods still draining during the rolling window would `SELECT verification_jobs.*` and crash on missing columns — a 4-5 minute outage for active verifications.

Splitting:
- **This PR**: remove all references to the legacy columns from the SQLAlchemy model + Python code. DB still has the columns. PR3 pods stay happy because the schema is intact.
- **PR5 (future)**: pure Alembic migration that drops columns. By then all pods are on PR4 code which doesn't reference them. Safe.

## Migration in this PR

`0021_decouple_verification_jobs_from_status.py` — small, additive:

1. `ALTER TABLE verification_jobs ALTER COLUMN status SET DEFAULT 'queued'` so INSERTs from the new model (which doesn't include `status`) satisfy the NOT NULL constraint.
2. Drop two now-unused legacy indexes: `ix_verification_jobs_status_updated` and `uq_verification_jobs_active_user_requirement`.
3. Defensive `DELETE` of any "ghost" rows where status is terminal but `result_submission_id IS NULL` — they'd otherwise sit in the PR3 partial unique index and block future submits. The only path that could've created such a row was pre-PR2 `_mark_missing_requirement`, which PR2 removed.

## Code changes

| File | Summary |
|------|---------|
| `models.py` | Drop `status`, `orchestration_instance_id`, `error_code`, `error_message`, `started_at`, `completed_at` columns from `VerificationJob`. Drop `VerificationJobStatus` enum. Drop the two legacy index entries. PR3 result_submission_id indexes stay. |
| `verification_job_repository.py` | Rewritten. Exposes only work-queue primitives: `create`, `create_or_get_active`, `get_*`, `link_submission`, `delete_active`. Removes `mark_*`, `update_status`, `ACTIVE_JOB_STATUSES`, `TERMINAL_JOB_STATUSES`. New `LinkResult` enum (`LINKED`/`ALREADY_LINKED`/`MISSING`) so the executor can distinguish activity-retry races from "row was deleted". `delete_active` guard simplified to just `result_submission_id IS NULL`. |
| `verification_job_executor.py` | `persist_verification_result` swaps the four `mark_*` branches for a single `link_submission`. Outcome derived from `ValidationResult` flags. On `ALREADY_LINKED`, the activity rolls back its duplicate Submission insert and reloads the canonical one. `prepare_verification_job`'s terminal short-circuit keys on `result_submission_id` instead of the status enum. `_mark_missing_requirement` rewritten to create+link a server-error Submission (keeps `prepare` idempotent on retry). New `_build_result_from_submission` helper centralizes the replay-result builder. `VerificationJobExecutionResult.status` is now `str` (preserves Durable payload compat with any pre-PR4 readers in flight). |

## Concurrency notes (per the rubber-duck review)

- **`link_submission` returns an enum, not a bool.** `LINKED` = first writer; `ALREADY_LINKED` = another activity attempt won; `MISSING` = poller deleted the row. The persist activity branches accordingly.
- **`link_submission` updates `updated_at` explicitly** in the UPDATE statement.
- **Missing-requirement path links a server-error Submission** instead of deleting the row, so `prepare` retries see the linked row and short-circuit via the replay path. No orphaned rows.
- **`delete_active` losing the status guard is safe**: that guard's only purpose was the "old code marked terminal without linking" state, which PR2 made unreachable. Pre-flight migration also deletes any historical ghosts.
- **`VerificationJobExecutionResult.status` stays as a string field** (`"succeeded"` / `"failed"` / `"server_error"`) for Durable payload compatibility — Functions activities can deserialize results written by either PR3 or PR4 code.

## Tests

- `tests/repositories/test_verification_job_repository.py` — rewritten. New `TestLinkSubmission` exercises the `LinkResult` matrix. `TestStatusTransitions` removed entirely.
- `tests/services/test_verification_job_executor.py` — rewritten. `status` is now a string. New `test_persist_raises_when_job_row_was_deleted` covers the poller-delete-wins race. `test_persist_is_idempotent_via_result_submission_id_guard` exercises the replay short-circuit.
- `api/tests/routes/test_htmx_routes.py` — drop assertions for `mark_*` calls that no longer exist on the repo.

## Quality gates

- prek (ruff lint + ruff format + ty) ✓
- pytest — **687 passed**
- `alembic upgrade head` + `downgrade -1` + `upgrade head` round-trip on test DB ✓
- verification-functions ruff + ty + `import function_app` ✓

## Rollout / safety

- **No column drops in this PR.** All legacy columns still in the DB.
- **Old code in flight stays correct.** PR3 pods reading their model's full column set are fine because the columns exist; PR3 pods writing `status='queued'` on INSERT match the new DB default.
- **Rollback**: revert this PR. The legacy indexes need to be re-created by `downgrade()` in 0021. Migration is reversible.

## Deferred to PR5

Pure Alembic migration — no code change:
- Drop `status`, `orchestration_instance_id`, `error_code`, `error_message`, `started_at`, `completed_at` columns.
- Drop the `verification_job_status` enum type.
- Drop the `result_submission_id` `ON DELETE SET NULL` (already keeps the link-clearing behavior we want, no change needed actually).

Should only run after this PR is fully deployed and PR3 pods have drained.