### PR TITLE
fix(migrations): detect silent alembic failures

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -5,14 +5,11 @@ import time
 from importlib import import_module
 from logging.config import fileConfig
 
-from learn_to_cloud_shared.core.azure_auth import (
-    AZURE_PG_SCOPE,
-)
-from learn_to_cloud_shared.core.config import get_settings
 from learn_to_cloud_shared.core.database import Base
 from sqlalchemy import Connection, create_engine, text
 
 from alembic import context
+from learn_to_cloud._migrations_url import get_sync_database_url
 
 # Import models to register them with Base.metadata
 import_module("learn_to_cloud_shared.models")
@@ -31,71 +28,9 @@ _ADVISORY_LOCK_KEY = 743028475  # hash("learn-to-cloud-migrations") % (2**31)
 _LOCK_TIMEOUT_SECONDS = 120
 
 
-def _get_azure_token_with_retry() -> str:
-    """Get Azure AD token with retry logic for transient failures.
-
-    Uses sync credential since Alembic runs outside asyncio event loop.
-    On Container Apps cold start the managed identity sidecar may take
-    up to 30s to become available, so we retry with exponential backoff.
-
-    Passes AZURE_CLIENT_ID (if set) to DefaultAzureCredential so it can
-    target the correct user-assigned managed identity.
-    """
-    import os
-
-    from azure.identity import DefaultAzureCredential
-
-    max_attempts = 6  # More attempts than core module — Alembic runs at cold start
-    initial_wait = 2  # Longer initial wait for sidecar readiness
-
-    # Pass managed_identity_client_id for user-assigned identity
-    client_id = os.environ.get("AZURE_CLIENT_ID")
-    cred_kwargs = {}
-    if client_id:
-        cred_kwargs["managed_identity_client_id"] = client_id
-
-    last_error = None
-    for attempt in range(max_attempts):
-        try:
-            credential = DefaultAzureCredential(**cred_kwargs)
-            token = credential.get_token(AZURE_PG_SCOPE)
-            return token.token
-        except Exception as e:
-            last_error = e
-            if attempt < max_attempts - 1:
-                delay = initial_wait * (2**attempt)  # 2, 4, 8, 16, 32s
-                time.sleep(delay)
-
-    raise RuntimeError(
-        f"Failed to acquire Azure AD token after {max_attempts} attempts"
-    ) from last_error
-
-
-def _get_sync_database_url() -> str:
-    """Get a synchronous database URL for migrations.
-
-    Uses psycopg2 (synchronous driver) instead of asyncpg to avoid
-    event loop conflicts when running in background threads.
-    """
-    settings = get_settings()
-    if settings.use_azure_postgres:
-        token = _get_azure_token_with_retry()
-        return (
-            f"postgresql+psycopg2://{settings.postgres_user}:{token}"
-            f"@{settings.postgres_host}:{settings.postgres_port}/{settings.postgres_database}"
-            f"?sslmode=require"
-        )
-
-    # Convert asyncpg URL to psycopg2 URL for local dev
-    url = settings.database_url
-    if "+asyncpg" in url:
-        url = url.replace("+asyncpg", "+psycopg2")
-    return url
-
-
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode."""
-    url = _get_sync_database_url()
+    url = get_sync_database_url()
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -139,7 +74,7 @@ def _run_migrations(connection: Connection) -> None:
                 "Another process may be stuck holding the lock."
             )
 
-    migration_error = None
+    migration_error: Exception | None = None
     try:
         context.configure(
             connection=connection,
@@ -151,19 +86,19 @@ def _run_migrations(connection: Connection) -> None:
         with context.begin_transaction():
             context.run_migrations()
     except Exception as e:
+        # Always log the underlying error. The previous substring-based
+        # "already exists" / "duplicate" swallow turned real UniqueViolations
+        # into silent no-ops, masking failed deploys for days. With the
+        # session-level advisory lock above, a second worker cannot advance
+        # the schema while we hold the lock, so there is no legitimate
+        # "another worker already ran it" race to swallow here — any
+        # exception is a real failure and must propagate.
+        logger.exception("alembic.migration.failed")
         migration_error = e
-        # Check if this is a "table already exists" error - another worker may have
-        # already run migrations even though we had the lock (race at startup)
-        error_str = str(e).lower()
-        if "already exists" in error_str or "duplicate" in error_str:
-            # Migrations were already applied by another process, this is OK
-            logger.info("Migrations already applied by another process, continuing...")
-            migration_error = None  # Don't re-raise this error
-        else:
-            try:
-                connection.rollback()
-            except Exception:
-                pass  # Ignore rollback errors
+        try:
+            connection.rollback()
+        except Exception as rb_err:
+            logger.warning("alembic.migration.rollback_failed: %s", rb_err)
     finally:
         if lock_acquired:
             try:
@@ -174,8 +109,15 @@ def _run_migrations(connection: Connection) -> None:
                 result.close()
                 logger.info("Released migration advisory lock")
             except Exception as unlock_error:
-                # Log but don't raise - lock released when session ends anyway
+                # Session-level advisory locks survive transaction rollback
+                # and only disappear on explicit unlock or session close.
+                # If unlock fails, invalidate the connection so SQLAlchemy
+                # doesn't return it to the pool still holding the lock.
                 logger.warning("advisory.lock.release.failed: %s", unlock_error)
+                try:
+                    connection.invalidate()
+                except Exception as inv_err:
+                    logger.warning("advisory.lock.invalidate_failed: %s", inv_err)
 
     if migration_error is not None:
         raise migration_error
@@ -187,7 +129,7 @@ def run_migrations_online() -> None:
     Uses psycopg2 (synchronous driver) to avoid event loop conflicts
     when running in a background thread during app startup.
     """
