### PR TITLE
Feat/aspire devcontainer mcp

### DIFF
--- a/.agents/skills/aspire/SKILL.md
+++ b/.agents/skills/aspire/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: aspire
+description: "Use when working with an Aspire distributed application: operate an AppHost or resources through the Aspire CLI; start, stop, restart, or wait for resources; inspect app state, logs, traces, docs, or health; add integrations; manage secrets/config; publish/deploy or run pipeline steps; initialize an existing app; recover TypeScript `.modules`; find frontend URLs for Playwright; expose custom dashboard/resource commands; or understand Aspire AppHost APIs in C# or TypeScript. Use even if the user says AppHost, resources, dashboard, bootstrap, Playwright URL, or local distributed app workflow without naming Aspire. Do not use for non-Aspire .NET apps, container-only repos without an AppHost, or ordinary build/test tasks."
+---
+
+# Aspire Skill
+
+Use this skill when the task is about operating an Aspire distributed application through the Aspire CLI rather than falling back to ad-hoc `dotnet`, `docker`, or shell workflows.
+
+Resources are typically defined in an AppHost such as, `AppHost.cs`, `apphost.ts`, or `AppHost/AppHost.csproj (Program.cs)`.
+
+## Use this skill for
+
+- Starting, restarting, and stopping AppHosts with `aspire start` and `aspire stop`
+- Initializing Aspire in an existing app with `aspire init` (drops skeleton files; use the `aspireify` skill to complete wiring)
+- Inspecting resources, logs, traces, and docs
+- Adding integrations with `aspire add`
+- Recovering missing TypeScript AppHost support files with `aspire restore`
+- Discovering the correct frontend URL before a Playwright handoff
+- Understanding unfamiliar Aspire AppHost APIs before editing C# or TypeScript AppHosts
+- Managing AppHost secrets and CLI config
+- Publishing and deploying Aspire apps, including single named steps with `aspire do`
+- Adding custom dashboard or resource commands with docs-backed AppHost patterns
+
+## Do not use this skill for
+
+- Non-Aspire .NET applications
+- Container-only workflows that do not involve an Aspire AppHost
+- Replacing normal build and test commands when the task is just compiling code or running unit tests
+
+## Default workflow
+
+1. Confirm that the workspace is an Aspire app and identify the AppHost.
+2. Start the app with `aspire start`. Use `--isolated` in git worktrees or whenever shared local state would be risky.
+3. Use `aspire wait <resource>` before interacting with a resource that needs to be healthy.
+4. Inspect state with `aspire describe`, then use `aspire otel logs`, `aspire logs`, `aspire otel traces`, and `aspire export` before making code changes. Display returned data using the formatting rules in [references/monitoring.md](references/monitoring.md).
+5. Before adding an integration, introducing a custom dashboard/resource command, or using an unfamiliar AppHost API, use `aspire docs search <topic>` and `aspire docs get <slug>` for workflow guidance, then use `aspire docs api search <query> --language csharp|typescript` and `aspire docs api get <id>` when you need the API reference entry itself.
+6. Re-run `aspire start` after AppHost changes. In git worktrees, re-run `aspire start --isolated` instead of switching to `aspire run`.
+
+## C# AppHosts
+
+When the AppHost is implemented in C# such as `AppHost.cs`, `apphost.cs`, or a `Program.cs`-based AppHost, use Aspire docs for workflow guidance and Aspire API docs for the reference entry before editing.
+
+- Use `aspire docs search <topic>` and `aspire docs get <slug>` when you need the documented workflow or pattern.
+- Use `aspire docs api search <query> --language csharp` and `aspire docs api get <id>` when you need the C# API reference entry for a resource builder, extension method, or member.
+- If the `dotnet-inspect` skill is available, use it to inspect local C# APIs, overloads, and builder chains when you need help understanding how the API surface is exposed in code.
+- Keep `dotnet-inspect` scoped to understanding APIs and symbols; use Aspire docs for the documented workflow and recommended pattern.
+
+## TypeScript AppHosts
+
+When the AppHost is `apphost.ts`, the `.modules/` folder at the project root contains generated TypeScript modules that expose the Aspire APIs available to the AppHost. Common files include `.modules/aspire.ts`, `base.ts`, and `transport.ts`.
+
+- Do not edit `.modules/` directly.
+- Use `aspire add <package>` to add integrations and regenerate the available APIs.
+- Inspect `.modules/aspire.ts` after `aspire add` to see the refreshed API surface.
+- The local `tsconfig.json` often includes `.modules/**/*.ts` in its compilation scope.
+
+## Key rules
+
+- Prefer `aspire start` over `dotnet run` for AppHosts. `aspire run` blocks the terminal and is a poor fit for agent workflows.
+- Re-running `aspire start` is the restart path. In git worktrees, `aspire start --isolated` is both the start and restart command. Do not combine `aspire stop` and `aspire run`.
+- Use `--apphost <path>` when the workspace has multiple AppHosts or discovery is ambiguous.
+- Use `--format Json` when another tool or script needs machine-readable output.
+- Do not guess the integration or command shape for unfamiliar AppHost changes. Use `aspire docs search` and `aspire docs get` for the documented pattern, then use `aspire docs api search` and `aspire docs api get` when you need the specific reference entry.
+- For unfamiliar C# AppHost APIs, use Aspire API docs as the primary reference and, if available, use `dotnet-inspect` only to inspect local symbols, overloads, and builder chains.
+- Never install the obsolete Aspire workload.
+- When a TypeScript AppHost uses `.modules/`, do not edit generated files directly. Use `aspire add` to regenerate APIs and inspect `.modules/aspire.ts` afterward.
+- Prefer official docs from `aspire.dev`.
+
+## Common capabilities
+
+- Use `aspire ps` when you need to discover running AppHosts before targeting one.
+- Use `aspire update` when the task is to refresh AppHost package references through the supported CLI workflow.
+- Use `aspire doctor` as an early diagnostics step when the local Aspire environment looks unhealthy.
+- Use `aspire resource`, `aspire secret`, `aspire config`, `aspire publish`, `aspire deploy`, and `aspire do` when the objective is resource operations, secrets/config management, or deployment.
+- Use `aspire restore`, `aspire cache clear`, `aspire certs trust`, and `aspire certs clean` when the task is local environment maintenance or recovery.
+
+## Playwright CLI
+
+If Playwright CLI is already configured in the environment, use Aspire first to discover the running app and its endpoints, especially when multiple frontends exist. Prefer `aspire describe --format Json` when the handoff needs to be scriptable or you need to disambiguate which frontend URL Playwright should use, then hand browser testing off to Playwright CLI.
+
+## References
+
+- For app-level lifecycle, bootstrap, and AppHost-wide commands, see [references/app-commands.md](references/app-commands.md).
+- For waiting on and operating on individual resources, see [references/resource-management.md](references/resource-management.md).
+- For app state, logs, traces, and export workflows, see [references/monitoring.md](references/monitoring.md).
+- For deployment and pipeline-step workflows, see [references/deployment.md](references/deployment.md).
+- For docs, secrets, config, diagnostics, cache, and certificates, see [references/tools-and-configuration.md](references/tools-and-configuration.md).
+- For C# AppHost API-understanding guidance, see [references/csharp-apphosts.md](references/csharp-apphosts.md).
+- For TypeScript AppHost guidance, see [references/typescript-apphosts.md](references/typescript-apphosts.md).
+- For Playwright handoff after Aspire endpoint discovery, see [references/playwright-handoff.md](references/playwright-handoff.md).
+- For investigation order and common agent workflows, see [references/agent-workflows.md](references/agent-workflows.md).

--- a/.agents/skills/aspire/references/agent-workflows.md
+++ b/.agents/skills/aspire/references/agent-workflows.md
@@ -1,0 +1,83 @@
+# Aspire Agent Workflows
+
+Use these patterns when a task needs investigation or orchestration rather than a one-off command lookup.
+
+## Scenario: I Am In A Worktree And Need A Safe Background Run
+
+Start the AppHost with `aspire start` so the CLI manages background execution. In git worktrees, use `--isolated` to avoid port conflicts and shared local state:
+
+```bash
+aspire start --isolated
+```
+
+If the next step depends on one resource, wait for it explicitly:
+
+```bash
+aspire start --isolated
+aspire wait myapi
+```
+
+Keep these points in mind:
+
+- In a git worktree, rerun `aspire start --isolated` whenever AppHost changes need to be picked up.
+- Outside worktrees, rerun `aspire start`.
+- Avoid `aspire run` in normal agent workflows because it blocks the terminal.
+
+## Scenario: Something Is Wrong, But Do Not Edit Code Yet
+
+Inspect the live app before editing code:
+
+1. `aspire describe` to check resource state.
+2. `aspire otel logs <resource>` to inspect structured logs.
+3. `aspire logs <resource>` to inspect console output.
+4. `aspire otel traces <resource>` to follow cross-service activity.
+5. `aspire export` when you need a zipped telemetry snapshot for deeper analysis or handoff.
+
+## Scenario: I Need To Add An Integration, Understand An API, Or Add A Custom Command Safely
+
+Use the docs commands first for the workflow, then use the API reference commands if you need the concrete API entry:
+
+```bash
+aspire docs search postgres
+aspire docs get <slug>
+aspire docs api search postgres --language csharp
+aspire docs api get <id>
+aspire add <package>
+```
+
+For dashboard or custom resource commands, use docs for the pattern and API docs for the specific entry:
+
+```bash
+aspire docs search "custom resource commands"
+aspire docs get custom-resource-commands
+aspire docs api search WithCommand --language csharp
+```
+
+Keep these points in mind:
+
+- Read the docs before editing the AppHost so the implementation follows a documented Aspire pattern instead of guessing the workflow.
+- Use `aspire docs api` when you need the C# or TypeScript reference entry for the exact API you are about to call.
+- If the AppHost is C# and you need to understand local overloads or builder chains, use the `dotnet-inspect` skill if it is available after checking the Aspire API reference.
+- After adding an integration, restart with `aspire start` so the updated AppHost takes effect.
+
+## Scenario: The AppHost Is TypeScript And Generated APIs Matter
+
+If the AppHost is `apphost.ts`, the `.modules/` directory contains generated TypeScript modules that expose Aspire APIs.
+
+- Do not edit `.modules/` directly.
+- Use `aspire add <package>` to regenerate the available APIs when adding integrations.
+- Use `aspire restore` if `.modules/` disappeared after a pull, clean, or branch switch.
+- Inspect `.modules/aspire.ts` after regeneration or restore to see the newly available APIs.
+
+## Scenario: I Need Secrets, Deployment, Or A Playwright Handoff
+
+Use `aspire secret` for AppHost user secrets, especially connection strings and passwords:
+
+```bash
+aspire secret set Parameters:postgres-password MySecretValue
+aspire secret list
+```
+
+Use `aspire publish` and `aspire deploy` for full deployment work, or `aspire do <step>` when the user only wants one named pipeline step such as seeding data or pushing containers.
+
+If Playwright CLI is configured in the environment, use Aspire to discover the endpoint first and let Playwright use that discovered URL afterward. When multiple frontends exist or the URL needs to be passed to another tool, prefer `aspire describe --format Json` before the Playwright handoff.

--- a/.agents/skills/aspire/references/app-commands.md
+++ b/.agents/skills/aspire/references/app-commands.md
@@ -1,0 +1,58 @@
+# App Commands
+
+Use this when the task is about app-level lifecycle, bootstrap, or AppHost-wide maintenance.
+
+## Scenario: Start The App Safely In The Background
+
+Use these commands when the user wants the AppHost running, needs a safe worktree session, or wants to pick up AppHost changes.
+
+```bash
+aspire start
+aspire start --isolated
+aspire stop
+```
+
+Keep these points in mind:
+
+- Use `aspire start` for normal background AppHost execution.
+- In git worktrees or when another local instance may already be running, use `aspire start --isolated`.
+- If the CLI shape may have changed or the skill instructions look older than the local CLI, confirm the exact command form with `aspire --help` or the relevant subcommand help before executing.
+- To restart after AppHost changes, rerun the same start command. In a worktree, rerun `aspire start --isolated`.
+- Use `aspire stop` only when the ask is explicitly to stop the app or clean up a running AppHost.
+- Avoid `aspire run` in normal agent workflows because it blocks the terminal.
+
+## Scenario: Create A New Aspire App Or Add Aspire To An Existing App
+
+Use these commands when the task is to bootstrap Aspire support.
+
+```bash
+aspire new
+aspire init
+aspire init --language typescript
+```
+
+Keep these points in mind:
+
+- Use `aspire new` when creating a brand-new Aspire app from scratch.
+- Use `aspire init` when adding Aspire to an existing application.
+- If you are unsure which arguments are supported by the installed CLI, check `aspire init --help` (or the parent help) before running it.
+- If the existing app flow needs a specific AppHost language, choose it explicitly rather than inventing unrelated scaffolding.
+
+## Scenario: Find The Right AppHost Or Refresh AppHost-Wide Support
+
+Use these commands when multiple AppHosts may be running locally, when the AppHost needs an integration, or when local AppHost support files need refresh or restore.
+
+```bash
+aspire ps
+aspire add <package>
+aspire update
+aspire restore
+```
+
+Keep these points in mind:
+
+- Use `aspire ps` first when you need to discover which AppHost is already running.
+- If command arguments may differ across CLI versions, verify the current shape with `aspire <command> --help` before execution.
+- Use `aspire add <package>` when the task is to add a supported integration or regenerate AppHost APIs.
+- Use `aspire update` when the ask is specifically to refresh AppHost package references through the supported CLI workflow.
+- Use `aspire restore` after pulls, cleans, or missing generated files when the AppHost needs its local support restored before running again.

--- a/.agents/skills/aspire/references/csharp-apphosts.md
+++ b/.agents/skills/aspire/references/csharp-apphosts.md
@@ -1,0 +1,30 @@
+# C# AppHosts
+
+Use this when the AppHost is implemented in C# and the task involves understanding APIs, extension methods, overloads, or builder chains before editing code.
+
+## Scenario: I Need Official Docs For An Unfamiliar C# AppHost API
+
+Use these commands when you need the documented Aspire pattern and the C# API reference before changing AppHost code.
+
+```bash
+aspire docs search <query>
+aspire docs get <slug>
+aspire docs api search <query> --language csharp
+aspire docs api get <id>
+```
+
+Keep these points in mind:
+
+- Use Aspire docs first when the task is about understanding an unfamiliar integration workflow or dashboard command pattern.
+- Use `aspire docs api` when the task is about finding the C# reference entry for a resource builder API, extension method, or member.
+- Search for the resource or pattern name before guessing the C# API shape.
+
+## Scenario: I Need To Read The Local C# API Surface More Closely
+
+Use this when the docs tell you what concept to use, but you still need to inspect local symbols, signatures, or overloads in C# code.
+
+Keep these points in mind:
+
+- If the `dotnet-inspect` skill is available, use it to inspect local C# APIs, extension methods, overloads, and chained builder return types.
+- Keep `dotnet-inspect` scoped to understanding APIs and symbols; do not treat it as a replacement for Aspire docs.
+- When `dotnet-inspect` is not available, fall back to reading local AppHost code together with the relevant Aspire docs pages.

--- a/.agents/skills/aspire/references/deployment.md
+++ b/.agents/skills/aspire/references/deployment.md
@@ -1,0 +1,35 @@
+# Deployment
+
+Use this when the task is about deployment artifacts, deployment execution, or named pipeline steps.
+
+## Scenario: Regenerate Deployment Artifacts And Redeploy
+
+Use these commands when the task is to build fresh deployment artifacts and run the full deployment flow.
+
+```bash
+aspire publish
+aspire deploy
+aspire deploy --clear-cache
+```
+
+Keep these points in mind:
+
+- Use `aspire publish` when artifact generation is part of the request.
+- Use `aspire deploy` when the goal is the full deployment flow, not just one step inside it.
+- Use `aspire deploy --clear-cache` when cached deployment state is stale or stuck.
+
+## Scenario: Run One Named Deployment Step Instead Of The Whole Deployment
+
+Use these commands when the deployment pipeline already exists and the user wants only one step, such as seeding data, running diagnostics, or pushing containers/images.
+
+```bash
+aspire do seed-data
+aspire do push-containers   # if the app defines this step
+aspire do diagnostics       # if the app defines this step
+```
+
+Keep these points in mind:
+
+- Use `aspire do <step>` when the request is specifically about one named pipeline step.
+- Common scenarios include seeding data, running a diagnostics step, or pushing containers/images, but the step names are app-defined.
+- Do not substitute `aspire deploy` when the request is to rerun only one step from the deployment pipeline.

--- a/.agents/skills/aspire/references/monitoring.md
+++ b/.agents/skills/aspire/references/monitoring.md
@@ -1,0 +1,82 @@
+# Monitoring
+
+Use this when the task is about inspecting app state, logs, traces, endpoints, or sharable diagnostics.
+
+## Scenario: I Need To Know What Is Running And Where The Endpoints Are
+
+Use these commands when the first job is to inspect current resource state, find URLs, or hand machine-readable app state to another tool.
+
+```bash
+aspire describe
+aspire resources
+aspire describe --apphost <path>
+aspire describe --apphost <path> --format Json
+```
+
+Keep these points in mind:
+
+- Use `aspire describe` first when you need the current state of the running app before deciding what to do next.
+- Use `--apphost <path>` when the workspace has multiple AppHosts or discovery is ambiguous.
+- Prefer `--format Json` when another tool or script needs to consume the result, such as a Playwright handoff or endpoint extraction.
+
+## Scenario: Something Is Wrong, But Investigate Before Editing Code
+
+Use these commands when the task is to diagnose behavior in the live app before making code changes.
+
+```bash
+aspire otel logs [resource] --format Json
+aspire otel traces [resource] --format Json
+aspire otel spans [resource] --format Json
+aspire otel logs --trace-id <id> --format Json
+aspire logs [resource]
+```
+
+Keep these points in mind:
+
+- Prefer structured telemetry before raw console logs when possible.
+- Use `aspire logs` as a secondary console-output view after checking structured telemetry.
+- Use the trace-filtered log command when you already have a trace id and want the related log slice.
+- Prefer `--format Json` when another tool or script needs to consume the result, such as a Playwright handoff or endpoint extraction.
+- `[resource]` is optional. Include it to filter results to a single resource; omit it to see all resources.
+
+## Scenario: I Need A Sharable Diagnostics Bundle
+
+Use this command when you need a portable handoff artifact for deeper analysis or for another person to inspect offline.
+
+```bash
+aspire export [resource]
+```
+
+Keep this point in mind:
+
+- Use `aspire export` when you need a sharable bundle of telemetry and resource state.
+
+## Dashboard Links
+
+Commands like `aspire describe`, `aspire otel logs`, `aspire otel traces`, and `aspire otel spans` may include dashboard URLs in their JSON output. Only use URLs that are explicitly returned by these commands — do not construct dashboard URLs yourself.
+
+When a dashboard link is returned alongside a resource or telemetry entry, make the resource name, trace ID, or span ID a clickable markdown link using the returned URL.
+
+## Displaying Resources
+
+When showing resource state to the user, display the state text with a circle emoji prefix:
+
+- 🟢 Running, healthy
+- 🟡 Starting, waiting
+- 🔴 Failed, error, unhealthy
+- ⚪ Stopped, exited
+
+Link resource names to their dashboard page when the dashboard URL is known.
+
+## Displaying Telemetry
+
+When showing structured logs, prefix each entry with an emoji matching the log level:
+
+- 🔴 Error / Critical
+- 🟡 Warning
+- 🔵 Information
+- ⚪ Debug / Trace
+
+Link resource names to their dashboard resource page. When trace IDs are present, display the first 7 characters and link that value to the full trace detail page.
+
+When showing traces or spans, use 🟢 for success/unset status and 🔴 for error status. Display only the first 7 characters of trace and span IDs, and link those values to their dashboard detail pages.

--- a/.agents/skills/aspire/references/playwright-handoff.md
+++ b/.agents/skills/aspire/references/playwright-handoff.md
@@ -1,0 +1,21 @@
+# Playwright Handoff
+
+Use this when Playwright CLI is already configured and the next step is browser testing against a running Aspire app.
+
+## Scenario: I Need The Right Frontend URL Before Browser Testing
+
+Use these commands when the task is to discover the live frontend endpoint from Aspire state and then hand that URL to Playwright.
+
+```bash
+aspire describe --format Json
+aspire describe --apphost <path> --format Json
+playwright-cli --help
+```
+
+Keep these points in mind:
+
+- Aspire discovers the endpoint first; Playwright uses the discovered endpoint after the handoff.
+- Prefer `aspire describe --format Json` when the URL needs to be consumed by a script or passed to another tool.
+- Use `--apphost <path>` when multiple AppHosts exist and the user is asking about one specific app.
+- Do not guess frontend endpoints without first consulting Aspire state.
+- If multiple frontends exist, use Aspire state to disambiguate which URL Playwright should use.

--- a/.agents/skills/aspire/references/resource-management.md
+++ b/.agents/skills/aspire/references/resource-management.md
@@ -1,0 +1,35 @@
+# Resource Management
+
+Use this when the task is scoped to one resource or depends on a specific resource becoming healthy.
+
+## Scenario: Wait For One Resource Before Touching It
+
+Use these commands when the next step depends on one resource being ready, such as before calling an API, opening a frontend, or querying a database.
+
+```bash
+aspire wait <resource>
+aspire wait <resource> --status up --timeout 60
+```
+
+Keep these points in mind:
+
+- Use `aspire wait` before a dependent action when readiness is the real blocker.
+- Add `--status` and `--timeout` when the ask calls for an explicit readiness condition rather than a generic wait.
+- Treat readiness as a resource-scoped concern; a missing ready signal is not automatically a reason to restart the whole AppHost.
+
+## Scenario: Fix Or Operate On One Resource Without Bouncing The Whole App
+
+Use these commands when the user calls out one resource by name, such as Redis, Postgres, cache, or a single custom resource command.
+
+```bash
+aspire resource <resource> start
+aspire resource <resource> stop
+aspire resource <resource> restart
+aspire resource <resource> <command>
+```
+
+Keep these points in mind:
+
+- Prefer resource-scoped commands when the task does not require an AppHost-wide restart.
+- If the user says one resource is wedged, use `aspire resource <resource> restart` before escalating to `aspire start`.
+- Use `aspire resource <resource> <command>` when the AppHost exposes a resource-specific dashboard or operational command.

