### PR TITLE
feat(curriculum): DB-backed loader coexists with YAML loader

### DIFF
--- a/api/alembic/versions/0026_add_requirements_order.py
+++ b/api/alembic/versions/0026_add_requirements_order.py
@@ -1,0 +1,50 @@
+"""add requirements order
+
+Why this change: Phase B (#463) created the ``requirements`` table but
+omitted an ``order`` column -- an oversight surfaced when planning
+Phase C (#464) parity tests. Phases, topics, steps, and
+learning_objectives all carry ``order``; requirements should too, so
+the DB faithfully represents the slug-list order from
+``_phase.yaml``'s ``requirements:``.
+
+Schema effect: Adds ``requirements.order BIGINT NOT NULL`` with a
+``server_default = '0'`` so existing rows are backfilled in place. The
+deploy-time sync (``scripts/sync_curriculum.py``) overwrites these
+values with the real position-based order on its next run, so the
+default never sticks.
+
+Rollback notes: Pure additive column. Downgrade drops it. Safe.
+
+Revision ID: 0026_add_requirements_order
+Create Date: 2026-05-24 18:32:03.167995
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0026_add_requirements_order"
+down_revision = "0025_add_curriculum_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    op.add_column(
+        "requirements",
+        sa.Column(
+            "order",
+            sa.BigInteger(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("requirements", "order")

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_db_loader.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_db_loader.py
@@ -1,0 +1,293 @@
+"""DB-backed curriculum loader (issue #464 / Phase C).
+
+Reads the curriculum tree (phases, topics, steps, learning_objectives,
+requirements) from the DB tables populated by ``content_sync.py``, and
+rebuilds the same Pydantic shape that the YAML loader returns from
+``content_service.get_all_phases()``.
+
+This module is intentionally **uncached**. The Phase C decision was to
+drop the YAML loader's ``@lru_cache`` rather than carry it forward: the
+DB query is fast (~466 active rows in our largest curriculum, all
+indexed) and a cache without invalidation creates a class of
+stale-data bugs we want to avoid.
+
+In Phase C PR 1 (this module's introduction) the public API in
+``content_service.py`` still goes through the YAML loader. PR 2 will
+flip the switch.
+
+Soft-deleted rows (``deleted_at IS NOT NULL``) are excluded everywhere.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud_shared.models import (
+    CurriculumLearningObjective,
+    CurriculumPhase,
+    CurriculumRequirement,
+    CurriculumStep,
+    CurriculumTopic,
+)
+from learn_to_cloud_shared.schemas import (
+    HandsOnRequirementAdapter,
+    LearningObjective,
+    LearningStep,
+    Phase,
+    PhaseHandsOnVerificationOverview,
+    Topic,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def load_all_phases_from_db(db: AsyncSession) -> tuple[Phase, ...]:
+    """Build the full curriculum tree from active DB rows.
+
+    Returns phases ordered by ``order``. Nested topics, steps,
+    learning_objectives, and requirements are likewise ordered by their
+    own ``order`` columns.
+
+    Uses 5 simple queries (one per table) and assembles the tree in
+    Python via dict-based grouping by parent UUID. This avoids the
+    fanout problems of a single JOIN over five tables and keeps each
+    query a straightforward index scan.
+    """
+    phase_rows = (
+        await db.scalars(
+            select(CurriculumPhase)
+            .where(CurriculumPhase.deleted_at.is_(None))
+            .order_by(CurriculumPhase.order)
+        )
+    ).all()
+
+    topic_rows = (
+        await db.scalars(
+            select(CurriculumTopic)
+            .where(CurriculumTopic.deleted_at.is_(None))
+            .order_by(CurriculumTopic.order)
+        )
+    ).all()
+
+    step_rows = (
+        await db.scalars(
+            select(CurriculumStep)
+            .where(CurriculumStep.deleted_at.is_(None))
+            .order_by(CurriculumStep.order)
+        )
+    ).all()
+
+    objective_rows = (
+        await db.scalars(
+            select(CurriculumLearningObjective)
+            .where(CurriculumLearningObjective.deleted_at.is_(None))
+            .order_by(CurriculumLearningObjective.order)
+        )
+    ).all()
+
+    requirement_rows = (
+        await db.scalars(
+            select(CurriculumRequirement)
+            .where(CurriculumRequirement.deleted_at.is_(None))
+            .order_by(CurriculumRequirement.order)
+        )
+    ).all()
+
+    return _assemble_phases(
+        phase_rows=phase_rows,
+        topic_rows=topic_rows,
+        step_rows=step_rows,
+        objective_rows=objective_rows,
+        requirement_rows=requirement_rows,
+    )
+
+
+async def load_phase_by_slug_from_db(db: AsyncSession, slug: str) -> Phase | None:
+    """Return the active phase with the given slug, or None.
+
+    Routes through ``load_all_phases_from_db`` so the visibility rules
+    (active topics inside active phases, etc.) are guaranteed identical.
+    Trivially cheap given curriculum size.
+    """
+    for phase in await load_all_phases_from_db(db):
+        if phase.slug == slug:
+            return phase
+    return None
+
+
+async def load_topic_by_id_from_db(db: AsyncSession, topic_id: str) -> Topic | None:
+    """Return the active topic with the given legacy_id, or None.
+
+    Routes through ``load_all_phases_from_db`` for consistency.
+    """
+    for phase in await load_all_phases_from_db(db):
+        for topic in phase.topics:
+            if topic.id == topic_id:
+                return topic
+    return None
+
+
+async def load_topic_by_slugs_from_db(
+    db: AsyncSession, phase_slug: str, topic_slug: str
+) -> Topic | None:
+    """Return the active topic by ``(phase_slug, topic_slug)``."""
+    phase = await load_phase_by_slug_from_db(db, phase_slug)
+    if phase is None:
+        return None
+    for topic in phase.topics:
+        if topic.slug == topic_slug:
+            return topic
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Internal assembly helpers
+# ---------------------------------------------------------------------------
+
+
+def _assemble_phases(
+    *,
+    phase_rows: Sequence[CurriculumPhase],
+    topic_rows: Sequence[CurriculumTopic],
+    step_rows: Sequence[CurriculumStep],
+    objective_rows: Sequence[CurriculumLearningObjective],
+    requirement_rows: Sequence[CurriculumRequirement],
+) -> tuple[Phase, ...]:
+    """Build the full Pydantic tree from already-loaded ORM rows."""
+    steps_by_topic: dict[UUID, list[LearningStep]] = defaultdict(list)
+    for step_row in step_rows:
+        steps_by_topic[step_row.topic_uuid].append(_build_step(step_row))
+
+    objectives_by_topic: dict[UUID, list[LearningObjective]] = defaultdict(list)
+    for obj_row in objective_rows:
+        objectives_by_topic[obj_row.topic_uuid].append(_build_objective(obj_row))
+
+    topics_by_phase: dict[UUID, list[Topic]] = defaultdict(list)
+    for topic_row in topic_rows:
+        topics_by_phase[topic_row.phase_uuid].append(
+            _build_topic(
+                topic_row,
+                learning_steps=steps_by_topic.get(topic_row.uuid, []),
+                learning_objectives=objectives_by_topic.get(topic_row.uuid, []),
+            )
+        )
+
+    requirements_by_phase: dict[UUID, list] = defaultdict(list)
+    for req_row in requirement_rows:
+        requirements_by_phase[req_row.phase_uuid].append(_build_requirement(req_row))
+
+    phases: list[Phase] = []
+    for phase_row in phase_rows:
+        phase_topics = topics_by_phase.get(phase_row.uuid, [])
+        phase_requirements = requirements_by_phase.get(phase_row.uuid, [])
+        phases.append(
+            _build_phase(
+                phase_row,
+                topics=phase_topics,
+                requirements=phase_requirements,
+            )
+        )
+    return tuple(phases)
+
+
+def _build_step(row: CurriculumStep) -> LearningStep:
+    # extra_config holds the non-core fields (options, checklist, tips,
+    # done_when) bundled into one JSONB column. Spread it back into the
+    # step payload so LearningStep.model_validate sees the same shape it
+    # would from YAML.
+    payload: dict = {
+        "uuid": row.uuid,
+        "id": row.legacy_id,
+        "order": row.order,
+        "action": row.action,
+        "title": row.title,
+        "url": row.url,
+        "description": row.description,
+        "code": row.code,
+    }
+    payload.update(row.extra_config or {})
+    return LearningStep.model_validate(payload)
+
+
+def _build_objective(row: CurriculumLearningObjective) -> LearningObjective:
+    return LearningObjective.model_validate(
+        {
+            "uuid": row.uuid,
+            "id": row.legacy_id,
+            "text": row.text_,
+            "order": row.order,
+        }
+    )
+
+
+def _build_topic(
+    row: CurriculumTopic,
+    *,
+    learning_steps: list[LearningStep],
+    learning_objectives: list[LearningObjective],
+) -> Topic:
+    return Topic.model_validate(
+        {
+            "uuid": row.uuid,
+            "id": row.legacy_id,
+            "slug": row.slug,
+            "name": row.name,
+            "description": row.description,
+            "order": row.order,
+            "learning_steps": learning_steps,
+            "learning_objectives": learning_objectives,
+        }
+    )
+
+
+def _build_requirement(row: CurriculumRequirement):
+    """Rehydrate a HandsOnRequirement via the discriminated union.
+
+    The submission_type discriminator picks the right subclass; the
+    type_config JSONB dict is validated against that subclass's
+    per-type config model.
+    """
+    return HandsOnRequirementAdapter.validate_python(
+        {
+            "uuid": row.uuid,
+            "id": row.id,
+            "submission_type": row.submission_type,
+            "name": row.name,
+            "description": row.description,
+            "type_config": row.type_config or {},
+        }
+    )
+
+
+def _build_phase(
+    row: CurriculumPhase,
+    *,
+    topics: list[Topic],
+    requirements: list,
+) -> Phase:
+    hov: PhaseHandsOnVerificationOverview | None = None
+    if requirements:
+        hov = PhaseHandsOnVerificationOverview(
+            requirement_slugs=[r.id for r in requirements],
+            requirements=requirements,
+        )
+    return Phase.model_validate(
+        {
+            "uuid": row.uuid,
+            "id": row.legacy_id,
+            "slug": row.slug,
+            "name": row.name,
+            "description": row.description,
+            "short_description": row.short_description,
+            "order": row.order,
+            "topic_slugs": [t.slug for t in topics],
+            "topics": topics,
+            "hands_on_verification": hov,
+        }
+    )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
@@ -131,6 +131,7 @@ _REQUIREMENT_UPDATE_FIELDS = (
     "name",
     "description",
     "submission_type",
+    "order",
     "type_config",
     "deleted_at",
     "updated_at",
@@ -220,7 +221,7 @@ def _build_objective_rows(phase: Phase, now: datetime) -> Iterable[dict[str, Any
 def _build_requirement_rows(phase: Phase, now: datetime) -> Iterable[dict[str, Any]]:
     if phase.hands_on_verification is None:
         return
-    for req in phase.hands_on_verification.requirements:
+    for idx, req in enumerate(phase.hands_on_verification.requirements):
         # type_config is a Pydantic submodel; dump as JSON-safe dict.
         type_config = req.type_config.model_dump(mode="json") if req.type_config else {}
         yield {
@@ -230,6 +231,9 @@ def _build_requirement_rows(phase: Phase, now: datetime) -> Iterable[dict[str, A
             "name": req.name,
             "description": req.description,
             "submission_type": req.submission_type.value,
+            # Position in _phase.yaml's requirement slug list = display order.
+            # Mirrors the topic-order convention from #470: one source of truth.
+            "order": idx + 1,
             "type_config": type_config,
             "deleted_at": None,
             "created_at": now,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -504,6 +504,11 @@ class CurriculumRequirement(TimestampMixin, Base):
     name: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
     submission_type: Mapped[str] = mapped_column(Text, nullable=False)
+    order: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        server_default=text("0"),
+    )
     type_config: Mapped[dict] = mapped_column(
         JSONB,
         nullable=False,

--- a/packages/learn-to-cloud-shared/tests/services/test_content_db_loader.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_db_loader.py
@@ -1,0 +1,347 @@
+"""Integration tests for content_db_loader (issue #464 / Phase C).
+
+PR 1 verifies that the DB loader returns the same Pydantic shape as
+the YAML loader for the seeded curriculum content. PR 2 will swap the
+public ``content_service`` API to delegate to the DB loader; until then
+both coexist.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud_shared.content_db_loader import (
+    load_all_phases_from_db,
+    load_phase_by_slug_from_db,
+    load_topic_by_id_from_db,
+    load_topic_by_slugs_from_db,
+)
+from learn_to_cloud_shared.content_service import (
+    clear_cache,
+    get_all_phases,
+)
+from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
+from learn_to_cloud_shared.models import (
+    CurriculumPhase,
+    CurriculumRequirement,
+    CurriculumStep,
+    CurriculumTopic,
+)
+from learn_to_cloud_shared.schemas import (
+    RepoForkRequirement,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def _seed_with_real_content(db: AsyncSession) -> None:
+    """Run the real sync against the packaged YAML content."""
+    clear_cache()
+    await sync_curriculum_to_db(db)
+
+
+# ---------------------------------------------------------------------------
+# Whole-tree parity: DB loader output == YAML loader output
+# ---------------------------------------------------------------------------
+
+
+async def test_db_loader_matches_yaml_loader_for_packaged_content(
+    db_session: AsyncSession,
+) -> None:
+    """The DB loader returns the same shape as the YAML loader.
+
+    Runs the real ``sync_curriculum_to_db`` against the packaged YAML
+    (the same content the production app would see), then compares
+    ``load_all_phases_from_db`` output against ``get_all_phases``.
+
+    Uses ``model_dump(mode='json')`` so equality failures produce a
+    readable diff instead of opaque Pydantic instance comparisons.
+    """
+    await _seed_with_real_content(db_session)
+
+    clear_cache()
+    yaml_phases = get_all_phases()
+    db_phases = await load_all_phases_from_db(db_session)
+
+    yaml_dump = [p.model_dump(mode="json") for p in yaml_phases]
+    db_dump = [p.model_dump(mode="json") for p in db_phases]
+
+    assert len(db_dump) == len(yaml_dump), (
+        f"DB returned {len(db_dump)} phases vs YAML's {len(yaml_dump)}"
+    )
+
+    for yaml_phase, db_phase in zip(yaml_dump, db_dump, strict=True):
+        assert db_phase == yaml_phase
+
+
+async def test_db_loader_returns_phases_in_order(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    phases = await load_all_phases_from_db(db_session)
+    orders = [p.order for p in phases]
+    assert orders == sorted(orders), f"phases not ordered: {orders}"
+
+
+async def test_db_loader_returns_steps_in_order_within_topic(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    phases = await load_all_phases_from_db(db_session)
+    for phase in phases:
+        for topic in phase.topics:
+            orders = [s.order for s in topic.learning_steps]
+            assert orders == sorted(orders), (
+                f"{phase.slug}/{topic.slug}: step orders {orders}"
+            )
+
+
+async def test_db_loader_returns_requirements_in_order_within_phase(
+    db_session: AsyncSession,
+) -> None:
+    """Slug-list order from _phase.yaml must round-trip through DB."""
+    await _seed_with_real_content(db_session)
+    db_phases = await load_all_phases_from_db(db_session)
+    clear_cache()
+    yaml_phases = get_all_phases()
+    yaml_by_slug = {p.slug: p for p in yaml_phases}
+    for db_phase in db_phases:
+        yaml_phase = yaml_by_slug[db_phase.slug]
+        db_req_ids = [
+            r.id
+            for r in (
+                db_phase.hands_on_verification.requirements
+                if db_phase.hands_on_verification
+                else []
+            )
+        ]
+        yaml_req_ids = [
+            r.id
+            for r in (
+                yaml_phase.hands_on_verification.requirements
+                if yaml_phase.hands_on_verification
+                else []
+            )
+        ]
+        assert db_req_ids == yaml_req_ids, (
+            f"{db_phase.slug}: DB requirement order {db_req_ids} "
+            f"differs from YAML {yaml_req_ids}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Lookup helpers
+# ---------------------------------------------------------------------------
+
+
+async def test_load_phase_by_slug_returns_known_phase(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    phase = await load_phase_by_slug_from_db(db_session, "phase0")
+    assert phase is not None
+    assert phase.slug == "phase0"
+
+
+async def test_load_phase_by_slug_returns_none_for_unknown(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    assert await load_phase_by_slug_from_db(db_session, "phase999") is None
+
+
+async def test_load_topic_by_id_returns_known_topic(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    clear_cache()
+    yaml_phases = get_all_phases()
+    sample_topic = yaml_phases[0].topics[0]
+    topic = await load_topic_by_id_from_db(db_session, sample_topic.id)
+    assert topic is not None
+    assert topic.id == sample_topic.id
+
+
+async def test_load_topic_by_id_returns_none_for_unknown(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    assert await load_topic_by_id_from_db(db_session, "no-such-topic") is None
+
+
+async def test_load_topic_by_slugs_returns_known_topic(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    topic = await load_topic_by_slugs_from_db(
+        db_session, "phase4", "monitoring-foundations-for-apps-and-vms"
+    )
+    assert topic is not None
+    assert topic.slug == "monitoring-foundations-for-apps-and-vms"
+
+
+async def test_load_topic_by_slugs_returns_none_when_phase_missing(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    assert await load_topic_by_slugs_from_db(db_session, "phase999", "anything") is None
+
+
+# ---------------------------------------------------------------------------
+# Soft-delete visibility
+# ---------------------------------------------------------------------------
+
+
+async def test_soft_deleted_phase_is_excluded(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    # Mark phase0 as soft-deleted in the DB; the loader must skip it.
+    p0 = (
+        await db_session.execute(
+            select(CurriculumPhase).where(CurriculumPhase.slug == "phase0")
+        )
+    ).scalar_one()
+    p0.deleted_at = datetime.now(UTC)
+    await db_session.flush()
+    db_session.expire_all()
+
+    phases = await load_all_phases_from_db(db_session)
+    assert all(p.slug != "phase0" for p in phases)
+
+
+async def test_soft_deleted_topic_is_excluded(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    # Pick a real topic and soft-delete it.
+    topic = (
+        await db_session.execute(
+            select(CurriculumTopic).where(CurriculumTopic.slug == "devops")
+        )
+    ).scalar_one()
+    target_phase_uuid = topic.phase_uuid
+    topic.deleted_at = datetime.now(UTC)
+    await db_session.flush()
+    db_session.expire_all()
+
+    phases = await load_all_phases_from_db(db_session)
+    phase = next(p for p in phases if p.uuid == target_phase_uuid)
+    assert all(t.slug != "devops" for t in phase.topics)
+
+
+async def test_soft_deleted_step_is_excluded(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    step = (
+        await db_session.execute(
+            select(CurriculumStep).where(CurriculumStep.deleted_at.is_(None)).limit(1)
+        )
+    ).scalar_one()
+    target_topic_uuid = step.topic_uuid
+    target_step_uuid = step.uuid
+    step.deleted_at = datetime.now(UTC)
+    await db_session.flush()
+    db_session.expire_all()
+
+    phases = await load_all_phases_from_db(db_session)
+    for phase in phases:
+        for topic in phase.topics:
+            if topic.uuid == target_topic_uuid:
+                assert all(s.uuid != target_step_uuid for s in topic.learning_steps)
+
+
+async def test_soft_deleted_requirement_is_excluded(
+    db_session: AsyncSession,
+) -> None:
+    await _seed_with_real_content(db_session)
+    req = (
+        await db_session.execute(
+            select(CurriculumRequirement)
+            .where(CurriculumRequirement.deleted_at.is_(None))
+            .limit(1)
+        )
+    ).scalar_one()
+    target_phase_uuid = req.phase_uuid
+    target_req_uuid = req.uuid
+    req.deleted_at = datetime.now(UTC)
+    await db_session.flush()
+    db_session.expire_all()
+
+    phases = await load_all_phases_from_db(db_session)
+    phase = next(p for p in phases if p.uuid == target_phase_uuid)
+    if phase.hands_on_verification:
+        assert all(
+            r.uuid != target_req_uuid for r in phase.hands_on_verification.requirements
+        )
+
+
+# ---------------------------------------------------------------------------
+# Requirement rehydration via discriminated union
+# ---------------------------------------------------------------------------
+
+
+async def test_requirement_rehydrates_to_correct_subclass(
+    db_session: AsyncSession,
+) -> None:
+    """A 'repo_fork' DB row must round-trip to a RepoForkRequirement."""
+    # Insert a synthetic phase + repo_fork requirement.
+    now = datetime.now(UTC)
+    phase = CurriculumPhase(
+        uuid=uuid4(),
+        legacy_id=99,
+        slug="phase99",
+        name="Phase 99",
+        description="d",
+        short_description="sd",
+        order=99,
+        deleted_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(phase)
+    await db_session.flush()
+
+    req_uuid = uuid4()
+    req = CurriculumRequirement(
+        uuid=req_uuid,
+        phase_uuid=phase.uuid,
+        id="repo-fork-test",
+        name="Test Fork",
+        description="desc",
+        submission_type="repo_fork",
+        order=1,
+        type_config={"required_repo": "owner/repo"},
+        deleted_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(req)
+    await db_session.flush()
+    db_session.expire_all()
+
+    phases = await load_all_phases_from_db(db_session)
+    phase99 = next(p for p in phases if p.slug == "phase99")
+    assert phase99.hands_on_verification is not None
+    rebuilt = phase99.hands_on_verification.requirements[0]
+    assert isinstance(rebuilt, RepoForkRequirement)
+    assert rebuilt.required_repo == "owner/repo"
+
+
+# ---------------------------------------------------------------------------
+# Empty curriculum (defense in depth)
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_db_returns_empty_tuple(
+    db_session: AsyncSession,
+) -> None:
+    """No content should give an empty tuple, not an error."""
+    phases = await load_all_phases_from_db(db_session)
+    assert phases == ()


### PR DESCRIPTION
Phase C PR 1 of the curriculum domain model rollout. Adds a DB-backed loader that returns the same Pydantic shape as the YAML loader. **Both coexist in this PR** -- the public API in `content_service.py` still uses YAML. PR 2 (next session) flips the switch.

Closes #464 partially. Part of #461.

## What ships

### Schema fix (gap from Phase B)
- New migration `0026_add_requirements_order` adds `requirements.order BigInteger NOT NULL` with `server_default='0'`. Phase B omitted this column; without it, DB-loaded requirements couldn't preserve YAML slug-list order.
- `CurriculumRequirement` ORM gets `order`.
- `content_sync._build_requirement_rows` sets order from slug-list position (mirrors topic-order pattern from #470).
- `_REQUIREMENT_UPDATE_FIELDS` includes `order` so idempotent re-runs detect reorderings.

### DB loader
- New `content_db_loader.py` with async `load_all_phases_from_db`, `load_phase_by_slug_from_db`, `load_topic_by_id_from_db`, `load_topic_by_slugs_from_db`.
- **Uncached by design** -- the Phase C decision was to drop the YAML loader's `@lru_cache` rather than carry it forward. ~466 active rows with proper indexes is single-digit milliseconds; caching without invalidation invites stale-data bugs.
- 5 simple queries (one per table) + Python grouping by parent UUID. Avoids JOIN fanout.
- Step rehydration merges `extra_config` JSONB back into the step payload (options, checklist, tips, done_when) before `model_validate`.
- Requirement rehydration via `HandsOnRequirementAdapter`; discriminator picks the right subclass, `type_config` validated per-type.
- Lookup helpers route through `load_all_phases_from_db` for consistent active-parent visibility.

## Tests (16 new, all passing)

The headline test is `test_db_loader_matches_yaml_loader_for_packaged_content`: runs the real sync, asserts `model_dump(mode='json')` equality between YAML loader and DB loader output for the entire curriculum tree. This is the regression guard that protects PR 2.

Plus order-preservation, lookup helpers, soft-delete visibility for every table, requirement-subclass round-trip via discriminated union, and empty-DB.

## What's NOT in this PR (deferred to PR 2)

- `content_service.get_all_phases()` etc. swapping to delegate to the DB loader
- Dropping `@lru_cache`
- Removing YAML-loader-internal tests
- Dog-food smoke

## Quality gates

- ruff + format + ty: green
- pytest API: 226 / shared: 465 (+16 new)
- squawk on new migration: clean
- end-to-end sync against local DB: 7/42/272/135/10 (unchanged)
- API `/health` + `/ready`: green