### PR TITLE
fix(curriculum): invoke sync as installed module to fix prod deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -251,7 +251,7 @@ jobs:
         # Matches the subprocess invocation in api/scripts/run_migrations.py.
         # Exercises the full deploy path so settings/packaging bugs surface
         # in CI instead of in the production migration job.
-        run: uv run python scripts/sync_curriculum.py
+        run: uv run python -m learn_to_cloud_shared.cli.sync_curriculum
 
       - name: Run API tests with coverage
         working-directory: api

--- a/api/alembic/versions/0026_add_requirements_order.py
+++ b/api/alembic/versions/0026_add_requirements_order.py
@@ -9,9 +9,10 @@ the DB faithfully represents the slug-list order from
 
 Schema effect: Adds ``requirements.order BIGINT NOT NULL`` with a
 ``server_default = '0'`` so existing rows are backfilled in place. The
-deploy-time sync (``scripts/sync_curriculum.py``) overwrites these
-values with the real position-based order on its next run, so the
-default never sticks.
+deploy-time sync
+(``python -m learn_to_cloud_shared.cli.sync_curriculum``) overwrites
+these values with the real position-based order on its next run, so
+the default never sticks.
 
 Rollback notes: Pure additive column. Downgrade drops it. Safe.
 

--- a/api/scripts/run_migrations.py
+++ b/api/scripts/run_migrations.py
@@ -11,14 +11,22 @@ Runs the full deploy-gate sequence:
 3. ``alembic check`` — assert the live schema matches ``Base.metadata``
    (autogenerate dry-run). Catches model fields added without
    corresponding migrations.