--- a/.agents/skills/aspire/references/tools-and-configuration.md
+++ b/.agents/skills/aspire/references/tools-and-configuration.md
@@ -1,0 +1,72 @@
+# Tools And Configuration
+
+Use this when the task is about docs lookup, API reference lookup, secrets, CLI configuration, diagnostics, cache cleanup, or local certificates.
+
+## Scenario: I Need Docs Or API Reference Before I Change The AppHost
+
+Use these commands when the task is to confirm the right Aspire workflow before editing code or retrieve a specific API reference entry.
+
+```bash
+aspire docs search <query>
+aspire docs get <slug>
+aspire docs api search <query> --language csharp|typescript
+aspire docs api list <scope>
+aspire docs api get <id>
+```
+
+Keep these points in mind:
+
+- Use docs commands before changing integrations when you need to confirm the supported path or recommended workflow.
+- Use docs commands before implementing custom resource commands or unfamiliar AppHost patterns such as `WithCommand`.
+- Use `aspire docs api` when the user needs the C# or TypeScript reference entry for a specific Aspire API.
+- Use `aspire docs api list <scope>` to browse children under a language, package, module, type, or symbol.
+
+## Scenario: I Need To Inspect Or Change AppHost Secrets
+
+Use these commands when the task is about AppHost user secrets such as connection strings, passwords, or API keys.
+
+```bash
+aspire secret set <key> <value>
+aspire secret get <key>
+aspire secret list
+aspire secret path
+aspire secret delete <key>
+```
+
+Keep these points in mind:
+
+- Use `aspire secret` for AppHost user secrets instead of inventing another storage path.
+- Use `aspire secret path` when the task is to locate the backing store without opening it manually.
+
+## Scenario: I Need To Explain Where Aspire CLI Settings Came From
+
+Use these commands when the question is about effective Aspire CLI configuration or conflicting local versus global settings.
+
+```bash
+aspire config set <key> <value>
+aspire config get <key>
+aspire config list
+aspire config delete <key>
+aspire config info
+```
+
+Keep these points in mind:
+
+- Use `aspire config info` when the user wants to know where settings come from, which settings files are in play, or why the CLI is behaving a certain way locally.
+
+## Scenario: My Local Aspire Setup Feels Broken
+
+Use these commands when the local Aspire environment looks unhealthy and needs recovery steps rather than AppHost code changes.
+
+```bash
+aspire doctor
+aspire cache clear
+aspire certs trust
+aspire certs clean
+```
+
+Keep these points in mind:
+
+- Use `aspire doctor` early when the symptoms suggest local environment drift rather than an app bug.
+- Use `aspire cache clear` when cached state is stale or interfering with normal operation.
+- Use `aspire certs trust` and `aspire certs clean` when local certificate state is part of the problem.

--- a/.agents/skills/aspire/references/typescript-apphosts.md
+++ b/.agents/skills/aspire/references/typescript-apphosts.md
@@ -1,0 +1,35 @@
+# TypeScript AppHosts
+
+Use this when the AppHost is `apphost.ts` and the task involves generated APIs or TypeScript-specific Aspire workflows.
+
+## Scenario: I Added An Integration And Need New APIs To Show Up In `apphost.ts`
+
+Use this when the task touches `.modules/` or newly added integrations.
+
+```bash
+aspire add <package>
+```
+
+Keep these points in mind:
+
+- The `.modules/` folder contains generated TypeScript modules that expose Aspire APIs to the AppHost.
+- Common generated files include `.modules/aspire.ts`, `base.ts`, and `transport.ts`.
+- Do not edit `.modules/` directly.
+- Use `aspire add <package>` to regenerate the available APIs after adding an integration.
+- Inspect `.modules/aspire.ts` after `aspire add` to see the refreshed API surface available to `apphost.ts`.
+- The local `tsconfig.json` often includes `.modules/**/*.ts` in its compilation scope.
+
+## Scenario: `.modules/` Disappeared After A Pull, Clean, Or Branch Switch
+
+Use this when generated support files are missing or stale and the TypeScript AppHost needs to be restored.
+
+```bash
+aspire restore
+```
+
+Keep these points in mind:
+
+- Try `aspire restore` first when generated `.modules/*` files are missing.
+- `aspire restore` restores and regenerates the TypeScript AppHost support files under `.modules/`.
+- Do not manually recreate or edit generated module files.
+- After recovery, inspect `.modules/aspire.ts` to confirm the available API surface.

