### PR TITLE
chore: drop legacy verification_jobs lifecycle columns (PR5 migration)

### DIFF
--- a/api/alembic/versions/0022_drop_verification_job_legacy_columns.py
+++ b/api/alembic/versions/0022_drop_verification_job_legacy_columns.py
@@ -1,0 +1,109 @@
+"""Drop legacy verification_jobs status / lifecycle columns.
+
+Final contract step of the verification-jobs slim-down. PR4 removed all
+application-code references to these columns; this revision drops them
+from the schema. Safe to run only after the PR4 ACA + Verification
+Functions rollouts have fully drained — older pods would crash on
+``SELECT verification_jobs.*`` once any of these columns disappear.
+
+Columns dropped:
+* ``status`` (VARCHAR with CHECK constraint; ``native_enum=False`` so
+  no native Postgres ENUM type to drop).
+* ``orchestration_instance_id``
+* ``error_code``
+* ``error_message``
+* ``started_at``
+* ``completed_at``
+
+The PR4 migration's ``status DEFAULT 'queued'`` goes with the column.
+
+Revision ID: 0022_drop_verification_job_legacy_columns
+Revises: 0021_decouple_verification_jobs_from_status
+Create Date: 2026-05-20
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0022_drop_verification_job_legacy_columns"
+down_revision = "0021_decouple_verification_jobs_from_status"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("verification_jobs", "status")
+    op.drop_column("verification_jobs", "orchestration_instance_id")
+    op.drop_column("verification_jobs", "error_code")
+    op.drop_column("verification_jobs", "error_message")
+    op.drop_column("verification_jobs", "started_at")
+    op.drop_column("verification_jobs", "completed_at")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "verification_jobs",
+        sa.Column(
+            "completed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "verification_jobs",
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "verification_jobs",
+        sa.Column(
+            "error_message",
+            sa.String(length=1024),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "verification_jobs",
+        sa.Column(
+            "error_code",
+            sa.String(length=100),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "verification_jobs",
+        sa.Column(
+            "orchestration_instance_id",
+            sa.String(length=255),
+            nullable=True,
+        ),
+    )
+    # Re-create ``status`` as nullable + DEFAULT so the downgrade does
+    # not require a backfill. The original NOT NULL constraint can only
+    # be safely re-applied by running PR4's data migration; if you need
+    # the strict original schema, restore from a pre-PR5 backup instead.
+    op.add_column(
+        "verification_jobs",
+        sa.Column(
+            "status",
+            sa.Enum(
+                "queued",
+                "starting",
+                "running",
+                "succeeded",
+                "failed",
+                "server_error",
+                "cancelled",
+                name="verification_job_status",
+                native_enum=False,
+            ),
+            nullable=True,
+            server_default="queued",
+        ),
+    )


### PR DESCRIPTION
**Final cleanup of the verification-jobs slim-down.** Pure Alembic migration — no code change.

PR4 (#422) removed all application-code references to the legacy columns. PR4 has been live in production for a deploy cycle, so PR3 pods have fully drained. This PR drops the columns from the schema.

## Migration

`0022_drop_verification_job_legacy_columns.py`:

| Column | Type | Notes |
|--------|------|-------|
| `status` | VARCHAR(12) + CHECK | `native_enum=False` on the original column, so the CHECK constraint goes away with the column — no native PG enum type to drop separately. |
| `orchestration_instance_id` | VARCHAR(255) | |
| `error_code` | VARCHAR(100) | |
| `error_message` | VARCHAR(1024) | |
| `started_at` | TIMESTAMPTZ | |
| `completed_at` | TIMESTAMPTZ | |

PR4's `status DEFAULT 'queued'` server default goes with the column.

## Safety

- **No code change.** Model already excludes these columns (since PR4).
- **Rolling-deploy safe.** Any PR4 pod still draining executes `SELECT verification_jobs.*` against its model column list, which already excludes the dropped columns. The migration is invisible to them.
- **Reversible.** `downgrade()` re-adds every column with its original type. `status` is re-added as nullable with `DEFAULT 'queued'` rather than the original `NOT NULL`, because restoring the strict constraint requires a backfill from outside the schema. For a true rollback, restore from a pre-PR5 backup.

## Round-trip verified locally

- Fresh `learn_to_cloud` database
- `alembic upgrade head` → applies 0001..0022 cleanly
- `alembic downgrade -1` → re-adds the six columns + the `status` default
- `alembic upgrade head` → drops them again
- Final `\d verification_jobs` matches the SQLAlchemy model exactly

## Quality gates

- `prek` (ruff lint + format + ty) ✓
- `pytest` — 687 passed (no behavior change; just a migration)

## After this lands

The verification_jobs slim-down work is done:

- PR1 (#419): phase 0-2 in FastAPI
- PR2 (#420): stop poller dual-write
- PR3 (#421): expand — new active-job index keyed on `result_submission_id IS NULL`
- PR4 (#422): contract — drop legacy code references + decouple columns
- PR5 (this PR): drop legacy schema