### PR TITLE
feat: add squawk SQL linter for new migrations (#449)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,6 +154,8 @@ jobs:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -216,6 +218,10 @@ jobs:
       - name: Lint migration filenames and docstrings
         working-directory: api
         run: uv run python scripts/check_migration_naming.py
+
+      - name: Lint new migration SQL with squawk
+        working-directory: api
+        run: uv run python scripts/lint_migration_sql.py
 
       - name: Apply migrations to CI database
         working-directory: api

--- a/api/.squawk.toml
+++ b/api/.squawk.toml
@@ -1,0 +1,15 @@
+# Squawk configuration for Alembic migration SQL linting.
+# See https://squawkhq.com/docs/ for rule documentation.
+
+pg_version = "16.0"
+
+# Alembic wraps migrations in transactions, and its --sql output
+# includes BEGIN/COMMIT. This tells squawk to expect that.
+assume_in_transaction = true
+
+# transaction-nesting: Alembic's --sql mode always emits BEGIN/COMMIT
+# which squawk sees as nesting inside the assumed transaction. This is
+# harmless and unavoidable with Alembic, so we exclude it.
+excluded_rules = [
+    "transaction-nesting",
+]

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -108,4 +108,5 @@ dev = [
     "ruff==0.15.12",
     "ty==0.0.34",
     "pytest-alembic>=0.12.1",
+    "squawk-cli>=2.53.0",
 ]

--- a/api/scripts/lint_migration_sql.py
+++ b/api/scripts/lint_migration_sql.py
@@ -1,0 +1,167 @@
+"""Lint new Alembic migration SQL with squawk.
+
+Finds migration files that were added (not modified) compared to the
+base branch, generates the SQL each migration would run, and feeds it
+to squawk for safety checks.
+
+Usage from the api/ directory::
+
+    uv run python scripts/lint_migration_sql.py [--base origin/main]
+
+Exit codes:
+    0  No new migrations, or all new migrations pass squawk.
+    1  Squawk found issues in one or more migrations.
+    2  Script error (bad revision, SQL generation failure, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+VERSIONS_DIR = Path(__file__).resolve().parent.parent / "alembic" / "versions"
+
+
+def _get_new_migration_files(base: str) -> list[Path]:
+    """Return migration files added (not modified) vs the base branch."""
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "diff",
+                "--name-only",
+                "--diff-filter=A",
+                base,
+                "--",
+                str(VERSIONS_DIR),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"git diff failed: {exc.stderr.strip()}", file=sys.stderr)
+        sys.exit(2)
+
+    files = []
+    for line in result.stdout.strip().splitlines():
+        path = Path(line)
+        if path.suffix == ".py" and path.name != "__init__.py":
+            files.append(path)
+    return files
+
+
+def _revision_id_from_file(path: Path) -> str:
+    """Extract the revision ID (filename stem) from a migration file."""
+    return path.stem
+
+
+def _get_down_revision(script_dir: ScriptDirectory, rev_id: str) -> str:
+    """Get the down_revision for a given revision ID."""
+    rev = script_dir.get_revision(rev_id)
+    if rev is None:
+        print(f"Could not find revision {rev_id}", file=sys.stderr)
+        sys.exit(2)
+    down = rev.down_revision
+    if down is None:
+        return "base"
+    if isinstance(down, (list, tuple)):
+        # Merge migration; use the first parent.
+        return down[0]
+    return down
+
+
+def _generate_sql(down_rev: str, rev_id: str) -> str | None:
+    """Run alembic upgrade --sql for one revision range."""
+    range_spec = f"{down_rev}:{rev_id}"
+    result = subprocess.run(
+        ["uv", "run", "alembic", "upgrade", "--sql", range_spec],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"alembic upgrade --sql {range_spec} failed:\n{result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return None
+    return result.stdout
+
+
+def _run_squawk(sql: str, label: str) -> bool:
+    """Run squawk on SQL text. Returns True if clean."""
+    with tempfile.NamedTemporaryFile(suffix=".sql", mode="w", delete=False) as f:
+        f.write(sql)
+        f.flush()
+        result = subprocess.run(
+            ["uv", "run", "squawk", f.name],
+            capture_output=True,
+            text=True,
+        )
+
+    if result.returncode != 0:
+        print(f"\n--- squawk issues in {label} ---")
+        print(result.stdout)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        return False
+
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Lint new Alembic migrations with squawk."
+    )
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="Git ref to diff against (default: origin/main)",
+    )
+    args = parser.parse_args()
+
+    new_files = _get_new_migration_files(args.base)
+    if not new_files:
+        print("No new migration files found. Nothing to lint.")
+        return 0
+
+    print(f"Found {len(new_files)} new migration(s) to lint:")
+    for f in new_files:
+        print(f"  {f.name}")
+
+    cfg = Config("alembic.ini")
+    script_dir = ScriptDirectory.from_config(cfg)
+
+    failed = False
+    for migration_file in new_files:
+        rev_id = _revision_id_from_file(migration_file)
+        down_rev = _get_down_revision(script_dir, rev_id)
+
+        sql = _generate_sql(down_rev, rev_id)
+        if sql is None:
+            print(
+                f"Skipping {rev_id}: could not generate SQL",
+                file=sys.stderr,
+            )
+            failed = True
+            continue
+
+        if not _run_squawk(sql, rev_id):
+            failed = True
+
+    if failed:
+        print("\nSquawk found issues. Fix them before merging.")
+        return 1
+
+    print("\nAll new migrations passed squawk lint.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -927,6 +927,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "squawk-cli" },
     { name = "ty" },
 ]
 
@@ -970,6 +971,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.12.0" },
     { name = "ruff", specifier = "==0.15.12" },
+    { name = "squawk-cli", specifier = ">=2.53.0" },
     { name = "ty", specifier = "==0.0.34" },
 ]
 
@@ -2104,6 +2106,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
     { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
     { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[[package]]
+name = "squawk-cli"
+version = "2.53.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/dc/eddd0b66bdcc090a2f471794d6a9c13a7be4a6b8636ff98b8ceecbb7fec8/squawk_cli-2.53.0.tar.gz", hash = "sha256:3c5e66cfbbe8194e9f10a0d6ac8f7da9b3af87236c6f1372fc52524c6591b1df", size = 825579, upload-time = "2026-05-17T23:57:52.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/45/3e529bdbaa3d36a70fcf7c5b30e25194f77ac9093b65010a56797eee5ac7/squawk_cli-2.53.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e924e0583823789f45a24079e528bb8a64df74d36f9e9153a859ac8e0bcbe4b5", size = 4613925, upload-time = "2026-05-17T23:57:51.15Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/71/b04ff43ca7f8b0e8a06cd08dd85bd4aa65b554c37fee7cffe0e9b242b166/squawk_cli-2.53.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:436160189472d84cfe1e1259064fc9d97172443c2e247ec9717570d501b03e09", size = 4469530, upload-time = "2026-05-17T23:57:49.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d7/76de6849f05ca47012477e4ecd49c7a129cb6764b16ccf99be7a5479218e/squawk_cli-2.53.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9edb4cb00198a0693603fe9fb179ec3dd074c75f0985ffbfdac8e2c0ef45e016", size = 5976823, upload-time = "2026-05-17T23:57:46.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/24/db1f8cdc3ec685216593cfd1b273ce7f564f9339445cbce5dd55f7daa796/squawk_cli-2.53.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b0868de362b7ae4847726dc391754c834a96dbd0954e284994d8ed979d1dc6", size = 6757296, upload-time = "2026-05-17T23:57:47.887Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/da/f3ca887ba77b4f90bbe700b8ef9f02f480313eaa1a1744f8cb199628a253/squawk_cli-2.53.0-py3-none-win32.whl", hash = "sha256:0bbd82801491ea011d133446e7384fcc38ced241fcfa7536d6665187224d57bc", size = 3767938, upload-time = "2026-05-17T23:57:55.975Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2f/3a6b9b31cc99ea9be2e99a5844e3eb9424ba8d5e5c73330c118a851e6744/squawk_cli-2.53.0-py3-none-win_amd64.whl", hash = "sha256:45f34827ab044884afa50ed394a74565eb267a86b40edfe7290720e33def9f32", size = 4093692, upload-time = "2026-05-17T23:57:54.147Z" },
 ]
 
 [[package]]

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -184,3 +184,31 @@ cd api && uv run pytest tests/test_migration_chain.py -v
 ```
 
 These tests are included in the standard `uv run pytest tests/` run.
+
+## SQL Linting with Squawk
+
+New migrations are automatically linted with
+[Squawk](https://squawkhq.com/) in CI. Squawk checks the generated SQL
+for unsafe Postgres patterns like:
+
+- Creating indexes without `CONCURRENTLY` (blocks writes)
+- Adding constraints without `NOT VALID` (blocks reads/writes during scan)
+- Missing `lock_timeout` / `statement_timeout` settings
+- Dropping tables or columns (breaks existing clients)
+
+### How it works
+
+The script `api/scripts/lint_migration_sql.py` finds migration files
+added in the PR (compared to `origin/main`), generates the SQL each
+migration would run via `alembic upgrade --sql`, and feeds it to squawk.
+
+Configuration lives in `api/.squawk.toml`.
+
+### Running locally
+
+```bash
+cd api && uv run python scripts/lint_migration_sql.py
+```
+
+This only checks new migrations (files added vs `origin/main`). If
+you're working on a branch with no new migrations, it exits cleanly.


### PR DESCRIPTION
New migrations are now linted with squawk in CI before they run. The linter generates SQL from each new migration file and checks for unsafe Postgres patterns like non-concurrent index creation, missing lock/statement timeouts, and constraint additions that block reads.

- Add squawk-cli dev dependency
- Add wrapper script (scripts/lint_migration_sql.py) that finds new migration files vs origin/main, generates SQL, and runs squawk
- Add .squawk.toml config (pg 16, transaction-nesting excluded)
- Add CI step before alembic upgrade head
- Add fetch-depth: 0 to CI checkout for git diff support
- Document squawk in docs/migrations.md
fix for #449