--- a/.agents/skills/aspireify/SKILL.md
+++ b/.agents/skills/aspireify/SKILL.md
@@ -1,0 +1,710 @@
+---
+name: aspireify
+description: "One-time skill for completing Aspire initialization in an existing app after `aspire init` has dropped the skeleton AppHost. Use this skill when an `aspire.config.json` exists but the AppHost has not yet been wired up."
+---
+
+# Aspireify
+
+This is a **one-time setup skill**. It completes the Aspire initialization that `aspire init` started. After this skill finishes successfully, the evergreen `aspire` skill handles ongoing AppHost work. Do not delete this skill unless the user explicitly asks.
+
+Keep this as **one skill with context-specific references**. Load the reference files that match the repo you discover instead of trying to keep every edge case in the main document.
+
+## Guiding principles
+
+### Minimize changes to the user's code
+
+The default stance is **adapt the AppHost to fit the app, not the other way around**. The user's services already work — the goal is to model them in Aspire without breaking anything.
+
+- Prefer `WithEnvironment()` to match existing env var names over asking users to rename vars in their code
+- Prefer Aspire-managed ports (`WithHttpsEndpoint(env: "PORT")`, `WithHttpEndpoint(env: "PORT")`, or no explicit port when supported) over fixed ports
+- Only preserve a specific port when the user confirms it is actually significant (for example: external callbacks, OAuth redirect URIs, browser extensions, webhooks, or a repo-documented hard requirement)
+- Map existing `docker-compose.yml` config 1:1 before optimizing
+- Don't restructure project directories, rename files, or change build scripts
+
+### Surface tradeoffs, don't decide silently
+
+Sometimes a small code change unlocks significantly better Aspire integration. When this happens, **present the tradeoff to the user and let them decide**. Examples:
+
+- **Connection strings**: A service reads `DATABASE_URL` but Aspire injects `ConnectionStrings__mydb`. You can use `WithEnvironment("DATABASE_URL", db.Resource.ConnectionStringExpression)` (zero code change) or suggest the service reads from config so `WithReference(db)` just works (enables service discovery, health checks, auto-retry).
+  → Ask: *"Your API reads DATABASE_URL. I can map that with WithEnvironment (no code change) or you could switch to reading ConnectionStrings:mydb which unlocks WithReference and automatic service discovery. Which do you prefer?"*
+
+- **Port binding**: A service hardcodes `PORT=3000`. You can preserve that with `WithHttpsEndpoint(port: 3000)` (zero code change) or switch the service to read `PORT` from env so Aspire can manage ports dynamically and avoid conflicts.
+  → Ask: *"Your frontend is currently fixed to port 3000. Unless that exact port is important for something external, I recommend switching it to read PORT from env so Aspire can manage the port and avoid conflicts. If you need 3000 to stay stable, I can preserve it. Which do you want?"*
+
+- **OTel setup**: Service has its own tracing config pointing to Jaeger. You can leave it (Aspire won't show its traces) or suggest switching the exporter to read `OTEL_EXPORTER_OTLP_ENDPOINT` (which Aspire injects).
+  → Ask: *"Your API exports traces to Jaeger directly. I can leave that, or switch it to use the OTEL_EXPORTER_OTLP_ENDPOINT env var so traces show up in the Aspire dashboard. The Jaeger endpoint would still work in non-Aspire environments. Want me to update it?"*
+
+**Format for presenting tradeoffs:**
+1. Explain what the current code does
+2. Show the zero-change option and what it gives you
+3. Show the small-change option and the extra benefits
+4. Ask which they prefer
+5. If they decline the change, implement the zero-change option without complaint
+
+### When in doubt, ask
+
+If you're unsure whether something is a service, whether two services depend on each other, whether a port is truly significant, or whether a Docker Compose service should be modeled — ask. Don't guess at architectural intent.
+
+### Always use latest Aspire APIs — verify before you write
+
+**Do not assume APIs exist.** Before writing any AppHost code, look up the correct API using `aspire docs search` and `aspire docs get`. Follow the tiered preference: Tier 1 (first-party `Aspire.Hosting.*`) → Tier 2 (community `CommunityToolkit.Aspire.Hosting.*`) → Tier 3 (raw `AddExecutable`/`AddDockerfile`/`AddContainer`). See the "Looking up APIs and integrations" section below for full discovery workflow, tier details, and auto-managed values.
+
+**Don't invent APIs** — if docs search and integration list don't return it, it doesn't exist. Fall back to Tier 3. **API shapes differ between C# and TypeScript** — always check the correct language docs.
+
+### Choosing the right JavaScript resource type
+
+For JavaScript/TypeScript apps, pick the right resource type (`AddViteApp`, `AddNodeApp`, or `AddJavaScriptApp`) and configure dev scripts and port binding. See [references/javascript-apps.md](references/javascript-apps.md) for the selection table, dev script patterns, framework-specific port binding, and browser suppression.
+
+### Never call it ".NET Aspire"
+
+Always refer to the product as just **Aspire**, never ".NET Aspire". This applies to all comments in generated AppHost code, messages to the user, and any documentation you produce.
+
+### Dashboard URL must include auth token
+
+When printing or displaying the Aspire dashboard URL to the user, always include the full login token query parameter. The dashboard requires authentication — a bare URL like `http://localhost:18888` won't work. Use the full URL as printed by `aspire start` (e.g., `http://localhost:18888/login?t=<token>`).
+
+### Redis and auto-TLS
+
+Aspire's infrastructure automatically provisions TLS certificates for container resources that register `WithHttpsCertificateConfiguration` callbacks. `AddRedis()` registers one by default, which means **Redis will get TLS automatically** when the Aspire dev cert infrastructure is active. This is usually fine, but some apps expect plain (non-TLS) Redis.
+
+If Redis health checks fail with `SslStream` / `RedisConnectionException` errors about SSL/TLS handshake failures, the cause is this auto-TLS behavior. **Do not fall back to `AddContainer()`.** Instead, disable the certificate on the Redis resource:
+
+```csharp
+var redis = builder.AddRedis("redis")
+    .WithoutHttpsCertificate();  // plain Redis, no TLS
+```
+
+`WithoutHttpsCertificate()` suppresses the auto-TLS cert injection so Redis stays on plain TCP. Use this when the consuming services don't support TLS Redis connections.
+
+### Prefer HTTPS over HTTP
+
+Always set up HTTPS endpoints by default. Use `WithHttpsEndpoint()` instead of `WithHttpEndpoint()` unless HTTPS doesn't work for a specific integration. For JavaScript and Python apps, call `WithHttpsDeveloperCertificate()` to configure the dev cert. If HTTPS causes issues for a specific resource, fall back to HTTP and leave a comment explaining why. See the "Endpoints and ports" section in the AppHost wiring reference below for detailed patterns and examples.
+
+### Never hardcode URLs — use endpoint references
+
+When a service needs another service's URL as an environment variable, **always** pass an endpoint reference — never a hardcoded string. Hardcoded URLs break whenever Aspire assigns different ports. See the "Cross-service environment variable wiring" section in the AppHost wiring reference below for examples.
+
+Similarly, **never use `withUrlForEndpoint` / `WithUrlForEndpoint` to set `dev.localhost` URLs**. That API is ONLY for setting display labels in the dashboard (e.g., `url.DisplayText = "Web UI"`). `dev.localhost` configuration belongs in `aspire.config.json` profiles — see Step 9.
+
+### Optimize for local dev, not deployment
+
+This skill is about getting a great **local development experience**. Don't worry about production deployment manifests, cloud provisioning, or publish configuration — that's a separate concern for later.
+
+This means:
+
+- Prefer `ContainerLifetime.Persistent` for databases and caches so data survives AppHost restarts
+- Use `WithDataVolume()` to persist data across container recreations
+- Cookie and session isolation with `*.dev.localhost` subdomains is encouraged
+- Don't add production health check probes, scaling config, or cloud resource definitions
+- If services reference external third-party APIs/services (e.g., a hardcoded Stripe URL, an external database host, a SaaS webhook endpoint), consider modeling those as parameters or connection strings in the AppHost so they're visible and configurable from one place:
+
+```csharp
+// Instead of the service hardcoding "https://api.stripe.com"
+var stripeUrl = builder.AddParameter("stripe-url", secret: false);
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithEnvironment("STRIPE_API_URL", stripeUrl);
+```
+
+This makes the external dependency visible in the dashboard and lets developers easily swap endpoints (e.g., to a Stripe test endpoint) without digging through service code. Present this as an option to the user — don't silently refactor their external service calls.
+
+### Migrate `.env` files into AppHost parameters
+
+Many projects use `.env` files for configuration. These should be migrated into the AppHost so that all config is centralized and visible in the dashboard. Scan for `.env`, `.env.local`, `.env.development`, etc. and propose migrating their contents:
+
+- **Secrets** (API keys, tokens, passwords, connection strings): use `AddParameter(name, secret: true)`. Aspire stores these securely via user secrets and prompts the developer to set them.
+- **Non-secret config** (feature flags, URLs, mode settings): use `AddParameter(name, secret: false)` with a default value, or `WithEnvironment()` directly.
+- **Values that map to Aspire resources** (e.g., `DATABASE_URL=postgres://...`, `REDIS_URL=redis://...`): replace with actual Aspire resources (`AddPostgres`, `AddRedis`) and `WithReference()` — the connection string is then managed by Aspire.
+
+```csharp
+// Before: .env file with DATABASE_URL=postgres://user:pass@localhost:5432/mydb
+//         STRIPE_KEY=sk_test_abc123
+//         DEBUG=true
+
+// After: modeled in AppHost
+var db = builder.AddPostgres("pg").AddDatabase("mydb");
+var stripeKey = builder.AddParameter("stripe-key", secret: true);
+
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithReference(db)                              // replaces DATABASE_URL
+    .WithEnvironment("STRIPE_KEY", stripeKey)       // secret, stored securely
+    .WithEnvironment("DEBUG", "true");              // plain config
+```
+
+**Important: Never delete `.env` files automatically.** After migrating all values into the AppHost, explicitly ask the user:
+> "I've migrated all the values from your `.env` file into the AppHost. The `.env` file is no longer needed for running via Aspire, but it still works for non-Aspire workflows. Would you like me to remove it, or keep it around?"
+
+Some teams still need `.env` files for CI, Docker Compose, or developers who haven't switched to Aspire yet. Respect that.
+
+Present this as a recommendation. Walk through the `.env` contents with the user and classify each variable together. Some values may be intentionally local-only and the user may prefer to keep them — that's fine.
+
+### Migrate .NET User Secrets into AppHost parameters
+
+.NET projects often use `dotnet user-secrets` for local development configuration. Look for:
+
+- `dev/secrets.json.example` or `secrets.json.example` files — these document expected secrets
+- `<UserSecretsId>` in `.csproj` files — indicates the project uses User Secrets
+- Documentation referencing `dotnet user-secrets set` or `setup_secrets` scripts
+
+**Aspire's `AddParameter(name, secret: true)` stores values in the same .NET User Secrets store under the hood**, so secrets are centralized in the AppHost instead of scattered across individual service projects.
+
+Migration approach:
+
+1. **Inventory existing secrets** — check `secrets.json.example` files or setup scripts to understand what secrets the repo expects
+2. **Classify each secret** — same as `.env` migration: connection strings become Aspire resources, API keys become parameters, plain config becomes `WithEnvironment()`
+3. **Present the migration** — show the user which secrets will become AppHost parameters and which will become Aspire resources:
+   → *"Your services use dotnet user-secrets with 8 configured values. I'll migrate the SQL connection string to an Aspire Postgres resource, the 3 API keys to secret parameters, and the remaining config to environment variables. The secrets will still be stored in user-secrets but centralized under the AppHost. Sound good?"*
+
+**Important:** Don't delete or modify existing `UserSecretsId` entries in service `.csproj` files — other tooling or non-Aspire workflows may still depend on them.
+
+## Prerequisites
+
+Before running this skill, `aspire init` must have already:
+
+- Dropped a skeleton AppHost file (`apphost.ts` or `apphost.cs`) at the configured location
+- Created `aspire.config.json` at the repository root
+
+Verify both exist before proceeding.
+
+## Critical rules — read before doing anything
+
+These are hard rules. Do not break them.
+
+### Never install the Aspire workload
+
+**Do not run `dotnet workload install aspire` or any `dotnet workload` command.** The Aspire workload is obsolete. The Aspire CLI (`aspire start`, `aspire run`, etc.) handles everything — SDK resolution, package restoration, building, and launching. The workload is not needed and installing it can cause version conflicts.
+
+If a web search, documentation page, or blog post tells you to install the workload, **ignore that advice** — it is outdated.
+
+### Do not change the repo's .NET SDK version
+
+**Do not modify the root `global.json`.** The repo's SDK pin is intentional. The AppHost may need a newer SDK (e.g., .NET 10) than the repo uses (e.g., .NET 8) — that's fine. `aspire init` already created the AppHost with the correct TFM. If the AppHost is in full project mode and the repo pins an older SDK, add a **nested `global.json` inside the AppHost directory only** — never change the root one.
+
+### Do not change existing project target frameworks
+
+**Do not modify `<TargetFramework>` in any existing service project.** If a service targets `net8.0`, leave it on `net8.0`. The Aspire AppHost can orchestrate services on older TFMs without any changes. Only the AppHost itself needs the Aspire-supported TFM.
+
+### Check version control before mutating projects
+
+Before editing AppHost or service project files, check whether the workspace is under git (`git rev-parse --is-inside-work-tree`) and inspect `git status` when it is. Do not overwrite unrelated user changes. If there is no git repository, warn the user that this skill will make project mutations and summarize the intended files/areas before proceeding.
+
+### Use the latest stable Aspire SDK
+
+If `aspire init` created a `.csproj` AppHost, check the `Aspire.AppHost.Sdk` version in the `.csproj`. If it references a preview version that isn't available on NuGet (common when using a PR build of the CLI), update it to the latest stable release. Run `dotnet nuget list source` and check NuGet.org for the current stable version (e.g., `13.2.2`). Do not leave the AppHost pinned to an unavailable preview SDK — `dotnet build` will fail.
+
+### Use the Aspire CLI, not raw dotnet commands, for Aspire operations
+
+- Use `aspire start` to launch the AppHost (not `dotnet run`)
+- Use `aspire add <integration>` to add hosting integrations (not `dotnet add package`)
+- Use `aspire restore` to restore TypeScript AppHost dependencies
+- Use `aspire docs search` to look up APIs
+
+Standard `dotnet` commands (`dotnet build`, `dotnet add reference`, `dotnet sln add`) are fine for normal .NET operations like building projects, adding project references, and managing solution membership.
+
+## Determine your context
+
+Read `aspire.config.json` at the repository root **if it exists**. Key fields:
+
+- **`appHost.language`**: `"typescript/nodejs"` or `"csharp"` — determines which syntax and tooling to use
+- **`appHost.path`**: path to the AppHost file or project directory — this is where you'll edit code
+
+For C# AppHosts, there are two sub-modes:
+
+- **Single-file mode**: `appHost.path` points directly to an `apphost.cs` file using the `#:sdk` directive. No `.csproj` needed. Configuration lives in `aspire.config.json`.
+- **Full project mode**: A directory containing a `.csproj`, `Program.cs`, and `Properties/launchSettings.json`. This was created by `aspire init` using the `aspire-apphost` template because a `.sln`/`.slnx` was found. **The template-generated AppHost is correct and complete** — it has proper SDK references, launch profiles with randomized ports, and a skeleton `Program.cs`. Do not recreate or hand-edit the `.csproj` or `launchSettings.json`. Configuration lives in `Properties/launchSettings.json` inside the AppHost project directory (standard .NET launch settings), **not** in `aspire.config.json`.
+
+### Configuration files — which is which
+
+**Do not confuse these files. Do not create or modify config files for the user's service projects — only for the AppHost.**
+
+| File | Where it lives | What it's for | Who uses it |
+|------|---------------|---------------|-------------|
+| `aspire.config.json` | Repo root | AppHost path, language, profiles (ports, env vars) | Single-file and polyglot AppHosts only |
+| `Properties/launchSettings.json` | Inside the AppHost project dir | Launch profiles (ports, env vars) | Full project mode `.csproj` AppHosts (standard .NET) |
+| `appsettings.json` | Inside service projects | Service-specific configuration | The services themselves — **do not create or modify these** |
+| `launchSettings.json` in service projects | Inside service project dirs | Service launch config | The services themselves — **do not create or modify these** |
+
+**Key rule:** When the AppHost is a `.csproj` project, it's a standard .NET project. It uses `Properties/launchSettings.json` for launch profiles, just like any other .NET project. `aspire init` creates this file with the correct ports. Do not create a duplicate `aspire.config.json` for project-mode AppHosts.
+
+Check which mode you're in by looking at what exists at the `appHost.path` location. If there's no `aspire.config.json`, look for a `.csproj` AppHost directory with `Properties/launchSettings.json` instead.
+
+If you're in **full project mode**, also load [references/full-solution-apphosts.md](references/full-solution-apphosts.md). It covers:
+
+- mixed-SDK solution boundaries
+- when to add or avoid solution membership
+- ServiceDefaults in solution-backed repos
+- legacy `Program.cs` / `Startup.cs` / `IHostBuilder` migration decisions
+- validation specific to `.csproj` AppHosts
+
+## Workflow
+
+Follow these steps in order. If any step fails, diagnose and fix before continuing. **The goal is a working `aspire start` — keep going until every resource starts cleanly and the dashboard is accessible. Do not stop at partial success.**
+
+### Step 1: Scan the repository
+
+Analyze the repository to discover all projects and services that could be modeled in the AppHost.
+
+**What to look for:**
+
+- **.NET projects**: `*.csproj` files. For each, run:
+  - `dotnet msbuild <project> -getProperty:OutputType` — `Exe`/`WinExe` = runnable service, `Library` = skip
+  - `dotnet msbuild <project> -getProperty:TargetFramework` — must be `net8.0` or newer
+  - `dotnet msbuild <project> -getProperty:IsAspireHost` — skip if `true`
+- **Solution files**: `*.sln` or `*.slnx` — if found, the C# AppHost **must** use full project mode (with `.csproj`) so it can be opened in Visual Studio alongside the rest of the solution. This is a hard requirement.
+- **Node.js/TypeScript apps**: directories with `package.json` containing a `start`, `dev`, or `main`/`module` entry. For each, also check:
+  - Does it have a `vite.config.*` file? → use `AddViteApp`
+  - Does it have a specific entry file (e.g., `src/index.ts`, `server.js`) and a `build` script that compiles TypeScript? → use `AddNodeApp` with `.WithRunScript()` and `.WithBuildScript()`
+  - Otherwise → use `AddJavaScriptApp`
+- **Monorepo/workspace detection**: Check root `package.json` for `"workspaces"` field (Yarn/npm) or `pnpm-workspace.yaml` (pnpm). If this is a monorepo:
+  - **Map workspace packages** — each workspace with a runnable script (`start`, `dev`) is a potential Aspire resource
+  - **Root scripts that delegate** — some monorepos have root-level scripts like `"start": "yarn --cwd ./subdir start"`. Model the *actual app directory* as the resource, not the root
+  - **Path resolution** — `appDirectory` is relative to the AppHost location. In monorepos you often need `../`, `../../`, or similar paths. Double-check these
+  - **Shared dependencies** — `.WithYarn()` / `.WithPnpm()` on each resource handles workspace-aware installs automatically
+- **Python apps**: directories with `pyproject.toml`, `requirements.txt`, or `main.py`/`app.py`
+- **Go apps**: directories with `go.mod`
+- **Java apps**: directories with `pom.xml` or `build.gradle`
+- **Dockerfiles**: standalone `Dockerfile` entries representing services
+- **Docker Compose**: `docker-compose.yml` or `compose.yml` files — these are a goldmine. Parse them to extract:
+  - **Profiles**: if any service has a `profiles:` key, the compose file uses profiles to organize services into groups (e.g., `cloud`, `storage`, `mssql`, `postgres`). When profiles exist:
+    1. List the available profiles and what services each includes
+    2. Ask the user which profile(s) to target for the AppHost (e.g., *"Your docker-compose uses profiles: cloud, mssql, postgres, storage, redis. Which represent your local dev stack?"*)
+    3. Only model services that belong to the selected profile(s) — skip the rest
+    4. If a service has no `profiles:` key, it runs in all profiles — always include it
+  - **Services**: each named service (in the selected profiles) maps to a potential AppHost resource
+  - **Images**: container images used (e.g., `postgres:16`, `redis:7`) → these become `AddContainer()` or typed Aspire integrations (e.g., `AddPostgres()`, `AddRedis()`)
+  - **Ports**: published port mappings → `WithHttpsEndpoint()` or `WithEndpoint()`
+  - **Environment variables**: env vars and `.env` file references → `WithEnvironment()`. Watch for `${VAR}` interpolation syntax — trace these back to `.env` files and migrate them to AppHost parameters
+  - **Volumes**: named/bind volumes → `WithVolume()` or `WithBindMount()`
+  - **Dependencies**: `depends_on` → `WithReference()` and `WaitFor()`
+  - **Build contexts**: `build:` entries → `AddDockerfile()` pointing to the build context directory
+  - Prefer typed Aspire integrations over raw `AddContainer()` when the image matches a known integration (use `aspire docs search` to check). For example, `postgres:16` → `AddPostgres()`, `redis:7` → `AddRedis()`, `rabbitmq:3` → `AddRabbitMQ()`.
+  - For complex compose files, also load [references/docker-compose.md](references/docker-compose.md) for detailed migration patterns.
+- **Static frontends**: Vite, Next.js, Create React App, or other frontend framework configs
+- **`.env` files**: Scan for `.env`, `.env.local`, `.env.development`, `.env.example`, etc. These contain configuration that should be migrated into AppHost parameters (see Guiding Principles above)
+- **User Secrets**: Scan for `secrets.json.example` files and `<UserSecretsId>` in `.csproj` files. These indicate .NET User Secrets are in use — migrate them into AppHost parameters (see Guiding Principles above)
+- **Package manager**: Detect which Node.js package manager the repo uses by looking for lock files: `pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, `package-lock.json` or none → npm. Use the detected package manager for all install/run commands throughout this skill.
+
+**Ignore:**
+
+- The AppHost directory/file itself
+- `node_modules/`, `.modules/`, `dist/`, `build/`, `bin/`, `obj/`, `.git/`
+- Test projects (directories named `test`/`tests`/`__tests__`, projects referencing xUnit/NUnit/MSTest, or test-only package.json scripts)
+
+### Step 2: Check prerequisites and smoke-test the skeleton
+
+Before investing time in wiring, run `aspire doctor` to verify the environment is ready:
+
+```bash
+aspire doctor
+```
+
+This checks for a working .NET SDK, container runtime (Docker/Podman), trusted dev certificates, and deprecated workloads. **Fix any failures before proceeding** — discovering that Docker isn't running *after* you've wired 10 services wastes significant time.
+
+Common issues caught by `aspire doctor`:
+- **Container runtime not running**: Start Docker Desktop or Podman before proceeding — container resources will fail to start without it.
+- **Deprecated aspire workload installed**: If installed by Visual Studio, it can't be removed via CLI — this is a warning, not a blocker.
+- **Untrusted dev certificate**: Run `aspire certs trust` to fix HTTPS endpoint failures.
+
+Once the environment is clean, verify the Aspire skeleton boots:
+
+```bash
+aspire start
+```
+
+The empty AppHost should start successfully — the dashboard should come up and the process should run without errors. You won't see any resources yet (that's expected), but if `aspire start` fails here, fix the issue before proceeding.
+
+For full project mode, the AppHost was created from the `aspire-apphost` template and should work out of the box. If it fails, common causes are:
+
+- **SDK version mismatch**: The repo's root `global.json` may pin an older SDK (e.g., 8.0). The AppHost directory needs its own nested `global.json` pinning the Aspire-supported SDK. Create one if missing (see Critical Rules above).
+- **Port conflicts**: If another Aspire app is running, the randomly assigned ports may conflict. Stop other instances first.
+
+For single-file mode:
+
+- **Missing profiles in `aspire.config.json`**: The file must have a `profiles` section with `applicationUrl`. Re-run `aspire init` to regenerate.
+- **Missing dependencies**: For TypeScript, ensure the `.modules/aspire.js` SDK is available. Run `aspire restore` if needed.
+
+Once it boots, stop it (Ctrl+C) and continue.
+
+### Step 3: Present findings and confirm with the user
+
+Show the user what you found. For each discovered project/service, show:
+
+- Name (project or directory name)
+- Type (.NET service, Node.js app, Python app, Dockerfile, etc.)
+- Framework/runtime info (e.g., net10.0, Node 20, Python 3.12)
+- Whether it exposes HTTP endpoints
+
+Ask the user:
+
+1. Which projects to include in the AppHost (pre-select all discovered runnable services)
+2. For C# AppHosts: which .NET projects should receive ServiceDefaults references (pre-select all .NET services)
+
+### Step 4: Create ServiceDefaults (C# only)
+
+> **Skip this step for TypeScript AppHosts.** OTel is handled in Step 8.
+
+If the AppHost is in **full project mode**, consult [references/full-solution-apphosts.md](references/full-solution-apphosts.md) before making ServiceDefaults changes. Some existing solutions need bootstrap updates before `AddServiceDefaults()` and `MapDefaultEndpoints()` can be applied safely.
+
+**Before creating ServiceDefaults, check for existing observability setup.** Many repos already have their own OpenTelemetry, Polly (HTTP resilience), or health check wiring — often in a shared extension method or SDK package. Search for:
+
+- `AddOpenTelemetry`, `UseOpenTelemetry`, `AddTracing`, `WithTracing`, `WithMetrics` — existing OTel setup
+- `AddStandardHttp`, `AddPolicyHandler`, `AddHttpStandardResilienceHandler` — existing Polly/resilience config
+- `AddHealthChecks`, `MapHealthChecks` — existing health check registration
+- Custom SDK extensions (e.g., `UseBitwardenSdk()`, `UseCompanySdk()`) — these often bundle OTel, health checks, and auth in one call
+
+If the repo already has OTel/health checks/resilience in a shared extension, **strip those from the generated ServiceDefaults** to avoid duplication. Only keep the parts that don't overlap. For example, if `UseBitwardenSdk()` already sets up OTel tracing and metrics, the ServiceDefaults should skip the OTel builder calls and only add service discovery and health endpoint mapping.
+
+Present the overlap to the user: *"Your services already set up OpenTelemetry via `UseBitwardenSdk()`. I'll create ServiceDefaults without the OTel setup to avoid duplication."*
+
+**Placement is your decision.** Where to put ServiceDefaults depends on the repo's structure:
+
+- If the AppHost has its own nested SDK boundary (nested `global.json`), ServiceDefaults should live next to the AppHost in that same boundary so it can target the same TFM.
+- If the repo's root SDK is compatible with the AppHost's TFM, ServiceDefaults can live alongside existing source (e.g., in `src/`).
+- If a ServiceDefaults project already exists (look for references to `Microsoft.Extensions.ServiceDiscovery` or `Aspire.ServiceDefaults`), skip creation and use the existing one.
+
+To create one:
+
+```bash
+dotnet new aspire-servicedefaults -n <SolutionName>.ServiceDefaults -o <path>
+```
+
+If a `.sln` exists and the ServiceDefaults project is compatible with the solution's SDK, add it:
+
+```bash
+dotnet sln <solution> add <ServiceDefaults.csproj>
+```
+
+### Step 5: Wire up the AppHost
+
+Edit the skeleton AppHost file to add resource definitions for each selected project. Use the appropriate syntax based on language.
+
+#### TypeScript AppHost (`apphost.ts`)
+
+```typescript
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+// Express/Node.js API with TypeScript — needs build for publish
+const api = await builder
+    .addNodeApp("api", "./api", "dist/index.js")   // production entry point
+    .withRunScript("start:dev")                      // dev: runs ts-node-dev or similar
+    .withBuildScript("build")                        // publish: compiles TS first
+    .withYarn()                                      // or .withPnpm() — match the repo
+    .withHttpsDeveloperCertificate()
+    .withHttpsEndpoint({ env: "PORT" });
+
+// Vite frontend — HTTPS with dev cert, suppress auto-browser
+const frontend = await builder
+    .addViteApp("frontend", "./frontend")
+    .withBuildScript("build")
+    .withYarn()
+    .withHttpsDeveloperCertificate()
+    .withEnvironment("BROWSER", "none")              // prevent auto-opening browser
+    .withReference(api)
+    .waitFor(api);
+
+// .NET project — HTTPS works out of the box
+const dotnetSvc = await builder
+    .addCSharpApp("catalog", "./src/Catalog");
+
+// Dockerfile-based service
+const worker = await builder
+    .addDockerfile("worker", "./worker");
+
+// Python app — HTTPS with dev cert
+const pyApi = await builder
+    .addPythonApp("py-api", "./py-api", "app.py")
+    .withHttpsDeveloperCertificate();
+
+await builder.build().run();
+```
+
+#### C# AppHost — single-file mode (`apphost.cs`)
+
+```csharp
+#:sdk Aspire.AppHost.Sdk@<version>
+#:property IsAspireHost=true
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var api = builder.AddCSharpApp("api", "../src/Api");
+
+var web = builder.AddCSharpApp("web", "../src/Web")
+    .WithReference(api)
+    .WaitFor(api);
+
+builder.Build().Run();
+```
+
+#### C# AppHost — full project mode (`Program.cs` + `.csproj`)
+
+In full project mode the AppHost has a `.csproj`, so prefer typed project references via `AddProject<T>()` — they give compile-time safety, auto-restart on rebuild, and the typed `Projects.*` namespace. Reserve `AddCSharpApp("name", "../path")` for cases where a project reference isn't possible (e.g., the service uses an SDK that can't be referenced from `Aspire.AppHost.Sdk`, or the AppHost is single-file mode).
+
+Edit the AppHost's `Program.cs`:
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+var api = builder.AddProject<Projects.Api>("api");
+
+var web = builder.AddProject<Projects.Web>("web")
+    .WithReference(api)
+    .WaitFor(api);
+
+builder.Build().Run();
+```
+
+And add project references so the `Projects.*` namespace is generated:
+
+```bash
+dotnet add <AppHost.csproj> reference <Api.csproj>
+dotnet add <AppHost.csproj> reference <Web.csproj>
+```
+
+#### Non-.NET services in a C# AppHost
+
+```csharp
+// Node.js app (Tier 1: Aspire.Hosting.JavaScript) — HTTPS with dev cert
+var frontend = builder.AddViteApp("frontend", "../frontend")
+    .WithHttpsDeveloperCertificate();
+
+// Python app (Tier 1: Aspire.Hosting.Python) — HTTPS with dev cert
+var pyApi = builder.AddPythonApp("py-api", "../py-api", "app.py")
+    .WithHttpsDeveloperCertificate();
+
+// Go app (Tier 2: CommunityToolkit.Aspire.Hosting.Golang)
+var goApi = builder.AddGolangApp("go-api", "../go-api")
+    .WithHttpsEndpoint(env: "PORT");
+
+// Dockerfile-based service (Tier 3: fallback for unsupported languages)
+var worker = builder.AddDockerfile("worker", "../worker");
+```
+
+Add required hosting packages — use `aspire add` or `dotnet add package`:
+
+```bash
+# Tier 1: first-party
+aspire add javascript    # or: dotnet add <AppHost.csproj> package Aspire.Hosting.JavaScript
+aspire add python        # or: dotnet add <AppHost.csproj> package Aspire.Hosting.Python
+
+# Tier 2: community toolkit
+aspire add communitytoolkit-golang
+# or: dotnet add <AppHost.csproj> package CommunityToolkit.Aspire.Hosting.Golang
+```
+
+Always check `aspire list integrations` and `aspire docs search "<language>"` to find the best available integration before falling back to `AddExecutable`/`AddDockerfile`.
+
+**Important rules:**
+
+- **Look up APIs before writing code** — see "Looking up APIs and integrations" section below. Do not guess API shapes.
+- Use meaningful resource names derived from the project/directory name.
+- Wire up `WithReference()`/`withReference()` and `WaitFor()`/`waitFor()` for services that depend on each other (ask the user if relationships are unclear).
+- Use `WithExternalHttpEndpoints()`/`withExternalHttpEndpoints()` for user-facing frontends.
+
+### Step 6: Configure dependencies
+
+#### TypeScript AppHost
+
+See [references/javascript-apps.md](references/javascript-apps.md) for `package.json`, `tsconfig.json`, and ESLint configuration patterns. Key points:
+
+- Augment existing files, never overwrite
+- Run `aspire restore` to generate `.modules/`, then install deps with the repo's package manager
+- Do not manually add Aspire SDK packages — `aspire restore` handles those
+
+#### C# AppHost
+
+**Full project mode**: dependencies are managed via the `.csproj` and `dotnet add package`/`dotnet add reference` (already handled in Steps 3-4).
+
+**Single-file mode**: dependencies are managed via `#:sdk` and `#:project` directives in the `apphost.cs` file.
+
+**NuGet feeds**: If `aspire.config.json` specifies a non-stable channel (preview, daily), ensure the appropriate NuGet feed is configured. For single-file mode this is automatic; for project mode, ensure a `NuGet.config` is in scope.
+
+### Step 7: Add ServiceDefaults to .NET projects (C# AppHost only)
+
+> **Skip this step for TypeScript AppHosts.**
+
+If any selected .NET service still uses a legacy `IHostBuilder` / `Startup.cs` bootstrap, consult [references/full-solution-apphosts.md](references/full-solution-apphosts.md) before editing it. Do not assume ServiceDefaults can be dropped into old hosting patterns unchanged.
+
+For each .NET project that the user selected for ServiceDefaults:
+
+```bash
+dotnet add <Project.csproj> reference <ServiceDefaults.csproj>
+```
+
+Then check each project's `Program.cs` (or equivalent entry point) and add if not already present:
+
+```csharp
+builder.AddServiceDefaults();  // Add early, after builder creation
+```
+
+And before `app.Run()`:
+
+```csharp
+app.MapDefaultEndpoints();
+```
+
+Be careful with code placement — look at existing structure (top-level statements vs `Startup.cs` vs `Program.Main`). Do not duplicate if already present.
+
+### Step 8: Wire up OpenTelemetry
+
+For .NET services, ServiceDefaults handles OTel automatically. For everything else, the services need a small setup to export telemetry. Aspire automatically injects `OTEL_EXPORTER_OTLP_ENDPOINT` into all managed resources — the services just need to read it.
+
+**Present this to the user as an option, not a mandatory step.** Some users may want to add OTel later, and that's fine — their services will still run, they just won't appear in the dashboard's trace/metrics views.
+
+**For each service that doesn't already have OTel, ask:**
+> "Would you like me to add OpenTelemetry instrumentation to `<service>`? This lets the Aspire dashboard show its traces, metrics, and logs. I'll need to add a few packages and an instrumentation setup file."
+
+If they say yes, follow the per-language setup guides in [references/opentelemetry.md](references/opentelemetry.md).
+
+### Step 9: Offer dev experience enhancements
+
+Before validating, present the user with optional quality-of-life improvements. These aren't required for `aspire start` to work, but they make the local dev experience significantly nicer.
+
+**Suggest each of these individually — don't apply without asking:**
+
+1. **Cookie and session isolation with `dev.localhost`**: When multiple services run on `localhost`, they share cookies and session storage — which can cause hard-to-debug auth problems. Using `*.dev.localhost` subdomains isolates each service's cookies and storage. Note: URLs still include ports (e.g., `frontend.dev.localhost:5173`), but the subdomain isolation prevents cross-service cookie collisions.
+   > "Would you like me to set up `dev.localhost` subdomains for your services? This gives each service its own cookie/session scope so they don't interfere with each other. URLs will look like `frontend.dev.localhost:5173` — the `*.dev.localhost` domain resolves to 127.0.0.1 automatically on most systems, no `/etc/hosts` changes needed."
+
+   **How to do it — pick the right config file based on AppHost mode** (see "Configuration files — which is which" earlier in this doc):
+
+   - **Single-file mode** (`apphost.cs` with `#:sdk` directive) and **polyglot AppHosts** (TypeScript, Python, Go, …): edit the `profiles` section in `aspire.config.json` at the repo root.
+   - **Full project mode** (`.csproj` AppHost): edit `Properties/launchSettings.json` inside the AppHost project directory. **Do not edit `aspire.config.json` for project-mode AppHosts** — they read launch profiles from `launchSettings.json`, so changes to `aspire.config.json` will be ignored.
+
+   In both cases, replace `localhost` with `<projectname>.dev.localhost` in `applicationUrl`, and use descriptive subdomains like `otlp.dev.localhost` and `resources.dev.localhost` for the infrastructure URLs. This is the same mechanism `aspire new` uses.
+
+   Example — `aspire.config.json` (single-file / polyglot):
+
+   ```json
+   {
+     "profiles": {
+       "https": {
+         "applicationUrl": "https://myproject.dev.localhost:17042;http://myproject.dev.localhost:15042",
+         "environmentVariables": {
+           "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://otlp.dev.localhost:21042",
+           "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://resources.dev.localhost:22042"
+         }
+       }
+     }
+   }
+   ```
+
+   Equivalent — `Properties/launchSettings.json` (full project mode):
+
+   ```json
+   {
+     "profiles": {
+       "https": {
+         "commandName": "Project",
+         "applicationUrl": "https://myproject.dev.localhost:17042;http://myproject.dev.localhost:15042",
+         "environmentVariables": {
+           "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://otlp.dev.localhost:21042",
+           "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://resources.dev.localhost:22042"
+         }
+       }
+     }
+   }
+   ```
+
+   Use the project/repo name (lowercased) as the subdomain prefix for `applicationUrl`. Use `otlp` and `resources` for the infrastructure URLs. Keep the existing port numbers — just swap `localhost` for the appropriate `*.dev.localhost` subdomain.
+
+2. **Custom URL labels in the dashboard** (display text only): Rename endpoint URLs in the Aspire dashboard for clarity:
+   ```csharp
+   .WithUrlForEndpoint("https", url => url.DisplayText = "Web UI")
+   ```
+
+3. **OpenTelemetry** (if not done in Step 8): "Would you like me to add observability to your services so they appear in the Aspire dashboard's traces and metrics views?"
+
+Present these as a batch: "I have a few optional dev experience improvements I can make. Want to hear about them?"
+
+### Step 10: Validate
+
+```bash
+aspire start
+```
+
+Once the app is running, use the Aspire CLI to verify everything is wired up correctly:
+
+1. **Resources are modeled**: `aspire describe` — confirm all expected resources appear with correct types, endpoints, and states.
+2. **Environment flows correctly**: `aspire describe` — check that environment variables (connection strings, ports, secrets from parameters) are injected into each resource as expected. Verify `.env` values that were migrated to parameters are present.
+3. **OTel is flowing** (if configured in Step 8): `aspire otel` — verify that services instrumented with OpenTelemetry are exporting traces and metrics to the Aspire dashboard collector.
+4. **No startup errors**: `aspire logs <resource>` — check logs for each resource to ensure clean startup with no crashes, missing config, or connection failures.
+5. **Dashboard is accessible**: Confirm the dashboard URL is printed and can be opened (remember: include the login token — see "Dashboard URL must include auth token" above).
+6. **Telemetry reaches the dashboard**: After resources are running, verify that traces and structured logs appear in the Aspire dashboard. Open the dashboard, navigate to the Traces view, and confirm at least one trace is visible from a service. If no telemetry flows:
+   - Check whether the service's OTel setup conditionally disables export (e.g., based on a `selfHosted` flag, a config key like `OpenTelemetry:Enabled`, or an environment check). Many SDKs default OTel OFF for self-hosted/local modes — set the enabling flag explicitly via `WithEnvironment()`.
+   - Check that `OTEL_EXPORTER_OTLP_ENDPOINT` is being injected by Aspire (it should be automatic for services modeled with `AddCSharpApp`/`AddProject`).
+   - Generate a trace by making an HTTP request to one of the services (e.g., `curl https://localhost:<port>/healthz` or any known endpoint). Some services don't emit traces until they receive traffic.
+   - Check service logs for OTLP exporter errors (connection refused, TLS handshake failures).
+
+**This skill is not done until `aspire start` runs without errors and every resource is in an expected terminal/runtime state.** Acceptable end states are:
+
+- **Healthy / Running** for long-lived services
+- **Finished** only for resources that were intentionally modeled as one-shot tasks (for example migrations or seed steps) **and** only if they exited cleanly with no errors
+- **Not started** only when that is intentional and understood (for example, an optional resource the user chose not to run yet)
+
+Treat these as failure states unless you intentionally designed for them:
+
+- **Finished** for long-lived APIs, frontends, workers, or databases
+- **Finished** after an exception, crash, or non-zero exit
+- unhealthy, degraded, failed, or crash-looping resources
+
+If anything lands in an unexpected state, diagnose it, fix it, and run `aspire start` again. Keep iterating until the app behaves as expected — do not move on to Step 11 with crash-shaped "success".
+
+Once everything is healthy, print a summary for the user:
+
+```
+✅ Aspire init complete!
+
+Dashboard: <full dashboard URL including login token>
+
+Resources:
+  <name>  <type>  <status>
+  <name>  <type>  <status>
+  ...
+
+<any notes about optional steps skipped, e.g., "OTel not configured — run the aspire skill to add it later">
+```
+
+Get the dashboard URL (with login token) from `aspire start` output. Get resource status from `aspire describe`. If any resource shows `Finished`, confirm from logs that it was an intentional one-shot resource that exited successfully before including it as success. This summary is the user's confirmation that init worked — make it complete and accurate.
+
+Common issues:
+
+- **TypeScript**: missing dependency install, TS compilation errors, port conflicts
+- **C# project mode**: missing project references, NuGet restore needed, TFM mismatches, build errors
+- **C# single-file**: `#:project` paths wrong, missing SDK directive
+- **Both**: missing environment variables, port conflicts
+- **Certificate errors**: if HTTPS fails, run `aspire certs trust` and retry
+
+### Step 11: Update solution file (C# full project mode only)
+
+If a `.sln`/`.slnx` exists, verify all new projects are included:
+
+```bash
+dotnet sln <solution> list
+```
+
+Ensure both the AppHost and ServiceDefaults projects appear.
+
+### Step 12: Clean up
+
+After successful validation:
+
+1. **Leave the AppHost running** — the user gets a fully running app with the dashboard open. Do not call `aspire stop`.
+2. Confirm the evergreen `aspire` skill is present for ongoing AppHost work.
+3. Do not delete the `aspireify/` skill directory unless the user explicitly asks.
+
+## Key rules
+
+- **Never overwrite existing files** — always augment/merge
+- **Ask the user before modifying service code** (especially OTel and ServiceDefaults injection)
+- **Respect existing project structure** — don't reorganize the repo
+- **If stuck, use `aspire doctor`** to diagnose environment issues
+- **Never hardcode URLs in `withEnvironment`** — when a service needs another service's URL (e.g., `VITE_APP_WS_SERVER_URL`), pass an endpoint reference, NOT a string literal. Use `room.getEndpoint("http")` (TS) or `room.GetEndpoint("http")` (C#) and pass that to `withEnvironment`. Hardcoded URLs break when ports change.
+- **Never use `withUrlForEndpoint` to set `dev.localhost` URLs** — `dev.localhost` configuration belongs in `aspire.config.json` profiles, not in AppHost code. `withUrlForEndpoint` is ONLY for setting display labels (e.g., `url.DisplayText = "Web UI"`).
+
+## References
+
+- For AppHost wiring patterns, API lookup, endpoint configuration, and resource wiring, see [references/apphost-wiring.md](references/apphost-wiring.md).
+- For solution-backed C# AppHosts (`.sln`/`.slnx` + `.csproj` AppHost), see [references/full-solution-apphosts.md](references/full-solution-apphosts.md).
+- For repos with `docker-compose.yml` or `compose.yml`, see [references/docker-compose.md](references/docker-compose.md).
+- For per-language OpenTelemetry setup (Node, Python, Go, Java), see [references/opentelemetry.md](references/opentelemetry.md).
+- For JavaScript/TypeScript resource types, dev scripts, and TypeScript AppHost config, see [references/javascript-apps.md](references/javascript-apps.md).

--- a/.agents/skills/aspireify/references/apphost-wiring.md
+++ b/.agents/skills/aspireify/references/apphost-wiring.md
@@ -1,0 +1,393 @@
+# AppHost wiring and API lookup reference
+
+Use this reference when writing Step 5 (Wire up the AppHost) or when you need to look up Aspire APIs, integration packages, or wiring patterns.
+
+> **⚠️ Always look up APIs before writing code.** Do not guess builder method names or parameter shapes. Use `aspire docs search "<topic>"` and `aspire docs get "<slug>"` for documented patterns, then `aspire docs api search "<query>" --language csharp|typescript` and `aspire docs api get "<id>"` to confirm the exact reference entry for the API you are about to call.
+
+## Looking up APIs and integrations
+
+Before writing AppHost code for an unfamiliar resource type or integration, **always** look it up. **Do not assume APIs exist or guess their shapes** — Aspire has many resource types with specific overloads.
+
+### Tiered preference for modeling resources
+
+#### Tier 1: First-party Aspire hosting packages (always prefer)
+
+Packages named `Aspire.Hosting.*` — maintained by the Aspire team and ship with every release. Examples:
+
+| Package | Unlocks |
+|---------|---------|
+| `Aspire.Hosting.Python` | `AddPythonApp()`, `AddUvicornApp()` |
+| `Aspire.Hosting.JavaScript` | `AddJavaScriptApp()`, `AddNodeApp()`, `AddViteApp()`, `.WithYarn()`, `.WithPnpm()` |
+| `Aspire.Hosting.PostgreSQL` | `AddPostgres()`, `AddDatabase()` |
+| `Aspire.Hosting.Redis` | `AddRedis()` |
+
+#### Tier 2: Community Toolkit packages (use when no first-party exists)
+
+Packages named `CommunityToolkit.Aspire.Hosting.*` — maintained by the community, documented on aspire.dev, and installable via `aspire add`. Examples:
+
+| Package | Unlocks |
+|---------|---------|
+| `CommunityToolkit.Aspire.Hosting.Golang` | `AddGolangApp()` — handles `go run .`, working dir, PORT env |
+| `CommunityToolkit.Aspire.Hosting.Rust` | `AddRustApp()` |
+| `CommunityToolkit.Aspire.Hosting.Java` | Java hosting support |
+
+These provide typed APIs with proper endpoint handling, health checks, and dashboard integration — significantly better than raw executables.
+
+#### Tier 3: Raw fallbacks (last resort)
+
+`AddExecutable()`, `AddDockerfile()`, `AddContainer()` — use only when no Tier 1 or Tier 2 package exists for the technology, or when the user's setup is too custom for a typed integration.
+
+### How to discover available packages
+
+```bash
+# Search for documentation on a topic
+aspire docs search "redis"
+aspire docs search "golang"
+aspire docs search "python uvicorn"
+
+# Get a specific doc page by slug (returned from search results)
+aspire docs get "redis-integration"
+aspire docs get "go-integration"
+
+# Find the exact C# / TypeScript API reference entry for a builder method
+aspire docs api search "AddRedis" --language csharp
+aspire docs api search "AddViteApp" --language typescript
+aspire docs api get "<id-from-api-search>"
+
+# List ALL available integrations (first-party and community toolkit)
+# Note: requires the Aspire MCP server to be connected. If this fails, use aspire docs search instead.
+aspire list integrations
+```
+
+Use `aspire docs search` / `aspire docs get` to find the right builder methods, configuration options, and patterns. Use `aspire docs api search` / `aspire docs api get` when you need the exact reference entry (parameter shapes, return types, overloads) for the API you are about to call. Use `aspire list integrations` to discover packages you might not have known about.
+
+**Don't invent APIs** — if docs search and integration list don't return it, it doesn't exist. Fall back to Tier 3 and note the limitation to the user. **API shapes differ between C# and TypeScript** — always check the correct language docs.
+
+### Check what integrations auto-manage
+
+Before modeling environment variables, passwords, ports, or volumes for a typed integration, **check the docs to see what the integration handles automatically**. Many typed integrations auto-generate passwords, manage ports dynamically, and handle volumes — duplicating this config causes errors or conflicts.
+
+```bash
+# Check what AddPostgres manages automatically
+aspire docs get "postgresql-hosting-integration" --section "Connection properties"
+
+# Check what AddSqlServer manages
+aspire docs get "sql-server-integration" --section "Hosting integration"
+```
+
+Look for the **"Connection properties"** section — it lists what the integration injects into consuming services. If it lists `Password`, `Host`, `Port` — the integration manages those. Do not create `AddParameter()` for values the integration already handles.
+
+Common auto-managed values (do NOT model these manually):
+
+| Integration | Auto-managed |
+|-------------|-------------|
+| `AddPostgres()` | Password, host, port, connection string |
+| `AddSqlServer()` | SA password, host, port, connection string |
+| `AddRedis()` | Connection string, port |
+| `AddMySql()` | Root password, host, port, connection string |
+| `AddRabbitMQ()` | Username, password, host, port, connection string |
+| `AddMongoDB()` | Connection string, port |
+
+To add an integration package (which unlocks typed builder methods):
+
+```bash
+# First-party
+aspire add redis
+aspire add python
+aspire add nodejs
+
+# Community Toolkit
+aspire add communitytoolkit-golang
+aspire add communitytoolkit-rust
+```
+
+After adding, run `aspire restore` (TypeScript) or `dotnet restore` (C#) to update available APIs, then check what methods are now available.
+
+**Always prefer a typed integration over raw `AddExecutable`/`AddContainer`.** Typed integrations handle working directories, port injection, health checks, and dashboard integration automatically.
+
+## Service communication: `WithReference` vs `WithEnvironment`
+
+**`WithReference()`** is the primary way to connect services. It does two things:
+
+1. Injects the referenced resource's connection information (connection string or URL) into the consuming service
+2. Enables Aspire service discovery — .NET services can resolve the referenced resource by name
+
+```csharp
+// C#: api gets the database connection string injected automatically
+var db = builder.AddPostgres("pg").AddDatabase("mydb");
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithReference(db);
+
+// C#: frontend gets service discovery URL for api
+var frontend = builder.AddCSharpApp("web", "../src/Web")
+    .WithReference(api);
+```
+
+```typescript
+// TypeScript equivalent
+const db = await builder.addPostgres("pg").addDatabase("mydb");
+const api = await builder.addCSharpApp("api", "./src/Api")
+    .withReference(db);
+```
+
+**How services consume references**: Services receive connection info as environment variables. The naming convention is:
+- Connection strings: `ConnectionStrings__<resourceName>` (e.g., `ConnectionStrings__mydb=Host=...`)
+- Service URLs: `services__<resourceName>__<endpointName>__0` (e.g., `services__api__http__0=http://localhost:5123`)
+
+**`WithEnvironment()`** injects raw environment variables. Use this for custom config that isn't a service reference:
+
+```csharp
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithEnvironment("FEATURE_FLAG_X", "true")
+    .WithEnvironment("API_KEY", someParameter);
+```
+
+**When to use which:**
+- Connecting service A to service B or a database/cache/queue → `WithReference()`
+- Passing configuration values, feature flags, API keys → `WithEnvironment()`
+- Never manually construct connection strings with `WithEnvironment()` when `WithReference()` would work
+
+## Endpoints and ports
+
+**Prefer HTTPS by default.** Use `WithHttpsEndpoint()` for all services and fall back to `WithHttpEndpoint()` only if HTTPS doesn't work for that resource.
+
+**Prefer Aspire-managed ports by default.** For most local development scenarios, let Aspire assign the port and inject it into the service. This avoids port collisions, makes multiple AppHosts easier to run side-by-side, and keeps cross-service wiring flexible.
+
+**Ask before pinning a fixed port.** If the repo already uses a hardcoded port, do **not** silently preserve it just because it exists. Ask whether that port is actually required. Good reasons to keep a fixed port include:
+
+- OAuth/callback URLs or external webhooks that expect a stable local address
+- Browser extensions or desktop/mobile clients that are already hardcoded to a specific port
+- Repo docs, scripts, or test tooling that explicitly depend on that exact port
+
+If none of those apply, steer the user toward managed ports.
+
+**`WithHttpsEndpoint()`** — expose an HTTPS endpoint. For services that serve traffic:
+
+```csharp
+// Let Aspire assign a random port (recommended for most cases)
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithHttpsEndpoint();
+
+// Use a specific port only when the user confirms it is required
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithHttpsEndpoint(port: 5001);
+
+// For services that read the port from an env var
+var nodeApi = builder.AddJavaScriptApp("api", "../api", "start")
+    .WithHttpsDeveloperCertificate()
+    .WithHttpsEndpoint(env: "PORT");  // Aspire injects PORT=<assigned-port>
+```
+
+**`WithHttpsDeveloperCertificate()`** — required for JavaScript and Python apps to serve HTTPS. Configures the ASP.NET Core dev cert. .NET apps handle this automatically.
+
+```csharp
+var frontend = builder.AddViteApp("frontend", "../frontend")
+    .WithHttpsDeveloperCertificate();
+
+var pyApi = builder.AddUvicornApp("api", "../api", "app:main")
+    .WithHttpsDeveloperCertificate();
+```
+
+> If `WithHttpsDeveloperCertificate()` causes issues for a resource, fall back to `WithHttpEndpoint()` and leave a comment explaining why.
+
+**`WithHttpEndpoint()`** — fallback for HTTP when HTTPS doesn't work:
+
+```csharp
+// Use when HTTPS causes issues with a specific integration
+var legacy = builder.AddJavaScriptApp("legacy", "../legacy", "start")
+    .WithHttpEndpoint(env: "PORT");  // HTTP fallback
+```
+
+**`WithEndpoint()`** — expose a non-HTTP endpoint (gRPC, TCP, custom protocols):
+
+```csharp
+var grpcService = builder.AddCSharpApp("grpc", "../src/GrpcService")
+    .WithEndpoint("grpc", endpoint =>
+    {
+        endpoint.Port = 5050;
+        endpoint.Protocol = "grpc";
+    });
+```
+
+**`WithExternalHttpEndpoints()`** — mark a resource's HTTP endpoints as externally visible. Use this for user-facing frontends so the URL appears prominently in the dashboard:
+
+```csharp
+var frontend = builder.AddViteApp("frontend", "../frontend")
+    .WithHttpsDeveloperCertificate()
+    .WithHttpsEndpoint(env: "PORT")
+    .WithExternalHttpEndpoints();
+```
+
+**Port injection**: Many frameworks (Express, Vite, Flask) need to know which port to listen on. Use the `env:` parameter:
+- `withHttpsEndpoint({ env: "PORT" })` (TypeScript)
+- `.WithHttpsEndpoint(env: "PORT")` (C#)
+
+Aspire assigns a port and injects it as the specified environment variable. The service should read it and listen on that port.
+
+**Recommended ask when a repo already hardcodes ports:**
+
+> "I found this service pinned to port 3000 today. Unless that exact port is needed for an external callback or another hard requirement, I recommend switching it to read PORT from env and letting Aspire manage the port. That avoids collisions and makes the AppHost more portable. Should I keep 3000 or make it Aspire-managed?"
+
+## Cross-service environment variable wiring
+
+When a service expects a **specific env var name** for a dependency's URL (not the standard `services__` format from `WithReference`), use `WithEnvironment` with an endpoint reference — **never a hardcoded string**:
+
+```typescript
+// ✅ CORRECT — endpoint reference resolves to the actual URL at runtime
+const roomEndpoint = await room.getEndpoint("http");
+
+const frontend = await builder
+    .addViteApp("frontend", "./frontend")
+    .withEnvironment("VITE_APP_WS_SERVER_URL", roomEndpoint)  // EndpointReference, not a string
+    .withReference(room)   // also sets up standard service discovery
+    .waitFor(room);
+
+// ❌ WRONG — hardcoded URL breaks when Aspire assigns different ports
+    .withEnvironment("VITE_APP_WS_SERVER_URL", "http://localhost:3002")  // NEVER DO THIS
+```
+
+```csharp
+// C# equivalent
+var roomEndpoint = room.GetEndpoint("http");
+var frontend = builder.AddViteApp("frontend", "../frontend")
+    .WithEnvironment("VITE_APP_WS_SERVER_URL", roomEndpoint)
+    .WithReference(room)
+    .WaitFor(room);
+```
+
+Use `WithEnvironment(name, endpointRef)` when the consuming service reads a **specific env var name**. Use `WithReference()` when the service uses Aspire service discovery or standard connection string patterns. You can use both together.
+
+## URL labels and dashboard niceties
+
+Customize how endpoints appear in the Aspire dashboard:
+
+```csharp
+// Named endpoints for clarity
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithHttpsEndpoint(name: "public", port: 8443)
+    .WithHttpsEndpoint(name: "internal", port: 8444);
+```
+
+For `dev.localhost` cookie isolation and config-based subdomain setup, see Step 9 in the main SKILL.md.
+
+## Dependency ordering: `WaitFor` and `WaitForCompletion`
+
+**`WaitFor()`** — delay starting a resource until another resource is healthy/ready:
+
+```csharp
+var db = builder.AddPostgres("pg").AddDatabase("mydb");
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithReference(db)
+    .WaitFor(db);  // Don't start api until db is healthy
+```
+
+Always pair `WithReference()` with `WaitFor()` for infrastructure dependencies (databases, caches, queues). Services that depend on other services should generally also wait for them.
+
+**`WaitForCompletion()`** — wait for a resource to run to completion (exit successfully). Use for init containers, database migrations, or seed data scripts:
+
+```csharp
+var migration = builder.AddCSharpApp("migration", "../src/MigrationRunner")
+    .WithReference(db)
+    .WaitFor(db);
+
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithReference(db)
+    .WaitFor(db)
+    .WaitForCompletion(migration);  // Don't start until migration finishes
+```
+
+## Secrets in process arguments — avoid `WithArgs` for sensitive values
+
+**⚠️ Never pass connection strings, passwords, or other secrets via `WithArgs()`.** Process arguments are visible in task managers, `ps` output, process inspection tools, and often end up in logs. This is a secret leakage risk.
+
+```csharp
+// ❌ WRONG — connection string visible in process arguments
+var migrator = builder.AddCSharpApp("migrator", "../util/Migrator")
+    .WithArgs(context =>
+    {
+        context.Args.Add(db.Resource.ConnectionStringExpression);
+    });
+
+// ✅ CORRECT — pass secrets via environment variables
+var migrator = builder.AddCSharpApp("migrator", "../util/Migrator")
+    .WithEnvironment("DB_CONNECTION_STRING", db.Resource.ConnectionStringExpression);
+```
+
+If the tool only accepts the connection string as a CLI argument (e.g., a third-party migration runner), note this limitation to the user and suggest modifying the tool to read from an environment variable or config file instead. If modification isn't possible, using `WithArgs` is acceptable as a pragmatic tradeoff — but flag it explicitly.
+
+## Container lifetimes
+
+By default, containers are stopped when the AppHost stops. Use **persistent lifetime** to keep containers running across restarts (useful for databases during development):
+
+```csharp
+var db = builder.AddPostgres("pg")
+    .WithLifetime(ContainerLifetime.Persistent);
+```
+
+This prevents data loss when restarting the AppHost — the container stays running and the AppHost reconnects.
+
+**TypeScript equivalent:**
+
+```typescript
+const db = await builder.addPostgres("pg")
+    .withLifetime("persistent");
+```
+
+Recommend persistent lifetime for databases and caches during local development.
+
+**⚠️ Stale persistent volumes can cause auth failures.** Typed integrations like `AddSqlServer()`, `AddPostgres()`, `AddRedis()`, and `AddMySql()` auto-generate passwords on first run. Those passwords are stored inside the container's data volume. If the AppHost is recreated or its user-secrets are reset, Aspire generates a *new* password — but the persistent volume still has the *old* one. The symptom is repeated `Login failed` or `password authentication failed` errors in the container logs.
+
+To fix: stop the AppHost, remove the stale container and its volume (`docker rm -f <name>; docker volume rm <volume>`), then restart. Aspire will recreate both with a matching password. Mention this to the user if they see auth failures on persistent infrastructure containers after recreating the AppHost.
+
+## Explicit start (manual start)
+
+Some resources shouldn't auto-start with the AppHost. Mark them for explicit start:
+
+```csharp
+var debugTool = builder.AddContainer("profiler", "myregistry/profiler")
+    .WithLifetime(ContainerLifetime.Persistent)
+    .ExcludeFromManifest()
+    .WithExplicitStart();
+```
+
+The resource appears in the dashboard but stays stopped until the user manually starts it. Useful for debugging tools, admin UIs, or optional services.
+
+## Parent resources (grouping in the dashboard)
+
+Group related resources under a parent for a cleaner dashboard:
+
+```csharp
+var postgres = builder.AddPostgres("pg");
+var ordersDb = postgres.AddDatabase("orders");
+var inventoryDb = postgres.AddDatabase("inventory");
+// ordersDb and inventoryDb appear nested under pg in the dashboard
+```
+
+This happens automatically for databases added to a server resource. For custom grouping of arbitrary resources, use `WithParentRelationship()`:
+
+```csharp
+var backend = builder.AddResource(new ContainerResource("backend-group"));
+var api = builder.AddCSharpApp("api", "../src/Api")
+    .WithParentRelationship(backend);
+var worker = builder.AddCSharpApp("worker", "../src/Worker")
+    .WithParentRelationship(backend);
+```
+
+Use `aspire docs search "parent relationship"` to verify the current API shape.
+
+## Volumes and data persistence
+
+```csharp
+// Named volume (managed by Docker, persists across container recreations)
+var db = builder.AddPostgres("pg")
+    .WithDataVolume("pg-data");
+
+// Bind mount (maps to a host directory)
+var db = builder.AddPostgres("pg")
+    .WithBindMount("./data/pg", "/var/lib/postgresql/data");
+```
+
+```typescript
+const db = await builder.addPostgres("pg")
+    .withDataVolume("pg-data");
+```

--- a/.agents/skills/aspireify/references/docker-compose.md
+++ b/.agents/skills/aspireify/references/docker-compose.md
@@ -1,0 +1,214 @@
+# Docker Compose migration
+
+Use this reference when the repo has a `docker-compose.yml` or `compose.yml` file. Docker Compose files are one of the most valuable discovery sources — they document the infrastructure the app actually needs to run locally.
+
+## When to load this reference
+
+- A `docker-compose.yml`, `compose.yml`, or `docker-compose.override.yml` exists anywhere in the repo
+- The repo has setup scripts that call `docker compose up` as part of the dev workflow
+
+## Profiles
+
+Docker Compose files can use `profiles:` to organize services into named groups. Not all services run at once — the developer chooses which profiles to activate.
+
+Example from a real repo:
+
+```yaml
+services:
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    profiles: [cloud, mssql]
+  postgres:
+    image: postgres:14
+    profiles: [postgres, ef]
+  redis:
+    image: redis:alpine
+    profiles: [redis, cloud]
+  storage:
+    image: mcr.microsoft.com/azure-storage/azurite:latest
+    profiles: [storage, cloud]
+  mail:
+    image: sj26/mailcatcher:latest
+    profiles: [mail]
+```
+
+When profiles are present:
+
+1. **List them clearly** — show the user which profiles exist and what services each activates
+2. **Ask which to target** — *"Your docker-compose has profiles: cloud, mssql, postgres, storage, redis, mail. Which ones represent your typical local dev stack?"*
+3. **Model only selected profiles** — services in unselected profiles are skipped entirely
+4. **Services without profiles always run** — if a service has no `profiles:` key, include it regardless of profile selection
+5. **Profile-specific infrastructure implies choices** — `mssql` vs `postgres` profiles often mean the repo supports multiple database backends. Ask which one to model in the AppHost.
+
+## Image-to-integration mapping
+
+Prefer typed Aspire integrations over raw `AddContainer()`. Use `aspire docs search <technology>` to check for available integrations.
+
+Common mappings:
+
+| Compose image | Aspire integration | Method |
+|---------------|-------------------|--------|
+| `postgres:*` | `Aspire.Hosting.PostgreSQL` | `AddPostgres()` |
+| `mcr.microsoft.com/mssql/server:*` | `Aspire.Hosting.SqlServer` | `AddSqlServer()` |
+| `mysql:*` / `mariadb:*` | `Aspire.Hosting.MySql` | `AddMySql()` |
+| `redis:*` | `Aspire.Hosting.Redis` | `AddRedis()` |
+| `rabbitmq:*` | `Aspire.Hosting.RabbitMQ` | `AddRabbitMQ()` |
+| `mongo:*` | `Aspire.Hosting.MongoDB` | `AddMongoDB()` |
+| `mcr.microsoft.com/azure-storage/azurite:*` | `Aspire.Hosting.Azure.Storage` | `AddAzureStorage().RunAsEmulator()` |
+| `kafka`, `confluentinc/cp-kafka:*` | `Aspire.Hosting.Kafka` | `AddKafka()` |
+| `nats:*` | `Aspire.Hosting.Nats` | `AddNats()` |
+| `mcr.microsoft.com/azure-messaging/servicebus-emulator:*` | `Aspire.Hosting.Azure.ServiceBus` | `AddAzureServiceBus().RunAsEmulator()` |
+
+For images not in this list, use `aspire docs search` to check, then fall back to `AddContainer()`.
+
+## Environment variable interpolation
+
+Compose files use `${VAR}` syntax to reference variables from `.env` files:
+
+```yaml
+environment:
+  MSSQL_SA_PASSWORD: ${MSSQL_PASSWORD}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+```
+
+**⚠️ CRITICAL: Do not model passwords for typed Aspire integrations.**
+
+`AddPostgres()`, `AddSqlServer()`, `AddRedis()`, `AddMySql()`, `AddRabbitMQ()`, and other typed integrations **auto-generate secure passwords**. The compose file needed `POSTGRES_PASSWORD` because Compose doesn't manage credentials — Aspire does. If you see a compose password variable that maps to a typed integration, **skip it entirely**. Do not create an `AddParameter` for it.
+
+```csharp
+// ❌ WRONG — don't model passwords that Aspire auto-generates
+var pgPassword = builder.AddParameter("postgres-password", secret: true);
+var postgres = builder.AddPostgres("postgres", password: pgPassword);
+
+// ✅ RIGHT — let Aspire handle the password
+var postgres = builder.AddPostgres("postgres");
+```
+
+Use `aspire docs get <integration-slug>` to check what each typed integration manages automatically. Look for the "Connection properties" section — if it lists `Password`, the integration handles it.
+
+When you see a `${VAR}` pattern in compose:
+
+1. **Check if it maps to a typed integration** — if `POSTGRES_PASSWORD`, `MSSQL_SA_PASSWORD`, `MYSQL_ROOT_PASSWORD`, `RABBITMQ_DEFAULT_PASS`, etc. are used by a typed Aspire integration, **skip them** — Aspire manages these
+2. **Trace non-integration variables** — find them in the `.env` or `.env.example` file
+3. **Classify** — is it a secret (API key, token) or plain config?
+4. **Model it** — secrets become `AddParameter(name, secret: true)`, plain config becomes `AddParameter(name)` with a default or `WithEnvironment()` directly
+
+## Volume mapping
+
+| Compose volume type | Aspire equivalent | Notes |
+|--------------------|--------------------|-------|
+| Named volume (`mssql_data:/var/opt/mssql`) | `WithDataVolume()` | Preferred — Aspire manages lifecycle |
+| Named volume (custom name) | `WithDataVolume(name: "custom")` | Preserves the name for familiarity |
+| Bind mount (`./data:/app/data`) | `WithBindMount("./data", "/app/data")` | Use for config files, scripts, or shared data |
+| Bind mount for config (`./config.json:/etc/config.json`) | `WithBindMount(...)` | Preserve for config injection |
+
+**Tip:** If the compose file mounts migration scripts or SQL files into a database container, those are likely init scripts. See "Init and setup scripts" below.
+
+## Dependency ordering
+
+Compose `depends_on` maps to Aspire's `WaitFor()`:
+
+```yaml
+# Compose
+services:
+  api:
+    depends_on:
+      - mssql
+      - redis
+```
+
+```csharp
+// Aspire
+var api = builder.AddProject<Projects.Api>("api")
+    .WithReference(mssql)
+    .WithReference(redis)
+    .WaitFor(mssql)
+    .WaitFor(redis);
+```
+
+`WithReference()` establishes the connection. `WaitFor()` ensures the dependency is healthy before the consuming service starts. Use both together.
+
+For `depends_on` with `condition: service_healthy`, the `WaitFor()` mapping is especially important — it replicates the same behavior.
+
+## Build contexts
+
+Compose services with `build:` are built from source, not pulled as images:
+
+```yaml
+services:
+  worker:
+    build:
+      context: ./worker
+      dockerfile: Dockerfile
+```
+
+Map these to `AddDockerfile()`:
+
+```csharp
+var worker = builder.AddDockerfile("worker", "../worker")
+    .WithHttpEndpoint(targetPort: 8080);
+```
+
+However, **prefer native Aspire project hosting over Dockerfiles when possible**. If the build context contains a `.csproj`, use `AddProject<T>()`. If it's a Node.js app, use `AddNodeApp()` or `AddViteApp()`. Dockerfiles are a last resort for Aspire modeling — they lose service discovery, health checks, and hot reload.
+
+## Init and setup scripts
+
+Repos often have setup scripts alongside their compose files:
+
+- `setup_azurite.ps1` — initializes storage emulator containers and queues
+- `migrate.ps1` / `ef_migrate.ps1` — runs database migrations
+- `setup_secrets.ps1` — configures .NET user secrets
+- `create_certificates_*.sh` — generates dev certificates
+
+**Present the user with options for how to handle these:**
+
+1. **Model as a lifecycle command on the relevant resource** — for example, a database migration script can be a startup command on the database resource. This runs automatically when the resource starts.
+   → *"Your repo has a migrate.ps1 that runs SQL migrations against the database. I can model this as a startup lifecycle hook on the database resource so migrations run automatically when you `aspire start`. Want that?"*
+
+2. **Model as a standalone executable resource** — for scripts that don't map cleanly to a single resource, use `AddExecutable()` with `WaitForCompletion()` so dependent services wait for the script to finish.
+
+3. **Leave as manual** — some setup scripts are one-time-only (like certificate generation) and don't need to run every time. Note them in the AppHost as a comment and move on.
+
+The right choice depends on the script. Present the tradeoff and let the user decide.
+
+## Putting it together
+
+A compose file like:
+
+```yaml
+services:
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      MSSQL_SA_PASSWORD: ${MSSQL_PASSWORD}
+    volumes:
+      - mssql_data:/var/opt/mssql
+    ports:
+      - "1433:1433"
+  redis:
+    image: redis:alpine
+    volumes:
+      - redis_data:/data
+    ports:
+      - "6379:6379"
+```
+
+Becomes:
+
+```csharp
+// ✅ Let Aspire auto-generate the SA password — don't model MSSQL_PASSWORD
+var mssql = builder.AddSqlServer("mssql")
+    .WithDataVolume();
+
+var redis = builder.AddRedis("redis")
+    .WithDataVolume();
+```
+
+Note: for typed integrations like `AddSqlServer()` and `AddRedis()`, you don't need to map ports or passwords — Aspire handles both. You also don't need to model `redis_data` as a named volume — `WithDataVolume()` handles persistence. The `${MSSQL_PASSWORD}` from the compose file is skipped entirely because `AddSqlServer()` auto-generates a secure SA password.
+
+## Common pitfalls
+
+- **Don't model every compose service** — some are dev-only tools (mailcatcher, reverse proxies, SAML IdPs for testing). Ask the user which are essential vs nice-to-have.
+- **Don't preserve hardcoded ports from compose** — Aspire manages ports dynamically. Only preserve a port if the user confirms it's required for external reasons (OAuth callbacks, etc.).
+- **Don't duplicate compose's `.env` interpolation** — Aspire parameters replace this pattern. Trace each `${VAR}` to its source and model it properly.
+- **Watch for services that conflict on the same port** — compose profiles often have services sharing ports (e.g., `mssql` and `postgres` both on different profiles). If the user selects conflicting profiles, surface the conflict.

--- a/.agents/skills/aspireify/references/full-solution-apphosts.md
+++ b/.agents/skills/aspireify/references/full-solution-apphosts.md
@@ -1,0 +1,332 @@
+# Full-solution C# AppHosts
+
+Use this reference when `aspire init` created a **full project mode** AppHost because a `.sln` or `.slnx` was discovered.
+
+This is the high-friction path: solution-backed repos often have older bootstrap patterns, SDK pins, existing ServiceDefaults-like code, build constraints, and significantly more projects than single-file repos. Some of these solutions have dozens or hundreds of projects — the skill must triage smartly, not try to wire everything.
+
+## What this reference is for
+
+Load this reference when any of the following are true:
+
+- `appHost.path` points to a directory containing `apphost.cs` and a `.csproj`
+- a `.sln` or `.slnx` exists near the AppHost
+- the repo has a root `global.json`
+- selected .NET services still use `Program.cs` + `Startup.cs`, `Host.CreateDefaultBuilder`, `ConfigureWebHostDefaults`, `UseStartup`, or other `IHostBuilder` patterns
+
+## Core rule: solution-backed AppHosts are not single-file AppHosts
+
+Treat these repos as **solution-aware C# init**, not as generic AppHost setup.
+
+- The AppHost may need project references
+- The AppHost may need its own SDK boundary
+- The solution may or may not be able to own the AppHost safely
+- ServiceDefaults changes may require bootstrap modernization
+
+Do not apply single-file assumptions here.
+
+## Large solution triage
+
+When a solution contains more than a handful of projects, don't try to model everything at once. Classify projects first, then present a focused list.
+
+### Step 1: Classify all projects
+
+For every `.csproj` in the solution, determine its role:
+
+| Classification | How to detect | Action |
+|---------------|---------------|--------|
+| **Runnable service** | `OutputType` = `Exe` or `WinExe`, not a test project, not the AppHost | Candidate for AppHost modeling |
+| **Class library** | `OutputType` = `Library` | Skip — these are dependencies, not services |
+| **Test project** | References xUnit/NUnit/MSTest, or name ends in `.Test`/`.Tests`/`.IntegrationTest` | Skip |
+| **Migration runner** | Name contains `Migrat`, or references `DbUp`/`FluentMigrator`/EF migrations tooling | Special handling — see below |
+| **Utility/tool** | Located in `util/`, `tools/`, or `scripts/` directories; not a long-running service | Skip unless user requests |
+| **AppHost** | `IsAspireHost` = `true` | Skip — this is the host itself |
+
+Run `dotnet msbuild <project> -getProperty:OutputType` to classify. For large solutions, batch these calls.
+
+### Step 2: Check for multiple source roots
+
+Some repos keep code in more than one top-level directory. Common patterns:
+
+- `src/` + `bitwarden_license/src/` (open-source vs commercial)
+- `src/` + `util/` (services vs utilities)
+- `apps/` + `packages/` (monorepo with shared packages)
+
+Scan all directories in the solution, not just `src/`. If you find projects outside `src/`, note them and ask the user if they should be included.
+
+### Step 3: Present the focused list
+
+Group runnable services by category and present them concisely. For a repo with 60+ projects, show something like:
+
+> *"I found 8 runnable web services (Api, Admin, Identity, Billing, Events, EventsProcessor, Icons, Notifications), 5 class libraries (Core, SharedWeb, Infrastructure.Dapper, Infrastructure.EntityFramework, Sql), 3 migration runners (Migrator, MsSqlMigratorUtility, PostgresMigrations), and 40+ test projects.*
+>
+> *I recommend starting with the core services. Which of the 8 web services should I include in the AppHost?"*
+
+**Do not dump a flat list of 60+ projects.** Classify, summarize, and let the user choose.
+
+### Incremental "core loop" wiring
+
+For solutions with 5 or more runnable services, recommend starting with a **core loop** — the minimum set of services needed for a useful local dev session — and expanding from there.
+
+The core loop is typically:
+
+1. The primary API service
+2. Its database dependency
+3. Any authentication/identity service
+4. The essential cache (Redis, etc.)
+
+Present this explicitly:
+
+> *"You have 8 services. I recommend wiring the core loop first — Api, Identity, and the database — so we can validate `aspire start` works. Then we'll add the remaining services. Sound good?"*
+
+**After the core loop succeeds with `aspire start`:**
+
+1. Stop the AppHost
+2. Add the next batch of services (2-3 at a time) to the AppHost
+3. Run `aspire start` again to validate
+4. If it fails, diagnose and fix before adding more
+5. Repeat until all selected services are wired
+
+Present progress to the user as you go:
+
+> *"Core loop is working (Api + Identity + Postgres + Redis). Adding the next batch: Admin, Billing, and Events..."*
+
+Do not consider the skill complete until all services the user selected in Step 3 are wired and `aspire start` runs with all of them healthy. The core loop is a risk-reduction strategy, not an excuse to stop early.
+
+## Migration runners and setup utilities
+
+Migration runners (database migrations, schema updates, data seeders) deserve special handling. They aren't long-running services — they run once and exit.
+
+Present the user with options:
+
+1. **Model as a project resource with `WaitForCompletion()`** — the migration runs at startup and dependent services wait for it to finish before starting:
+
+```csharp
+var db = builder.AddSqlServer("mssql").AddDatabase("vault");
+var migrator = builder.AddProject<Projects.Migrator>("migrator")
+    .WithReference(db)
+    .WaitFor(db);
+
+var api = builder.AddProject<Projects.Api>("api")
+    .WithReference(db)
+    .WaitForCompletion(migrator);  // api waits for migrations to finish
+```
+
+2. **Leave as manual** — the developer runs migrations separately before `aspire start`. Note this in an AppHost comment:
+
+```csharp
+// Run migrations manually: dotnet run --project ../util/Migrator
+var db = builder.AddSqlServer("mssql").AddDatabase("vault");
+```
+
+Recommend option 1 for repos that currently run migrations as part of their docker-compose or startup scripts. Recommend option 2 for repos where migrations are a deliberate, explicit step.
+
+## Custom MSBuild SDKs
+
+Check `global.json` for `msbuild-sdks` entries beyond the standard Microsoft ones. Common SDKs like `Microsoft.Build.Traversal` are well-known, but custom SDKs (e.g., `Bitwarden.Server.Sdk`) are opaque.
+
+When you find a custom MSBuild SDK:
+
+- **Don't assume project properties are reliable** — the custom SDK may override `OutputType`, inject implicit references, or modify build behavior in ways you can't see
+- **Note it to the user** — *"This repo uses a custom MSBuild SDK (Bitwarden.Server.Sdk). I'll classify projects based on their directory structure and names as well as MSBuild properties, since the custom SDK may affect property evaluation."*
+- **Cross-reference with directory structure** — if `OutputType` says `Library` but the project is in `src/Api/` and has a `Program.cs` and `Startup.cs`, it's likely a runnable service whose OutputType is set by the custom SDK
+
+## Conditional compilation
+
+Some repos use `#if` / `#endif` to maintain multiple build variants from the same source:
+
+```csharp
+#if OSS
+    services.AddOosServices();
+#else
+    services.AddCommercialCoreServices();
+#endif
+```
+
+When you detect conditional compilation in `Program.cs` or `Startup.cs`:
+
+1. **Surface it early** — *"Your services use `#if OSS` conditional compilation, which means the app behaves differently depending on the build configuration. Which variant should the AppHost target — OSS or commercial?"*
+2. **Don't try to model both** — pick the variant the user selects and wire accordingly
+3. **Note the other variant** — leave a comment in the AppHost: `// This AppHost targets the OSS build. For commercial, adjust service registrations.`
+
+This is not a priority to solve perfectly — just make sure the agent doesn't silently pick the wrong variant.
+
+## Mixed SDK repos
+
+Some repos pin the root `global.json` to an older SDK such as .NET 8. A `.csproj`-based Aspire AppHost should still stay on the current Aspire-supported SDK (for example, .NET 10), while existing service projects can remain on `net8.0`.
+
+**Do not downgrade the AppHost project to match the repo's root SDK pin. Do not change the root `global.json`. Do not change any existing project's `<TargetFramework>`.**
+
+### Create a nested `global.json` for the AppHost
+
+If the repo's root `global.json` pins an older SDK and the AppHost is in full project mode, you **must** create a nested `global.json` inside the AppHost directory so it builds with the correct SDK. Check whether one already exists before creating it.
+
+Steps:
+
+1. Keep the repo root `global.json` unchanged.
+2. Check if a `global.json` already exists in the AppHost directory — if so, skip this.
+3. Create a `global.json` next to the AppHost `.csproj` that pins the Aspire-supported SDK:
+
+```json
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}
+```
+
+4. Leave existing services targeting their current TFM unless the user explicitly asks to migrate them.
+
+### Important solution caveat
+
+If the repo's normal root build runs under SDK 8, do **not** assume it can safely own a `net10.0` AppHost project.
+
+When that's likely to break the repo's normal build:
+
+- tell the user explicitly
+- prefer keeping the AppHost isolated in its own folder
+- only add it to the root solution if the user wants that tradeoff
+
+## Solution membership
+
+A discovered solution means the AppHost was created in project mode, but that does **not** always mean every new project should be added to the root solution automatically.
+
+Use this decision order:
+
+1. If the root solution already includes the services being modeled and is the normal local entry point, prefer adding the AppHost and ServiceDefaults there.
+2. If the root solution is tightly coupled to an older SDK/toolchain and adding a `net10.0` AppHost is likely to break routine builds, keep the AppHost outside the solution or in a safer sibling solution boundary.
+3. If you're unsure, ask instead of guessing.
+
+## ServiceDefaults in solution-backed repos
+
+Before creating or wiring ServiceDefaults:
+
+1. Look for an existing ServiceDefaults project or equivalent shared bootstrap code.
+2. Check whether selected services already have tracing, health checks, or service discovery setup.
+3. Check whether the service bootstrap is modern enough for `AddServiceDefaults()` and `MapDefaultEndpoints()`.
+
+If a ServiceDefaults project already exists, reuse it instead of creating another one.
+
+## Legacy bootstrap detection: `IHostBuilder` vs `IHostApplicationBuilder`
+
+This is the easy-to-forget gotcha.
+
+The generated ServiceDefaults extensions typically target **`IHostApplicationBuilder`** and **`WebApplication`** patterns:
+
+```csharp
+builder.AddServiceDefaults();
+app.MapDefaultEndpoints();
+```
+
+That drops cleanly into modern code such as:
+
+- `var builder = WebApplication.CreateBuilder(args);`
+- `var builder = Host.CreateApplicationBuilder(args);`
+
+It does **not** automatically map onto older patterns such as:
+
+- `Host.CreateDefaultBuilder(args)`
+- `ConfigureWebHostDefaults(...)`
+- `UseStartup<Startup>()`
+- `IHostBuilder`-only worker/bootstrap code
+
+### What to do when you find legacy hosting
+
+Do **not** silently jam ServiceDefaults into the old shape. **Do not create adapter extension methods on `IHostBuilder`** — ServiceDefaults is designed for `IHostApplicationBuilder` and should only be used with the modern bootstrap pattern.
+
+There are exactly two options. Present them clearly:
+
+1. **Skip ServiceDefaults for now** (recommended for initial setup)
+   - Model the service in the AppHost with `AddProject<T>()` or `AddCSharpApp()`
+   - The service appears in the dashboard, gets environment wiring, and shows logs
+   - No code changes to the service project needed
+   - Health checks, service discovery, and OTel from ServiceDefaults are deferred
+
+2. **Modernize the service's bootstrap** (larger change, per-service)
+   - Convert `Program.cs` from `Host.CreateDefaultBuilder()` to `WebApplication.CreateBuilder()`
+   - Inline the `Startup.ConfigureServices()` into `builder.Services.*` calls
+   - Inline the `Startup.Configure()` into the `app.*` middleware pipeline
+   - Then add `builder.AddServiceDefaults()` and `app.MapDefaultEndpoints()`
+   - Existing `IHostBuilder` extensions (like custom logging, SDK setup) can be called via `builder.Host.*`
+
+**When multiple services share the same legacy pattern, batch the decision.** If 8 services all use `Host.CreateDefaultBuilder` + `UseStartup<T>`, don't ask 8 times. Ask once:
+
+> *"All 8 of your web services use the legacy IHostBuilder + Startup pattern. I can either (a) model them all in the AppHost without ServiceDefaults for now — they'll appear in the dashboard and get environment wiring but won't have health checks or service discovery — or (b) modernize each service's bootstrap to the WebApplicationBuilder pattern so ServiceDefaults works fully. Which approach do you prefer? You can also mix — modernize a few key services and leave the rest."*
+
+If the repo is conservative or large, default to **asking**, not migrating automatically.
+
+## Modernization guidance
+
+### ASP.NET Core app using `IHostBuilder` / `Startup`
+
+If the user wants full ServiceDefaults support, migrate toward a `WebApplicationBuilder` shape.
+
+Target pattern:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+
+builder.Services.AddControllers();
+
+var app = builder.Build();
+
+app.MapControllers();
+app.MapDefaultEndpoints();
+
+app.Run();
+```
+
+Preserve existing service registrations and middleware ordering carefully. Move only what is required to land on a `WebApplicationBuilder`/`WebApplication` pipeline.
+
+When the `Startup` class has custom extension methods (e.g., `UseBitwardenSdk()`, `AddGlobalSettingsServices()`), those typically need to be called on the new `builder` or `app` in the appropriate phase. Don't silently drop them — trace each call to its registration phase (services vs middleware) and preserve it.
+
+### Worker/background service using `IHostBuilder`
+
+If the service is a worker and the user wants ServiceDefaults, migrate toward `Host.CreateApplicationBuilder(args)`:
+
+```csharp
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddServiceDefaults();
+builder.Services.AddHostedService<Worker>();
+
+var host = builder.Build();
+await host.RunAsync();
+```
+
+For non-web workers, `MapDefaultEndpoints()` usually does not apply unless the app exposes HTTP endpoints.
+
+## AppHost project references
+
+For full project mode, prefer explicit project references from the AppHost to selected .NET services:
+
+```bash
+dotnet add <AppHost.csproj> reference <Api.csproj>
+```
+
+This keeps solution-backed AppHosts easier to navigate and build.
+
+## Validation checklist for full-solution mode
+
+Before declaring success:
+
+1. The AppHost project builds under its intended SDK boundary.
+2. The root solution still behaves the way the user expects, or the user has explicitly accepted any tradeoff.
+3. Any ServiceDefaults changes compile in the selected services.
+4. `aspire start` works from the AppHost context, and long-lived app resources are healthy rather than merely `Finished`.
+5. Legacy `IHostBuilder` services were either modernized intentionally or explicitly left unchanged.
+6. Migration runners, if modeled, complete successfully before dependent services start.
+
+## When to ask the user instead of deciding
+
+Ask when:
+
+- adding the AppHost to the root solution might break the repo's normal SDK/build
+- a service uses `Startup.cs` / `IHostBuilder` and would need real bootstrap surgery
+- there are multiple plausible ServiceDefaults/shared-bootstrap projects to reuse
+- the repo has mixed solution boundaries and it's unclear which one is the real developer entry point
+- the repo has a custom MSBuild SDK and project classification is ambiguous
+- the repo uses conditional compilation and the target variant is unclear
+- there are more than 5 runnable services and you need to decide which to wire first

--- a/.agents/skills/aspireify/references/javascript-apps.md
+++ b/.agents/skills/aspireify/references/javascript-apps.md
@@ -1,0 +1,150 @@
+# JavaScript and TypeScript app patterns
+
+Use this reference when wiring JavaScript/TypeScript services into the AppHost or configuring TypeScript AppHost dependencies (Step 5 and Step 6).
+
+## Choosing the right JavaScript resource type
+
+The `Aspire.Hosting.JavaScript` package provides three resource types. Pick the right one:
+
+| Signal | Use | Example |
+|--------|-----|---------|
+| Vite app (has `vite.config.*`) | `AddViteApp(name, dir)` | Frontend SPA, Vite + React/Vue/Svelte |
+| App runs via package.json script only | `AddJavaScriptApp(name, dir, { runScriptName })` | CRA app, Next.js, monorepo root scripts |
+| App has a specific Node entry file (`.js`/`.ts`) and uses a dev script like `ts-node-dev` | `AddNodeApp(name, dir, "entry.js")` + `.WithRunScript("start:dev")` | Express/Fastify API, Socket.IO server |
+
+**Key distinctions:**
+- `AddNodeApp` is for apps that run a **specific file** with Node (e.g., an Express server at `src/index.ts`). Use `.WithRunScript("start:dev")` to override the dev-time command (e.g., `ts-node-dev`).
+- `AddJavaScriptApp` runs a **package.json script** — simpler, good when the script handles everything.
+- `AddViteApp` is `AddJavaScriptApp` with Vite-specific defaults (auto-HTTPS config augmentation, `dev` as default script).
+
+## JavaScript dev scripts
+
+Use `.WithRunScript()` to control which package.json script runs during development:
+
+```typescript
+// Express API with TypeScript: uses ts-node-dev for hot reload in dev
+const api = await builder
+    .addNodeApp("api", "./api", "src/index.ts")
+    .withRunScript("start:dev")                      // runs "yarn start:dev" (ts-node-dev)
+    .withYarn()
+    .withHttpEndpoint({ env: "PORT" });
+
+// Vite frontend: default "dev" script is fine, just add yarn
+const web = await builder
+    .addViteApp("web", "./frontend")
+    .withYarn();
+```
+
+## Framework-specific port binding
+
+Not all frameworks read ports from env vars the same way:
+
+| Framework | Port mechanism | AppHost pattern |
+|-----------|---------------|-----------------|
+| Express/Fastify | `process.env.PORT` | `.withHttpEndpoint({ env: "PORT" })` |
+| Vite | `--port` CLI arg or `server.port` in config | `.withHttpEndpoint({ env: "PORT" })` — Aspire's Vite integration handles this automatically |
+| Next.js | `PORT` env or `--port` | `.withHttpEndpoint({ env: "PORT" })` |
+| CRA | `PORT` env | `.withHttpEndpoint({ env: "PORT" })` |
+
+When the framework supports reading the port from an env var or Aspire already handles it, **prefer that over pinning a fixed port**. Managed ports make repeated local runs more reliable and work better when multiple services or multiple Aspire apps are running.
+
+**Suppress auto-browser-open:** Many dev servers (Vite, CRA, Next.js) auto-open a browser on start. Add `.withEnvironment("BROWSER", "none")` to prevent this in Aspire-managed apps. Vite also respects `server.open: false` in its config.
+
+## Yarn/pnpm workspace monorepos
+
+In monorepos that use **yarn workspaces** or **pnpm workspaces**, all workspace packages share a single root-level `node_modules/` directory (hoisted or symlinked). This creates two specific problems with `.withYarn()` / `.withPnpm()`:
+
+1. **Concurrent install conflicts (Windows)**: `.withYarn()` runs `yarn install` before each resource starts. When multiple resources start concurrently, each triggers a root-level `yarn install` that tries to write to the shared `node_modules/`. On Windows, this causes `EPERM: operation not permitted` errors when one resource's running process (e.g., `esbuild.exe`) holds a file lock while another `yarn install` tries to overwrite it.
+
+2. **Redundant installs**: In a properly set up workspace, `yarn` at the root installs everything for all workspaces. Running `yarn install` per-resource is redundant and slow.
+
+**The fix: don't use `.withYarn()` on individual workspace resources.** Instead, ensure dependencies are installed once at the root before starting:
+
+```typescript
+// ❌ WRONG for workspace monorepos — concurrent installs cause file locking errors
+const app = await builder.addViteApp("app", "./packages/frontend")
+    .withYarn();  // triggers yarn install at startup → EPERM on Windows
+
+const api = await builder.addNodeApp("api", "./packages/api", "src/index.ts")
+    .withYarn();  // second concurrent yarn install → file lock conflict
+
+// ✅ CORRECT for workspace monorepos — deps already installed at root
+const app = await builder.addViteApp("app", "./packages/frontend");
+
+const api = await builder.addNodeApp("api", "./packages/api", "src/index.ts")
+    .withRunScript("start:dev");
+```
+
+Tell the user: *"This is a yarn workspace monorepo — I'll skip `.withYarn()` on individual resources since dependencies are shared at the root. Make sure to run `yarn` at the root before `aspire start`."*
+
+**This only applies to workspace monorepos with shared `node_modules`.** For standalone apps or apps with independent `node_modules` directories, `.withYarn()` / `.withPnpm()` is correct and should be used — it ensures deps are installed before the resource starts.
+
+## TypeScript AppHost dependency configuration (Step 6)
+
+### package.json
+
+If one exists at the root, augment it (do not overwrite). Add/merge these scripts that delegate to the Aspire CLI:
+
+```json
+{
+  "type": "module",
+  "scripts": {
+    "dev": "aspire run",
+    "build": "tsc",
+    "watch": "tsc --watch"
+  }
+}
+```
+
+If no root `package.json` exists, create a minimal one matching the canonical Aspire template:
+
+```json
+{
+  "name": "<repo-name>",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "aspire run",
+    "build": "tsc",
+    "watch": "tsc --watch"
+  },
+  "engines": {
+    "node": "^20.19.0 || ^22.13.0 || >=24"
+  }
+}
+```
+
+**Important**: Scripts should point to `aspire run`/`aspire start` — the Aspire CLI handles TypeScript compilation internally. Do not use `npx tsc && node apphost.js` patterns.
+
+Never overwrite existing `scripts`, `dependencies`, or `devDependencies` — merge only. Do not manually add Aspire SDK packages — `aspire restore` handles those.
+
+Run `aspire restore` to generate the `.modules/` directory with TypeScript SDK bindings, then install dependencies with the repo's package manager (`npm install`, `pnpm install`, or `yarn`).
+
+### tsconfig.json
+
+Augment if it exists:
+
+- Ensure `".modules/**/*.ts"` and `"apphost.ts"` are in `include`
+- Ensure `"module"` is `"nodenext"` or `"node16"` (ESM required)
+- Ensure `"moduleResolution"` matches
+
+If no `tsconfig.json` exists and `aspire restore` didn't create one, create a minimal one:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": ["apphost.ts", ".modules/**/*.ts"]
+}
+```
+
+### ESLint
+
+Only augment if config already exists. If it uses `parserOptions.project` or `parserOptions.projectService`, ensure the AppHost tsconfig is discoverable. Do not create ESLint configuration from scratch.

--- a/.agents/skills/aspireify/references/opentelemetry.md
+++ b/.agents/skills/aspireify/references/opentelemetry.md
@@ -1,0 +1,112 @@
+# OpenTelemetry setup for non-.NET services
+
+Use this reference when the user opts in to adding OpenTelemetry instrumentation to non-.NET services (Step 8). Aspire automatically injects `OTEL_EXPORTER_OTLP_ENDPOINT` into all managed resources — the services just need to read it.
+
+## Node.js/TypeScript services
+
+```bash
+# Use the repo's package manager (npm/pnpm/yarn)
+npm install @opentelemetry/sdk-node @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-otlp-grpc
+# or: pnpm add ...
+# or: yarn add ...
+```
+
+Create an instrumentation file (e.g., `instrumentation.ts` or `instrumentation.js`):
+
+```typescript
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-otlp-grpc';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-otlp-grpc';
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+
+const sdk = new NodeSDK({
+  traceExporter: new OTLPTraceExporter(),
+  metricReader: new PeriodicExportingMetricReader({
+    exporter: new OTLPMetricExporter(),
+  }),
+  instrumentations: [getNodeAutoInstrumentations()],
+  serviceName: process.env.OTEL_SERVICE_NAME,
+});
+
+sdk.start();
+```
+
+Then ensure the service loads it early — either via `--require`/`--import` in the start script or by importing it as the first line of the entry point.
+
+## Python services
+
+```bash
+pip install opentelemetry-distro opentelemetry-exporter-otlp
+opentelemetry-bootstrap -a install  # auto-detect and install framework instrumentations
+```
+
+Add to the service's startup (e.g., top of `main.py` or as a separate `instrumentation.py`):
+
+```python
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry import trace, metrics
+import os
+
+resource = Resource.create({"service.name": os.environ.get("OTEL_SERVICE_NAME", "unknown")})
+
+# Traces
+trace.set_tracer_provider(TracerProvider(resource=resource))
+trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+
+# Metrics
+metrics.set_meter_provider(MeterProvider(
+    resource=resource,
+    metric_readers=[PeriodicExportingMetricReader(OTLPMetricExporter())],
+))
+```
+
+Or more simply, run with the auto-instrumentation wrapper:
+
+```bash
+opentelemetry-instrument uvicorn main:app --host 0.0.0.0
+```
+
+## Go services
+
+```bash
+go get go.opentelemetry.io/otel
+go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc
+go get go.opentelemetry.io/otel/sdk/trace
+go get go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
+```
+
+Add initialization in `main()`:
+
+```go
+import (
+    "go.opentelemetry.io/otel"
+    "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+    sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+func initTracer() func() {
+    exporter, _ := otlptracegrpc.New(context.Background())
+    tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(exporter))
+    otel.SetTracerProvider(tp)
+    return func() { tp.Shutdown(context.Background()) }
+}
+```
+
+Wrap HTTP handlers with `otelhttp.NewHandler()` for automatic HTTP span creation.
+
+## Java services
+
+Point the user to the [OpenTelemetry Java Agent](https://opentelemetry.io/docs/zero-code/java/agent/) — it's the easiest approach:
+
+```bash
+java -javaagent:opentelemetry-javaagent.jar -jar myapp.jar
+```
+
+The agent auto-instruments common frameworks. Aspire injects `OTEL_EXPORTER_OTLP_ENDPOINT` automatically.

--- a/.agents/skills/playwright-cli/SKILL.md
+++ b/.agents/skills/playwright-cli/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: playwright-cli
+description: Automate browser interactions, test web pages and work with Playwright tests.
+allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
+---
+
+# Browser Automation with playwright-cli
+
+## Quick start
+
+```bash
+# open new browser
+playwright-cli open
+# navigate to a page
+playwright-cli goto https://playwright.dev
+# interact with the page using refs from the snapshot
+playwright-cli click e15
+playwright-cli type "page.click"
+playwright-cli press Enter
+# take a screenshot (rarely used, as snapshot is more common)
+playwright-cli screenshot
+# close the browser
+playwright-cli close
+```
+
+## Commands
+
+### Core
+
+```bash
+playwright-cli open
+# open and navigate right away
+playwright-cli open https://example.com/
+playwright-cli goto https://playwright.dev
+playwright-cli type "search query"
+playwright-cli click e3
+playwright-cli dblclick e7
+# --submit presses Enter after filling the element
+playwright-cli fill e5 "user@example.com"  --submit
+playwright-cli drag e2 e8
+# drop files or data onto an element (from outside the page)
+playwright-cli drop e4 --path=./image.png
+playwright-cli drop e4 --data="text/plain=hello world"
+playwright-cli hover e4
+playwright-cli select e9 "option-value"
+playwright-cli upload ./document.pdf
+playwright-cli check e12
+playwright-cli uncheck e12
+playwright-cli snapshot
+playwright-cli eval "document.title"
+playwright-cli eval "el => el.textContent" e5
+# get element id, class, or any attribute not visible in the snapshot
+playwright-cli eval "el => el.id" e5
+playwright-cli eval "el => el.getAttribute('data-testid')" e5
+playwright-cli dialog-accept
+playwright-cli dialog-accept "confirmation text"
+playwright-cli dialog-dismiss
+playwright-cli resize 1920 1080
+playwright-cli close
+```
+
+### Navigation
+
+```bash
+playwright-cli go-back
+playwright-cli go-forward
+playwright-cli reload
+```
+
+### Keyboard
+
+```bash
+playwright-cli press Enter
+playwright-cli press ArrowDown
+playwright-cli keydown Shift
+playwright-cli keyup Shift
+```
+
+### Mouse
+
+```bash
+playwright-cli mousemove 150 300
+playwright-cli mousedown
+playwright-cli mousedown right
+playwright-cli mouseup
+playwright-cli mouseup right
+playwright-cli mousewheel 0 100
+```
+
+### Save as
+
+```bash
+playwright-cli screenshot
+playwright-cli screenshot e5
+playwright-cli screenshot --filename=page.png
+playwright-cli pdf --filename=page.pdf
+```
+
+### Tabs
+
+```bash
+playwright-cli tab-list
+playwright-cli tab-new
+playwright-cli tab-new https://example.com/page
+playwright-cli tab-close
+playwright-cli tab-close 2
+playwright-cli tab-select 0
+```
+
+### Storage
+
+```bash
+playwright-cli state-save
+playwright-cli state-save auth.json
+playwright-cli state-load auth.json
+
+# Cookies
+playwright-cli cookie-list
+playwright-cli cookie-list --domain=example.com
+playwright-cli cookie-get session_id
+playwright-cli cookie-set session_id abc123
+playwright-cli cookie-set session_id abc123 --domain=example.com --httpOnly --secure
+playwright-cli cookie-delete session_id
+playwright-cli cookie-clear
+
+# LocalStorage
+playwright-cli localstorage-list
+playwright-cli localstorage-get theme
+playwright-cli localstorage-set theme dark
+playwright-cli localstorage-delete theme
+playwright-cli localstorage-clear
+
+# SessionStorage
+playwright-cli sessionstorage-list
+playwright-cli sessionstorage-get step
+playwright-cli sessionstorage-set step 3
+playwright-cli sessionstorage-delete step
+playwright-cli sessionstorage-clear
+```
+
+### Network
+
+```bash
+playwright-cli route "**/*.jpg" --status=404
+playwright-cli route "https://api.example.com/**" --body='{"mock": true}'
+playwright-cli route-list
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+### DevTools
+
+```bash
+playwright-cli console
+playwright-cli console warning
+playwright-cli requests
+playwright-cli request 5
+playwright-cli run-code "async page => await page.context().grantPermissions(['geolocation'])"
+playwright-cli run-code --filename=script.js
+playwright-cli tracing-start
+playwright-cli tracing-stop
+playwright-cli video-start video.webm
+playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
+playwright-cli video-stop
+
+# launch the dashboard for UI review / design feedback — user annotates the page, you receive the annotated screenshot, snapshot, and notes
+playwright-cli show --annotate
+
+# generate a Playwright locator for an element from its ref or selector
+playwright-cli generate-locator e5 --raw
+
+# show a persistent highlight overlay for an element, optionally with a custom style
+playwright-cli highlight e5
+playwright-cli highlight e5 --style="outline: 3px dashed red"
+# hide a single element highlight, or all page highlights when no target is given
+playwright-cli highlight e5 --hide
+playwright-cli highlight --hide
+```
+
+## Raw output
+
+The global `--raw` option strips page status, generated code, and snapshot sections from the output, returning only the result value. Use it to pipe command output into other tools. Commands that don't produce output return nothing.
+
+```bash
+playwright-cli --raw eval "JSON.stringify(performance.timing)" | jq '.loadEventEnd - .navigationStart'
+playwright-cli --raw eval "JSON.stringify([...document.querySelectorAll('a')].map(a => a.href))" > links.json
+playwright-cli --raw snapshot > before.yml
+playwright-cli click e5
+playwright-cli --raw snapshot > after.yml
+diff before.yml after.yml
+TOKEN=$(playwright-cli --raw cookie-get session_id)
+playwright-cli --raw localstorage-get theme
+```
+
+For structured output wrapping every reply as JSON, pass --json
+```bash
+playwright-cli list --json
+```
+
+## Open parameters
+```bash
+# Use specific browser when creating session
+playwright-cli open --browser=chrome
+playwright-cli open --browser=firefox
+playwright-cli open --browser=webkit
+playwright-cli open --browser=msedge
+
+# Use persistent profile (by default profile is in-memory)
+playwright-cli open --persistent
+# Use persistent profile with custom directory
+playwright-cli open --profile=/path/to/profile
+
+# Connect to browser via Playwright Extension
+playwright-cli attach --extension=chrome
+
+# Connect to a running Chrome or Edge by channel name
+playwright-cli attach --cdp=chrome
+playwright-cli attach --cdp=msedge
+
+# Connect to a running browser via CDP endpoint
+playwright-cli attach --cdp=http://localhost:9222
+
+# Start with config file
+playwright-cli open --config=my-config.json
+
+# Close the browser
+playwright-cli close
+# Detach from an attached browser (leaves the external browser running)
+playwright-cli -s=msedge detach
+# Delete user data for the default session
+playwright-cli delete-data
+```
+
+## Snapshots
+
+After each command, playwright-cli provides a snapshot of the current browser state.
+
+```bash
+> playwright-cli goto https://example.com
+### Page
+- Page URL: https://example.com/
+- Page Title: Example Domain
+### Snapshot
+[Snapshot](.playwright-cli/page-2026-02-14T19-22-42-679Z.yml)
+```
+
+You can also take a snapshot on demand using `playwright-cli snapshot` command. All the options below can be combined as needed.
+
+```bash
+# default - save to a file with timestamp-based name
+playwright-cli snapshot
+
+# save to file, use when snapshot is a part of the workflow result
+playwright-cli snapshot --filename=after-click.yaml
+
+# snapshot an element instead of the whole page
+playwright-cli snapshot "#main"
+
+# limit snapshot depth for efficiency, take a partial snapshot afterwards
+playwright-cli snapshot --depth=4
+playwright-cli snapshot e34
+
+# include each element's bounding box as [box=x,y,width,height]
+playwright-cli snapshot --boxes
+```
+
+## Targeting elements
+
+By default, use refs from the snapshot to interact with page elements.
+
+```bash
+# get snapshot with refs
+playwright-cli snapshot
+
+# interact using a ref
+playwright-cli click e15
+```
+
+You can also use css selectors or Playwright locators.
+
+```bash
+# css selector
+playwright-cli click "#main > button.submit"
+
+# role locator
+playwright-cli click "getByRole('button', { name: 'Submit' })"
+
+# test id
+playwright-cli click "getByTestId('submit-button')"
+```
+
+## Browser Sessions
+
+```bash
+# create new browser session named "mysession" with persistent profile
+playwright-cli -s=mysession open example.com --persistent
+# same with manually specified profile directory (use when requested explicitly)
+playwright-cli -s=mysession open example.com --profile=/path/to/profile
+playwright-cli -s=mysession click e6
+playwright-cli -s=mysession close  # stop a named browser
+playwright-cli -s=mysession delete-data  # delete user data for persistent session
+
+playwright-cli list
+# Close all browsers
+playwright-cli close-all
+# Forcefully kill all browser processes
+playwright-cli kill-all
+```
+
+## Installation
+
+If global `playwright-cli` command is not available, try a local version via `npx playwright-cli`:
+
+```bash
+npx --no-install playwright-cli --version
+```
+
+When local version is available, use `npx playwright-cli` in all commands. Otherwise, install `playwright-cli` as a global command:
+
+```bash
+npm install -g @playwright/cli@latest
+```
+
+## Example: Form submission
+
+```bash
+playwright-cli open https://example.com/form
+playwright-cli snapshot
+
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Multi-tab workflow
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tab-new https://example.com/other
+playwright-cli tab-list
+playwright-cli tab-select 0
+playwright-cli snapshot
+playwright-cli close
+```
+
+## Example: Debugging with DevTools
+
+```bash
+playwright-cli open https://example.com
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli console
+playwright-cli requests
+playwright-cli close
+```
+
+```bash
+playwright-cli open https://example.com
+playwright-cli tracing-start
+playwright-cli click e4
+playwright-cli fill e7 "test"
+playwright-cli tracing-stop
+playwright-cli close
+```
+
+## Example: Interactive session
+
+Ask the user for UI review or design feedback. The user draws boxes on the live page and types comments; you receive the annotated screenshot, the snapshot of the marked region, and the user's notes. Use this whenever the user asks for "UI review", "design feedback", or to "ask the user what they think / want / mean":
+
+```bash
+playwright-cli open https://example.com
+playwright-cli show --annotate
+```
+
+## Specific tasks
+
+* **Running and Debugging Playwright tests** [references/playwright-tests.md](references/playwright-tests.md)
+* **Request mocking** [references/request-mocking.md](references/request-mocking.md)
+* **Running Playwright code** [references/running-code.md](references/running-code.md)
+* **Browser session management** [references/session-management.md](references/session-management.md)
+* **Spec-driven testing (plan / generate / heal)** [references/spec-driven-testing.md](references/spec-driven-testing.md)
+* **Storage state (cookies, localStorage)** [references/storage-state.md](references/storage-state.md)
+* **Test generation** [references/test-generation.md](references/test-generation.md)
+* **Tracing** [references/tracing.md](references/tracing.md)
+* **Video recording** [references/video-recording.md](references/video-recording.md)
+* **Inspecting element attributes** [references/element-attributes.md](references/element-attributes.md)

--- a/.agents/skills/playwright-cli/references/element-attributes.md
+++ b/.agents/skills/playwright-cli/references/element-attributes.md
@@ -1,0 +1,23 @@
+# Inspecting Element Attributes
+
+When the snapshot doesn't show an element's `id`, `class`, `data-*` attributes, or other DOM properties, use `eval` to inspect them.
+
+## Examples
+
+```bash
+playwright-cli snapshot
+# snapshot shows a button as e7 but doesn't reveal its id or data attributes
+
+# get the element's id
+playwright-cli eval "el => el.id" e7
+
+# get all CSS classes
+playwright-cli eval "el => el.className" e7
+
+# get a specific attribute
+playwright-cli eval "el => el.getAttribute('data-testid')" e7
+playwright-cli eval "el => el.getAttribute('aria-label')" e7
+
+# get a computed style property
+playwright-cli eval "el => getComputedStyle(el).display" e7
+```

--- a/.agents/skills/playwright-cli/references/playwright-tests.md
+++ b/.agents/skills/playwright-cli/references/playwright-tests.md
@@ -1,0 +1,39 @@
+# Running Playwright Tests
+
+To run Playwright tests, use the `npx playwright test` command, or a package manager script. To avoid opening the interactive html report, use `PLAYWRIGHT_HTML_OPEN=never` environment variable.
+
+```bash
+# Run all tests
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+
+# Run all tests through a custom npm script
+PLAYWRIGHT_HTML_OPEN=never npm run special-test-command
+```
+
+# Debugging Playwright Tests
+
+To debug a failing Playwright test, run it with `--debug=cli` option. This command will pause the test at the start and print the debugging instructions.
+
+**IMPORTANT**: run the command in the background and check the output until "Debugging Instructions" is printed. Make sure to stop the command after you have finished.
+
+Once instructions containing a session name are printed, use `playwright-cli` to attach the session and explore the page.
+
+```bash
+# Run the test
+PLAYWRIGHT_HTML_OPEN=never npx playwright test --debug=cli
+# ...
+# ... debugging instructions for "tw-abcdef" session ...
+# ...
+
+# Attach to the test
+playwright-cli attach tw-abcdef
+```
+
+Keep the test running in the background while you explore and look for a fix.
+The test is paused at the start, so you should step over or pause at a particular location
+where the problem is most likely to be.
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into the test. Most of the time, a specific locator or an expectation should be updated, but it could also be a bug in the app. Use your judgement.
+
+After fixing the test, stop the background test run. Rerun to check that test passes.

--- a/.agents/skills/playwright-cli/references/request-mocking.md
+++ b/.agents/skills/playwright-cli/references/request-mocking.md
@@ -1,0 +1,87 @@
+# Request Mocking
+
+Intercept, mock, modify, and block network requests.
+
+## CLI Route Commands
+
+```bash
+# Mock with custom status
+playwright-cli route "**/*.jpg" --status=404
+
+# Mock with JSON body
+playwright-cli route "**/api/users" --body='[{"id":1,"name":"Alice"}]' --content-type=application/json
+
+# Mock with custom headers
+playwright-cli route "**/api/data" --body='{"ok":true}' --header="X-Custom: value"
+
+# Remove headers from requests
+playwright-cli route "**/*" --remove-header=cookie,authorization
+
+# List active routes
+playwright-cli route-list
+
+# Remove a route or all routes
+playwright-cli unroute "**/*.jpg"
+playwright-cli unroute
+```
+
+## URL Patterns
+
+```
+**/api/users           - Exact path match
+**/api/*/details       - Wildcard in path
+**/*.{png,jpg,jpeg}    - Match file extensions
+**/search?q=*          - Match query parameters
+```
+
+## Advanced Mocking with run-code
+
+For conditional responses, request body inspection, response modification, or delays:
+
+### Conditional Response Based on Request
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/login', route => {
+    const body = route.request().postDataJSON();
+    if (body.username === 'admin') {
+      route.fulfill({ body: JSON.stringify({ token: 'mock-token' }) });
+    } else {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: 'Invalid' }) });
+    }
+  });
+}"
+```
+
+### Modify Real Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/user', async route => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.isPremium = true;
+    await route.fulfill({ response, json });
+  });
+}"
+```
+
+### Simulate Network Failures
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/offline', route => route.abort('internetdisconnected'));
+}"
+# Options: connectionrefused, timedout, connectionreset, internetdisconnected
+```
+
+### Delayed Response
+
+```bash
+playwright-cli run-code "async page => {
+  await page.route('**/api/slow', async route => {
+    await new Promise(r => setTimeout(r, 3000));
+    route.fulfill({ body: JSON.stringify({ data: 'loaded' }) });
+  });
+}"
+```