-    url = _get_sync_database_url()
+    url = get_sync_database_url()
     engine = create_engine(url)
 
     with engine.connect() as connection:

--- a/api/scripts/run_migrations.py
+++ b/api/scripts/run_migrations.py
@@ -1,11 +1,53 @@
+"""Run alembic migrations to head and verify the schema actually advanced.
+
+Used both by the Container App Job (`infra/migrations.tf`) and locally. The
+post-upgrade verification step exists because the previous migration env
+had a substring-based exception swallow that turned real failures into
+silent no-ops. This is defense in depth: even if anything ever swallows a
+migration error, the final SELECT here will fail the script.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
 import alembic.command
 import alembic.config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine
+
+from learn_to_cloud._migrations_url import get_sync_database_url
+
+logger = logging.getLogger(__name__)
 
 
 def main() -> None:
-    """Run all Alembic migrations."""
-    alembic.command.upgrade(alembic.config.Config("alembic.ini"), "head")
+    """Run all alembic migrations, then verify the version row matches head."""
+    cfg = alembic.config.Config("alembic.ini")
+    alembic.command.upgrade(cfg, "head")
+
+    expected_heads = set(ScriptDirectory.from_config(cfg).get_heads())
+    engine = create_engine(get_sync_database_url())
+    try:
+        with engine.connect() as conn:
+            migration_ctx = MigrationContext.configure(conn)
+            current_heads = set(migration_ctx.get_current_heads())
+    finally:
+        engine.dispose()
+
+    if current_heads != expected_heads:
+        raise RuntimeError(
+            "Migration verification failed: alembic_version "
+            f"current={sorted(current_heads) or 'none'} "
+            f"expected={sorted(expected_heads) or 'none'}"
+        )
+
+    logger.info("migration.verified heads=%s", sorted(current_heads))
+    print(f"Schema verified at head(s): {sorted(current_heads)}", file=sys.stderr)
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
     main()

--- a/api/src/learn_to_cloud/_migrations_url.py
+++ b/api/src/learn_to_cloud/_migrations_url.py
@@ -1,0 +1,68 @@
+"""Synchronous database URL builder shared by the alembic env and helper scripts.
+
+Lives in the ``learn_to_cloud`` package rather than the alembic directory so
+non-alembic callers (notably ``scripts/run_migrations.py`` post-upgrade
+verification) can import the URL helper without triggering ``env.py``'s
+module-level ``run()`` call, which would execute migrations as a side effect.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from azure.identity import DefaultAzureCredential
+from learn_to_cloud_shared.core.azure_auth import AZURE_PG_SCOPE
+from learn_to_cloud_shared.core.config import get_settings
+
+
+def _get_azure_token_with_retry() -> str:
+    """Get an Entra ID access token for PostgreSQL with retry.
+
+    Uses the sync credential because alembic runs outside an asyncio loop.
+    On Container Apps cold starts the managed identity sidecar can take
+    up to ~30s to come up, so we retry with exponential backoff.
+    """
+    max_attempts = 6
+    initial_wait = 2
+
+    client_id = os.environ.get("AZURE_CLIENT_ID")
+    cred_kwargs: dict[str, str] = {}
+    if client_id:
+        cred_kwargs["managed_identity_client_id"] = client_id
+
+    last_error: Exception | None = None
+    for attempt in range(max_attempts):
+        try:
+            credential = DefaultAzureCredential(**cred_kwargs)
+            token = credential.get_token(AZURE_PG_SCOPE)
+            return token.token
+        except Exception as e:
+            last_error = e
+            if attempt < max_attempts - 1:
+                time.sleep(initial_wait * (2**attempt))
+
+    raise RuntimeError(
+        f"Failed to acquire Azure AD token after {max_attempts} attempts"
+    ) from last_error
+
+
+def get_sync_database_url() -> str:
+    """Return a psycopg2 URL suitable for alembic.
+
+    Uses psycopg2 (synchronous) instead of asyncpg to avoid event loop
+    conflicts when running in background threads or one-off scripts.
+    """
+    settings = get_settings()
+    if settings.use_azure_postgres:
+        token = _get_azure_token_with_retry()
+        return (
+            f"postgresql+psycopg2://{settings.postgres_user}:{token}"
+            f"@{settings.postgres_host}:{settings.postgres_port}/{settings.postgres_database}"
+            f"?sslmode=require"
+        )
+
+    url = settings.database_url
+    if "+asyncpg" in url:
+        url = url.replace("+asyncpg", "+psycopg2")
+    return url

