### PR TITLE
fix: add data cleanup to migration 0020 and regression test (#439)

### DIFF
--- a/api/alembic/versions/0020_add_result_submission_id_indexes.py
+++ b/api/alembic/versions/0020_add_result_submission_id_indexes.py
@@ -22,6 +22,20 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # Clean up ghost rows that would violate the new partial unique index.
+    # These are verification jobs with a terminal status but no linked
+    # submission (result_submission_id IS NULL). Without this DELETE,
+    # create_index below fails on databases with real data because
+    # multiple terminal jobs for the same (user_id, requirement_id)
+    # all satisfy the WHERE clause. See incident #432.
+    op.execute(
+        "DELETE FROM verification_jobs "
+        "WHERE result_submission_id IS NULL "
+        "AND status IN ("
+        "'succeeded', 'failed', 'server_error', 'cancelled'"
+        ")"
+    )
+
     # New partial unique index: replaces the role of
     # ``uq_verification_jobs_active_user_requirement`` (status-based) once
     # all pods are on the new code. Kept additive in this revision so old

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -21,6 +21,7 @@ markers =
     slow: tests that take > 1s
     smoke: minimal smoke test subset
     skip_until_fixed: temporarily skipped tests tied to issues
+    migration_chain: migration chain tests (runs alembic against fixture data)
 
 # Coverage config is in pyproject.toml [tool.coverage.*]
 # Run with coverage: uv run pytest --cov=. --cov-report=term-missing --cov-report=html:htmlcov --cov-report=xml:coverage.xml

--- a/api/tests/fixtures/migration_data_shapes.sql
+++ b/api/tests/fixtures/migration_data_shapes.sql
@@ -1,0 +1,84 @@
+-- migration_data_shapes.sql
+--
+-- Append-only fixture of "weird shapes seen in prod." Each time a
+-- migration failure surfaces a new data pattern, the fix PR adds
+-- INSERTs here so the migration-chain test catches regressions.
+--
+-- The test stamps the database at revision 0019, loads this file,
+-- then runs ``alembic upgrade head``.  Data must be valid at the
+-- 0019 schema (all NOT NULL / CHECK constraints enforced by 0019).
+--
+-- IMPORTANT: only append to this file. Never edit or remove rows.
+
+-- ============================================================
+-- Users
+-- ============================================================
+INSERT INTO users (id, github_username, is_admin, created_at, updated_at)
+VALUES
+  (1001, 'alice',   false, NOW(), NOW()),
+  (1002, 'bob',     false, NOW(), NOW()),
+  (1003, 'charlie', true,  NOW(), NOW());
+
+-- ============================================================
+-- Submissions (various types and states)
+-- ============================================================
+INSERT INTO submissions
+  (user_id, requirement_id, submission_type, phase_id,
+   submitted_value, is_validated, verification_completed,
+   created_at, updated_at)
+VALUES
+  -- Validated submission
+  (1001, 'phase1-github-profile', 'github_profile', 1,
+   'https://github.com/alice', true, true, NOW(), NOW()),
+  -- Unvalidated submission
+  (1002, 'phase1-github-profile', 'github_profile', 1,
+   'https://github.com/bob', false, false, NOW(), NOW()),
+  -- CTF token submission
+  (1001, 'phase2-networking', 'networking_token', 2,
+   'flag{test123}', true, true, NOW(), NOW());
+
+-- ============================================================
+-- Step progress
+-- ============================================================
+INSERT INTO step_progress
+  (user_id, topic_id, phase_id, step_order, step_id, completed_at)
+VALUES
+  (1001, 'linux-basics', 1, 1, 'linux-basics-step-1', NOW()),
+  (1001, 'linux-basics', 1, 2, 'linux-basics-step-2', NOW()),
+  (1002, 'linux-basics', 1, 1, 'linux-basics-step-1', NOW());
+
+-- ============================================================
+-- Verification jobs: the #432 incident pattern
+--
+-- Ghost rows: terminal status but result_submission_id IS NULL.
+-- Two such rows for the SAME (user_id, requirement_id) pair.
+-- Before the fix in 0020, these would violate the new partial
+-- unique index on (user_id, requirement_id) WHERE
+-- result_submission_id IS NULL.
+-- ============================================================
+INSERT INTO verification_jobs
+  (id, user_id, requirement_id, phase_id, submission_type,
+   submitted_value, status, result_submission_id,
+   created_at, updated_at)
+VALUES
+  -- Ghost row 1: failed, no linked submission
+  ('a0000000-0000-0000-0000-000000000001',
+   1001, 'phase1-github-profile', 1, 'github_profile',
+   'https://github.com/alice', 'failed', NULL,
+   NOW(), NOW()),
+  -- Ghost row 2: same user+requirement, also failed, no linked submission
+  -- This is the duplicate that caused incident #432
+  ('a0000000-0000-0000-0000-000000000002',
+   1001, 'phase1-github-profile', 1, 'github_profile',
+   'https://github.com/alice', 'server_error', NULL,
+   NOW(), NOW()),
+  -- Normal completed job with a linked submission (not a ghost)
+  ('a0000000-0000-0000-0000-000000000003',
+   1001, 'phase2-networking', 2, 'networking_token',
+   'flag{test123}', 'succeeded', 3,
+   NOW(), NOW()),
+  -- Active job (queued, no result yet) -- should survive cleanup
+  ('a0000000-0000-0000-0000-000000000004',
+   1002, 'phase1-github-profile', 1, 'github_profile',
+   'https://github.com/bob', 'queued', NULL,
+   NOW(), NOW());

--- a/api/tests/test_migration_chain.py
+++ b/api/tests/test_migration_chain.py
@@ -1,0 +1,148 @@
+"""Test that the full alembic migration chain works with prod-like data.
+
+Stamps the database to an intermediate revision, loads fixture data that
+reproduces real-world edge cases (e.g. ghost verification jobs from
+incident #432), then runs ``alembic upgrade head`` and verifies it
+succeeds.  The fixture file is append-only: each time a new prod data
+shape causes a migration failure, the fix PR adds INSERTs to the
+fixture so CI catches regressions permanently.
+
+See: https://github.com/learntocloud/learn-to-cloud-app/issues/439
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+STAMP_REVISION = "0019_enforce_not_null_columns"
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "migration_data_shapes.sql"
+API_DIR = str(Path(__file__).parent.parent)
+MIGRATION_DB = "test_migration_chain"
+
+
+def _build_sync_url() -> str:
+    """Derive a psycopg2 URL from the DATABASE_URL env var."""
+    raw = os.environ.get(
+        "DATABASE_URL",
+        "postgresql+asyncpg://postgres:postgres@db:5432/learntocloud",
+    )
+    return raw.replace("+asyncpg", "+psycopg2")
+
+
+def _admin_url(sync_url: str) -> str:
+    return sync_url.rsplit("/", 1)[0] + "/postgres"
+
+
+def _migration_url(sync_url: str) -> str:
+    return sync_url.rsplit("/", 1)[0] + f"/{MIGRATION_DB}"
+
+
+def _drop_db(admin_engine, db_name: str) -> None:  # type: ignore[no-any-explicit]
+    """Terminate connections then drop the database."""
+    with admin_engine.connect() as conn:
+        conn.execute(
+            text(
+                "SELECT pg_terminate_backend(pid) "
+                "FROM pg_stat_activity "
+                f"WHERE datname = '{db_name}' "
+                "AND pid <> pg_backend_pid()"
+            )
+        )
+        conn.execute(text(f"DROP DATABASE IF EXISTS {db_name}"))
+
+
+def _run_alembic(*args: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run an alembic command via subprocess for full isolation."""
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=API_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+@pytest.mark.migration_chain
+def test_upgrade_head_with_prod_data_shapes() -> None:
+    """Full chain upgrade succeeds against realistic prod data."""
+    sync_url = _build_sync_url()
+    admin_eng = create_engine(_admin_url(sync_url), isolation_level="AUTOCOMMIT")
+    mig_url = _migration_url(sync_url)
+
+    try:
+        # Create a fresh database for this test
+        _drop_db(admin_eng, MIGRATION_DB)
+        with admin_eng.connect() as conn:
+            conn.execute(text(f"CREATE DATABASE {MIGRATION_DB}"))
+
+        # Build env for subprocess (don't mutate os.environ)
+        sub_env = {
+            **os.environ,
+            "DATABASE_URL": mig_url.replace("+psycopg2", "+asyncpg"),
+        }
+
+        # Upgrade to the stamp revision
+        result = _run_alembic("upgrade", STAMP_REVISION, env=sub_env)
+        assert result.returncode == 0, (
+            f"Stamp to {STAMP_REVISION} failed:\n{result.stderr}"
+        )
+
+        # Load fixture data
+        fixture_sql = FIXTURE_PATH.read_text()
+        engine = create_engine(mig_url)
+        try:
+            with engine.begin() as conn:
+                conn.exec_driver_sql(fixture_sql)
+        finally:
+            engine.dispose()
+
+        # Run the remaining migrations -- this is the actual test
+        result = _run_alembic("upgrade", "head", env=sub_env)
+        assert result.returncode == 0, f"Migration to head failed:\n{result.stderr}"
+
+    finally:
+        admin_eng = create_engine(_admin_url(sync_url), isolation_level="AUTOCOMMIT")
+        _drop_db(admin_eng, MIGRATION_DB)
+        admin_eng.dispose()
+
+
+@pytest.mark.migration_chain
+def test_downgrade_and_reupgrade() -> None:
+    """Downgrade one revision then re-upgrade succeeds."""
+    sync_url = _build_sync_url()
+    admin_eng = create_engine(_admin_url(sync_url), isolation_level="AUTOCOMMIT")
+    mig_url = _migration_url(sync_url)
+
+    try:
+        _drop_db(admin_eng, MIGRATION_DB)
+        with admin_eng.connect() as conn:
+            conn.execute(text(f"CREATE DATABASE {MIGRATION_DB}"))
+
+        sub_env = {
+            **os.environ,
+            "DATABASE_URL": mig_url.replace("+psycopg2", "+asyncpg"),
+        }
+
+        # Full upgrade first
+        result = _run_alembic("upgrade", "head", env=sub_env)
+        assert result.returncode == 0, f"Initial upgrade failed:\n{result.stderr}"
+
+        # Downgrade one revision
+        result = _run_alembic("downgrade", "-1", env=sub_env)
+        assert result.returncode == 0, f"Downgrade failed:\n{result.stderr}"
+
+        # Re-upgrade to head
+        result = _run_alembic("upgrade", "head", env=sub_env)
+        assert result.returncode == 0, f"Re-upgrade failed:\n{result.stderr}"
+
+    finally:
+        admin_eng = create_engine(_admin_url(sync_url), isolation_level="AUTOCOMMIT")
+        _drop_db(admin_eng, MIGRATION_DB)
+        admin_eng.dispose()


### PR DESCRIPTION
## What

Fixes the migration ordering bug from incident #432 and adds a regression test to prevent similar issues.

## Problem

Migration `0020` creates a unique partial index on `verification_jobs(user_id, requirement_id) WHERE result_submission_id IS NULL`. But it didn't clean up ghost rows (terminal status jobs with no linked submission) that violate this uniqueness constraint. When run against a database with real data, PostgreSQL refuses to create the index because duplicate rows exist.

Migration `0021` had the cleanup (DELETE of ghost rows), but it runs AFTER `0020`, so it never gets a chance to help.

## Fix

1. **Added DELETE before CREATE INDEX in `0020`**: Cleans up ghost rows (terminal status + `result_submission_id IS NULL`) before creating the unique index. This follows the Alembic cookbook pattern of combining data cleanup with schema changes in the same migration.

2. **Added migration chain fixture test**: Stamps the database at revision `0019`, loads prod-like fixture data (including the duplicate ghost rows from #432), then runs `alembic upgrade head`. This catches data-dependent migration failures that testing against an empty database misses.

3. **Added downgrade/re-upgrade test**: Verifies `downgrade -1` followed by `upgrade head` works correctly.

## Safety

- Production already ran past `0024`, so the edited `0020` won't re-run there
- The DELETE is idempotent and a no-op on fresh installs (no data to delete)
- The same DELETE exists in `0021`, providing defense in depth

## Files changed

- `api/alembic/versions/0020_add_result_submission_id_indexes.py` - Added ghost row cleanup
- `api/tests/test_migration_chain.py` - New regression tests
- `api/tests/fixtures/migration_data_shapes.sql` - Append-only prod-shaped fixture data
- `api/pytest.ini` - Added `migration_chain` marker

Closes #439