--- a/.agents/skills/playwright-cli/references/running-code.md
+++ b/.agents/skills/playwright-cli/references/running-code.md
@@ -1,0 +1,241 @@
+# Running Custom Playwright Code
+
+Use `run-code` to execute arbitrary Playwright code for advanced scenarios not covered by CLI commands.
+
+## Syntax
+
+```bash
+playwright-cli run-code "async page => {
+  // Your Playwright code here
+  // Access page.context() for browser context operations
+}"
+```
+
+You can also load the function from a file:
+
+```bash
+playwright-cli run-code --filename=./my-script.js
+```
+
+
+The code must be a single function expression, it is wrapped in `(...)` and evaluated.
+import/export/require syntax is not supported.
+
+## Geolocation
+
+```bash
+# Grant geolocation permission and set location
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 37.7749, longitude: -122.4194 });
+}"
+
+# Set location to London
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['geolocation']);
+  await page.context().setGeolocation({ latitude: 51.5074, longitude: -0.1278 });
+}"
+
+# Clear geolocation override
+playwright-cli run-code "async page => {
+  await page.context().clearPermissions();
+}"
+```
+
+## Permissions
+
+```bash
+# Grant multiple permissions
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions([
+    'geolocation',
+    'notifications',
+    'camera',
+    'microphone'
+  ]);
+}"
+
+# Grant permissions for specific origin
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read'], {
+    origin: 'https://example.com'
+  });
+}"
+```
+
+## Media Emulation
+
+```bash
+# Emulate dark color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'dark' });
+}"
+
+# Emulate light color scheme
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ colorScheme: 'light' });
+}"
+
+# Emulate reduced motion
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+}"
+
+# Emulate print media
+playwright-cli run-code "async page => {
+  await page.emulateMedia({ media: 'print' });
+}"
+```
+
+## Wait Strategies
+
+```bash
+# Wait for network idle
+playwright-cli run-code "async page => {
+  await page.waitForLoadState('networkidle');
+}"
+
+# Wait for specific element
+playwright-cli run-code "async page => {
+  await page.locator('.loading').waitFor({ state: 'hidden' });
+}"
+
+# Wait for function to return true
+playwright-cli run-code "async page => {
+  await page.waitForFunction(() => window.appReady === true);
+}"
+
+# Wait with timeout
+playwright-cli run-code "async page => {
+  await page.locator('.result').waitFor({ timeout: 10000 });
+}"
+```
+
+## Frames and Iframes
+
+```bash
+# Work with iframe
+playwright-cli run-code "async page => {
+  const frame = page.locator('iframe#my-iframe').contentFrame();
+  await frame.locator('button').click();
+}"
+
+# Get all frames
+playwright-cli run-code "async page => {
+  const frames = page.frames();
+  return frames.map(f => f.url());
+}"
+```
+
+## File Downloads
+
+```bash
+# Handle file download
+playwright-cli run-code "async page => {
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('link', { name: 'Download' }).click();
+  const download = await downloadPromise;
+  await download.saveAs('./downloaded-file.pdf');
+  return download.suggestedFilename();
+}"
+```
+
+## Clipboard
+
+```bash
+# Read clipboard (requires permission)
+playwright-cli run-code "async page => {
+  await page.context().grantPermissions(['clipboard-read']);
+  return await page.evaluate(() => navigator.clipboard.readText());
+}"
+
+# Write to clipboard
+playwright-cli run-code "async page => {
+  await page.evaluate(text => navigator.clipboard.writeText(text), 'Hello clipboard!');
+}"
+```
+
+## Page Information
+
+```bash
+# Get page title
+playwright-cli run-code "async page => {
+  return await page.title();
+}"
+
+# Get current URL
+playwright-cli run-code "async page => {
+  return page.url();
+}"
+
+# Get page content
+playwright-cli run-code "async page => {
+  return await page.content();
+}"
+
+# Get viewport size
+playwright-cli run-code "async page => {
+  return page.viewportSize();
+}"
+```
+
+## JavaScript Execution
+
+```bash
+# Execute JavaScript and return result
+playwright-cli run-code "async page => {
+  return await page.evaluate(() => {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      cookiesEnabled: navigator.cookieEnabled
+    };
+  });
+}"
+
+# Pass arguments to evaluate
+playwright-cli run-code "async page => {
+  const multiplier = 5;
+  return await page.evaluate(m => document.querySelectorAll('li').length * m, multiplier);
+}"
+```
+
+## Error Handling
+
+```bash
+# Try-catch in run-code
+playwright-cli run-code "async page => {
+  try {
+    await page.getByRole('button', { name: 'Submit' }).click({ timeout: 1000 });
+    return 'clicked';
+  } catch (e) {
+    return 'element not found';
+  }
+}"
+```
+
+## Complex Workflows
+
+```bash
+# Login and save state
+playwright-cli run-code "async page => {
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('secret');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard');
+  await page.context().storageState({ path: 'auth.json' });
+  return 'Login successful';
+}"
+
+# Scrape data from multiple pages
+playwright-cli run-code "async page => {
+  const results = [];
+  for (let i = 1; i <= 3; i++) {
+    await page.goto(\`https://example.com/page/\${i}\`);
+    const items = await page.locator('.item').allTextContents();
+    results.push(...items);
+  }
+  return results;
+}"
+```