--- a/api/tests/test_alembic_env_regression.py
+++ b/api/tests/test_alembic_env_regression.py
@@ -1,0 +1,181 @@
+"""Regression test for issue #432: silent migration failure.
+
+Before this fix, ``api/alembic/env.py`` swallowed any exception whose message
+contained the substrings ``"duplicate"`` or ``"already exists"``, treating it
+as "another worker already applied" and exiting cleanly. A real
+``UniqueViolation`` on ``CREATE UNIQUE INDEX`` matched and got silently
+ignored, leaving production stuck on an older schema for days while CI
+reported successful deploys.
+
+This test invokes the real production env.py against SQLite with a
+two-revision chain whose second revision raises a Postgres-style error
+containing the words ``"is duplicated"``. The migration must propagate.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_PRODUCTION_ENV_PY = Path(__file__).parent.parent / "alembic" / "env.py"
+
+
+def _write_fixture_project(root: Path, db_path: Path) -> None:
+    """Stand up a minimal alembic project that imports the production env.py."""
+    alembic_dir = root / "alembic"
+    versions_dir = alembic_dir / "versions"
+    versions_dir.mkdir(parents=True)
+
+    shutil.copy(_PRODUCTION_ENV_PY, alembic_dir / "env.py")
+    (alembic_dir / "script.py.mako").write_text(
+        textwrap.dedent(
+            '''\
+            """${message}"""
+            revision = ${repr(up_revision)}
+            down_revision = ${repr(down_revision)}
+            branch_labels = ${repr(branch_labels)}
+            depends_on = ${repr(depends_on)}
+
+            def upgrade() -> None:
+                pass
+
+            def downgrade() -> None:
+                pass
+            '''
+        )
+    )
+
+    (root / "alembic.ini").write_text(
+        textwrap.dedent(
+            f"""\
+            [alembic]
+            script_location = alembic
+            sqlalchemy.url = sqlite:///{db_path}
+
+            [loggers]
+            keys = root,alembic
+            [handlers]
+            keys = console
+            [formatters]
+            keys = generic
+            [logger_root]
+            level = WARN
+            handlers = console
+            qualname =
+            [logger_alembic]
+            level = INFO
+            handlers =
+            qualname = alembic
+            [handler_console]
+            class = StreamHandler
+            args = (sys.stderr,)
+            level = NOTSET
+            formatter = generic
+            [formatter_generic]
+            format = %(levelname)-5.5s [%(name)s] %(message)s
+            """
+        )
+    )
+
+    (versions_dir / "0001_baseline.py").write_text(
+        textwrap.dedent(
+            '''\
+            """baseline"""
+            from alembic import op
+            import sqlalchemy as sa
+
+            revision = "0001_baseline"
+            down_revision = None
+            branch_labels = None
+            depends_on = None
+
+            def upgrade() -> None:
+                op.create_table(
+                    "things",
+                    sa.Column("id", sa.Integer, primary_key=True),
+                )
+
+            def downgrade() -> None:
+                op.drop_table("things")
+            '''
+        )
+    )
+
+    # This revision raises an error whose message contains the substring
+    # "duplicate" — exactly the shape that used to trigger the silent
+    # swallow in env.py. The regression test asserts the upgrade fails
+    # loudly instead of being treated as benign.
+    (versions_dir / "0002_fail.py").write_text(
+        textwrap.dedent(
+            '''\
+            """fails with a duplicate-key style message"""
+            from alembic import op
+
+            revision = "0002_fail"
+            down_revision = "0001_baseline"
+            branch_labels = None
+            depends_on = None
+
+            def upgrade() -> None:
+                op.execute(
+                    "SELECT RAISE(ABORT, "
+                    "'Key (user_id, requirement_id) is duplicated.')"
+                )
+
+            def downgrade() -> None:
+                pass
+            '''
+        )
+    )
+
+
+def _run_alembic_upgrade(project: Path) -> subprocess.CompletedProcess[str]:
+    """Run ``alembic upgrade head`` against the fixture project."""
+    env_overrides = {
+        "DATABASE_URL": f"sqlite:///{project / 'test.db'}",
+        "GITHUB_TOKEN": "test_github_token",
+        "LABS_VERIFICATION_SECRET": "test_ctf_secret_must_be_32_chars!",
+        "DEBUG": "true",
+        "USE_AZURE_POSTGRES": "false",
+    }
+    import os
+
+    env = {**os.environ, **env_overrides}
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=project,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(
+    shutil.which(sys.executable) is None,
+    reason="Python interpreter not available for subprocess",
+)
+def test_env_py_does_not_swallow_duplicate_errors(tmp_path: Path) -> None:
+    """If env.py ever silently swallows a 'duplicate'-flavored error again,
+    this test will fail — alembic upgrade will exit 0 with the SQLite DB
+    sitting at 0001_baseline.
+    """
+    db_path = tmp_path / "test.db"
+    _write_fixture_project(tmp_path, db_path)
+
+    result = _run_alembic_upgrade(tmp_path)
+
+    assert result.returncode != 0, (
+        "alembic upgrade must propagate the failure. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    combined = result.stdout + result.stderr
+    assert "duplicated" in combined.lower() or "Key (user_id" in combined, (
+        "The underlying error message must be visible in logs. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )

--- a/api/tests/test_run_migrations.py
+++ b/api/tests/test_run_migrations.py
@@ -1,0 +1,152 @@
+"""Tests for the migration runner's post-upgrade verification.
+
+The verification step is defense-in-depth against the class of bug that
+caused issue #432: a silent-failure path in env.py let migrations report
+success while the schema stayed at an older revision. With these checks,
+even if a swallow ever creeps back in, the script will still exit non-zero
+when ``alembic_version`` doesn't match the script directory head.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts import run_migrations as runner
+
+
+class _FakeMigrationCtx:
+    def __init__(self, heads: list[str]) -> None:
+        self._heads = heads
+
+    def get_current_heads(self) -> tuple[str, ...]:
+        return tuple(self._heads)
+
+
+class _FakeScript:
+    def __init__(self, heads: list[str]) -> None:
+        self._heads = heads
+
+    def get_heads(self) -> list[str]:
+        return list(self._heads)
+
+
+def _patch_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    script_heads: list[str],
+    db_heads: list[str],
+    upgrade_should_raise: Exception | None = None,
+) -> MagicMock:
+    """Set up the common monkeypatches used by every verification test."""
+    upgrade_mock = MagicMock()
+    if upgrade_should_raise is not None:
+        upgrade_mock.side_effect = upgrade_should_raise
+
+    monkeypatch.setattr(runner.alembic.command, "upgrade", upgrade_mock)
+    monkeypatch.setattr(
+        runner.ScriptDirectory,
+        "from_config",
+        lambda _cfg: _FakeScript(script_heads),
+    )
+    monkeypatch.setattr(
+        runner.MigrationContext,
+        "configure",
+        lambda _conn: _FakeMigrationCtx(db_heads),
+    )
+
+    fake_engine = MagicMock()
+    fake_engine.connect.return_value.__enter__.return_value = MagicMock()
+    fake_engine.connect.return_value.__exit__.return_value = False
+    monkeypatch.setattr(runner, "create_engine", lambda _url: fake_engine)
+    monkeypatch.setattr(runner, "get_sync_database_url", lambda: "sqlite:///:memory:")
+    return upgrade_mock
+
+
+def test_main_succeeds_when_schema_at_head(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    upgrade_mock = _patch_runner(monkeypatch, script_heads=["0023"], db_heads=["0023"])
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "alembic.ini").write_text("[alembic]\nscript_location = alembic\n")
+
+    runner.main()
+
+    upgrade_mock.assert_called_once()
+
+
+def test_main_raises_when_db_below_head(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The exact production failure mode: alembic.command.upgrade returns
+    successfully (because env.py used to swallow), but the version row
+    didn't actually advance. The script-level check must catch this.
+    """
+    _patch_runner(monkeypatch, script_heads=["0023"], db_heads=["0019"])
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "alembic.ini").write_text("[alembic]\nscript_location = alembic\n")
+
+    with pytest.raises(RuntimeError, match="Migration verification failed"):
+        runner.main()
+
+
+def test_main_raises_when_db_has_no_version_row(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """First-time deploy where upgrade silently no-ops: alembic_version
+    row is empty but script directory has heads. Must not be treated as
+    success.
+    """
+    _patch_runner(monkeypatch, script_heads=["0023"], db_heads=[])
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "alembic.ini").write_text("[alembic]\nscript_location = alembic\n")
+
+    with pytest.raises(RuntimeError, match="Migration verification failed"):
+        runner.main()
+
+
+def test_main_propagates_upgrade_exception(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When alembic.command.upgrade itself raises, the exception must
+    propagate. The verification step should not run after a failed upgrade.
+    """
+    boom = RuntimeError("alembic exploded")
+    _patch_runner(
+        monkeypatch,
+        script_heads=["0023"],
+        db_heads=["0019"],
+        upgrade_should_raise=boom,
+    )
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "alembic.ini").write_text("[alembic]\nscript_location = alembic\n")
+
+    with pytest.raises(RuntimeError, match="alembic exploded"):
+        runner.main()
+
+
+def test_get_sync_database_url_converts_asyncpg_to_psycopg2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The URL helper must produce a psycopg2 URL so alembic can use
+    synchronous drivers; asyncpg-only URLs would crash at engine init.
+    """
+    from learn_to_cloud import _migrations_url
+
+    fake_settings = MagicMock()
+    fake_settings.use_azure_postgres = False
+    fake_settings.database_url = (
+        "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud"
+    )
+
+    with patch.object(_migrations_url, "get_settings", return_value=fake_settings):
+        url = _migrations_url.get_sync_database_url()
+
+    assert url.startswith("postgresql+psycopg2://")
+    assert "+asyncpg" not in url

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -23,6 +23,25 @@ privileges.
 > PostgreSQL advisory lock (defined in `alembic/env.py`) to guard against
 > accidental concurrent executions.
 
+### Failure Detection
+
+Two layers guard against silent migration failures:
+
+1. **`alembic/env.py`** logs and re-raises every exception from
+   `context.run_migrations()`. Earlier versions substring-matched
+   `"duplicate"` / `"already exists"` and swallowed those errors as
+   "already applied by another process." Because real `UniqueViolation`s
+   contain the word `duplicate`, that swallow turned genuine failures
+   into silent no-ops, and the migration job exited 0 against an unmoved
+   schema. The session-level advisory lock above already guarantees serial
+   execution, so there is no legitimate concurrent-race case to swallow.
+2. **`scripts/run_migrations.py`** verifies the post-upgrade schema
+   matches the script directory head by comparing
+   `MigrationContext.get_current_heads()` to
+   `ScriptDirectory.get_heads()`. If they diverge, the script raises and
+   the job exits non-zero, failing the deploy. This is defense in depth
+   against future regressions in the env.py swallow path.
+
 ## Production Database Identities
 
 Production uses separate PostgreSQL data-plane principals. The production


### PR DESCRIPTION
Issue #432: production was stuck on schema 0019 for 8 days while CI
reported every deploy as green. Root cause: alembic/env.py substring-
matched 'duplicate' / 'already exists' in failure messages and swallowed
them as 'Migrations already applied by another process'. A real
UniqueViolation on CREATE UNIQUE INDEX (caused by 11 ghost rows that
predate the new partial unique index in 0020) matched the substring and
was silenced.

Fixes:

- alembic/env.py: remove the substring swallow entirely. The session-
  level pg advisory lock above already guarantees serial migration
  execution, so there is no legitimate concurrent-race case to swallow.
  Always log the exception with logger.exception(), rollback, release the
  lock (invalidating the connection if the unlock itself fails so we
  don't return a lock-holding connection to the pool), and re-raise.
- scripts/run_migrations.py: after alembic.command.upgrade(cfg, 'head'),
  verify MigrationContext.get_current_heads() matches
  ScriptDirectory.get_heads(). Defense in depth — even if anything ever
  silently swallows again, this fails the migration job loudly.
- learn_to_cloud._migrations_url (new): shared sync-URL builder. Lives
  outside alembic/env.py so run_migrations.py can import the URL helper
  without triggering env.py's module-level run() side effect.

Tests:

- test_alembic_env_regression.py: drives the real production env.py
  against SQLite with a migration that raises a 'duplicate'-flavored
  error and asserts the subprocess exits non-zero. Verified this fails
  against the pre-fix code with the exact silent-success log line from
  production.
- test_run_migrations.py: covers the post-upgrade verification — passes
  when heads match, raises when they don't, raises when alembic_version
  is empty, propagates alembic.command.upgrade exceptions.

Docs: updated docs/migrations.md to describe the two-layer failure
detection.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