-4. ``sync_curriculum.py`` — populate curriculum DB tables from packaged
-   YAML (issue #463 / Phase B). Runs as a subprocess so its settings
-   singleton starts fresh as ``WorkerSettings``; sharing the Alembic
-   process would lock it to ``DatabaseSettings``.
+4. ``python -m learn_to_cloud_shared.cli.sync_curriculum`` — populate
+   curriculum DB tables from packaged YAML (issue #463 / Phase B).
+   Runs as a subprocess so its settings singleton starts fresh as
+   ``WorkerSettings``; sharing the Alembic process would lock it to
+   ``DatabaseSettings``.
 
 Steps 1-3 share the same ``Config`` instance and run in the same Python
 process, so the ``DefaultAzureCredential`` token cache is hit for the
 second and third calls — only one IMDS roundtrip happens per job.
+
+The sync CLI lives inside the installed package
+(``learn_to_cloud_shared.cli.sync_curriculum``) rather than a
+filesystem script, because the runtime container does not copy the
+package source tree -- only the installed wheel ends up in
+``/app/.venv``. ``python -m`` finds the module via the wheel's import
+path, which is portable across local devcontainer, CI, and production.
 """
 
 from __future__ import annotations
@@ -26,33 +34,25 @@ from __future__ import annotations
 import logging
 import subprocess
 import sys
-from pathlib import Path
 
 import alembic.command
 import alembic.config
 
 logger = logging.getLogger(__name__)
 
-# packages/learn-to-cloud-shared at the repo root.
-_SHARED_PACKAGE_DIR = (
-    Path(__file__).resolve().parent.parent.parent / "packages" / "learn-to-cloud-shared"
-)
-
 
 def _run_curriculum_sync() -> None:
     """Run the curriculum YAML -> DB sync as a separate subprocess.
 
     Settings-singleton isolation: this entry point's process has already
-    instantiated ``DatabaseSettings`` via Alembic. The sync script needs
+    instantiated ``DatabaseSettings`` via Alembic. The sync needs
     ``WorkerSettings`` (for ``content_dir_path``), so it must run in a
     fresh interpreter where ``configure_settings(WorkerSettings)`` can
     fire before any other code touches the settings tree.
     """
-    script = _SHARED_PACKAGE_DIR / "scripts" / "sync_curriculum.py"
-    logger.info("Running curriculum sync via subprocess: %s", script)
+    logger.info("Running curriculum sync via subprocess")
     result = subprocess.run(
-        [sys.executable, str(script)],
-        cwd=_SHARED_PACKAGE_DIR,
+        [sys.executable, "-m", "learn_to_cloud_shared.cli.sync_curriculum"],
         check=False,
     )
     if result.returncode != 0:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/cli/sync_curriculum.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/cli/sync_curriculum.py
@@ -1,23 +1,26 @@
 """Run the curriculum YAML -> DB sync (issue #463 / Phase B).
 
-Standalone entry point for the deploy-time curriculum sync. Must run
-in a separate Python process from the Alembic migration runner so the
-settings singleton starts fresh as WorkerSettings (Alembic uses
+Importable CLI entry point for the deploy-time curriculum sync. Must
+run in a separate Python process from the Alembic migration runner so
+the settings singleton starts fresh as WorkerSettings (Alembic uses
 DatabaseSettings; sharing the same process can lock the singleton to
 the wrong profile).
 
-Usage::
+Usage (anywhere the ``learn-to-cloud-shared`` wheel is installed)::
 
-    cd packages/learn-to-cloud-shared && uv run python scripts/sync_curriculum.py
+    python -m learn_to_cloud_shared.cli.sync_curriculum
 
 Exit codes:
     0  Sync completed cleanly.
     1  Sync aborted (validation error, collision, or other ContentSyncError).
     2  Unexpected exception.
 
+Lives inside the installed package (not in ``scripts/``) so the
+production runtime container has it via the wheel -- the runtime image
+does not copy the source tree (see ``api/Dockerfile``).
+
 Wired into ``api/scripts/run_migrations.py`` as a subprocess that runs
-after ``alembic upgrade head`` in the production Container Apps
-migration job.
+after ``alembic upgrade head`` in the Container Apps migration job.
 """
 
 from __future__ import annotations
@@ -31,7 +34,7 @@ from dataclasses import asdict
 # Register the minimal settings profile before importing anything that
 # touches the shared settings tree. WebSettings (the package default)
 # would demand GitHub OAuth secrets in production; not needed here.
-from learn_to_cloud_shared.core.config import (  # noqa: I001
+from learn_to_cloud_shared.core.config import (
     WorkerSettings,
     configure_settings,
 )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
@@ -8,8 +8,8 @@ re-runs leave ``updated_at`` untouched unless something actually
 changed.
 
 This module does NOT load on app startup. It's intended to run once
-per deploy via ``scripts/sync_curriculum.py`` in the Container Apps
-migration job, after ``alembic upgrade head``.
+per deploy via ``python -m learn_to_cloud_shared.cli.sync_curriculum``
+in the Container Apps migration job, after ``alembic upgrade head``.
 
 Design decisions (#461):
 - **Strict load**: bypasses the tolerant ``get_all_phases`` to avoid


### PR DESCRIPTION
## Production impact

After PR #473 merged, the production deploy ran migrations successfully but **left the curriculum_phases, curriculum_topics, curriculum_steps, curriculum_learning_objectives, and curriculum_requirements tables empty**.

The sync subprocess in `run_migrations.py` pointed at a filesystem path (`/packages/learn-to-cloud-shared/scripts/sync_curriculum.py`) that does not exist in the runtime container. The api Dockerfile only copies the built wheel into `/app/.venv`, not the package source tree.

## Fix

Move the sync entrypoint inside the installed package as a CLI module so the wheel includes it, and invoke via `python -m`. This is path-independent.

- `packages/learn-to-cloud-shared/scripts/sync_curriculum.py` -> `packages/learn-to-cloud-shared/src/learn_to_cloud_shared/cli/sync_curriculum.py`
- `api/scripts/run_migrations.py` uses `[sys.executable, '-m', 'learn_to_cloud_shared.cli.sync_curriculum']`
- `.github/workflows/deploy.yml` CI step uses `uv run python -m learn_to_cloud_shared.cli.sync_curriculum`
- Docstrings updated

## Verification

End-to-end against a fresh local DB:

```
alembic upgrade head -> 0026_add_requirements_order (head)
alembic check        -> No new upgrade operations detected.
curriculum sync      -> 7 phases, 42 topics, 272 steps, 135 objectives, 10 requirements
```

Also verified the sync invocation works from `/tmp` (proves path-independence).

## After merge

Watch the deploy workflow. Then verify production tables are populated.