### PR TITLE
tier 1 improvements to db design and alembic setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,6 +47,20 @@ Do not push unless all of the following pass:
 
 Do not write `# noqa`, `type: ignore`, or ty/ruff suppression comments unless absolutely unavoidable.
 
+### Validation Workflow (run continuously, not just at the end)
+
+The Quality Gates commands above are the source of truth — **not `prek run --all-files`**. `prek --all-files` only inspects git-tracked files, so newly-created files (new migrations, new modules, new tests) get silently skipped. Relying on prek alone will let real ruff/ty violations slip through until the commit hook fires.
+
+Follow this loop:
+
+1. **After every batch of edits**, run the explicit Quality Gates commands for the project(s) you touched. At minimum, run `ruff check`, `ruff format --check`, and `ty check`. Do this even if you only changed one file — it takes seconds.
+2. **When creating new files**, either `git add` them first (so prek sees them) or run ruff/ty directly against the file path: `uv run ruff check path/to/new_file.py`.
+3. **Before declaring work complete**, run the entire Quality Gates block from top to bottom, in addition to any test/dog-food steps. Treat any failure as blocking.
+4. **Write code that respects ruff and ty by default** — match `line-length = 88`, prefer explicit imports, keep functions type-annotated, avoid unused imports/variables. Don't write code first and clean up later; getting it right the first time is faster.
+5. **Long SQL or string literals in migrations** must respect `line-length = 88`. Break long `SELECT` / `INSERT` lists across multiple lines inside the SQL string — ruff lints the Python source, not the SQL.
+
+If a check fails, fix it before moving on. Do not batch lint fixes for the end of the task.
+
 ## Research
 
 If you need to research something that is azure related, use azure-skills plugin. If you need more info or another topic, use firecrawl and or context7.

--- a/.github/skills/reset-local-submissions/SKILL.md
+++ b/.github/skills/reset-local-submissions/SKILL.md
@@ -61,9 +61,9 @@ cd <workspace>/api && uv run python scripts/reset_local_submissions.py \
 
 - Matching rows found and affected user IDs
 - Number of deleted submission rows
-- Recomputed `user_phase_progress.validated_submissions` per affected phase
 
 ## Notes
 
 - This is for local/testing databases only.
-- The script updates denormalized progress counts so dashboard progress remains consistent.
+- Progress is derived live from the submissions table on next page load,
+  so no denormalized counter needs updating.

--- a/.github/skills/reset-prod-submissions/SKILL.md
+++ b/.github/skills/reset-prod-submissions/SKILL.md
@@ -63,12 +63,13 @@ psql -h psql-ltc-dev-8v4tyz.postgres.database.azure.com -d learntocloud -U "$PG_
       ORDER BY created_at;" | cat
 ```
 
-Also check the current progress counter:
+Also check the current validated submissions for this phase:
 
 ```bash
 psql -h psql-ltc-dev-8v4tyz.postgres.database.azure.com -d learntocloud -U "$PG_USER" \
   --set=sslmode=require -P pager=off \
-  -c "SELECT * FROM user_phase_progress WHERE user_id = <USER_ID> AND phase_id = <PHASE_ID>;" | cat
+  -c "SELECT COUNT(*) FROM submissions
+      WHERE user_id = <USER_ID> AND phase_id = <PHASE_ID> AND is_validated = true;" | cat
 ```
 
 ## Step 5: Confirm with User
@@ -85,11 +86,12 @@ psql -h psql-ltc-dev-8v4tyz.postgres.database.azure.com -d learntocloud -U "$PG_
   -c "
 BEGIN;
 DELETE FROM submissions WHERE user_id = <USER_ID> AND phase_id = <PHASE_ID>;
-UPDATE user_phase_progress SET validated_submissions = 0, updated_at = NOW()
-  WHERE user_id = <USER_ID> AND phase_id = <PHASE_ID>;
 COMMIT;
 " | cat
 ```
+
+Progress is derived live from the submissions table, so no separate
+counter table needs to be updated.
 
 ### Resetting Specific Requirements Only
 
@@ -103,12 +105,6 @@ BEGIN;
 DELETE FROM submissions
   WHERE user_id = <USER_ID> AND phase_id = <PHASE_ID>
     AND requirement_id IN ('<REQ_1>', '<REQ_2>');