--- a/.agents/skills/playwright-cli/references/session-management.md
+++ b/.agents/skills/playwright-cli/references/session-management.md
@@ -1,0 +1,225 @@
+# Browser Session Management
+
+Run multiple isolated browser sessions concurrently with state persistence.
+
+## Named Browser Sessions
+
+Use `-s` flag to isolate browser contexts:
+
+```bash
+# Browser 1: Authentication flow
+playwright-cli -s=auth open https://app.example.com/login
+
+# Browser 2: Public browsing (separate cookies, storage)
+playwright-cli -s=public open https://example.com
+
+# Commands are isolated by browser session
+playwright-cli -s=auth fill e1 "user@example.com"
+playwright-cli -s=public snapshot
+```
+
+## Browser Session Isolation Properties
+
+Each browser session has independent:
+- Cookies
+- LocalStorage / SessionStorage
+- IndexedDB
+- Cache
+- Browsing history
+- Open tabs
+
+## Browser Session Commands
+
+```bash
+# List all browser sessions
+playwright-cli list
+
+# Stop a browser session (close the browser)
+playwright-cli close                # stop the default browser
+playwright-cli -s=mysession close   # stop a named browser
+
+# Stop all browser sessions
+playwright-cli close-all
+
+# Forcefully kill all daemon processes (for stale/zombie processes)
+playwright-cli kill-all
+
+# Delete browser session user data (profile directory)
+playwright-cli delete-data                # delete default browser data
+playwright-cli -s=mysession delete-data   # delete named browser data
+```
+
+## Environment Variable
+
+Set a default browser session name via environment variable:
+
+```bash
+export PLAYWRIGHT_CLI_SESSION="mysession"
+playwright-cli open example.com  # Uses "mysession" automatically
+```
+
+## Common Patterns
+
+### Concurrent Scraping
+
+```bash
+#!/bin/bash
+# Scrape multiple sites concurrently
+
+# Start all browsers
+playwright-cli -s=site1 open https://site1.com &
+playwright-cli -s=site2 open https://site2.com &
+playwright-cli -s=site3 open https://site3.com &
+wait
+
+# Take snapshots from each
+playwright-cli -s=site1 snapshot
+playwright-cli -s=site2 snapshot
+playwright-cli -s=site3 snapshot
+
+# Cleanup
+playwright-cli close-all
+```
+
+### A/B Testing Sessions
+
+```bash
+# Test different user experiences
+playwright-cli -s=variant-a open "https://app.com?variant=a"
+playwright-cli -s=variant-b open "https://app.com?variant=b"
+
+# Compare
+playwright-cli -s=variant-a screenshot
+playwright-cli -s=variant-b screenshot
+```
+
+### Persistent Profile
+
+By default, browser profile is kept in memory only. Use `--persistent` flag on `open` to persist the browser profile to disk:
+
+```bash
+# Use persistent profile (auto-generated location)
+playwright-cli open https://example.com --persistent
+
+# Use persistent profile with custom directory
+playwright-cli open https://example.com --profile=/path/to/profile
+```
+
+## Attaching to a Running Browser
+
+Use `attach` to connect to a browser that is already running, instead of launching a new one.
+
+### Attach by channel name
+
+Connect to a running Chrome or Edge instance by its channel name. The browser must have remote debugging enabled — navigate to `chrome://inspect/#remote-debugging` in the target browser and check "Allow remote debugging for this browser instance".
+
+```bash
+# Attach to Chrome
+playwright-cli attach --cdp=chrome
+
+# Attach to Chrome Canary
+playwright-cli attach --cdp=chrome-canary
+
+# Attach to Microsoft Edge
+playwright-cli attach --cdp=msedge
+
+# Attach to Edge Dev
+playwright-cli attach --cdp=msedge-dev
+```
+
+Supported channels: `chrome`, `chrome-beta`, `chrome-dev`, `chrome-canary`, `msedge`, `msedge-beta`, `msedge-dev`, `msedge-canary`.
+
+When `--session` is not provided, the session is named after the channel (e.g. `--cdp=msedge` creates a session called `msedge`), so parallel attaches to Chrome and Edge don't collide on `default`. Pass `--session=<name>` to override.
+
+### Attach via CDP endpoint
+
+Connect to a browser that exposes a Chrome DevTools Protocol endpoint:
+
+```bash
+playwright-cli attach --cdp=http://localhost:9222
+```
+
+### Attach via browser extension
+
+Connect to a browser with the Playwright extension installed:
+
+```bash
+playwright-cli attach --extension
+```
+
+### Detach
+
+Tear down an attached session without affecting the external browser:
+
+```bash
+# Detach the default attached session
+playwright-cli detach
+
+# Detach a specific attached session
+playwright-cli -s=msedge detach
+```
+
+`detach` only works on sessions created via `attach`. For sessions created via `open`, use `close`.
+
+## Default Browser Session
+
+When `-s` is omitted, commands use the default browser session:
+
+```bash
+# These use the same default browser session
+playwright-cli open https://example.com
+playwright-cli snapshot
+playwright-cli close  # Stops default browser
+```
+
+## Browser Session Configuration
+
+Configure a browser session with specific settings when opening:
+
+```bash
+# Open with config file
+playwright-cli open https://example.com --config=.playwright/my-cli.json
+
+# Open with specific browser
+playwright-cli open https://example.com --browser=firefox
+
+# Open in headed mode
+playwright-cli open https://example.com --headed
+
+# Open with persistent profile
+playwright-cli open https://example.com --persistent
+```
+
+## Best Practices
+
+### 1. Name Browser Sessions Semantically
+
+```bash
+# GOOD: Clear purpose
+playwright-cli -s=github-auth open https://github.com
+playwright-cli -s=docs-scrape open https://docs.example.com
+
+# AVOID: Generic names
+playwright-cli -s=s1 open https://github.com
+```
+
+### 2. Always Clean Up
+
+```bash
+# Stop browsers when done
+playwright-cli -s=auth close
+playwright-cli -s=scrape close
+
+# Or stop all at once
+playwright-cli close-all
+
+# If browsers become unresponsive or zombie processes remain
+playwright-cli kill-all
+```
+
+### 3. Delete Stale Browser Data
+
+```bash
+# Remove old browser data to free disk space
+playwright-cli -s=oldsession delete-data
+```

--- a/.agents/skills/playwright-cli/references/spec-driven-testing.md
+++ b/.agents/skills/playwright-cli/references/spec-driven-testing.md
@@ -1,0 +1,305 @@
+# Spec-driven testing (plan → generate → heal)
+
+End-to-end workflow for authoring and maintaining Playwright tests using `playwright-cli`. The three sections below can be used independently:
+
+- **Planning** — explore the app, produce a spec file describing what to test.
+- **Generate** — turn a spec into Playwright test files. Update the spec if it's vague or stale.
+- **Heal** — diagnose failing tests, fix the code, reconcile the spec with reality.
+
+All three lean on the same mechanic: run `npx playwright test --debug=cli` in the background, then `playwright-cli attach tw-XXXX` to drive the paused page interactively. See [playwright-tests.md](playwright-tests.md) for the debug/attach mechanics and [test-generation.md](test-generation.md) for how every `playwright-cli` action emits Playwright TypeScript.
+
+---
+
+## 1. Planning
+
+Goal: produce a spec file (e.g. `specs/<feature>.plan.md`) that enumerates the scenarios to test. **Always** write the spec to a file.
+
+### 1.1 Prerequisite: workspace
+
+Check the workspace has Playwright installed before anything else:
+
+```bash
+# Either of these confirms a workspace:
+test -f playwright.config.ts || test -f playwright.config.js
+npx --no-install playwright --version
+```
+
+If there is no Playwright install, bootstrap one and let the user pick the defaults:
+
+```bash
+npm init playwright@latest
+```
+
+### 1.2 Prerequisite: seed test
+
+A **seed test** is a minimal test that lands the page in the state every scenario starts from: navigation to the app, any required login, feature flags, etc. Scenarios assume a fresh start *after* the seed. `--debug=cli` pauses *inside* this test, so the seed is where every planning and generation session begins.
+
+Minimum viable seed:
+
+```ts
+// tests/seed.spec.ts
+import { test } from '@playwright/test';
+
+test('seed', async ({ page }) => {
+  await page.goto('https://example.com/');
+});
+```
+
+Preferred — push navigation into a fixture so scenario tests reuse it:
+
+```ts
+// tests/fixtures.ts
+import { test as baseTest } from '@playwright/test';
+export { expect } from '@playwright/test';
+
+export const test = baseTest.extend({
+  page: async ({ page }, use) => {
+    await page.goto('https://example.com/');
+    await use(page);
+  },
+});
+```
+
+```ts
+// tests/seed.spec.ts
+import { test } from './fixtures';
+
+test('seed', async ({ page }) => {
+  // Fixture already navigates. This empty body tells agents where to start.
+});
+```
+
+If no seed exists, create one that at least navigates to the app.
+
+### 1.3 Explore the app
+
+Launch the app via the seed in the background and attach:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/seed.spec.ts --debug=cli
+# wait for "Debugging Instructions" and the session name tw-XXXX
+playwright-cli attach tw-XXXX
+```
+
+Resume so the seed runs, then probe the app:
+
+```bash
+playwright-cli resume                   # resume so that seed test runs fully
+playwright-cli snapshot                 # inventory of interactive elements
+playwright-cli click e5                 # follow a flow
+playwright-cli eval "location.href"     # read URL / state
+playwright-cli show --annotate          # ask the user to point at something
+```
+
+Map out:
+
+- Interactive surfaces (forms, buttons, lists, filters, modals).
+- Primary user journeys end-to-end.
+- Edge cases: empty states, validation errors, very long input, boundary values.
+- Persistence: reload, local/session storage, URL fragments.
+- Navigation: which controls change the URL, back/forward behaviour.
+
+**Important**: Do not just open the app url with playwright-cli, always go through the test to capture any custom setup done there.
+**Important**: Stop the background test when done exploring.
+
+### 1.4 Write the spec file
+
+Save under `specs/<feature>.plan.md`. Use this structure:
+
+```markdown
+# <Feature> Test Plan
+
+## Application Overview
+
+<One paragraph describing what the feature does and why it matters.>
+
+## Test Scenarios
+
+### 1. <Group Name>
+
+**Seed:** `tests/seed.spec.ts`
+
+#### 1.1. <kebab-case-scenario-name>
+
+**File:** `tests/<group>/<kebab-case-scenario-name>.spec.ts`
+
+**Steps:**
+  1. <Concrete user step>
+    - expect: <observable outcome>
+    - expect: <another observable outcome>
+  2. <Next step>
+    - expect: <outcome>
+
+#### 1.2. <next-scenario>
+...
+
+### 2. <Next Group>
+
+**Seed:** `tests/seed.spec.ts`
+...
+```
+
+Guidelines:
+
+- Each scenario is independent and starts from the seed's fresh state — never chain scenarios.
+- Scenario names are kebab-case and match the test file name (`should-add-single-todo` → `should-add-single-todo.spec.ts`).
+- Cover happy path, edge cases, validation, negative flows, persistence.
+- Write steps at the user level ("Type 'Buy milk' into the input"), not the API level ("call `fill`").
+- Put observable outcomes in `- expect:` bullets; each becomes an assertion during generation.
+
+---
+
+## 2. Generate
+
+Goal: take a spec file and produce Playwright test files. Optionally update the spec if it has drifted.
+
+### 2.1 Inputs
+
+- **Spec file**, e.g. `specs/basic-operations.plan.md`.
+- **Target**: either a single scenario (e.g. `1.2`), a whole group (`1`), or all.
+- **Seed file**, read from the `**Seed:**` line of the scenario's group.
+
+### 2.2 Generate one scenario
+
+For each target scenario, in sequence (never in parallel — scenarios share the seed session):
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test <seed-file> --debug=cli   # background
+playwright-cli attach tw-XXXX
+# resume
+```
+
+**Do not** just open the app url with playwright-cli, always go through the test to capture any custom setup done there.
+
+Walk the scenario's `Steps:` one by one with `playwright-cli`, treating the spec as the plan and the live app as the source of truth. If a step is vague ("click the button" — which button?), references an element that no longer exists, or contradicts the app's actual behaviour, use your judgement: update the spec to match what the app really does, then keep going. Editing the spec mid-generation is expected.
+
+Every action prints the equivalent Playwright TypeScript (see [test-generation.md](test-generation.md)):
+
+```bash
+playwright-cli snapshot                         # find refs
+playwright-cli fill e3 "John Doe"               # -> page.getByRole('textbox', {...}).fill(...)
+playwright-cli press Enter
+playwright-cli click e7
+```
+
+For each `- expect:` bullet, add an explicit assertion. See [test-generation.md](test-generation.md) for details.
+
+Collect the generated code and write the test file at the path given in the spec:
+
+```ts
+// spec: specs/basic-operations.plan.md
+// seed: tests/seed.spec.ts
+import { test, expect } from './fixtures';   // or '@playwright/test' if no fixtures file
+
+test.describe('Singing in and out', () => {
+  test('should sign in', async ({ page }) => {
+    // 1. Navigate to the application
+    // (handled by the seed fixture)
+
+    // 2. Type 'John Doe' into the username field
+    await page.getByRole('textbox', { name: 'username' }).fill('John Doe');
+
+    // 3. Type password
+    await page.getByRole('textbox', { name: 'password' }).fill('TestPassword');
+
+    // 4. Press Enter to submit
+    await page.getByRole('textbox', { name: 'password' }).press('Enter');
+
+    await expect(page.getByRole('heading')).toContainText('Welcome, John Doe!');
+  });
+});
+```
+
+Rules:
+
+- **One test per file.** File path, describe name, and test name come verbatim from the spec (minus the ordinal).
+- Prefix each numbered step with a `// N. <step text>` comment before its actions.
+- Use the describe group name verbatim from the spec (no `1.` ordinal).
+- Import from `./fixtures` if the project has one; otherwise `@playwright/test`.
+- **Important**: close the CLI session and stop the background test before moving to the next scenario.
+
+### 2.3 Generate multiple scenarios
+
+Loop 2.2 over the targeted scenarios one at a time, restarting the seed between each so every test starts from a clean page. This is safe to parallelise due to unique generated session names - just make sure each test run is stopped.
+
+### 2.4 Run generated tests
+
+After generation, run the new tests once:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/<group>/<scenario>.spec.ts
+```
+
+Any failure goes to Section 3.
+
+---
+
+## 3. Heal
+
+Goal: fix failing tests, and update the spec if the app's intended behaviour changed.
+
+### 3.1 Find failing tests
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test
+```
+
+Record the list of failing `<file>:<line>` entries and process them one at a time. Do not attempt parallel fixes — shared state and the single CLI session make that fragile.
+
+### 3.2 Debug one failure
+
+Run the single failing test in debug mode in the background, then attach:
+
+```bash
+PLAYWRIGHT_HTML_OPEN=never npx playwright test tests/<group>/<scenario>.spec.ts:<line> --debug=cli
+# wait for "Debugging Instructions" and the tw-XXXX session name
+playwright-cli attach tw-XXXX
+```
+
+The test is paused at the start. Step forward or run to until just before the failing action or assertion, then diagnose:
+
+```bash
+playwright-cli snapshot                # did the element change / move / rename?
+playwright-cli console                 # app-side errors?
+playwright-cli network                 # failed request? wrong payload?
+playwright-cli show --annotate         # ask the user to point somewhere
+```
+
+Common causes: selector drift, new wrapper element, label/ARIA rename, timing (transition, async load), assertion text updated in the app, test data leaking between runs.
+
+Rehearse the corrected interaction with `playwright-cli` — the generated code in the output is what you paste back into the test.
+
+### 3.3 Apply the fix
+
+Edit the test file: update the locator, assertion, step order, or inputs to match the corrected behaviour. Stop the background debug run. Rerun the single test to confirm green.
+
+Never skip hooks or add sleeps as a fix. Never use `networkidle`.
+
+### 3.4 Reconcile with the spec
+
+Open the spec referenced by the `// spec:` header in the test file and locate the scenario that matches the test.
+
+- **Fix was purely technical** (locator drift, better assertion shape) and the spec's user-level behaviour still matches the app → leave the spec alone.
+- **Fix changed user-visible steps, inputs, order, or expected outcomes** that the spec describes → update the spec to match reality. Keep the scenario id and file path stable; only the step / expect lines change.
+- **Unclear whether the app change is intentional** (spec is stale) **or a regression** (test was right, app is wrong) → **stop and ask the user**. Provide:
+  - the scenario id (e.g. `2.3`),
+  - the spec lines that no longer match,
+  - the observed app behaviour (quote a snapshot excerpt or a concrete outcome).
+
+Only after the user answers, either update the spec (intentional change) or file/flag the test as covering a bug (regression).
+
+### 3.5 Iteration and giving up
+
+- Fix failures one at a time; rerun after each.
+- If after thorough investigation you are confident the test is correct but the app is wrong *and* the user has confirmed it's a bug: mark the test `test.fixme(...)` with a comment pointing at the user's decision or issue link. Never silently skip.
+
+---
+
+## Cross-references
+
+| For... | See |
+|---|---|
+| `--debug=cli` / attach mechanics | [playwright-tests.md](playwright-tests.md) |
+| How `playwright-cli` actions become TS | [test-generation.md](test-generation.md) |
+| Mocking requests during exploration/generation | [request-mocking.md](request-mocking.md) |
+| Managing the CLI browser session | [session-management.md](session-management.md) |