-UPDATE user_phase_progress
-  SET validated_submissions = (
-    SELECT COUNT(*) FROM submissions
-    WHERE user_id = <USER_ID> AND phase_id = <PHASE_ID> AND is_validated = true
-  ), updated_at = NOW()
-  WHERE user_id = <USER_ID> AND phase_id = <PHASE_ID>;
 COMMIT;
 " | cat
 ```
@@ -121,7 +117,8 @@ Confirm the reset was successful:
 psql -h psql-ltc-dev-8v4tyz.postgres.database.azure.com -d learntocloud -U "$PG_USER" \
   --set=sslmode=require -P pager=off \
   -c "SELECT COUNT(*) as remaining FROM submissions WHERE user_id = <USER_ID> AND phase_id = <PHASE_ID>;
-      SELECT validated_submissions FROM user_phase_progress WHERE user_id = <USER_ID> AND phase_id = <PHASE_ID>;" | cat
+      SELECT COUNT(*) as validated FROM submissions
+       WHERE user_id = <USER_ID> AND phase_id = <PHASE_ID> AND is_validated = true;" | cat
 ```
 
 ## Known Users
@@ -132,4 +129,4 @@ psql -h psql-ltc-dev-8v4tyz.postgres.database.azure.com -d learntocloud -U "$PG_
 
 ## Tables
 
-`users` · `submissions` · `user_phase_progress`
+`users` · `submissions`

--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -118,6 +118,32 @@ def _verify_schema_at_head(connection: Connection, logger: logging.Logger) -> No
     logger.info("alembic.verified heads=%s", sorted(current_heads))
 
 
+def _should_verify_head() -> bool:
+    """Verify schema reached head only when the command's destination is head.
+
+    Skip verification for ``alembic current``, ``alembic downgrade``, or any
+    targeted upgrade to a non-head revision — those intentionally leave the
+    database off head and the verify check would otherwise raise spuriously
+    during local dev.
+
+    The deploy job runs ``alembic upgrade head``, so verification stays
+    active in production. Alembic resolves the literal ``"head"`` to the
+    concrete revision id before storing it, so we compare against the
+    script directory's current head(s) rather than the string.
+    """
+    try:
+        destination = context.get_revision_argument()
+    except KeyError:
+        # Commands like ``alembic current`` set no destination revision.
+        return False
+    if destination is None:
+        return False
+    if destination == "head":
+        return True
+    expected_heads = set(ScriptDirectory.from_config(config).get_heads())
+    return destination in expected_heads
+
+
 def run_migrations_offline() -> None:
     """Run migrations in 'offline' mode (emit SQL, no DB connection)."""
     context.configure(
@@ -125,6 +151,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         compare_type=True,
+        compare_server_default=True,
         dialect_opts={"paramstyle": "named"},
     )
     with context.begin_transaction():
@@ -142,11 +169,12 @@ def run_migrations_online() -> None:
                 connection=connection,
                 target_metadata=target_metadata,
                 compare_type=True,
-                render_as_batch=True,
+                compare_server_default=True,
             )
             with context.begin_transaction():
                 context.run_migrations()
-            _verify_schema_at_head(connection, logger)
+            if _should_verify_head():
+                _verify_schema_at_head(connection, logger)
     except Exception:
         # Always log so silent failures (e.g. swallowed by some future
         # exception handler) cannot ship green. See issue #432.

--- a/api/alembic/versions/0024_db_cleanup_tier1.py
+++ b/api/alembic/versions/0024_db_cleanup_tier1.py
@@ -1,0 +1,79 @@
+"""Tier 1 DB cleanup: drop redundant indexes and unused user_phase_progress.
+
+Three subtractive changes that remove pure dead weight:
+
+* ``ix_submissions_user_phase`` is fully covered by the wider
+  ``ix_submissions_user_phase_req`` index added later.
+* ``ix_step_progress_completed_at`` has no queries that filter by
+  ``completed_at`` alone; the index has not been used by any code path
+  since at least the htmx baseline.
+* ``user_phase_progress`` is denormalized state that the runtime app
+  no longer reads. ``progress_service.fetch_user_progress`` derives
+  validated counts live from the ``submissions`` table. The only
+  remaining writers are operational reset runbooks, which are updated
+  in the same change to stop touching the table.
+
+Revision ID: 0024_db_cleanup_tier1
+Revises: 0023_rename_ci_status_submission_type
+Create Date: 2026-05-23
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0024_db_cleanup_tier1"
+down_revision = "0023_rename_ci_status_submission_type"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_submissions_user_phase", table_name="submissions")
+    op.drop_index("ix_step_progress_completed_at", table_name="step_progress")
+    op.drop_index("ix_user_phase_progress_user", table_name="user_phase_progress")
+    op.drop_table("user_phase_progress")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "user_phase_progress",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("phase_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "validated_submissions",
+            sa.Integer(),
+            server_default="0",
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "phase_id", name="uq_user_phase_progress"),
+    )
+    op.create_index("ix_user_phase_progress_user", "user_phase_progress", ["user_id"])
+    op.execute(
+        """
+        INSERT INTO user_phase_progress
+            (user_id, phase_id, validated_submissions, updated_at)
+        SELECT
+            user_id,
+            phase_id,
+            COUNT(DISTINCT requirement_id) AS validated_submissions,
+            NOW()
+        FROM submissions
+        WHERE is_validated = true
+        GROUP BY user_id, phase_id
+        """
+    )
+
+    op.create_index("ix_step_progress_completed_at", "step_progress", ["completed_at"])
+    op.create_index("ix_submissions_user_phase", "submissions", ["user_id", "phase_id"])

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -142,9 +142,11 @@ async def test_engine() -> AsyncGenerator[AsyncEngine]:
         echo=False,
     )
 
-    # Recreate all tables to ensure schema matches current models
+    # Reset to a clean slate so tables dropped from current metadata (e.g.
+    # across branch switches) cannot linger as orphans and block FK chains.
     async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
+        await conn.execute(text("DROP SCHEMA public CASCADE"))
+        await conn.execute(text("CREATE SCHEMA public"))
         await conn.run_sync(Base.metadata.create_all)
 
     yield engine

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -73,10 +73,6 @@ class User(TimestampMixin, Base):
         back_populates="user",
         cascade="all, delete-orphan",
     )
-    phase_progress: Mapped[list["UserPhaseProgress"]] = relationship(
-        back_populates="user",
-        cascade="all, delete-orphan",
-    )
 
 
 class SubmissionType(StrEnum):
@@ -137,7 +133,6 @@ class Submission(TimestampMixin, Base):
             "attempt_number",
             name="uq_user_requirement_attempt",
         ),
-        Index("ix_submissions_user_phase", "user_id", "phase_id"),
         Index(
             "ix_submissions_user_verified_updated",
             "user_id",
@@ -295,7 +290,6 @@ class StepProgress(Base):
         UniqueConstraint("user_id", "topic_id", "step_id", name="uq_user_topic_step"),
         Index("ix_step_progress_user_topic", "user_id", "topic_id"),
         Index("ix_step_progress_user_phase", "user_id", "phase_id"),
-        Index("ix_step_progress_completed_at", "completed_at"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -320,32 +314,3 @@ class StepProgress(Base):
     )
 
     user: Mapped["User"] = relationship(back_populates="step_progress")
-
-
-class UserPhaseProgress(Base):
-    """Denormalized per-user per-phase submission counts.
-
-    Tracks validated_submissions per phase to avoid aggregate queries
-    on the submissions table for every dashboard load.
-    Step completion is computed live from step_progress rows.
-    """
-
-    __tablename__ = "user_phase_progress"
-    __table_args__ = (
-        UniqueConstraint("user_id", "phase_id", name="uq_user_phase_progress"),
-        Index("ix_user_phase_progress_user", "user_id"),
-    )
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(
-        BigInteger,
-        ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
-    )
-    phase_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    validated_submissions: Mapped[int] = mapped_column(Integer, default=0)
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=utcnow, onupdate=utcnow
-    )
-
-    user: Mapped["User"] = relationship(back_populates="phase_progress")

--- a/packages/learn-to-cloud-shared/tests/conftest.py
+++ b/packages/learn-to-cloud-shared/tests/conftest.py
@@ -109,8 +109,11 @@ async def test_engine() -> AsyncGenerator[AsyncEngine]:
         echo=False,
     )
 
+    # Reset to a clean slate so tables dropped from current metadata (e.g.
+    # across branch switches) cannot linger as orphans and block FK chains.
     async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
+        await conn.execute(text("DROP SCHEMA public CASCADE"))
+        await conn.execute(text("CREATE SCHEMA public"))
         await conn.run_sync(Base.metadata.create_all)
 
     yield engine


### PR DESCRIPTION
This pull request performs a significant cleanup of the database schema and related documentation, removing the now-unused `user_phase_progress` table and associated denormalized logic. It also updates operational scripts and tests to reflect this change, and improves Alembic migration safety and test reliability. The most important changes are grouped below.

**Database schema cleanup:**

* Drops the `user_phase_progress` table and its related indexes, as well as two unused indexes (`ix_submissions_user_phase` and `ix_step_progress_completed_at`), since validated submission counts are now derived live from the `submissions` table. (`api/alembic/versions/0024_db_cleanup_tier1.py`, `packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py`) [[1]](diffhunk://#diff-83d2e54fbd52cf9b525327459ad20663a6ccbd304fc92628fb81e3360ac67935R1-R79) [[2]](diffhunk://#diff-e9cfe018a9c3a4c8f3fd6f85ed239b6e405f2955ef4c412febb58195647ccb3fL76-L79) [[3]](diffhunk://#diff-e9cfe018a9c3a4c8f3fd6f85ed239b6e405f2955ef4c412febb58195647ccb3fL140) [[4]](diffhunk://#diff-e9cfe018a9c3a4c8f3fd6f85ed239b6e405f2955ef4c412febb58195647ccb3fL298) [[5]](diffhunk://#diff-e9cfe018a9c3a4c8f3fd6f85ed239b6e405f2955ef4c412febb58195647ccb3fL323-L351)
* Removes all model references and relationships to `UserPhaseProgress`. (`packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py`) [[1]](diffhunk://#diff-e9cfe018a9c3a4c8f3fd6f85ed239b6e405f2955ef4c412febb58195647ccb3fL76-L79) [[2]](diffhunk://#diff-e9cfe018a9c3a4c8f3fd6f85ed239b6e405f2955ef4c412febb58195647ccb3fL323-L351)

**Operational and documentation updates:**

* Updates reset scripts and documentation to stop updating or querying the removed `user_phase_progress` table, instead instructing users to check live counts from the `submissions` table. (`.github/skills/reset-local-submissions/SKILL.md`, `.github/skills/reset-prod-submissions/SKILL.md`) [[1]](diffhunk://#diff-53618a429b2d859610a87dfd68916df253e1b9a0b1bf8761a7818147e509572aL64-R69) [[2]](diffhunk://#diff-a466a8ece7939118ffb452ecc89888c1b6ceaf30f2a55a8eaf8404e41b017f54L66-R72) [[3]](diffhunk://#diff-a466a8ece7939118ffb452ecc89888c1b6ceaf30f2a55a8eaf8404e41b017f54L88-R95) [[4]](diffhunk://#diff-a466a8ece7939118ffb452ecc89888c1b6ceaf30f2a55a8eaf8404e41b017f54L106-L111) [[5]](diffhunk://#diff-a466a8ece7939118ffb452ecc89888c1b6ceaf30f2a55a8eaf8404e41b017f54L124-R121) [[6]](diffhunk://#diff-a466a8ece7939118ffb452ecc89888c1b6ceaf30f2a55a8eaf8404e41b017f54L135-R132)
* Updates developer instructions to clarify best practices for local validation and linting, emphasizing the correct workflow for new files and quality gates. (`.github/copilot-instructions.md`)

**Testing and migration reliability:**

* Improves test database setup to fully reset the schema, preventing orphaned tables and ensuring consistency across branch switches. (`api/tests/conftest.py`, `packages/learn-to-cloud-shared/tests/conftest.py`) [[1]](diffhunk://#diff-c3f4507069825606d4fa23843dcfa3b85b28d1dded7b533606a1d910e9e1b0e9L145-R149) [[2]](diffhunk://#diff-8c042b5e8396060f050112fac71014f0436e9073078cd89749a0cba7f9d00748R112-R116)
* Enhances Alembic migration safety by only verifying schema head after upgrades to the latest revision, and by comparing server defaults during migrations. (`api/alembic/env.py`) [[1]](diffhunk://#diff-473462093ee1527c2cc8c62c2dae99153fb9c037a1eda105c15c4afeb99833a7R121-R154) [[2]](diffhunk://#diff-473462093ee1527c2cc8c62c2dae99153fb9c037a1eda105c15c4afeb99833a7L145-R176)