--- a/.agents/skills/playwright-cli/references/storage-state.md
+++ b/.agents/skills/playwright-cli/references/storage-state.md
@@ -1,0 +1,275 @@
+# Storage Management
+
+Manage cookies, localStorage, sessionStorage, and browser storage state.
+
+## Storage State
+
+Save and restore complete browser state including cookies and storage.
+
+### Save Storage State
+
+```bash
+# Save to auto-generated filename (storage-state-{timestamp}.json)
+playwright-cli state-save
+
+# Save to specific filename
+playwright-cli state-save my-auth-state.json
+```
+
+### Restore Storage State
+
+```bash
+# Load storage state from file
+playwright-cli state-load my-auth-state.json
+
+# Reload page to apply cookies
+playwright-cli open https://example.com
+```
+
+### Storage State File Format
+
+The saved file contains:
+
+```json
+{
+  "cookies": [
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": "example.com",
+      "path": "/",
+      "expires": 1735689600,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        { "name": "theme", "value": "dark" },
+        { "name": "user_id", "value": "12345" }
+      ]
+    }
+  ]
+}
+```
+
+## Cookies
+
+### List All Cookies
+
+```bash
+playwright-cli cookie-list
+```
+
+### Filter Cookies by Domain
+
+```bash
+playwright-cli cookie-list --domain=example.com
+```
+
+### Filter Cookies by Path
+
+```bash
+playwright-cli cookie-list --path=/api
+```
+
+### Get Specific Cookie
+
+```bash
+playwright-cli cookie-get session_id
+```
+
+### Set a Cookie
+
+```bash
+# Basic cookie
+playwright-cli cookie-set session abc123
+
+# Cookie with options
+playwright-cli cookie-set session abc123 --domain=example.com --path=/ --httpOnly --secure --sameSite=Lax
+
+# Cookie with expiration (Unix timestamp)
+playwright-cli cookie-set remember_me token123 --expires=1735689600
+```
+
+### Delete a Cookie
+
+```bash
+playwright-cli cookie-delete session_id
+```
+
+### Clear All Cookies
+
+```bash
+playwright-cli cookie-clear
+```
+
+### Advanced: Multiple Cookies or Custom Options
+
+For complex scenarios like adding multiple cookies at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.context().addCookies([
+    { name: 'session_id', value: 'sess_abc123', domain: 'example.com', path: '/', httpOnly: true },
+    { name: 'preferences', value: JSON.stringify({ theme: 'dark' }), domain: 'example.com', path: '/' }
+  ]);
+}"
+```
+
+## Local Storage
+
+### List All localStorage Items
+
+```bash
+playwright-cli localstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli localstorage-get token
+```
+
+### Set Value
+
+```bash
+playwright-cli localstorage-set theme dark
+```
+
+### Set JSON Value
+
+```bash
+playwright-cli localstorage-set user_settings '{"theme":"dark","language":"en"}'
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli localstorage-delete token
+```
+
+### Clear All localStorage
+
+```bash
+playwright-cli localstorage-clear
+```
+
+### Advanced: Multiple Operations
+
+For complex scenarios like setting multiple values at once, use `run-code`:
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'jwt_abc123');
+    localStorage.setItem('user_id', '12345');
+    localStorage.setItem('expires_at', Date.now() + 3600000);
+  });
+}"
+```
+
+## Session Storage
+
+### List All sessionStorage Items
+
+```bash
+playwright-cli sessionstorage-list
+```
+
+### Get Single Value
+
+```bash
+playwright-cli sessionstorage-get form_data
+```
+
+### Set Value
+
+```bash
+playwright-cli sessionstorage-set step 3
+```
+
+### Delete Single Item
+
+```bash
+playwright-cli sessionstorage-delete step
+```
+
+### Clear sessionStorage
+
+```bash
+playwright-cli sessionstorage-clear
+```
+
+## IndexedDB
+
+### List Databases
+
+```bash
+playwright-cli run-code "async page => {
+  return await page.evaluate(async () => {
+    const databases = await indexedDB.databases();
+    return databases;
+  });
+}"
+```
+
+### Delete Database
+
+```bash
+playwright-cli run-code "async page => {
+  await page.evaluate(() => {
+    indexedDB.deleteDatabase('myDatabase');
+  });
+}"
+```
+
+## Common Patterns
+
+### Authentication State Reuse
+
+```bash
+# Step 1: Login and save state
+playwright-cli open https://app.example.com/login
+playwright-cli snapshot
+playwright-cli fill e1 "user@example.com"
+playwright-cli fill e2 "password123"
+playwright-cli click e3
+
+# Save the authenticated state
+playwright-cli state-save auth.json
+
+# Step 2: Later, restore state and skip login
+playwright-cli state-load auth.json
+playwright-cli open https://app.example.com/dashboard
+# Already logged in!
+```
+
+### Save and Restore Roundtrip
+
+```bash
+# Set up authentication state
+playwright-cli open https://example.com
+playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
+
+# Save state to file
+playwright-cli state-save my-session.json
+
+# ... later, in a new session ...
+
+# Restore state
+playwright-cli state-load my-session.json
+playwright-cli open https://example.com
+# Cookies and localStorage are restored!
+```
+
+## Security Notes
+
+- Never commit storage state files containing auth tokens
+- Add `*.auth-state.json` to `.gitignore`
+- Delete state files after automation completes
+- Use environment variables for sensitive data
+- By default, sessions run in-memory mode which is safer for sensitive operations

--- a/.agents/skills/playwright-cli/references/test-generation.md
+++ b/.agents/skills/playwright-cli/references/test-generation.md
@@ -1,0 +1,134 @@
+# Test Generation
+
+Generate Playwright test code automatically as you interact with the browser.
+
+## How It Works
+
+Every action you perform with `playwright-cli` generates corresponding Playwright TypeScript code.
+This code appears in the output and can be copied directly into your test files.
+
+## Example Workflow
+
+```bash
+# Start a session
+playwright-cli open https://example.com/login
+
+# Take a snapshot to see elements
+playwright-cli snapshot
+# Output shows: e1 [textbox "Email"], e2 [textbox "Password"], e3 [button "Sign In"]
+
+# Fill form fields - generates code automatically
+playwright-cli fill e1 "user@example.com"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+
+playwright-cli fill e2 "password123"
+# Ran Playwright code:
+# await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+
+playwright-cli click e3
+# Ran Playwright code:
+# await page.getByRole('button', { name: 'Sign In' }).click();
+```
+
+## Building a Test File
+
+Collect the generated code into a Playwright test:
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('login flow', async ({ page }) => {
+  // Generated code from playwright-cli session:
+  await page.goto('https://example.com/login');
+  await page.getByRole('textbox', { name: 'Email' }).fill('user@example.com');
+  await page.getByRole('textbox', { name: 'Password' }).fill('password123');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  // Add assertions
+  await expect(page).toHaveURL(/.*dashboard/);
+});
+```
+
+## Best Practices
+
+### 1. Use Semantic Locators
+
+The generated code uses role-based locators when possible, which are more resilient:
+
+```typescript
+// Generated (good - semantic)
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Avoid (fragile - CSS selectors)
+await page.locator('#submit-btn').click();
+```
+
+### 2. Explore Before Recording
+
+Take snapshots to understand the page structure before recording actions:
+
+```bash
+playwright-cli open https://example.com
+playwright-cli snapshot
+# Review the element structure
+playwright-cli click e5
+```
+
+### 3. Add Assertions Manually
+
+Generated code captures actions but not assertions. Add expectations in your test using one of the recommended matchers:
+
+- `toBeVisible()` — element is rendered and visible
+- `toHaveText(text)` — element text content matches
+- `toHaveValue(value) / toBeEmpty()` — input/select value matches
+- `toBeChecked() / toBeUnchecked()` — checkbox state matches
+- `toMatchAriaSnapshot(snapshot)` — page (or locator) matches a partial accessibility snapshot
+
+Use `playwright-cli generate-locator <target>` to produce the locator expression for the assertion, and the snapshot/eval commands to capture the expected value.
+
+When asserting text content, make sure that generated locator does not contain text from the element itself. `getByTestId()` or `getByLabel()` usually work well with asserting text. When locator is text-based, prefer `toBeVisible()` instead.
+
+Snapshot to be matched does not have to contain all the information - only capture what's necessary for the assertion. You can use regular expressions for unstable values.
+
+```bash
+# Get a stable locator for an element ref to use in the assertion
+playwright-cli --raw generate-locator e5
+# getByRole('button', { name: 'Submit' })
+
+# Capture expected text content for toHaveText
+playwright-cli --raw eval "el => el.textContent" e5
+
+# Capture expected input value for toHaveValue/toBeEmpty
+playwright-cli --raw eval "el => el.value" e5
+
+# Capture expected aria snapshot for toMatchAriaSnapshot/toBeChecked
+# (whole page, or use a ref to scope to a region)
+playwright-cli --raw snapshot
+playwright-cli --raw snapshot e5
+```
+
+```typescript
+// Generated action
+await page.getByRole('button', { name: 'Submit' }).click();
+
+// Manual assertions using the outputs above:
+await expect(page.getByRole('alert', { name: 'Success' })).toBeVisible();
+await expect(page.getByTestId('main-header')).toHaveText('Welcome, user');
+await expect(page.getByRole('textbox', { name: 'Email' })).toHaveValue('user@example.com');
+await expect(page.getByRole('checkbox', { name: 'Enable notifications' })).toBeChecked();
+
+// toMatchAriaSnapshot on the whole page, finds a matching region
+await expect(page).toMatchAriaSnapshot(`
+  - heading "Welcome, user"
+  - link /\\d+ new messages?/
+  - button "Sign out"
+`);
+
+// toMatchAriaSnapshot scoped to a region
+await expect(page.getByRole('navigation')).toMatchAriaSnapshot(`
+  - link "Home"
+  - link /\\d+ new messages?/
+  - link "Profile"
+`);
+```

--- a/.agents/skills/playwright-cli/references/tracing.md
+++ b/.agents/skills/playwright-cli/references/tracing.md
@@ -1,0 +1,139 @@
+# Tracing
+
+Capture detailed execution traces for debugging and analysis. Traces include DOM snapshots, screenshots, network activity, and console logs.
+
+## Basic Usage
+
+```bash
+# Start trace recording
+playwright-cli tracing-start
+
+# Perform actions
+playwright-cli open https://example.com
+playwright-cli click e1
+playwright-cli fill e2 "test"
+
+# Stop trace recording
+playwright-cli tracing-stop
+```
+
+## Trace Output Files
+
+When you start tracing, Playwright creates a `traces/` directory with several files:
+
+### `trace-{timestamp}.trace`
+
+**Action log** - The main trace file containing:
+- Every action performed (clicks, fills, navigations)
+- DOM snapshots before and after each action
+- Screenshots at each step
+- Timing information
+- Console messages
+- Source locations
+
+### `trace-{timestamp}.network`
+
+**Network log** - Complete network activity:
+- All HTTP requests and responses
+- Request headers and bodies
+- Response headers and bodies
+- Timing (DNS, connect, TLS, TTFB, download)
+- Resource sizes
+- Failed requests and errors
+
+### `resources/`
+
+**Resources directory** - Cached resources:
+- Images, fonts, stylesheets, scripts
+- Response bodies for replay
+- Assets needed to reconstruct page state
+
+## What Traces Capture
+
+| Category | Details |
+|----------|---------|
+| **Actions** | Clicks, fills, hovers, keyboard input, navigations |
+| **DOM** | Full DOM snapshot before/after each action |
+| **Screenshots** | Visual state at each step |
+| **Network** | All requests, responses, headers, bodies, timing |
+| **Console** | All console.log, warn, error messages |
+| **Timing** | Precise timing for each operation |
+
+## Use Cases
+
+### Debugging Failed Actions
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://app.example.com
+
+# This click fails - why?
+playwright-cli click e5
+
+playwright-cli tracing-stop
+# Open trace to see DOM state when click was attempted
+```
+
+### Analyzing Performance
+
+```bash
+playwright-cli tracing-start
+playwright-cli open https://slow-site.com
+playwright-cli tracing-stop
+
+# View network waterfall to identify slow resources
+```
+
+### Capturing Evidence
+
+```bash
+# Record a complete user flow for documentation
+playwright-cli tracing-start
+
+playwright-cli open https://app.example.com/checkout
+playwright-cli fill e1 "4111111111111111"
+playwright-cli fill e2 "12/25"
+playwright-cli fill e3 "123"
+playwright-cli click e4
+
+playwright-cli tracing-stop
+# Trace shows exact sequence of events
+```
+
+## Trace vs Video vs Screenshot
+
+| Feature | Trace | Video | Screenshot |
+|---------|-------|-------|------------|
+| **Format** | .trace file | .webm video | .png/.jpeg image |
+| **DOM inspection** | Yes | No | No |
+| **Network details** | Yes | No | No |
+| **Step-by-step replay** | Yes | Continuous | Single frame |
+| **File size** | Medium | Large | Small |
+| **Best for** | Debugging | Demos | Quick capture |
+
+## Best Practices
+
+### 1. Start Tracing Before the Problem
+
+```bash
+# Trace the entire flow, not just the failing step
+playwright-cli tracing-start
+playwright-cli open https://example.com
+# ... all steps leading to the issue ...
+playwright-cli tracing-stop
+```
+
+### 2. Clean Up Old Traces
+
+Traces can consume significant disk space:
+
+```bash
+# Remove traces older than 7 days
+find .playwright-cli/traces -mtime +7 -delete
+```
+
+## Limitations
+
+- Traces add overhead to automation
+- Large traces can consume significant disk space
+- Some dynamic content may not replay perfectly

--- a/.agents/skills/playwright-cli/references/video-recording.md
+++ b/.agents/skills/playwright-cli/references/video-recording.md
@@ -1,0 +1,143 @@
+# Video Recording
+
+Capture browser automation sessions as video for debugging, documentation, or verification. Produces WebM (VP8/VP9 codec).
+
+## Basic Recording
+
+```bash
+# Open browser first
+playwright-cli open
+
+# Start recording
+playwright-cli video-start demo.webm
+
+# Add a chapter marker for section transitions
+playwright-cli video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
+
+# Navigate and perform actions
+playwright-cli goto https://example.com
+playwright-cli snapshot
+playwright-cli click e1
+
+# Add another chapter
+playwright-cli video-chapter "Filling Form" --description="Entering test data" --duration=2000
+playwright-cli fill e2 "test input"
+
+# Stop and save
+playwright-cli video-stop
+```
+
+## Best Practices
+
+### 1. Use Descriptive Filenames
+
+```bash
+# Include context in filename
+playwright-cli video-start recordings/login-flow-2024-01-15.webm
+playwright-cli video-start recordings/checkout-test-run-42.webm
+```
+
+### 2. Record entire hero scripts.
+
+When recording a video for the user or as a proof of work, it is best to create a code snippet and execute it with run-code.
+It allows pulling appropriate pauses between the actions and annotating the video. There are new Playwright APIs for that.
+
+1) Perform scenario using CLI and take note of all locators and actions. You'll need those locators to request their bounding boxes for highlight.
+2) Create a file with the intended script for video (below). Use pressSequentially w/ delay for nice typing, make reasonable pauses.
+3) Use playwright-cli run-code --filename your-script.js
+
+**Important**: Overlays are `pointer-events: none` — they do not interfere with page interactions. You can safely keep sticky overlays visible while clicking, filling, or performing any actions on the page.
+
+```js
+async page => {
+  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } });
+  await page.goto('https://demo.playwright.dev/todomvc');
+
+  // Show a chapter card — blurs the page and shows a dialog.
+  // Blocks until duration expires, then auto-removes.
+  // Use this for simple use cases, but always feel free to hand-craft your own beautiful
+  // overlay via await page.screencast.showOverlay().
+  await page.screencast.showChapter('Adding Todo Items', {
+    description: 'We will add several items to the todo list.',
+    duration: 2000,
+  });
+
+  // Perform action
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Walk the dog', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1000);
+
+  // Show next chapter
+  await page.screencast.showChapter('Verifying Results', {
+    description: 'Checking the item appeared in the list.',
+    duration: 2000,
+  });
+
+  // Add a sticky annotation that stays while you perform actions.
+  // Overlays are pointer-events: none, so they won't block clicks.
+  const annotation = await page.screencast.showOverlay(`
+    <div style="position: absolute; top: 8px; right: 8px;
+      padding: 6px 12px; background: rgba(0,0,0,0.7);
+      border-radius: 8px; font-size: 13px; color: white;">
+      ✓ Item added successfully
+    </div>
+  `);
+
+  // Perform more actions while the annotation is visible
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).pressSequentially('Buy groceries', { delay: 60 });
+  await page.getByRole('textbox', { name: 'What needs to be done?' }).press('Enter');
+  await page.waitForTimeout(1500);
+
+  // Remove the annotation when done
+  await annotation.dispose();
+
+  // You can also highlight relevant locators and provide contextual annotations.
+  const bounds = await page.getByText('Walk the dog').boundingBox();
+  await page.screencast.showOverlay(`
+    <div style="position: absolute;
+      top: ${bounds.y}px;
+      left: ${bounds.x}px;
+      width: ${bounds.width}px;
+      height: ${bounds.height}px;
+      border: 1px solid red;">
+    </div>
+    <div style="position: absolute;
+      top: ${bounds.y + bounds.height + 5}px;
+      left: ${bounds.x + bounds.width / 2}px;
+      transform: translateX(-50%);
+      padding: 6px;
+      background: #808080;
+      border-radius: 10px;
+      font-size: 14px;
+      color: white;">Check it out, it is right above this text
+    </div>
+  `, { duration: 2000 });
+
+  await page.screencast.stop();
+}
+```
+
+Embrace creativity, overlays are powerful.
+
+### Overlay API Summary
+
+| Method | Use Case |
+|--------|----------|
+| `page.screencast.showChapter(title, { description?, duration?, styleSheet? })` | Full-screen chapter card with blurred backdrop — ideal for section transitions |
+| `page.screencast.showOverlay(html, { duration? })` | Custom HTML overlay — use for callouts, labels, highlights |
+| `disposable.dispose()` | Remove a sticky overlay added without duration |
+| `page.screencast.hideOverlays()` / `page.screencast.showOverlays()` | Temporarily hide/show all overlays |
+
+## Tracing vs Video
+
+| Feature | Video | Tracing |
+|---------|-------|---------|
+| Output | WebM file | Trace file (viewable in Trace Viewer) |
+| Shows | Visual recording | DOM snapshots, network, console, actions |
+| Use case | Demos, documentation | Debugging, analysis |
+| Size | Larger | Smaller |
+
+## Limitations
+
+- Recording adds slight overhead to automation
+- Large recordings can consume significant disk space

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -29,6 +29,11 @@
       "version": "1.1.4",
       "resolved": "ghcr.io/va-h/devcontainers-features/uv@sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1",
       "integrity": "sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1"
+    },
+    "ghcr.io/microsoft/aspire-devcontainer-feature/aspire:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/microsoft/aspire-devcontainer-feature/aspire@sha256:85cef97f2de880d21a742f799120af2e53f69f4c9334d525381629f81c0409af",
+      "integrity": "sha256:85cef97f2de880d21a742f799120af2e53f69f4c9334d525381629f81c0409af"
     }
   }
 }

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -25,15 +25,15 @@
       "resolved": "ghcr.io/devcontainers/features/terraform@sha256:503d0888b3a43a32335e08cd4477f8c4629404ad83f6a36f0e0fee7f567c06c7",
       "integrity": "sha256:503d0888b3a43a32335e08cd4477f8c4629404ad83f6a36f0e0fee7f567c06c7"
     },
-    "ghcr.io/va-h/devcontainers-features/uv:1": {
-      "version": "1.1.4",
-      "resolved": "ghcr.io/va-h/devcontainers-features/uv@sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1",
-      "integrity": "sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1"
-    },
     "ghcr.io/microsoft/aspire-devcontainer-feature/aspire:2": {
       "version": "2.0.0",
       "resolved": "ghcr.io/microsoft/aspire-devcontainer-feature/aspire@sha256:85cef97f2de880d21a742f799120af2e53f69f4c9334d525381629f81c0409af",
       "integrity": "sha256:85cef97f2de880d21a742f799120af2e53f69f4c9334d525381629f81c0409af"
+    },
+    "ghcr.io/va-h/devcontainers-features/uv:1": {
+      "version": "1.1.4",
+      "resolved": "ghcr.io/va-h/devcontainers-features/uv@sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1",
+      "integrity": "sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,8 @@
       "tflint": "none",
       "terragrunt": "none"
     },
-    "ghcr.io/va-h/devcontainers-features/uv:1": {}
+    "ghcr.io/va-h/devcontainers-features/uv:1": {},
+    "ghcr.io/microsoft/aspire-devcontainer-feature/aspire:2": {}
   },
   "customizations": {
     "vscode": {
@@ -45,7 +46,8 @@
         "dbaeumer.vscode-eslint",
         "bradlc.vscode-tailwindcss",
         "GitHub.copilot",
-        "ms-azuretools.vscode-azure-mcp-server"
+        "ms-azuretools.vscode-azure-mcp-server",
+        "microsoft-aspire.aspire-vscode"
       ]
     }
   },

--- a/.mcp.json
+++ b/.mcp.json
@@ -17,6 +17,12 @@
       "command": "azmcp",
       "args": ["server", "start"],
       "tools": ["*"]
+    },
+    "aspire": {
+      "type": "local",
+      "command": "aspire",
+      "args": ["agent", "mcp"],
+      "tools": ["*"]
     }
   }
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,12 @@
+{
+  "servers": {
+    "aspire": {
+      "type": "stdio",
+      "command": "aspire",
+      "args": [
+        "agent",
+        "mcp"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Key additions and improvements include:

**Aspire Skill Overview and Guidance**
- Added `.agents/skills/aspire/SKILL.md`, a detailed skill definition explaining when and how to use the Aspire skill, including workflows for starting/stopping AppHosts, inspecting state/logs/traces, adding integrations, managing secrets, deployment, and Playwright handoff. It also clarifies when not to use the skill and provides rules for both C# and TypeScript AppHosts.

**Reference Documentation by Theme**

*Agent Workflows and App Lifecycle*
- Added `.agents/skills/aspire/references/agent-workflows.md` with scenario-based guidance for safe background runs, investigation before code changes, adding integrations, handling TypeScript AppHosts, managing secrets/deployment, and Playwright handoff.
- Added `.agents/skills/aspire/references/app-commands.md` covering app-level lifecycle commands, bootstrapping new/existing Aspire apps, discovering AppHosts, and refreshing support files.

*Monitoring and Resource Management*
- Added `.agents/skills/aspire/references/monitoring.md` detailing commands and formatting for inspecting app state, logs, traces, endpoints, and sharing diagnostics, including emoji conventions and markdown linking.
- Added `.agents/skills/aspire/references/resource-management.md` with instructions for waiting on, operating, or recovering individual resources without restarting the entire AppHost.

*Deployment and Integration*
- Added `.agents/skills/aspire/references/deployment.md` describing deployment artifact generation, full deployment, and running named pipeline steps.

*Language-Specific Guidance*
- Added `.agents/skills/aspire/references/csharp-apphosts.md` for C# AppHost API investigation, including when to use Aspire docs versus the `dotnet-inspect` skill.
- Added `.agents/skills/aspire/references/playwright-handoff.md` for safely discovering frontend URLs and integrating with Playwright CLI.