### PR TITLE
feat(curriculum): switch runtime reads from YAML to DB (Phase C PR 2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -441,9 +441,17 @@ jobs:
           DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud" PYTHONPATH="$PWD/.python_packages/lib/site-packages" python - <<'PY'
           import asyncpg
           import function_app
-          from learn_to_cloud_shared.verification.requirements import get_requirement_by_id
+          from learn_to_cloud_shared.content_yaml_loader import (
+              get_all_phases_from_yaml,
+          )
 
-          assert get_requirement_by_id("journal-api-implementation") is not None
+          phases = get_all_phases_from_yaml()
+          assert any(
+              req.id == "journal-api-implementation"
+              for phase in phases
+              if phase.hands_on_verification
+              for req in phase.hands_on_verification.requirements
+          ), "journal-api-implementation requirement not found in packaged YAML"
           PY
 
       - name: Deploy verification Functions

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -13,7 +13,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
-from learn_to_cloud_shared.content_service import get_all_phases
 from learn_to_cloud_shared.core.azure_auth import close_credential
 from learn_to_cloud_shared.core.config import get_web_settings
 from learn_to_cloud_shared.core.database import (
@@ -42,7 +41,6 @@ from learn_to_cloud.routes import (
     pages_router,
     users_router,
 )
-from learn_to_cloud.services.progress_service import get_all_phase_ids
 
 # Configure stdlib logging before Azure Monitor adds any logging handlers.
 # Azure Monitor must run before fastapi.FastAPI() is instantiated so request
@@ -109,16 +107,6 @@ async def validation_exception_handler(
     )
 
 
-async def _background_warmup(app: fastapi.FastAPI) -> None:
-    """Preload content caches in the background after the app starts serving."""
-    try:
-        get_all_phases()
-        get_all_phase_ids()
-        logger.info("content.preloaded")
-    except Exception:
-        logger.warning("content.preload.failed", exc_info=True)
-
-
 @asynccontextmanager
 async def lifespan(app: fastapi.FastAPI):
     """Create DB engine at startup, dispose on shutdown."""
@@ -154,20 +142,9 @@ async def lifespan(app: fastapi.FastAPI):
         )
         raise
 
-    warmup_task = asyncio.create_task(_background_warmup(app))
-
     try:
         yield
     finally:
-        if not warmup_task.done():
-            warmup_task.cancel()
-        try:
-            await warmup_task
-        except asyncio.CancelledError:
-            pass  # Expected when shutdown cancels an in-progress warmup
-        except Exception:
-            logger.exception("background.task.failed")
-
         await close_github_client()
         await dispose_engine(app.state.engine)
         if get_web_settings().use_azure_postgres:

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -118,15 +118,16 @@ def _status_error_response(message: str, *, status_code: int = 400) -> HTMLRespo
     )
 
 
-def _render_processing_card(
+async def _render_processing_card(
     request: Request,
+    db: DbSession,
     current_user: AuthenticatedUser,
     token_data: VerificationStatusToken,
     token: str,
     *,
     delay_seconds: int,
 ) -> HTMLResponse:
-    requirement = get_requirement_by_id(token_data.requirement_id)
+    requirement = await get_requirement_by_id(db, token_data.requirement_id)
     if requirement is None:
         return HTMLResponse(_reload_verification_html())
 
@@ -186,7 +187,7 @@ async def _render_step_toggle(
     Looks up the step content and returns the combined step + progress
     HTML partials.
     """
-    topic = get_topic_by_id(topic_id)
+    topic = await get_topic_by_id(db, topic_id)
     step = None
     if topic:
         for s in topic.learning_steps:
@@ -288,6 +289,7 @@ async def htmx_uncomplete_step(
 @limiter.limit("10/minute")
 async def htmx_submit_verification(
     request: Request,
+    db: DbSession,
     current_user: CurrentUser,
     requirement_id: Annotated[str, Form(max_length=100)],
     submitted_value: Annotated[str, Form(max_length=2048)] = "",
@@ -308,7 +310,7 @@ async def htmx_submit_verification(
     user_id = current_user.user_id
     github_username = current_user.github_username
 
-    requirement = get_requirement_by_id(requirement_id)
+    requirement = await get_requirement_by_id(db, requirement_id)
 
     session_maker = request.app.state.session_maker
 
@@ -511,6 +513,7 @@ async def _start_async_job_and_render(
 @router.get("/verification/jobs/status", response_class=HTMLResponse)
 async def htmx_verification_job_status(
     request: Request,
+    db: DbSession,
     token: Annotated[str, Query(max_length=4096)],
     current_user: CurrentUser,
 ) -> HTMLResponse:
@@ -559,8 +562,9 @@ async def htmx_verification_job_status(
 
     status = durable_status.runtime_status.lower()
     if status in _ACTIVE_DURABLE_STATUSES:
-        return _render_processing_card(
+        return await _render_processing_card(
             request,
+            db,
             current_user,
             token_data,
             token,

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -12,7 +12,6 @@ from fastapi.responses import HTMLResponse
 from learn_to_cloud_shared.content_service import (
     get_all_phases,
     get_phase_by_slug,
-    get_topic_by_slugs,
 )
 from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.models import User
@@ -74,7 +73,7 @@ async def home_page(
 ) -> HTMLResponse:
     """Home page with phase overview."""
     user = await _get_user_or_none(db, user_id)
-    phases = get_all_phases()
+    phases = await get_all_phases(db)
 
     return templates.TemplateResponse(
         request,
@@ -91,7 +90,7 @@ async def curriculum_page(
 ) -> HTMLResponse:
     """Full curriculum overview with all phases and topics."""
     user = await _get_user_or_none(db, user_id)
-    phases = get_all_phases()
+    phases = await get_all_phases(db)
 
     return templates.TemplateResponse(
         request,
@@ -113,7 +112,7 @@ async def phase_page(
 ) -> HTMLResponse:
     """Single phase detail with topics and verification (requires auth)."""
     user = await _get_user_or_none(db, user_id)
-    phase = get_phase_by_slug(f"phase{phase_id}")
+    phase = await get_phase_by_slug(db, f"phase{phase_id}")
     if phase is None:
         return templates.TemplateResponse(
             request,
@@ -204,8 +203,10 @@ async def topic_page(
     """Single topic with learning steps (requires auth)."""
     user = await _get_user_or_none(db, user_id)
     phase_slug = f"phase{phase_id}"
-    phase = get_phase_by_slug(phase_slug)
-    topic = get_topic_by_slugs(phase_slug, topic_slug)
+    phase = await get_phase_by_slug(db, phase_slug)
+    topic = None
+    if phase is not None:
+        topic = next((t for t in phase.topics if t.slug == topic_slug), None)
 
     if phase is None or topic is None:
         return templates.TemplateResponse(

--- a/api/src/learn_to_cloud/services/dashboard_service.py
+++ b/api/src/learn_to_cloud/services/dashboard_service.py
@@ -53,7 +53,7 @@ async def get_dashboard_data(
     Returns phase list, overall stats, and continue-phase pointer.
     For unauthenticated users, returns phases only with zeroed stats.
     """
-    phases = get_all_phases()
+    phases = await get_all_phases(db)
 
     if user_id is None:
         return DashboardData(
@@ -64,7 +64,7 @@ async def get_dashboard_data(
             is_program_complete=False,
         )
 
-    user_progress = await fetch_user_progress(db, user_id)
+    user_progress = await fetch_user_progress(db, user_id, phases=phases)
 
     phase_summaries = [
         _build_phase_summary(

--- a/api/src/learn_to_cloud/services/progress_service.py
+++ b/api/src/learn_to_cloud/services/progress_service.py
@@ -2,16 +2,16 @@
 
 Progress is a derived value, not stored state:
 
-    progress = what the user has done ÷ what the content requires
+    progress = what the user has done / what the content requires
 
 Data sources:
 - Step completions: ``step_progress`` table (canonical)
 - Hands-on validations: ``submissions`` table (canonical)
-- Requirements: Content YAML (cached at startup)
+- Curriculum shape: DB-backed via ``content_service`` (synced from YAML
+  at deploy time)
 """
 
 import logging
-from functools import lru_cache
 
 from learn_to_cloud_shared.content_service import get_all_phases
 from learn_to_cloud_shared.repositories.progress_repository import (
@@ -29,61 +29,26 @@ from learn_to_cloud_shared.schemas import (
     TopicProgressData,
     UserProgress,
 )
-from learn_to_cloud_shared.verification.requirements import get_requirements_for_phase
+from learn_to_cloud_shared.verification.requirements import RequirementIndex
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
 
-@lru_cache(maxsize=1)
-def _build_phase_requirements() -> dict[int, PhaseRequirements]:
-    """Build PHASE_REQUIREMENTS from content JSON files at startup.
-
-    This derives step/topic counts from the actual content,
-    eliminating the need for hardcoded values that can get out of sync.
-    """
+def _build_phase_requirements(
+    phases: tuple[Phase, ...],
+) -> dict[int, PhaseRequirements]:
+    """Derive per-phase totals (topic count, step count) from loaded phases."""
     requirements: dict[int, PhaseRequirements] = {}
-    phases = get_all_phases()
-
     for phase in phases:
-        total_steps = 0
-        for topic in phase.topics:
-            total_steps += len(topic.learning_steps)
-
+        total_steps = sum(len(topic.learning_steps) for topic in phase.topics)
         requirements[phase.id] = PhaseRequirements(
             phase_id=phase.id,
             name=phase.name,
             topics=len(phase.topics),
             steps=total_steps,
         )
-
-    logger.info(
-        "phase_requirements.built",
-        extra={
-            "phases": len(requirements),
-            "steps": sum(r.steps for r in requirements.values()),
-        },
-    )
     return requirements
-
-
-def get_phase_requirements(phase_id: int) -> PhaseRequirements | None:
-    """Get requirements for a specific phase."""
-    return _build_phase_requirements().get(phase_id)
-
-
-def get_all_phase_ids() -> list[int]:
-    """Get all phase IDs in order."""
-    return sorted(_build_phase_requirements().keys())
-
-
-def _get_requirement_ids_by_phase() -> dict[int, set[str]]:
-    """Get current content requirement IDs grouped by phase."""
-    result: dict[int, set[str]] = {}
-    for phase_id in get_all_phase_ids():
-        requirements = get_requirements_for_phase(phase_id)
-        result[phase_id] = {r.id for r in requirements}
-    return result
 
 
 def _compute_phase_progress(
@@ -108,6 +73,8 @@ def _compute_phase_progress(
 async def fetch_user_progress(
     db: AsyncSession,
     user_id: int,
+    *,
+    phases: tuple[Phase, ...] | None = None,
 ) -> UserProgress:
     """Fetch complete progress data for a user.
 
@@ -116,23 +83,22 @@ async def fetch_user_progress(
     - Validated submissions (from submissions table, filtered to current content)
 
     Args:
-        db: Database session
-        user_id: User identifier
+        db: Database session.
+        user_id: User identifier.
+        phases: Optional pre-loaded phase tree. When provided (e.g. by the
+            dashboard service), avoids a redundant curriculum load.
 
     Returns a UserProgress object with all phase completion data.
     """
+    if phases is None:
+        phases = await get_all_phases(db)
 
-    phases = get_all_phases()
+    phase_requirements = _build_phase_requirements(phases)
+    req_index = RequirementIndex.from_phases(phases)
 
-    # Query validated requirement IDs from submissions (source of truth)
     sub_repo = SubmissionRepository(db)
     validated_req_ids = await sub_repo.get_validated_requirement_ids(user_id)
 
-    # Get current content requirement IDs per phase
-    req_ids_by_phase = _get_requirement_ids_by_phase()
-
-    # Canonical step completion: filter persisted completions by currently-defined
-    # step ids so content edits (add/remove/reorder) cannot inflate progress.
     step_repo = StepProgressRepository(db)
     all_topic_ids = [topic.id for phase in phases for topic in phase.topics]
     completed_by_topic = await step_repo.get_completed_for_topics(
@@ -149,12 +115,10 @@ async def fetch_user_progress(
         phase_steps[phase.id] = total_completed
 
     phase_progress_map: dict[int, PhaseProgress] = {}
-    for phase_id in get_all_phase_ids():
-        requirements = get_phase_requirements(phase_id)
-        if not requirements:
-            continue
-
-        current_req_ids = req_ids_by_phase.get(phase_id, set())
+    for phase_id, requirements in phase_requirements.items():
+        current_req_ids = {
+            req_id for req_id in req_index.requirement_ids_for_phase(phase_id)
+        }
         hands_on_validated = len(validated_req_ids & current_req_ids)
         hands_on_required = len(current_req_ids)
 
@@ -166,12 +130,11 @@ async def fetch_user_progress(
             hands_on_required=hands_on_required,
         )
 
-    all_phase_ids = get_all_phase_ids()
-    result = UserProgress(
-        user_id=user_id, phases=phase_progress_map, total_phases=len(all_phase_ids)
+    return UserProgress(
+        user_id=user_id,
+        phases=phase_progress_map,
+        total_phases=len(phase_requirements),
     )
-
-    return result
 
 
 def compute_topic_progress(
@@ -181,12 +144,6 @@ def compute_topic_progress(
     """Compute progress for a single topic.
 
     Topic Progress = Steps Completed / Total Steps
-
-    Args:
-        topic: The topic content definition
-        completed_steps: Set of completed step IDs
-    Returns:
-        TopicProgressData with completion status and percentages
     """
     valid_step_ids = {step.id for step in topic.learning_steps}
     steps_completed = len(completed_steps & valid_step_ids)
@@ -219,8 +176,8 @@ async def fetch_phase_progress(
 ) -> PhaseProgress:
     """Compute progress for a single phase with per-topic breakdown.
 
-    Used by the phase detail page. Same computation as fetch_user_progress
-    but scoped to one phase and includes topic-level detail.
+    Derives required totals and requirement ids from the passed ``phase``
+    object so we never re-load the curriculum here.
     """
     step_repo = StepProgressRepository(db)
     topic_ids = [t.id for t in phase.topics]
@@ -237,9 +194,9 @@ async def fetch_phase_progress(
         total_completed += tp.steps_completed
         total_steps += tp.steps_total
 
-    # Count validated submissions from source of truth, filtered to current content
-    hands_on_requirements = get_requirements_for_phase(phase.id)
-    current_req_ids = {r.id for r in hands_on_requirements}
+    current_req_ids: set[str] = set()
+    if phase.hands_on_verification:
+        current_req_ids = {r.id for r in phase.hands_on_verification.requirements}
     hands_on_required = len(current_req_ids)
 
     hands_on_validated = 0
@@ -249,30 +206,18 @@ async def fetch_phase_progress(
             user_id, current_req_ids
         )
 
-    requirements = get_phase_requirements(phase.id)
-    steps_required = requirements.steps if requirements else total_steps
-
-    result = _compute_phase_progress(
+    return _compute_phase_progress(
         phase_id=phase.id,
         steps_completed=total_completed,
-        steps_required=steps_required,
+        steps_required=total_steps,
         hands_on_validated=hands_on_validated,
         hands_on_required=hands_on_required,
         topic_progress=topic_progress,
     )
 
-    return result
-
 
 def phase_progress_to_data(progress: PhaseProgress) -> PhaseProgressData:
-    """Convert PhaseProgress to PhaseProgressData response model.
-
-    Args:
-        progress: The phase progress data
-
-    Returns:
-        PhaseProgressData suitable for API responses
-    """
+    """Convert PhaseProgress to PhaseProgressData response model."""
     return PhaseProgressData(
         steps_completed=progress.steps_completed,
         steps_required=progress.steps_required,

--- a/api/src/learn_to_cloud/services/steps_service.py
+++ b/api/src/learn_to_cloud/services/steps_service.py
@@ -34,13 +34,15 @@ class StepInvalidStepIdError(StepValidationError):
         super().__init__(f"Invalid step_id '{step_id}' for {topic_id}")
 
 
-def _resolve_step(topic_id: str, step_id: str) -> tuple[str, int, int]:
+async def _resolve_step(
+    db: AsyncSession, topic_id: str, step_id: str
+) -> tuple[str, int, int]:
     """Resolve and validate a step by stable step id.
 
     Returns:
         Tuple of (resolved_step_id, step_order, total_steps)
     """
-    topic = get_topic_by_id(topic_id)
+    topic = await get_topic_by_id(db, topic_id)
     if topic is None:
         raise StepUnknownTopicError(topic_id)
 
@@ -101,7 +103,7 @@ async def complete_step(
         Idempotent — completing an already-completed step is a no-op
         that returns the current state without error.
     """
-    resolved_step_id, step_order, _ = _resolve_step(topic_id, step_id)
+    resolved_step_id, step_order, _ = await _resolve_step(db, topic_id, step_id)
 
     step_repo = StepProgressRepository(db)
     phase_id = parse_phase_id_from_topic_id(topic_id)
@@ -165,7 +167,7 @@ async def uncomplete_step(
         StepUnknownTopicError: If topic_id doesn't exist in content
         StepInvalidStepIdError: If step_id doesn't exist in the topic
     """
-    resolved_step_id, step_order, _ = _resolve_step(topic_id, step_id)
+    resolved_step_id, step_order, _ = await _resolve_step(db, topic_id, step_id)
 
     step_repo = StepProgressRepository(db)
     deleted = await step_repo.delete_step(user_id, topic_id, resolved_step_id)

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -32,10 +32,8 @@ from learn_to_cloud_shared.verification.execution import (
     to_submission_data,
 )
 from learn_to_cloud_shared.verification.requirements import (
-    get_phase_id_for_requirement,
     get_prerequisite_phase,
-    get_requirement_by_id,
-    get_requirement_ids_for_phase,
+    load_requirement_index,
 )
 from opentelemetry import trace
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -168,17 +166,18 @@ async def _check_submission_preconditions(
 
     Opens a short-lived DB session for reads, then releases it before returning.
     """
-    requirement = get_requirement_by_id(requirement_id)
-    if not requirement:
-        raise RequirementNotFoundError(f"Requirement not found: {requirement_id}")
-
-    phase_id = get_phase_id_for_requirement(requirement_id)
-    if phase_id is None:
-        raise RequirementNotFoundError(
-            f"Requirement not mapped to a phase: {requirement_id}"
-        )
-
     async with session_maker() as read_session:
+        index = await load_requirement_index(read_session)
+        requirement = index.by_id.get(requirement_id)
+        if not requirement:
+            raise RequirementNotFoundError(f"Requirement not found: {requirement_id}")
+
+        phase_id = index.phase_id_by_req_id.get(requirement_id)
+        if phase_id is None:
+            raise RequirementNotFoundError(
+                f"Requirement not mapped to a phase: {requirement_id}"
+            )
+
         submission_repo = SubmissionRepository(read_session)
 
         existing = await submission_repo.get_by_user_and_requirement(
@@ -190,7 +189,7 @@ async def _check_submission_preconditions(
         # Sequential phase gating
         prereq_phase = get_prerequisite_phase(phase_id)
         if prereq_phase is not None:
-            prereq_req_ids = get_requirement_ids_for_phase(prereq_phase)
+            prereq_req_ids = index.requirement_ids_for_phase(prereq_phase)
             if prereq_req_ids:
                 all_done = await submission_repo.are_all_requirements_validated(
                     user_id, prereq_req_ids

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -259,6 +259,7 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
+                AsyncMock(),
                 current_user,
                 requirement_id="req-1",
                 submitted_value="test",
@@ -292,6 +293,7 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
+                AsyncMock(),
                 current_user,
                 requirement_id="req-1",
                 submitted_value="test",
@@ -345,6 +347,7 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
+                AsyncMock(),
                 current_user,
                 requirement_id="req-1",
                 submitted_value="https://github.com/user/repo",
@@ -401,6 +404,7 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
+                AsyncMock(),
                 current_user,
                 requirement_id="req-1",
                 submitted_value="https://github.com/user",
@@ -454,6 +458,7 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
+                AsyncMock(),
                 current_user,
                 requirement_id="req-1",
                 submitted_value="https://github.com/user",
@@ -506,6 +511,7 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
+                AsyncMock(),
                 current_user,
                 requirement_id="req-1",
                 submitted_value="https://github.com/user/repo",
@@ -550,6 +556,7 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
+                AsyncMock(),
                 current_user,
                 requirement_id="req-1",
                 submitted_value="https://github.com/user/repo",
@@ -590,6 +597,7 @@ class TestHtmxVerificationJobStatus:
         ):
             result = await htmx_verification_job_status(
                 request,
+                AsyncMock(),
                 token="signed-token",
                 current_user=current_user,
             )
@@ -624,6 +632,7 @@ class TestHtmxVerificationJobStatus:
         ):
             result = await htmx_verification_job_status(
                 request,
+                AsyncMock(),
                 token="signed-token",
                 current_user=current_user,
             )
@@ -669,6 +678,7 @@ class TestHtmxVerificationJobStatus:
 
             result = await htmx_verification_job_status(
                 request,
+                AsyncMock(),
                 token="signed-token",
                 current_user=current_user,
             )
@@ -714,6 +724,7 @@ class TestHtmxVerificationJobStatus:
 
             result = await htmx_verification_job_status(
                 request,
+                AsyncMock(),
                 token="signed-token",
                 current_user=current_user,
             )
@@ -758,6 +769,7 @@ class TestHtmxVerificationJobStatus:
 
             result = await htmx_verification_job_status(
                 request,
+                AsyncMock(),
                 token="signed-token",
                 current_user=current_user,
             )

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -81,7 +81,9 @@ class TestHomePage:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_all_phases", return_value=phases
+                "learn_to_cloud.routes.pages_routes.get_all_phases",
+                new_callable=AsyncMock,
+                return_value=phases,
             ),
             patch(
                 "learn_to_cloud.routes.pages_routes.get_user_by_id",
@@ -107,7 +109,9 @@ class TestHomePage:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_all_phases", return_value=phases
+                "learn_to_cloud.routes.pages_routes.get_all_phases",
+                new_callable=AsyncMock,
+                return_value=phases,
             ),
             patch(
                 "learn_to_cloud.routes.pages_routes.get_user_by_id",
@@ -133,7 +137,9 @@ class TestCurriculumPage:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_all_phases", return_value=phases
+                "learn_to_cloud.routes.pages_routes.get_all_phases",
+                new_callable=AsyncMock,
+                return_value=phases,
             ),
             patch(
                 "learn_to_cloud.routes.pages_routes.get_user_by_id",
@@ -160,6 +166,7 @@ class TestPhasePage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
+                new_callable=AsyncMock,
                 return_value=None,
             ),
             patch(
@@ -189,6 +196,7 @@ class TestPhasePage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
+                new_callable=AsyncMock,
                 return_value=phase,
             ),
             patch(
@@ -241,10 +249,7 @@ class TestTopicPage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
-                return_value=None,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_topic_by_slugs",
+                new_callable=AsyncMock,
                 return_value=None,
             ),
             patch(
@@ -264,15 +269,13 @@ class TestTopicPage:
         request, template = _mock_request(_patch_templates)
         mock_db = AsyncMock()
         phase = _fake_phase()
+        phase.topics = []  # no topic matches the requested slug
 
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
+                new_callable=AsyncMock,
                 return_value=phase,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_topic_by_slugs",
-                return_value=None,
             ),
             patch(
                 "learn_to_cloud.routes.pages_routes.get_user_by_id",
@@ -297,11 +300,8 @@ class TestTopicPage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
+                new_callable=AsyncMock,
                 return_value=phase,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_topic_by_slugs",
-                return_value=topic,
             ),
             patch(
                 "learn_to_cloud.routes.pages_routes.get_user_by_id",

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -84,7 +84,47 @@ def _fake_dashboard() -> DashboardData:
 
 
 @pytest_asyncio.fixture
-async def anon_client():
+async def _patched_content():
+    """Route smoke tests don't run against a real DB; redirect content reads
+    to the packaged YAML loader so routes get a real curriculum tree."""
+    from learn_to_cloud_shared.content_yaml_loader import (
+        get_all_phases_from_yaml,
+    )
+
+    yaml_phases = get_all_phases_from_yaml()
+
+    async def _all_phases(_db):
+        return yaml_phases
+
+    async def _phase_by_slug(_db, slug):
+        return next((p for p in yaml_phases if p.slug == slug), None)
+
+    async def _topic_by_id(_db, topic_id):
+        for phase in yaml_phases:
+            for topic in phase.topics:
+                if topic.id == topic_id:
+                    return topic
+        return None
+
+    with (
+        patch(
+            "learn_to_cloud.routes.pages_routes.get_all_phases",
+            side_effect=_all_phases,
+        ),
+        patch(
+            "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
+            side_effect=_phase_by_slug,
+        ),
+        patch(
+            "learn_to_cloud.routes.htmx_routes.get_topic_by_id",
+            side_effect=_topic_by_id,
+        ),
+    ):
+        yield yaml_phases
+
+
+@pytest_asyncio.fixture
+async def anon_client(_patched_content):
     """HTTP client for anonymous (unauthenticated) requests.
 
     Mocks DB dependencies and auth to return None (anonymous user).
@@ -120,7 +160,7 @@ async def anon_client():
 
 
 @pytest_asyncio.fixture
-async def auth_client():
+async def auth_client(_patched_content):
     """HTTP client for authenticated requests.
 
     Overrides auth to return user_id=1, mocks DB and user service.
@@ -219,9 +259,11 @@ class TestAuthPageSmoke:
 
     async def test_phase_page_renders(self, auth_client: AsyncClient):
         """GET /phase/1 renders the phase detail template."""
-        from learn_to_cloud_shared.content_service import get_all_phases
+        from learn_to_cloud_shared.content_yaml_loader import (
+            get_all_phases_from_yaml,
+        )
 
-        phases = get_all_phases()
+        phases = get_all_phases_from_yaml()
         if not phases:
             pytest.skip("No content phases loaded")
 
@@ -266,9 +308,13 @@ class TestAuthPageSmoke:
 
     async def test_topic_page_renders(self, auth_client: AsyncClient):
         """GET /phase/1/{topic_slug} renders the topic detail template."""
-        from learn_to_cloud_shared.content_service import get_phase_by_slug
+        from learn_to_cloud_shared.content_yaml_loader import (
+            get_all_phases_from_yaml,
+        )
 
-        phase = get_phase_by_slug("phase1")
+        phase = next(
+            (p for p in get_all_phases_from_yaml() if p.slug == "phase1"), None
+        )
         if not phase or not phase.topics:
             pytest.skip("No topics in phase1")
 

--- a/api/tests/services/test_progress_service.py
+++ b/api/tests/services/test_progress_service.py
@@ -19,7 +19,6 @@ from learn_to_cloud_shared.schemas import (
 )
 
 from learn_to_cloud.services.progress_service import (
-    _build_phase_requirements,
     compute_topic_progress,
     fetch_phase_progress,
     fetch_user_progress,
@@ -65,15 +64,8 @@ def _make_phase(
     )
 
 
-@pytest.fixture(autouse=True)
-def _clear_lru_caches():
-    """Clear lru_cache between tests to prevent leakage."""
-    yield
-    _build_phase_requirements.cache_clear()
-
-
 # ---------------------------------------------------------------------------
-# compute_topic_progress (pure function — no mocking needed)
+# compute_topic_progress (pure function -- no mocking needed)
 # ---------------------------------------------------------------------------
 
 
@@ -186,7 +178,7 @@ class TestFetchUserProgress:
         with (
             patch(
                 "learn_to_cloud.services.progress_service.get_all_phases",
-                autospec=True,
+                new_callable=AsyncMock,
                 return_value=(phase,),
             ),
             patch(
@@ -197,11 +189,6 @@ class TestFetchUserProgress:
                 "learn_to_cloud.services.progress_service.StepProgressRepository",
                 autospec=True,
             ) as MockStepRepo,
-            patch(
-                "learn_to_cloud.services.progress_service.get_requirements_for_phase",
-                autospec=True,
-                return_value=[],
-            ),
         ):
             MockSubRepo.return_value.get_validated_requirement_ids = AsyncMock(
                 return_value=set()
@@ -225,22 +212,10 @@ class TestFetchPhaseProgress:
         topic = _make_topic(steps=["s1", "s2"])
         phase = _make_phase(0, topics=[topic])
 
-        with (
-            patch(
-                "learn_to_cloud.services.progress_service.StepProgressRepository",
-                autospec=True,
-            ) as MockStepRepo,
-            patch(
-                "learn_to_cloud.services.progress_service.get_requirements_for_phase",
-                autospec=True,
-                return_value=[],
-            ),
-            patch(
-                "learn_to_cloud.services.progress_service.get_phase_requirements",
-                autospec=True,
-                return_value=None,
-            ),
-        ):
+        with patch(
+            "learn_to_cloud.services.progress_service.StepProgressRepository",
+            autospec=True,
+        ) as MockStepRepo:
             MockStepRepo.return_value.get_completed_for_topics = AsyncMock(
                 return_value={"phase0-topic1": {"s1", "s2"}}
             )
@@ -251,11 +226,22 @@ class TestFetchPhaseProgress:
 
     @pytest.mark.asyncio
     async def test_percentage_includes_hands_on(self):
-        """All steps done but hands-on incomplete → not 100%."""
-        topic = _make_topic(topic_id="phase3-topic1", steps=["s1", "s2"])
-        phase = _make_phase(3, topics=[topic])
+        """All steps done but hands-on incomplete should not be 100%."""
+        from learn_to_cloud_shared.schemas import PhaseHandsOnVerificationOverview
+        from learn_to_cloud_shared.testing.requirement_factories import (
+            journal_api_verifier_requirement,
+        )
 
-        mock_req = type("Req", (), {"id": "req1"})()
+        topic = _make_topic(topic_id="phase3-topic1", steps=["s1", "s2"])
+        req = journal_api_verifier_requirement(id="req1", name="R", description="d")
+        phase = _make_phase(3, topics=[topic])
+        phase = phase.model_copy(
+            update={
+                "hands_on_verification": PhaseHandsOnVerificationOverview(
+                    requirements=[req],
+                ),
+            }
+        )
 
         with (
             patch(
@@ -263,19 +249,9 @@ class TestFetchPhaseProgress:
                 autospec=True,
             ) as MockStepRepo,
             patch(
-                "learn_to_cloud.services.progress_service.get_requirements_for_phase",
-                autospec=True,
-                return_value=[mock_req],
-            ),
-            patch(
                 "learn_to_cloud.services.progress_service.SubmissionRepository",
                 autospec=True,
             ) as MockSubRepo,
-            patch(
-                "learn_to_cloud.services.progress_service.get_phase_requirements",
-                autospec=True,
-                return_value=None,
-            ),
         ):
             MockStepRepo.return_value.get_completed_for_topics = AsyncMock(
                 return_value={"phase3-topic1": {"s1", "s2"}}
@@ -285,7 +261,7 @@ class TestFetchPhaseProgress:
             )
             result = await fetch_phase_progress(AsyncMock(), user_id=1, phase=phase)
 
-        # 2 steps done + 0 hands-on out of 2 steps + 1 hands-on = 2/3 ≈ 67%
+        # 2 steps done + 0 hands-on out of 2 steps + 1 hands-on = 2/3 ~ 67%
         assert result.steps_completed == 2
         assert result.hands_on_validated == 0
         assert result.hands_on_required == 1
@@ -294,11 +270,22 @@ class TestFetchPhaseProgress:
 
     @pytest.mark.asyncio
     async def test_is_complete_when_all_done(self):
-        """All steps and hands-on done → 100% and is_complete."""
-        topic = _make_topic(topic_id="phase3-topic1", steps=["s1", "s2"])
-        phase = _make_phase(3, topics=[topic])
+        """All steps and hands-on done means 100% and is_complete."""
+        from learn_to_cloud_shared.schemas import PhaseHandsOnVerificationOverview
+        from learn_to_cloud_shared.testing.requirement_factories import (
+            journal_api_verifier_requirement,
+        )
 
-        mock_req = type("Req", (), {"id": "req1"})()
+        topic = _make_topic(topic_id="phase3-topic1", steps=["s1", "s2"])
+        req = journal_api_verifier_requirement(id="req1", name="R", description="d")
+        phase = _make_phase(3, topics=[topic])
+        phase = phase.model_copy(
+            update={
+                "hands_on_verification": PhaseHandsOnVerificationOverview(
+                    requirements=[req],
+                ),
+            }
+        )
 
         with (
             patch(
@@ -306,19 +293,9 @@ class TestFetchPhaseProgress:
                 autospec=True,
             ) as MockStepRepo,
             patch(
-                "learn_to_cloud.services.progress_service.get_requirements_for_phase",
-                autospec=True,
-                return_value=[mock_req],
-            ),
-            patch(
                 "learn_to_cloud.services.progress_service.SubmissionRepository",
                 autospec=True,
             ) as MockSubRepo,
-            patch(
-                "learn_to_cloud.services.progress_service.get_phase_requirements",
-                autospec=True,
-                return_value=None,
-            ),
         ):
             MockStepRepo.return_value.get_completed_for_topics = AsyncMock(
                 return_value={"phase3-topic1": {"s1", "s2"}}

--- a/api/tests/services/test_steps_service.py
+++ b/api/tests/services/test_steps_service.py
@@ -57,37 +57,42 @@ def _make_topic(
 
 @pytest.mark.unit
 class TestResolveStep:
-    def test_valid_step_resolved(self):
+    @pytest.mark.asyncio
+    async def test_valid_step_resolved(self):
         topic = _make_topic(steps=["step-intro", "step-basics"])
         with patch(
             "learn_to_cloud.services.steps_service.get_topic_by_id",
-            autospec=True,
+            new_callable=AsyncMock,
             return_value=topic,
         ):
-            step_id, order, total = _resolve_step("phase0-topic1", "step-intro")
+            step_id, order, total = await _resolve_step(
+                AsyncMock(), "phase0-topic1", "step-intro"
+            )
         assert step_id == "step-intro"
         assert order == 0
         assert total == 2
 
-    def test_unknown_topic_raises(self):
+    @pytest.mark.asyncio
+    async def test_unknown_topic_raises(self):
         with patch(
             "learn_to_cloud.services.steps_service.get_topic_by_id",
-            autospec=True,
+            new_callable=AsyncMock,
             return_value=None,
         ):
             with pytest.raises(StepUnknownTopicError) as exc_info:
-                _resolve_step("nonexistent", "step-1")
+                await _resolve_step(AsyncMock(), "nonexistent", "step-1")
             assert exc_info.value.topic_id == "nonexistent"
 
-    def test_invalid_step_id_raises(self):
+    @pytest.mark.asyncio
+    async def test_invalid_step_id_raises(self):
         topic = _make_topic(steps=["step-intro"])
         with patch(
             "learn_to_cloud.services.steps_service.get_topic_by_id",
-            autospec=True,
+            new_callable=AsyncMock,
             return_value=topic,
         ):
             with pytest.raises(StepInvalidStepIdError) as exc_info:
-                _resolve_step("phase0-topic1", "nonexistent-step")
+                await _resolve_step(AsyncMock(), "phase0-topic1", "nonexistent-step")
             assert exc_info.value.step_id == "nonexistent-step"
 
 

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.schemas import HandsOnRequirement
+from learn_to_cloud_shared.verification.requirements import RequirementIndex
 
 from learn_to_cloud.services.submissions_service import (
     AlreadyValidatedError,
@@ -23,29 +24,6 @@ from learn_to_cloud.services.submissions_service import (
     create_verification_job,
     get_phase_submission_context,
 )
-
-
-@pytest.fixture(autouse=True)
-def _mock_phase_id_mapping():
-    """Mock requirement → phase mapping and prerequisite functions for all tests."""
-    with (
-        patch(
-            "learn_to_cloud.services.submissions_service.get_phase_id_for_requirement",
-            autospec=True,
-            return_value=3,
-        ),
-        patch(
-            "learn_to_cloud.services.submissions_service.get_prerequisite_phase",
-            autospec=True,
-            return_value=None,
-        ),
-        patch(
-            "learn_to_cloud.services.submissions_service.get_requirement_ids_for_phase",
-            autospec=True,
-            return_value=[],
-        ),
-    ):
-        yield
 
 
 def _make_mock_requirement(
@@ -91,8 +69,8 @@ def _mock_session_maker():
     """Create a mock async_sessionmaker for testing.
 
     Returns a callable that produces async context managers yielding
-    an AsyncMock session.  Since tests patch SubmissionRepository,
-    the actual session object is irrelevant — it just needs to support
+    an AsyncMock session. Since tests patch SubmissionRepository,
+    the actual session object is irrelevant -- it just needs to support
     the async-with protocol and have a .commit() coroutine.
     """
 
@@ -103,20 +81,60 @@ def _mock_session_maker():
     return _factory
 
 
+def _build_index(
+    requirement: HandsOnRequirement | None,
+    *,
+    phase_id: int = 3,
+    prereq_phase: int | None = None,
+    prereq_req_ids: list[str] | None = None,
+) -> RequirementIndex:
+    """Build a RequirementIndex containing the given requirement plus optional
+    prerequisite-phase requirement ids.
+
+    The submissions service only ever reads ``by_id``, ``phase_id_by_req_id``,
+    and ``requirement_ids_for_phase`` from the index. We construct the prereq
+    requirements with the real factory so the index's type signature stays
+    honest.
+    """
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        journal_api_verifier_requirement,
+    )
+
+    by_phase: dict[int, list[HandsOnRequirement]] = {}
+    by_id: dict[str, HandsOnRequirement] = {}
+    phase_id_by_req_id: dict[str, int] = {}
+    if requirement is not None:
+        by_phase[phase_id] = [requirement]
+        by_id[requirement.id] = requirement
+        phase_id_by_req_id[requirement.id] = phase_id
+    if prereq_phase is not None and prereq_req_ids:
+        prereq_reqs = [
+            journal_api_verifier_requirement(id=req_id, name="stub", description="stub")
+            for req_id in prereq_req_ids
+        ]
+        by_phase[prereq_phase] = list(prereq_reqs)
+        for req in prereq_reqs:
+            phase_id_by_req_id[req.id] = prereq_phase
+    return RequirementIndex(
+        by_phase=by_phase,
+        by_id=by_id,
+        phase_id_by_req_id=phase_id_by_req_id,
+    )
+
+
 @pytest.mark.unit
 class TestSubmissionValidationErrors:
     """Tests for error handling in create_verification_job."""
 
     @pytest.mark.asyncio
     async def test_requirement_not_found_raises_error(self):
-        """Unknown requirement ID should raise RequirementNotFoundError."""
         mock_session_maker = _mock_session_maker()
 
         with (
             patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
-                autospec=True,
-                return_value=None,
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(None),
             ),
             pytest.raises(RequirementNotFoundError),
         ):
@@ -130,7 +148,6 @@ class TestSubmissionValidationErrors:
 
     @pytest.mark.asyncio
     async def test_github_username_required_for_journal_api_verifier(self):
-        """JOURNAL_API_VERIFIER without github_username should raise error."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.JOURNAL_API_VERIFIER
@@ -138,9 +155,9 @@ class TestSubmissionValidationErrors:
 
         with (
             patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
-                autospec=True,
-                return_value=mock_requirement,
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(mock_requirement),
             ),
             patch(
                 "learn_to_cloud.services.submissions_service.SubmissionRepository",
@@ -157,25 +174,22 @@ class TestSubmissionValidationErrors:
                     user_id=123,
                     requirement_id="test-requirement",
                     submitted_value="https://github.com/user/repo",
-                    github_username=None,  # Missing!
+                    github_username=None,
                 )
 
 
 @pytest.mark.unit
 class TestAlreadyValidatedShortCircuit:
-    """Tests for already-validated requirement short-circuit."""
-
     @pytest.mark.asyncio
     async def test_already_validated_raises_error(self):
-        """Re-submitting a validated requirement should raise AlreadyValidatedError."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement()
 
         with (
             patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
-                autospec=True,
-                return_value=mock_requirement,
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(mock_requirement),
             ),
             patch(
                 "learn_to_cloud.services.submissions_service.SubmissionRepository",
@@ -183,7 +197,6 @@ class TestAlreadyValidatedShortCircuit:
             ) as mock_repo_class,
         ):
             mock_repo = MagicMock()
-            # Existing submission is already validated
             mock_repo.get_by_user_and_requirement = AsyncMock(
                 return_value=MagicMock(is_validated=True)
             )
@@ -200,15 +213,14 @@ class TestAlreadyValidatedShortCircuit:
 
     @pytest.mark.asyncio
     async def test_failed_submission_allows_retry(self):
-        """A previously failed (not validated) submission should allow retry."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement()
 
         with (
             patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
-                autospec=True,
-                return_value=mock_requirement,
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(mock_requirement),
             ),
             patch(
                 "learn_to_cloud.services.submissions_service.SubmissionRepository",
@@ -220,7 +232,6 @@ class TestAlreadyValidatedShortCircuit:
             ) as mock_job_repo_class,
         ):
             mock_repo = MagicMock()
-            # Existing submission is NOT validated — retry allowed
             mock_repo.get_by_user_and_requirement = AsyncMock(
                 return_value=_make_mock_submission()
             )
@@ -248,12 +259,8 @@ class TestAlreadyValidatedShortCircuit:
 
 @pytest.mark.unit
 class TestSequentialPhaseGating:
-    """Tests for sequential phase verification gating."""
-
     @pytest.mark.asyncio
     async def test_submission_blocked_when_prior_phase_incomplete(self):
-        """Submission should raise PriorPhaseNotCompleteError
-        when prerequisite phase is incomplete."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.DEPLOYED_API,
@@ -261,24 +268,14 @@ class TestSequentialPhaseGating:
 
         with (
             patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
-                autospec=True,
-                return_value=mock_requirement,
-            ),
-            patch(
-                "learn_to_cloud.services.submissions_service.get_phase_id_for_requirement",
-                return_value=4,  # no autospec: autouse fixture
-            ),
-            patch(
-                "learn_to_cloud.services.submissions_service.get_prerequisite_phase",
-                return_value=3,  # no autospec: autouse fixture
-            ),
-            patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_ids_for_phase",
-                return_value=[
-                    "journal-pr-logging",
-                    "journal-pr-get-entry",
-                ],  # no autospec: autouse fixture
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(
+                    mock_requirement,
+                    phase_id=4,
+                    prereq_phase=3,
+                    prereq_req_ids=["journal-pr-logging", "journal-pr-get-entry"],
+                ),
             ),
             patch(
                 "learn_to_cloud.services.submissions_service.SubmissionRepository",
@@ -294,7 +291,7 @@ class TestSequentialPhaseGating:
                 await create_verification_job(
                     session_maker=mock_session_maker,
                     user_id=123,
-                    requirement_id="deployed-journal-api",
+                    requirement_id="test-requirement",
                     submitted_value="https://api.example.com",
                     github_username="user",
                 )
@@ -304,7 +301,6 @@ class TestSequentialPhaseGating:
 
     @pytest.mark.asyncio
     async def test_submission_allowed_when_prior_phase_complete(self):
-        """Submission should proceed when prerequisite phase is fully verified."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.DEPLOYED_API,
@@ -312,21 +308,14 @@ class TestSequentialPhaseGating:
 
         with (
             patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
-                autospec=True,
-                return_value=mock_requirement,
-            ),
-            patch(
-                "learn_to_cloud.services.submissions_service.get_phase_id_for_requirement",
-                return_value=4,  # no autospec: autouse fixture
-            ),
-            patch(
-                "learn_to_cloud.services.submissions_service.get_prerequisite_phase",
-                return_value=3,  # no autospec: autouse fixture
-            ),
-            patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_ids_for_phase",
-                return_value=["journal-pr-logging"],  # no autospec: autouse fixture
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(
+                    mock_requirement,
+                    phase_id=4,
+                    prereq_phase=3,
+                    prereq_req_ids=["journal-pr-logging"],
+                ),
             ),
             patch(
                 "learn_to_cloud.services.submissions_service.SubmissionRepository",
@@ -352,7 +341,7 @@ class TestSequentialPhaseGating:
             result = await create_verification_job(
                 session_maker=mock_session_maker,
                 user_id=123,
-                requirement_id="deployed-journal-api",
+                requirement_id="test-requirement",
                 submitted_value="https://api.example.com",
                 github_username="user",
             )
@@ -365,12 +354,8 @@ class TestSequentialPhaseGating:
 
 @pytest.mark.unit
 class TestSyncDispatchBranch:
-    """Tests for the sync (phase 0-2) execution branch in create_verification_job."""
-
     @pytest.mark.asyncio
     async def test_sync_type_runs_in_process_and_returns_sync_result(self):
-        """A sync submission type calls execute_sync_submission_validation
-        and never touches VerificationJobRepository."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.GITHUB_PROFILE,
@@ -379,9 +364,9 @@ class TestSyncDispatchBranch:
 
         with (
             patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
-                autospec=True,
-                return_value=mock_requirement,
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(mock_requirement),
             ),
             patch(
                 "learn_to_cloud.services.submissions_service.SubmissionRepository",
@@ -412,13 +397,10 @@ class TestSyncDispatchBranch:
         assert isinstance(result, SyncVerificationResult)
         assert result.submission_result is sentinel_result
         mock_sync_execute.assert_awaited_once()
-        # Critical: sync path must not create or look up VerificationJob rows.
         mock_job_repo_class.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_async_type_returns_verification_job_submission(self):
-        """A phase 3+ submission type still goes through the Durable
-        VerificationJob path and returns VerificationJobSubmission."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.JOURNAL_API_VERIFIER,
@@ -427,9 +409,9 @@ class TestSyncDispatchBranch:
 
         with (
             patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
-                autospec=True,
-                return_value=mock_requirement,
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(mock_requirement),
             ),
             patch(
                 "learn_to_cloud.services.submissions_service.SubmissionRepository",
@@ -465,15 +447,11 @@ class TestSyncDispatchBranch:
         assert isinstance(result, VerificationJobSubmission)
         assert result.job is mock_job
         assert result.created is True
-        # Critical: async path must not run the in-request sync validator.
         mock_sync_execute.assert_not_awaited()
         mock_job_repo.create_or_get_active.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_sync_preconditions_still_enforced(self):
-        """Sync path still rejects already-validated requirements before
-        running the validator. Guards against regression where the branch
-        skips _check_submission_preconditions."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.CTF_TOKEN,
@@ -481,9 +459,9 @@ class TestSyncDispatchBranch:
 
         with (
             patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
-                autospec=True,
-                return_value=mock_requirement,
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(mock_requirement),
             ),
             patch(
                 "learn_to_cloud.services.submissions_service.SubmissionRepository",
@@ -513,8 +491,6 @@ class TestSyncDispatchBranch:
 
     @pytest.mark.asyncio
     async def test_sync_path_requires_github_username_for_ctf_token(self):
-        """CTF_TOKEN without github_username must still raise even on the
-        sync path, since the validator can't run anonymously."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.CTF_TOKEN,
@@ -522,9 +498,9 @@ class TestSyncDispatchBranch:
 
         with (
             patch(
-                "learn_to_cloud.services.submissions_service.get_requirement_by_id",
-                autospec=True,
-                return_value=mock_requirement,
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(mock_requirement),
             ),
             patch(
                 "learn_to_cloud.services.submissions_service.SubmissionRepository",
@@ -597,12 +573,10 @@ class TestGetPhaseSubmissionContext:
             '[{"task_name":"A","passed":true,"feedback":"ok",'
             '"next_steps":"review the rubric"}]'
         )
-        with (
-            patch(
-                "learn_to_cloud.services.submissions_service.SubmissionRepository",
-                autospec=True,
-            ) as MockRepo,
-        ):
+        with patch(
+            "learn_to_cloud.services.submissions_service.SubmissionRepository",
+            autospec=True,
+        ) as MockRepo:
             MockRepo.return_value.get_by_user_and_phase = AsyncMock(
                 return_value=[mock_sub]
             )

--- a/packages/learn-to-cloud-shared/scripts/validate_content.py
+++ b/packages/learn-to-cloud-shared/scripts/validate_content.py
@@ -1,6 +1,6 @@
 """Validate curriculum content for cross-file integrity (issue #462).
 
-Runs the strict validators in ``content_service.validate_content()``
+Runs the strict validators in ``content_yaml_loader.validate_content()``
 against the currently-loaded YAML and exits non-zero on any violation.
 
 Run from the package root::
@@ -18,7 +18,7 @@ import sys
 # anything that touches the shared settings tree. The shared package
 # defaults to WebSettings, which demands GitHub OAuth secrets in
 # production -- irrelevant for a content validator. WorkerSettings is
-# enough; it has content_dir_path. This MUST run before content_service
+# enough; it has content_dir_path. This MUST run before the YAML loader
 # is imported, so the import below is intentionally out of order.
 from learn_to_cloud_shared.core.config import (
     WorkerSettings,
@@ -27,7 +27,7 @@ from learn_to_cloud_shared.core.config import (
 
 configure_settings(WorkerSettings)
 
-from learn_to_cloud_shared.content_service import (  # noqa: E402
+from learn_to_cloud_shared.content_yaml_loader import (  # noqa: E402
     clear_cache,
     validate_content,
 )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py
@@ -1,416 +1,50 @@
-"""Content loading service.
+"""Public curriculum read API (DB-backed).
 
-This module loads course content from YAML files and provides
-a clean interface for accessing phases and topics.
+After Phase C (issue #461), runtime reads in the API go through the DB
+loader populated at deploy time by ``content_sync.py``. This module
+provides the thin async wrappers callers use: pass an
+``AsyncSession`` and get back the same Pydantic shape the YAML loader
+used to return.
 
-Content files are packaged with learn_to_cloud_shared and loaded once at startup
-for performance.
+Per-request loads are uncached by design -- the curriculum is small
+(~466 active rows, all indexed, 5 simple SELECTs) and a process-level
+cache without invalidation creates a class of stale-data bugs we want
+to avoid.
+
+For the deploy-time YAML to DB sync and the strict cross-file
+validators, use ``learn_to_cloud_shared.content_yaml_loader``.
 """
 
 from __future__ import annotations
 
-import logging
-from functools import lru_cache
-from pathlib import Path
-from typing import Any
+from sqlalchemy.ext.asyncio import AsyncSession
 
-import yaml
-from pydantic import ValidationError
-
-from learn_to_cloud_shared.core.config import get_worker_settings
-from learn_to_cloud_shared.schemas import (
-    HandsOnRequirementAdapter,
-    Phase,
-    Topic,
+from learn_to_cloud_shared.content_db_loader import (
+    load_all_phases_from_db,
+    load_phase_by_slug_from_db,
+    load_topic_by_id_from_db,
+    load_topic_by_slugs_from_db,
 )
-
-logger = logging.getLogger(__name__)
-
-
-class ContentValidationError(Exception):
-    """Raised when content YAML fails structural validation."""
+from learn_to_cloud_shared.schemas import Phase, Topic
 
 
-def _validate_topic_payload(data: dict, topic_file: Path) -> None:
-    """Validate topic payload learning step IDs are explicit and unique."""
-    topic_id = str(data.get("id", "")).strip()
-    topic_name = topic_id or topic_file.stem
-    steps = data.get("learning_steps", [])
-    if not isinstance(steps, list):
-        raise ContentValidationError("learning_steps must be a list")
-
-    seen: set[str] = set()
-    for step in steps:
-        if not isinstance(step, dict):
-            raise ContentValidationError("Each learning step must be a mapping")
-
-        step_id = str(step.get("id", "")).strip()
-        if not step_id:
-            raise ContentValidationError(
-                f"Missing learning_steps[].id in topic '{topic_name}'"
-            )
-        if len(step_id) > 100:
-            raise ContentValidationError(
-                f"learning_steps[].id '{step_id[:60]}...' is {len(step_id)} chars "
-                f"(max 100) in topic '{topic_name}'"
-            )
-        if step_id in seen:
-            raise ContentValidationError(
-                f"Duplicate learning_steps[].id '{step_id}' in topic '{topic_name}'"
-            )
-        seen.add(step_id)
+async def get_all_phases(db: AsyncSession) -> tuple[Phase, ...]:
+    """Get all active phases in order, with nested topics and requirements."""
+    return await load_all_phases_from_db(db)
 
 
-def _get_content_dir() -> Path:
-    """Get the content directory from settings.
-
-    Lazily accessed to avoid module-level settings initialization.
-    """
-    return get_worker_settings().content_dir_path
+async def get_phase_by_slug(db: AsyncSession, slug: str) -> Phase | None:
+    """Get a phase by its slug (e.g. ``phase1``)."""
+    return await load_phase_by_slug_from_db(db, slug)
 
 
-def _load_topic(phase_dir: Path, topic_slug: str, *, order: int) -> Topic | None:
-    """Load a single topic from its YAML file.
-
-    ``order`` is supplied by the caller from the topic's position in the
-    parent phase's ``topics:`` slug list. Topic YAML files must not
-    carry their own ``order`` field; the loader rejects it to keep one
-    source of truth (issue #463).
-    """
-    topic_file = phase_dir / f"{topic_slug}.yaml"
-    if not topic_file.exists():
-        return None
-
-    try:
-        with open(topic_file, encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-        if isinstance(data, dict) and "order" in data:
-            raise ContentValidationError(
-                f"topic {topic_file.name}: 'order' field is no longer allowed. "
-                "Topic order is derived from the position in _phase.yaml's "
-                "'topics:' list -- remove the 'order' field from this file."
-            )
-        _validate_topic_payload(data, topic_file)
-        data["order"] = order
-        return Topic.model_validate(data)
-    except (yaml.YAMLError, ContentValidationError, ValueError, KeyError):
-        logger.exception(
-            "content.topic.load_failed",
-            extra={
-                "topic_slug": topic_slug,
-                "path": str(topic_file),
-            },
-        )
-        return None
+async def get_topic_by_id(db: AsyncSession, topic_id: str) -> Topic | None:
+    """Get a topic by its legacy_id (e.g. ``phase0-topic1``)."""
+    return await load_topic_by_id_from_db(db, topic_id)
 
 
-def _load_requirement(phase_dir: Path, requirement_slug: str) -> Any | None:
-    """Load a single hands-on requirement from its YAML file.
-
-    Returns one of the typed ``HandsOnRequirement`` subclasses (resolved
-    via the discriminated union) or ``None`` if the file is missing or
-    fails validation.
-    """
-    req_file = phase_dir / "requirements" / f"{requirement_slug}.yaml"
-    if not req_file.exists():
-        return None
-
-    try:
-        with open(req_file, encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-        if not isinstance(data, dict):
-            raise ContentValidationError(
-                f"requirement {req_file.name} must be a YAML mapping"
-            )
-        file_stem = req_file.stem
-        yaml_id = str(data.get("id", "")).strip()
-        if yaml_id != file_stem:
-            raise ContentValidationError(
-                f"requirement {req_file.name}: id '{yaml_id}' does not match "
-                f"filename stem '{file_stem}'"
-            )
-        return HandsOnRequirementAdapter.validate_python(data)
-    except (
-        yaml.YAMLError,
-        ContentValidationError,
-        ValidationError,
-        ValueError,
-        KeyError,
-    ):
-        logger.exception(
-            "content.requirement.load_failed",
-            extra={
-                "requirement_slug": requirement_slug,
-                "path": str(req_file),
-            },
-        )
-        return None
-
-
-def _load_phase(phase_slug: str) -> Phase | None:
-    """Load a single phase from its directory."""
-    phase_dir = _get_content_dir() / phase_slug
-    meta_file = phase_dir / "_phase.yaml"
-
-    if not meta_file.exists():
-        return None
-
-    try:
-        with open(meta_file, encoding="utf-8") as f:
-            data: dict = yaml.safe_load(f)
-
-        # "topics" in the YAML is a list of slug strings; resolve to Topic objects.
-        # The slug's position in the list becomes the topic's ``order`` -- one
-        # source of truth (issue #463).
-        topic_slugs: list[str] = data.get("topics", [])
-        topics = [
-            t
-            for idx, slug in enumerate(topic_slugs)
-            if (t := _load_topic(phase_dir, slug, order=idx + 1)) is not None
-        ]
-        data["topic_slugs"] = topic_slugs
-        data["topics"] = topics
-
-        # ``hands_on_verification.requirements`` is a list of slug strings in
-        # YAML; resolve each to a ``HandsOnRequirement`` loaded from
-        # ``phase<N>/requirements/<slug>.yaml``.
-        hov = data.get("hands_on_verification")
-        if isinstance(hov, dict):
-            requirement_slugs: list[str] = hov.get("requirements", []) or []
-            if not all(isinstance(s, str) for s in requirement_slugs):
-                raise ContentValidationError(
-                    f"phase '{phase_slug}' hands_on_verification.requirements "
-                    "must be a list of slug strings"
-                )
-            loaded_requirements = [
-                r
-                for slug in requirement_slugs
-                if (r := _load_requirement(phase_dir, slug)) is not None
-            ]
-            hov["requirement_slugs"] = requirement_slugs
-            hov["requirements"] = loaded_requirements
-
-        return Phase.model_validate(data)
-    except (yaml.YAMLError, ContentValidationError, ValueError, KeyError):
-        logger.exception(
-            "content.phase.load_failed",
-            extra={
-                "phase_slug": phase_slug,
-                "path": str(meta_file),
-            },
-        )
-        return None
-
-
-@lru_cache(maxsize=1)
-def get_all_phases() -> tuple[Phase, ...]:
-    """Get all phases in order.
-
-    Results are cached for performance.
-    Dynamically discovers phase directories (phase0, phase1, etc.).
-    """
-    phases: list[Phase] = []
-    content_dir = _get_content_dir()
-    if not content_dir.exists():
-        return ()
-
-    for phase_dir in sorted(content_dir.iterdir()):
-        if phase_dir.is_dir() and phase_dir.name.startswith("phase"):
-            phase = _load_phase(phase_dir.name)
-            if phase:
-                phases.append(phase)
-
-    return tuple(sorted(phases, key=lambda p: p.order))
-
-
-def get_phase_by_slug(slug: str) -> Phase | None:
-    """Get a phase by its slug."""
-    for phase in get_all_phases():
-        if phase.slug == slug:
-            return phase
-    return None
-
-
-def get_topic_by_id(topic_id: str) -> Topic | None:
-    """Get a topic by its ID (e.g., 'phase0-topic1')."""
-    for phase in get_all_phases():
-        for topic in phase.topics:
-            if topic.id == topic_id:
-                return topic
-    return None
-
-
-def get_topic_by_slugs(phase_slug: str, topic_slug: str) -> Topic | None:
-    """Get a topic by phase and topic slugs."""
-    phase = get_phase_by_slug(phase_slug)
-    if not phase:
-        return None
-    for topic in phase.topics:
-        if topic.slug == topic_slug:
-            return topic
-    return None
-
-
-def clear_cache() -> None:
-    """Clear the content cache (useful for testing)."""
-    get_all_phases.cache_clear()
-
-
-# ---------------------------------------------------------------------------
-# Cross-file validators (issue #462)
-#
-# get_all_phases() is intentionally tolerant -- it logs and skips broken
-# files so the app keeps running on partially-bad content. The validators
-# below are STRICT: they raise on the first violation. They are intended
-# for CI and for the sync step that writes YAML into the DB.
-# ---------------------------------------------------------------------------
-
-
-def _collect_uuids(phases: tuple[Phase, ...]) -> list[tuple[str, str]]:
-    """Return (uuid_str, locator) tuples for every curriculum entity.
-
-    Locator is a human-readable path like ``phases[0]`` or
-    ``topics[phase0-topic5].learning_steps[s1]`` so duplicates can be
-    pointed at concretely.
-    """
-    items: list[tuple[str, str]] = []
-    for phase in phases:
-        items.append((str(phase.uuid), f"phase[{phase.slug}]"))
-        if phase.hands_on_verification:
-            for req in phase.hands_on_verification.requirements:
-                items.append(
-                    (
-                        str(req.uuid),
-                        f"phase[{phase.slug}].requirements[{req.id}]",
-                    )
-                )
-        for topic in phase.topics:
-            items.append((str(topic.uuid), f"topic[{topic.slug}]"))
-            for obj in topic.learning_objectives:
-                items.append(
-                    (
-                        str(obj.uuid),
-                        f"topic[{topic.slug}].objectives[{obj.id}]",
-                    )
-                )
-            for step in topic.learning_steps:
-                items.append((str(step.uuid), f"topic[{topic.slug}].steps[{step.id}]"))
-    return items
-
-
-def _check_uuid_uniqueness(phases: tuple[Phase, ...]) -> list[str]:
-    """Return error messages for any duplicate UUIDs."""
-    by_uuid: dict[str, list[str]] = {}
-    for uuid_str, locator in _collect_uuids(phases):
-        by_uuid.setdefault(uuid_str, []).append(locator)
-
-    errors: list[str] = []
-    for uuid_str, locators in by_uuid.items():
-        if len(locators) > 1:
-            errors.append(f"Duplicate uuid {uuid_str} used by: {', '.join(locators)}")
-    return errors
-
-
-def _check_topic_slugs_resolve(phases: tuple[Phase, ...]) -> list[str]:
-    """Return error messages for topic_slugs in phase yaml without a topic file.
-
-    Compares counts: the loader silently drops topics whose files fail to
-    parse, so a length mismatch between ``phase.topic_slugs`` (the YAML
-    list of expected topic filenames) and ``phase.topics`` (successfully
-    loaded ``Topic`` objects) means at least one slug did not load.
-    """
-    errors: list[str] = []
-    for phase in phases:
-        if len(phase.topics) < len(phase.topic_slugs):
-            loaded_ids = {t.id for t in phase.topics}
-            errors.append(
-                f"phase[{phase.slug}] expected {len(phase.topic_slugs)} "
-                f"topics but only {len(phase.topics)} loaded. "
-                f"Listed topics: {phase.topic_slugs}. "
-                f"Loaded topic ids: {sorted(loaded_ids)}. "
-                "Check for YAML parse errors in the missing files."
-            )
-    return errors
-
-
-def _check_step_order_uniqueness(phases: tuple[Phase, ...]) -> list[str]:
-    """Return error messages for steps that share an order within a topic."""
-    errors: list[str] = []
-    for phase in phases:
-        for topic in phase.topics:
-            by_order: dict[int, list[str]] = {}
-            for step in topic.learning_steps:
-                by_order.setdefault(step.order, []).append(step.id)
-            for order, step_ids in by_order.items():
-                if len(step_ids) > 1:
-                    errors.append(
-                        f"topic[{topic.slug}] has multiple steps with "
-                        f"order={order}: {', '.join(step_ids)}"
-                    )
-    return errors
-
-
-def _check_requirement_slugs_resolve(phases: tuple[Phase, ...]) -> list[str]:
-    """Return errors for requirement slugs in phase yaml without a loaded file.
-
-    Same pattern as ``_check_topic_slugs_resolve``: counts of declared
-    vs loaded must match; missing means a per-phase requirement file
-    failed to parse.
-    """
-    errors: list[str] = []
-    for phase in phases:
-        if phase.hands_on_verification is None:
-            continue
-        declared = phase.hands_on_verification.requirement_slugs
-        loaded = phase.hands_on_verification.requirements
-        if len(loaded) < len(declared):
-            loaded_ids = {r.id for r in loaded}
-            errors.append(
-                f"phase[{phase.slug}] expected {len(declared)} requirements "
-                f"but only {len(loaded)} loaded. "
-                f"Listed: {declared}. Loaded ids: {sorted(loaded_ids)}. "
-                "Check for YAML parse errors in the missing requirement files."
-            )
-    return errors
-
-
-def _check_requirement_ids_globally_unique(
-    phases: tuple[Phase, ...],
-) -> list[str]:
-    """Return errors for requirement IDs that collide across the whole curriculum.
-
-    Requirement IDs are used as filenames and as form field values.
-    Two requirements sharing an ID would clash in lookup and break UI.
-    """
-    by_id: dict[str, list[str]] = {}
-    for phase in phases:
-        if phase.hands_on_verification is None:
-            continue
-        for req in phase.hands_on_verification.requirements:
-            by_id.setdefault(req.id, []).append(phase.slug)
-
-    errors: list[str] = []
-    for req_id, phase_slugs in by_id.items():
-        if len(phase_slugs) > 1:
-            errors.append(
-                f"Duplicate requirement id '{req_id}' appears in phases: "
-                f"{', '.join(phase_slugs)}"
-            )
-    return errors
-
-
-def validate_content() -> list[str]:
-    """Run all cross-file validators against the currently-loaded content.
-
-    Returns a list of error messages; empty list means no issues.
-    Does not raise -- callers (CI scripts, sync step) decide how to handle
-    the result.
-    """
-    phases = get_all_phases()
-    errors: list[str] = []
-    errors.extend(_check_uuid_uniqueness(phases))
-    errors.extend(_check_topic_slugs_resolve(phases))
-    errors.extend(_check_step_order_uniqueness(phases))
-    errors.extend(_check_requirement_slugs_resolve(phases))
-    errors.extend(_check_requirement_ids_globally_unique(phases))
-    return errors
+async def get_topic_by_slugs(
+    db: AsyncSession, phase_slug: str, topic_slug: str
+) -> Topic | None:
+    """Get a topic by ``(phase_slug, topic_slug)``."""
+    return await load_topic_by_slugs_from_db(db, phase_slug, topic_slug)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
@@ -38,9 +38,9 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from learn_to_cloud_shared.content_service import (
+from learn_to_cloud_shared.content_yaml_loader import (
     clear_cache,
-    get_all_phases,
+    get_all_phases_from_yaml,
     validate_content,
 )
 from learn_to_cloud_shared.models import (
@@ -449,7 +449,7 @@ async def sync_curriculum_to_db(
             f"Curriculum validation failed; refusing to sync:\n  - {joined}"
         )
 
-    phases = get_all_phases()
+    phases = get_all_phases_from_yaml()
     if not phases and not allow_empty:
         raise ContentSyncError(
             "No phases loaded from YAML. Refusing to sync (would soft-delete "

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
@@ -1,0 +1,368 @@
+"""YAML-backed curriculum loader (legacy source of truth).
+
+This module loads the curriculum tree from the packaged YAML files. After
+Phase C (issue #461), runtime reads in the API go through the DB loader in
+``content_db_loader.py`` via the public ``content_service`` module. The
+YAML loader is still authoritative -- it remains the source of truth for
+the deploy-time YAML to DB sync (``content_sync.py``) and for the strict
+cross-file validators run in CI.
+
+Do not import from this module in request-serving code paths. Use
+``learn_to_cloud_shared.content_service`` (async, DB-backed) instead.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from learn_to_cloud_shared.core.config import get_worker_settings
+from learn_to_cloud_shared.schemas import (
+    HandsOnRequirementAdapter,
+    Phase,
+    Topic,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ContentValidationError(Exception):
+    """Raised when content YAML fails structural validation."""
+
+
+def _validate_topic_payload(data: dict, topic_file: Path) -> None:
+    """Validate topic payload learning step IDs are explicit and unique."""
+    topic_id = str(data.get("id", "")).strip()
+    topic_name = topic_id or topic_file.stem
+    steps = data.get("learning_steps", [])
+    if not isinstance(steps, list):
+        raise ContentValidationError("learning_steps must be a list")
+
+    seen: set[str] = set()
+    for step in steps:
+        if not isinstance(step, dict):
+            raise ContentValidationError("Each learning step must be a mapping")
+
+        step_id = str(step.get("id", "")).strip()
+        if not step_id:
+            raise ContentValidationError(
+                f"Missing learning_steps[].id in topic '{topic_name}'"
+            )
+        if len(step_id) > 100:
+            raise ContentValidationError(
+                f"learning_steps[].id '{step_id[:60]}...' is {len(step_id)} chars "
+                f"(max 100) in topic '{topic_name}'"
+            )
+        if step_id in seen:
+            raise ContentValidationError(
+                f"Duplicate learning_steps[].id '{step_id}' in topic '{topic_name}'"
+            )
+        seen.add(step_id)
+
+
+def _get_content_dir() -> Path:
+    """Get the content directory from settings.
+
+    Lazily accessed to avoid module-level settings initialization.
+    """
+    return get_worker_settings().content_dir_path
+
+
+def _load_topic(phase_dir: Path, topic_slug: str, *, order: int) -> Topic | None:
+    """Load a single topic from its YAML file.
+
+    ``order`` is supplied by the caller from the topic's position in the
+    parent phase's ``topics:`` slug list. Topic YAML files must not
+    carry their own ``order`` field; the loader rejects it to keep one
+    source of truth (issue #463).
+    """
+    topic_file = phase_dir / f"{topic_slug}.yaml"
+    if not topic_file.exists():
+        return None
+
+    try:
+        with open(topic_file, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict) and "order" in data:
+            raise ContentValidationError(
+                f"topic {topic_file.name}: 'order' field is no longer allowed. "
+                "Topic order is derived from the position in _phase.yaml's "
+                "'topics:' list -- remove the 'order' field from this file."
+            )
+        _validate_topic_payload(data, topic_file)
+        data["order"] = order
+        return Topic.model_validate(data)
+    except (yaml.YAMLError, ContentValidationError, ValueError, KeyError):
+        logger.exception(
+            "content.topic.load_failed",
+            extra={
+                "topic_slug": topic_slug,
+                "path": str(topic_file),
+            },
+        )
+        return None
+
+
+def _load_requirement(phase_dir: Path, requirement_slug: str) -> Any | None:
+    """Load a single hands-on requirement from its YAML file.
+
+    Returns one of the typed ``HandsOnRequirement`` subclasses (resolved
+    via the discriminated union) or ``None`` if the file is missing or
+    fails validation.
+    """
+    req_file = phase_dir / "requirements" / f"{requirement_slug}.yaml"
+    if not req_file.exists():
+        return None
+
+    try:
+        with open(req_file, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            raise ContentValidationError(
+                f"requirement {req_file.name} must be a YAML mapping"
+            )
+        file_stem = req_file.stem
+        yaml_id = str(data.get("id", "")).strip()
+        if yaml_id != file_stem:
+            raise ContentValidationError(
+                f"requirement {req_file.name}: id '{yaml_id}' does not match "
+                f"filename stem '{file_stem}'"
+            )
+        return HandsOnRequirementAdapter.validate_python(data)
+    except (
+        yaml.YAMLError,
+        ContentValidationError,
+        ValidationError,
+        ValueError,
+        KeyError,
+    ):
+        logger.exception(
+            "content.requirement.load_failed",
+            extra={
+                "requirement_slug": requirement_slug,
+                "path": str(req_file),
+            },
+        )
+        return None
+
+
+def _load_phase(phase_slug: str) -> Phase | None:
+    """Load a single phase from its directory."""
+    phase_dir = _get_content_dir() / phase_slug
+    meta_file = phase_dir / "_phase.yaml"
+
+    if not meta_file.exists():
+        return None
+
+    try:
+        with open(meta_file, encoding="utf-8") as f:
+            data: dict = yaml.safe_load(f)
+
+        topic_slugs: list[str] = data.get("topics", [])
+        topics = [
+            t
+            for idx, slug in enumerate(topic_slugs)
+            if (t := _load_topic(phase_dir, slug, order=idx + 1)) is not None
+        ]
+        data["topic_slugs"] = topic_slugs
+        data["topics"] = topics
+
+        hov = data.get("hands_on_verification")
+        if isinstance(hov, dict):
+            requirement_slugs: list[str] = hov.get("requirements", []) or []
+            if not all(isinstance(s, str) for s in requirement_slugs):
+                raise ContentValidationError(
+                    f"phase '{phase_slug}' hands_on_verification.requirements "
+                    "must be a list of slug strings"
+                )
+            loaded_requirements = [
+                r
+                for slug in requirement_slugs
+                if (r := _load_requirement(phase_dir, slug)) is not None
+            ]
+            hov["requirement_slugs"] = requirement_slugs
+            hov["requirements"] = loaded_requirements
+
+        return Phase.model_validate(data)
+    except (yaml.YAMLError, ContentValidationError, ValueError, KeyError):
+        logger.exception(
+            "content.phase.load_failed",
+            extra={
+                "phase_slug": phase_slug,
+                "path": str(meta_file),
+            },
+        )
+        return None
+
+
+@lru_cache(maxsize=1)
+def get_all_phases_from_yaml() -> tuple[Phase, ...]:
+    """Get all phases in order from packaged YAML files.
+
+    Results are cached for performance. Dynamically discovers phase
+    directories (phase0, phase1, ...). Used by ``content_sync.py``
+    (deploy-time YAML to DB sync) and by the strict cross-file validators
+    invoked in CI.
+    """
+    phases: list[Phase] = []
+    content_dir = _get_content_dir()
+    if not content_dir.exists():
+        return ()
+
+    for phase_dir in sorted(content_dir.iterdir()):
+        if phase_dir.is_dir() and phase_dir.name.startswith("phase"):
+            phase = _load_phase(phase_dir.name)
+            if phase:
+                phases.append(phase)
+
+    return tuple(sorted(phases, key=lambda p: p.order))
+
+
+def clear_cache() -> None:
+    """Clear the YAML loader cache (useful for testing)."""
+    get_all_phases_from_yaml.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Cross-file validators (issue #462)
+#
+# get_all_phases_from_yaml() is intentionally tolerant -- it logs and skips
+# broken files so the app keeps running on partially-bad content. The
+# validators below are STRICT: they raise on the first violation. They are
+# intended for CI and for the sync step that writes YAML into the DB.
+# ---------------------------------------------------------------------------
+
+
+def _collect_uuids(phases: tuple[Phase, ...]) -> list[tuple[str, str]]:
+    """Return (uuid_str, locator) tuples for every curriculum entity."""
+    items: list[tuple[str, str]] = []
+    for phase in phases:
+        items.append((str(phase.uuid), f"phase[{phase.slug}]"))
+        if phase.hands_on_verification:
+            for req in phase.hands_on_verification.requirements:
+                items.append(
+                    (
+                        str(req.uuid),
+                        f"phase[{phase.slug}].requirements[{req.id}]",
+                    )
+                )
+        for topic in phase.topics:
+            items.append((str(topic.uuid), f"topic[{topic.slug}]"))
+            for obj in topic.learning_objectives:
+                items.append(
+                    (
+                        str(obj.uuid),
+                        f"topic[{topic.slug}].objectives[{obj.id}]",
+                    )
+                )
+            for step in topic.learning_steps:
+                items.append((str(step.uuid), f"topic[{topic.slug}].steps[{step.id}]"))
+    return items
+
+
+def _check_uuid_uniqueness(phases: tuple[Phase, ...]) -> list[str]:
+    """Return error messages for any duplicate UUIDs."""
+    by_uuid: dict[str, list[str]] = {}
+    for uuid_str, locator in _collect_uuids(phases):
+        by_uuid.setdefault(uuid_str, []).append(locator)
+
+    errors: list[str] = []
+    for uuid_str, locators in by_uuid.items():
+        if len(locators) > 1:
+            errors.append(f"Duplicate uuid {uuid_str} used by: {', '.join(locators)}")
+    return errors
+
+
+def _check_topic_slugs_resolve(phases: tuple[Phase, ...]) -> list[str]:
+    """Return error messages for topic_slugs in phase yaml without a topic file."""
+    errors: list[str] = []
+    for phase in phases:
+        if len(phase.topics) < len(phase.topic_slugs):
+            loaded_ids = {t.id for t in phase.topics}
+            errors.append(
+                f"phase[{phase.slug}] expected {len(phase.topic_slugs)} "
+                f"topics but only {len(phase.topics)} loaded. "
+                f"Listed topics: {phase.topic_slugs}. "
+                f"Loaded topic ids: {sorted(loaded_ids)}. "
+                "Check for YAML parse errors in the missing files."
+            )
+    return errors
+
+
+def _check_step_order_uniqueness(phases: tuple[Phase, ...]) -> list[str]:
+    """Return error messages for steps that share an order within a topic."""
+    errors: list[str] = []
+    for phase in phases:
+        for topic in phase.topics:
+            by_order: dict[int, list[str]] = {}
+            for step in topic.learning_steps:
+                by_order.setdefault(step.order, []).append(step.id)
+            for order, step_ids in by_order.items():
+                if len(step_ids) > 1:
+                    errors.append(
+                        f"topic[{topic.slug}] has multiple steps with "
+                        f"order={order}: {', '.join(step_ids)}"
+                    )
+    return errors
+
+
+def _check_requirement_slugs_resolve(phases: tuple[Phase, ...]) -> list[str]:
+    """Return errors for requirement slugs in phase yaml without a loaded file."""
+    errors: list[str] = []
+    for phase in phases:
+        if phase.hands_on_verification is None:
+            continue
+        declared = phase.hands_on_verification.requirement_slugs
+        loaded = phase.hands_on_verification.requirements
+        if len(loaded) < len(declared):
+            loaded_ids = {r.id for r in loaded}
+            errors.append(
+                f"phase[{phase.slug}] expected {len(declared)} requirements "
+                f"but only {len(loaded)} loaded. "
+                f"Listed: {declared}. Loaded ids: {sorted(loaded_ids)}. "
+                "Check for YAML parse errors in the missing requirement files."
+            )
+    return errors
+
+
+def _check_requirement_ids_globally_unique(
+    phases: tuple[Phase, ...],
+) -> list[str]:
+    """Return errors for requirement IDs that collide across the whole curriculum."""
+    by_id: dict[str, list[str]] = {}
+    for phase in phases:
+        if phase.hands_on_verification is None:
+            continue
+        for req in phase.hands_on_verification.requirements:
+            by_id.setdefault(req.id, []).append(phase.slug)
+
+    errors: list[str] = []
+    for req_id, phase_slugs in by_id.items():
+        if len(phase_slugs) > 1:
+            errors.append(
+                f"Duplicate requirement id '{req_id}' appears in phases: "
+                f"{', '.join(phase_slugs)}"
+            )
+    return errors
+
+
+def validate_content() -> list[str]:
+    """Run all cross-file validators against the YAML-loaded content.
+
+    Returns a list of error messages; empty list means no issues. Does
+    not raise -- callers (CI scripts, the sync step) decide how to
+    handle the result.
+    """
+    phases = get_all_phases_from_yaml()
+    errors: list[str] = []
+    errors.extend(_check_uuid_uniqueness(phases))
+    errors.extend(_check_topic_slugs_resolve(phases))
+    errors.extend(_check_step_order_uniqueness(phases))
+    errors.extend(_check_requirement_slugs_resolve(phases))
+    errors.extend(_check_requirement_ids_globally_unique(phases))
+    return errors

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/requirements.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/requirements.py
@@ -1,64 +1,98 @@
-"""Phase hands-on requirements sourced from content.
+"""Phase hands-on requirements lookup helpers.
 
-Requirements live in packaged content under hands_on_verification.requirements.
-This module provides access helpers.
+Backed by the DB curriculum (see ``content_service``). Each convenience
+helper loads the full phase tree and builds a ``RequirementIndex``;
+hot paths that need several lookups should load phases once and call
+``RequirementIndex.from_phases`` themselves to avoid redundant queries.
 """
 
 from __future__ import annotations
 
-from functools import lru_cache
+from collections.abc import Sequence
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from learn_to_cloud_shared.content_service import get_all_phases
 from learn_to_cloud_shared.repositories.submission_repository import (
     SubmissionRepository,
 )
-from learn_to_cloud_shared.schemas import HandsOnRequirement
+from learn_to_cloud_shared.schemas import HandsOnRequirement, Phase
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
 
-@lru_cache(maxsize=1)
-def _get_requirements_map() -> dict[int, list[HandsOnRequirement]]:
-    requirements_map: dict[int, list[HandsOnRequirement]] = {}
-    for phase in get_all_phases():
-        requirements = []
-        if phase.hands_on_verification:
-            requirements = list(phase.hands_on_verification.requirements)
-        requirements_map[phase.id] = requirements
-    return requirements_map
+@dataclass(frozen=True)
+class RequirementIndex:
+    """Precomputed lookups over the loaded phases.
+
+    Build once per request via ``from_phases`` and reuse for all
+    requirement-shaped lookups in that request.
+    """
+
+    by_phase: dict[int, list[HandsOnRequirement]] = field(default_factory=dict)
+    by_id: dict[str, HandsOnRequirement] = field(default_factory=dict)
+    phase_id_by_req_id: dict[str, int] = field(default_factory=dict)
+
+    @classmethod
+    def from_phases(cls, phases: Sequence[Phase]) -> RequirementIndex:
+        by_phase: dict[int, list[HandsOnRequirement]] = {}
+        by_id: dict[str, HandsOnRequirement] = {}
+        phase_id_by_req_id: dict[str, int] = {}
+        for phase in phases:
+            reqs: list[HandsOnRequirement] = []
+            if phase.hands_on_verification:
+                reqs = list(phase.hands_on_verification.requirements)
+            by_phase[phase.id] = reqs
+            for req in reqs:
+                by_id[req.id] = req
+                phase_id_by_req_id[req.id] = phase.id
+        return cls(
+            by_phase=by_phase,
+            by_id=by_id,
+            phase_id_by_req_id=phase_id_by_req_id,
+        )
+
+    def requirements_for_phase(self, phase_id: int) -> list[HandsOnRequirement]:
+        return self.by_phase.get(phase_id, [])
+
+    def requirement_ids_for_phase(self, phase_id: int) -> list[str]:
+        return [req.id for req in self.requirements_for_phase(phase_id)]
 
 
-def get_requirements_for_phase(phase_id: int) -> list[HandsOnRequirement]:
+async def load_requirement_index(db: AsyncSession) -> RequirementIndex:
+    """Load all phases and build a ``RequirementIndex`` from them."""
+    return RequirementIndex.from_phases(await get_all_phases(db))
+
+
+async def get_requirements_for_phase(
+    db: AsyncSession, phase_id: int
+) -> list[HandsOnRequirement]:
     """Get all hands-on requirements for a specific phase."""
-    return _get_requirements_map().get(phase_id, [])
+    idx = await load_requirement_index(db)
+    return idx.requirements_for_phase(phase_id)
 
 
-@lru_cache(maxsize=1)
-def _get_requirement_id_map() -> dict[str, HandsOnRequirement]:
-    """Build flat lookup map of requirement_id → HandsOnRequirement."""
-    return {req.id: req for reqs in _get_requirements_map().values() for req in reqs}
-
-
-@lru_cache(maxsize=1)
-def _get_requirement_phase_id_map() -> dict[str, int]:
-    """Build lookup map of requirement_id → parent phase_id."""
-    requirement_phase_map: dict[str, int] = {}
-    for phase_id, requirements in _get_requirements_map().items():
-        for requirement in requirements:
-            requirement_phase_map[requirement.id] = phase_id
-    return requirement_phase_map
-
-
-def get_requirement_by_id(requirement_id: str) -> HandsOnRequirement | None:
+async def get_requirement_by_id(
+    db: AsyncSession, requirement_id: str
+) -> HandsOnRequirement | None:
     """Get a specific requirement by its ID."""
-    return _get_requirement_id_map().get(requirement_id)
+    idx = await load_requirement_index(db)
+    return idx.by_id.get(requirement_id)
 
 
-def get_phase_id_for_requirement(requirement_id: str) -> int | None:
+async def get_phase_id_for_requirement(
+    db: AsyncSession, requirement_id: str
+) -> int | None:
     """Get parent phase_id for a requirement ID."""
-    return _get_requirement_phase_id_map().get(requirement_id)
+    idx = await load_requirement_index(db)
+    return idx.phase_id_by_req_id.get(requirement_id)
+
+
+async def get_requirement_ids_for_phase(db: AsyncSession, phase_id: int) -> list[str]:
+    """Return all requirement IDs for a phase."""
+    idx = await load_requirement_index(db)
+    return idx.requirement_ids_for_phase(phase_id)
 
 
 # Sequential gating: these phases require the prior phase's verification
@@ -72,13 +106,11 @@ _PHASE_PREREQUISITES: dict[int, int] = {
 
 
 def get_prerequisite_phase(phase_id: int) -> int | None:
-    """Return the phase that must be fully verified before this one, or None."""
+    """Return the phase that must be fully verified before this one, or None.
+
+    Pure lookup over a static dict; no DB or content access needed.
+    """
     return _PHASE_PREREQUISITES.get(phase_id)
-
-
-def get_requirement_ids_for_phase(phase_id: int) -> list[str]:
-    """Return all requirement IDs for a phase."""
-    return [req.id for req in get_requirements_for_phase(phase_id)]
 
 
 async def is_phase_verification_locked(
@@ -89,14 +121,14 @@ async def is_phase_verification_locked(
     """Check if a phase's verification is locked behind an incomplete prerequisite.
 
     Returns:
-        (is_locked, prerequisite_phase_id) — if locked, the phase that
-        must be completed first; otherwise (False, None).
+        (is_locked, prerequisite_phase_id). If locked, the second item is
+        the phase that must be completed first; otherwise (False, None).
     """
     prereq = get_prerequisite_phase(phase_id)
     if prereq is None:
         return False, None
 
-    prereq_req_ids = get_requirement_ids_for_phase(prereq)
+    prereq_req_ids = await get_requirement_ids_for_phase(db, prereq)
     if not prereq_req_ids:
         return False, None
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -408,7 +408,7 @@ async def prepare_verification_job(
                         f"job {normalized_job_id} references missing submission "
                         f"{payload.result_submission_id}"
                     )
-                requirement = get_requirement_by_id(payload.requirement_id)
+                requirement = await get_requirement_by_id(db, payload.requirement_id)
                 result = _build_result_from_submission(
                     job_id=normalized_job_id,
                     submission=submission,
@@ -418,7 +418,8 @@ async def prepare_verification_job(
                 span.set_attribute("verification.replay", True)
                 return VerificationJobPreparation(terminal_result=result)
 
-        requirement = get_requirement_by_id(payload.requirement_id)
+            requirement = await get_requirement_by_id(db, payload.requirement_id)
+
         if requirement is None:
             result = await _handle_missing_requirement(
                 session_maker=session_maker,

--- a/packages/learn-to-cloud-shared/tests/services/test_content_db_loader.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_db_loader.py
@@ -21,11 +21,13 @@ from learn_to_cloud_shared.content_db_loader import (
     load_topic_by_id_from_db,
     load_topic_by_slugs_from_db,
 )
-from learn_to_cloud_shared.content_service import (
-    clear_cache,
-    get_all_phases,
-)
 from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
+from learn_to_cloud_shared.content_yaml_loader import (
+    clear_cache,
+)
+from learn_to_cloud_shared.content_yaml_loader import (
+    get_all_phases_from_yaml as get_all_phases,
+)
 from learn_to_cloud_shared.models import (
     CurriculumPhase,
     CurriculumRequirement,

--- a/packages/learn-to-cloud-shared/tests/services/test_content_sync.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_sync.py
@@ -131,7 +131,7 @@ async def _patch_validators_and_run(
     """Patch the loader and validators for deterministic test input."""
     with (
         patch(
-            "learn_to_cloud_shared.content_sync.get_all_phases",
+            "learn_to_cloud_shared.content_sync.get_all_phases_from_yaml",
             return_value=phases,
         ),
         patch(
@@ -311,7 +311,7 @@ async def test_validation_failure_blocks_sync(
     """If validate_content returns errors, sync aborts before any writes."""
     with (
         patch(
-            "learn_to_cloud_shared.content_sync.get_all_phases",
+            "learn_to_cloud_shared.content_sync.get_all_phases_from_yaml",
             return_value=fresh_curriculum,
         ),
         patch(

--- a/packages/learn-to-cloud-shared/tests/services/test_content_yaml_loader.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_yaml_loader.py
@@ -1,4 +1,4 @@
-"""Unit tests for content_service.
+"""Unit tests for content_yaml_loader.
 
 Tests cover:
 - _validate_topic_payload step ID validation rules
@@ -14,16 +14,15 @@ from unittest.mock import patch
 
 import pytest
 
-from learn_to_cloud_shared.content_service import (
+from learn_to_cloud_shared.content_yaml_loader import (
     ContentValidationError,
     _load_phase,
     _load_topic,
     _validate_topic_payload,
     clear_cache,
-    get_all_phases,
-    get_phase_by_slug,
-    get_topic_by_id,
-    get_topic_by_slugs,
+)
+from learn_to_cloud_shared.content_yaml_loader import (
+    get_all_phases_from_yaml as get_all_phases,
 )
 
 
@@ -193,7 +192,7 @@ learning_steps:
 class TestLoadPhase:
     def test_missing_meta_file_returns_none(self, tmp_path: Path):
         with patch(
-            "learn_to_cloud_shared.content_service._get_content_dir",
+            "learn_to_cloud_shared.content_yaml_loader._get_content_dir",
             autospec=True,
             return_value=tmp_path,
         ):
@@ -229,7 +228,7 @@ learning_steps:
 """
         )
         with patch(
-            "learn_to_cloud_shared.content_service._get_content_dir",
+            "learn_to_cloud_shared.content_yaml_loader._get_content_dir",
             autospec=True,
             return_value=tmp_path,
         ):
@@ -265,8 +264,8 @@ class TestGetAllPhases:
         ] == ["journal-api-implementation"]
 
     def test_phase5_aws_observability_link_uses_current_adot_guide(self):
-        topic = get_topic_by_slugs("phase5", "monitoring-observability")
-        assert topic is not None
+        phase5 = next(phase for phase in get_all_phases() if phase.slug == "phase5")
+        topic = next(t for t in phase5.topics if t.slug == "monitoring-observability")
         step = next(
             step
             for step in topic.learning_steps
@@ -278,7 +277,7 @@ class TestGetAllPhases:
 
     def test_empty_directory(self, tmp_path: Path):
         with patch(
-            "learn_to_cloud_shared.content_service._get_content_dir",
+            "learn_to_cloud_shared.content_yaml_loader._get_content_dir",
             autospec=True,
             return_value=tmp_path,
         ):
@@ -286,7 +285,7 @@ class TestGetAllPhases:
 
     def test_nonexistent_directory(self, tmp_path: Path):
         with patch(
-            "learn_to_cloud_shared.content_service._get_content_dir",
+            "learn_to_cloud_shared.content_yaml_loader._get_content_dir",
             autospec=True,
             return_value=tmp_path / "nonexistent",
         ):
@@ -296,7 +295,7 @@ class TestGetAllPhases:
         (tmp_path / "README.md").touch()
         (tmp_path / "not-a-phase").mkdir()
         with patch(
-            "learn_to_cloud_shared.content_service._get_content_dir",
+            "learn_to_cloud_shared.content_yaml_loader._get_content_dir",
             autospec=True,
             return_value=tmp_path,
         ):
@@ -304,48 +303,10 @@ class TestGetAllPhases:
 
 
 # ---------------------------------------------------------------------------
-# Lookup functions
+# Lookup-by-walking helpers used to live in this module. Phase C (#464)
+# moved them to the DB loader, where ``test_content_db_loader.py`` exercises
+# the same behavior against real curriculum tables.
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestLookupFunctions:
-    def test_get_phase_by_slug_found(self):
-        from uuid import uuid4
-
-        from learn_to_cloud_shared.schemas import Phase
-
-        phase = Phase(uuid=uuid4(), id=0, name="P0", slug="phase0", order=0, topics=[])
-        with patch(
-            "learn_to_cloud_shared.content_service.get_all_phases",
-            autospec=True,
-            return_value=(phase,),
-        ):
-            assert get_phase_by_slug("phase0") is phase
-
-    def test_get_phase_by_slug_not_found(self):
-        with patch(
-            "learn_to_cloud_shared.content_service.get_all_phases",
-            autospec=True,
-            return_value=(),
-        ):
-            assert get_phase_by_slug("nonexistent") is None
-
-    def test_get_topic_by_id_not_found(self):
-        with patch(
-            "learn_to_cloud_shared.content_service.get_all_phases",
-            autospec=True,
-            return_value=(),
-        ):
-            assert get_topic_by_id("nonexistent") is None
-
-    def test_get_topic_by_slugs_phase_not_found(self):
-        with patch(
-            "learn_to_cloud_shared.content_service.get_all_phases",
-            autospec=True,
-            return_value=(),
-        ):
-            assert get_topic_by_slugs("nonexistent", "topic") is None
 
 
 # ---------------------------------------------------------------------------
@@ -415,11 +376,11 @@ class TestValidateContent:
         )
 
     def test_returns_empty_list_when_no_violations(self):
-        from learn_to_cloud_shared.content_service import validate_content
+        from learn_to_cloud_shared.content_yaml_loader import validate_content
 
         phase = self._build_phase(topics=[self._build_topic()], topic_slugs=["topic1"])
         with patch(
-            "learn_to_cloud_shared.content_service.get_all_phases",
+            "learn_to_cloud_shared.content_yaml_loader.get_all_phases_from_yaml",
             autospec=True,
             return_value=(phase,),
         ):
@@ -428,7 +389,7 @@ class TestValidateContent:
     def test_detects_duplicate_uuid_across_entities(self):
         from uuid import UUID
 
-        from learn_to_cloud_shared.content_service import validate_content
+        from learn_to_cloud_shared.content_yaml_loader import validate_content
         from learn_to_cloud_shared.schemas import LearningStep
 
         # Same UUID used for a topic and one of its steps.
@@ -441,7 +402,7 @@ class TestValidateContent:
         )
         phase = self._build_phase(topics=[topic], topic_slugs=["topic1"])
         with patch(
-            "learn_to_cloud_shared.content_service.get_all_phases",
+            "learn_to_cloud_shared.content_yaml_loader.get_all_phases_from_yaml",
             autospec=True,
             return_value=(phase,),
         ):
@@ -449,7 +410,7 @@ class TestValidateContent:
         assert any("Duplicate uuid" in e for e in errors)
 
     def test_detects_topic_slug_count_mismatch(self):
-        from learn_to_cloud_shared.content_service import validate_content
+        from learn_to_cloud_shared.content_yaml_loader import validate_content
 
         # phase declares two topics in YAML but only one loaded.
         phase = self._build_phase(
@@ -457,7 +418,7 @@ class TestValidateContent:
             topic_slugs=["topic1", "missing-topic"],
         )
         with patch(
-            "learn_to_cloud_shared.content_service.get_all_phases",
+            "learn_to_cloud_shared.content_yaml_loader.get_all_phases_from_yaml",
             autospec=True,
             return_value=(phase,),
         ):
@@ -467,7 +428,7 @@ class TestValidateContent:
     def test_detects_duplicate_step_order_within_topic(self):
         from uuid import UUID
 
-        from learn_to_cloud_shared.content_service import validate_content
+        from learn_to_cloud_shared.content_yaml_loader import validate_content
         from learn_to_cloud_shared.schemas import LearningStep
 
         topic = self._build_topic(
@@ -486,7 +447,7 @@ class TestValidateContent:
         )
         phase = self._build_phase(topics=[topic], topic_slugs=["topic1"])
         with patch(
-            "learn_to_cloud_shared.content_service.get_all_phases",
+            "learn_to_cloud_shared.content_yaml_loader.get_all_phases_from_yaml",
             autospec=True,
             return_value=(phase,),
         ):

--- a/packages/learn-to-cloud-shared/tests/services/test_phase_requirements_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_phase_requirements_service.py
@@ -1,9 +1,9 @@
-"""Unit tests for phase_requirements_service.
+"""Unit tests for verification.requirements.
 
 Tests cover:
 - get_prerequisite_phase returns correct gating rules
-- get_requirements_for_phase returns requirements or empty list
-- get_requirement_by_id / get_phase_id_for_requirement lookups
+- RequirementIndex.from_phases builds the expected lookups
+- Async convenience helpers (get_requirement_by_id, etc.) delegate via the index
 - is_phase_verification_locked prerequisite checking
 """
 
@@ -18,9 +18,7 @@ from learn_to_cloud_shared.schemas import (
     PhaseHandsOnVerificationOverview,
 )
 from learn_to_cloud_shared.verification.requirements import (
-    _get_requirement_id_map,
-    _get_requirement_phase_id_map,
-    _get_requirements_map,
+    RequirementIndex,
     get_phase_id_for_requirement,
     get_prerequisite_phase,
     get_requirement_by_id,
@@ -28,15 +26,6 @@ from learn_to_cloud_shared.verification.requirements import (
     get_requirements_for_phase,
     is_phase_verification_locked,
 )
-
-
-@pytest.fixture(autouse=True)
-def _clear_lru_caches():
-    """Clear lru_cache between tests."""
-    yield
-    _get_requirements_map.cache_clear()
-    _get_requirement_id_map.cache_clear()
-    _get_requirement_phase_id_map.cache_clear()
 
 
 def _make_requirement(req_id: str = "req-1") -> HandsOnRequirement:
@@ -65,7 +54,7 @@ def _make_phase_with_requirements(phase_id: int, req_ids: list[str]) -> Phase:
 
 
 # ---------------------------------------------------------------------------
-# get_prerequisite_phase (pure lookup — no mocking)
+# get_prerequisite_phase (pure lookup -- no mocking)
 # ---------------------------------------------------------------------------
 
 
@@ -91,67 +80,115 @@ class TestGetPrerequisitePhase:
 
 
 # ---------------------------------------------------------------------------
-# Requirement lookup functions
+# RequirementIndex.from_phases
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestRequirementLookups:
-    def test_get_requirements_for_known_phase(self):
+class TestRequirementIndex:
+    def test_from_phases_builds_lookups(self):
+        phase3 = _make_phase_with_requirements(3, ["req-a", "req-b"])
+        phase4 = _make_phase_with_requirements(4, ["req-c"])
+
+        index = RequirementIndex.from_phases([phase3, phase4])
+
+        assert sorted(index.by_phase.keys()) == [3, 4]
+        assert {r.id for r in index.by_phase[3]} == {"req-a", "req-b"}
+        assert set(index.by_id.keys()) == {"req-a", "req-b", "req-c"}
+        assert index.phase_id_by_req_id["req-a"] == 3
+        assert index.phase_id_by_req_id["req-c"] == 4
+
+    def test_from_phases_handles_no_verification(self):
+        phase = Phase(
+            uuid=uuid4(),
+            id=0,
+            name="P0",
+            slug="phase0",
+            order=0,
+            topics=[],
+            hands_on_verification=None,
+        )
+
+        index = RequirementIndex.from_phases([phase])
+
+        assert index.by_phase[0] == []
+        assert index.by_id == {}
+        assert index.phase_id_by_req_id == {}
+
+    def test_requirements_for_phase_returns_empty_for_unknown(self):
+        index = RequirementIndex()
+        assert index.requirements_for_phase(99) == []
+        assert index.requirement_ids_for_phase(99) == []
+
+
+# ---------------------------------------------------------------------------
+# Async lookup helpers (delegate to load_requirement_index)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestAsyncRequirementLookups:
+    @pytest.mark.asyncio
+    async def test_get_requirements_for_known_phase(self):
         phase = _make_phase_with_requirements(3, ["req-a", "req-b"])
         with patch(
             "learn_to_cloud_shared.verification.requirements.get_all_phases",
-            autospec=True,
+            new_callable=AsyncMock,
             return_value=(phase,),
         ):
-            reqs = get_requirements_for_phase(3)
+            reqs = await get_requirements_for_phase(AsyncMock(), 3)
         assert len(reqs) == 2
 
-    def test_get_requirements_for_unknown_phase(self):
+    @pytest.mark.asyncio
+    async def test_get_requirements_for_unknown_phase(self):
         with patch(
             "learn_to_cloud_shared.verification.requirements.get_all_phases",
-            autospec=True,
+            new_callable=AsyncMock,
             return_value=(),
         ):
-            reqs = get_requirements_for_phase(99)
+            reqs = await get_requirements_for_phase(AsyncMock(), 99)
         assert reqs == []
 
-    def test_get_requirement_by_id_found(self):
+    @pytest.mark.asyncio
+    async def test_get_requirement_by_id_found(self):
         phase = _make_phase_with_requirements(3, ["req-a"])
         with patch(
             "learn_to_cloud_shared.verification.requirements.get_all_phases",
-            autospec=True,
+            new_callable=AsyncMock,
             return_value=(phase,),
         ):
-            req = get_requirement_by_id("req-a")
+            req = await get_requirement_by_id(AsyncMock(), "req-a")
         assert req is not None
         assert req.id == "req-a"
 
-    def test_get_requirement_by_id_not_found(self):
+    @pytest.mark.asyncio
+    async def test_get_requirement_by_id_not_found(self):
         with patch(
             "learn_to_cloud_shared.verification.requirements.get_all_phases",
-            autospec=True,
+            new_callable=AsyncMock,
             return_value=(),
         ):
-            assert get_requirement_by_id("nonexistent") is None
+            assert await get_requirement_by_id(AsyncMock(), "nonexistent") is None
 
-    def test_get_phase_id_for_requirement(self):
+    @pytest.mark.asyncio
+    async def test_get_phase_id_for_requirement(self):
         phase = _make_phase_with_requirements(3, ["req-a"])
         with patch(
             "learn_to_cloud_shared.verification.requirements.get_all_phases",
-            autospec=True,
+            new_callable=AsyncMock,
             return_value=(phase,),
         ):
-            assert get_phase_id_for_requirement("req-a") == 3
+            assert await get_phase_id_for_requirement(AsyncMock(), "req-a") == 3
 
-    def test_get_requirement_ids_for_phase(self):
+    @pytest.mark.asyncio
+    async def test_get_requirement_ids_for_phase(self):
         phase = _make_phase_with_requirements(3, ["req-a", "req-b"])
         with patch(
             "learn_to_cloud_shared.verification.requirements.get_all_phases",
-            autospec=True,
+            new_callable=AsyncMock,
             return_value=(phase,),
         ):
-            ids = get_requirement_ids_for_phase(3)
+            ids = await get_requirement_ids_for_phase(AsyncMock(), 3)
         assert ids == ["req-a", "req-b"]
 
 
@@ -178,7 +215,7 @@ class TestIsPhaseVerificationLocked:
         with (
             patch(
                 "learn_to_cloud_shared.verification.requirements.get_all_phases",
-                autospec=True,
+                new_callable=AsyncMock,
                 return_value=(phase3, phase4),
             ),
             patch(
@@ -204,7 +241,7 @@ class TestIsPhaseVerificationLocked:
         with (
             patch(
                 "learn_to_cloud_shared.verification.requirements.get_all_phases",
-                autospec=True,
+                new_callable=AsyncMock,
                 return_value=(phase3, phase4),
             ),
             patch(

--- a/scripts/seed_progress.py
+++ b/scripts/seed_progress.py
@@ -1,7 +1,7 @@
 """Seed all progress data for a user so they can test full completion.
 
-Reads topic IDs and step counts directly from the content YAML files to ensure
-the seeded data matches exactly what the app expects.
+Reads curriculum from the DB (synced from YAML at deploy time) and writes
+step_progress + submissions rows so the user shows as fully complete.
 
 Usage: uv run --directory api python ../scripts/seed_progress.py <github_username>
 """
@@ -11,154 +11,158 @@ import os
 import sys
 from datetime import UTC, datetime
 
-import asyncpg
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from learn_to_cloud_shared.content_service import get_all_phases
 
 DATABASE_URL = os.environ.get(
-    "DATABASE_URL", "postgresql://postgres:postgres@db:5432/learn_to_cloud"
+    "DATABASE_URL", "postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud"
 )
 
 
-def load_content() -> tuple[
-    dict[int, list[tuple[str, list[str]]]],
-    dict[int, list[dict[str, str | None]]],
-]:
-    """Load topic IDs, step IDs, and requirements from packaged content."""
-    phase_topics: dict[int, list[tuple[str, list[str]]]] = {}
-    phase_requirements: dict[int, list[dict[str, str | None]]] = {}
-
-    for phase in get_all_phases():
-        phase_topics[phase.id] = [
-            (topic.id, [step.id for step in topic.learning_steps])
-            for topic in phase.topics
-        ]
-
-        if phase.hands_on_verification:
-            phase_requirements[phase.id] = [
-                {
-                    "id": req.id,
-                    "submission_type": str(req.submission_type),
-                    "required_repo": req.required_repo,
-                }
-                for req in phase.hands_on_verification.requirements
-            ]
-
-    return phase_topics, phase_requirements
-
-
 async def main(github_username: str) -> None:
-    phase_topics, phase_requirements = load_content()
-    print(f"Loaded {len(phase_topics)} phases from content YAML")
-
-    conn = await asyncpg.connect(DATABASE_URL)
+    engine = create_async_engine(DATABASE_URL)
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
     try:
-        user = await conn.fetchrow(
-            "SELECT id, github_username FROM users WHERE github_username = $1",
-            github_username,
-        )
-        if not user:
-            print(f"ERROR: User '{github_username}' not found in the database.")
-            print("Make sure you've logged in at least once via the app.")
+        async with session_maker() as session:
+            phases = await get_all_phases(session)
+        if not phases:
+            print("ERROR: No curriculum loaded from DB. Run the sync job first.")
             sys.exit(1)
+        print(f"Loaded {len(phases)} phases from curriculum DB")
 
-        user_id = user["id"]
-        print(f"Found user: {github_username} (id={user_id})")
-
-        now = datetime.now(UTC)
-
-        deleted = await conn.execute(
-            "DELETE FROM step_progress WHERE user_id = $1", user_id
-        )
-        print(f"Cleaned existing step_progress: {deleted}")
-
-        step_count = 0
-        for phase_id, topics in phase_topics.items():
-            for topic_id, step_ids in topics:
-                for step_order, step_id in enumerate(step_ids, 1):
-                    await conn.execute(
-                        """
-                        INSERT INTO step_progress (
-                            user_id,
-                            topic_id,
-                            step_id,
-                            phase_id,
-                            step_order,
-                            completed_at
-                        )
-                        VALUES ($1, $2, $3, $4, $5, $6)
-                        ON CONFLICT (user_id, topic_id, step_id) DO NOTHING
-                        """,
-                        user_id,
-                        topic_id,
-                        step_id,
-                        phase_id,
-                        step_order,
-                        now,
-                    )
-                    step_count += 1
-        print(f"Inserted {step_count} step_progress records")
-
-        sub_count = 0
-        for phase_id, requirements in phase_requirements.items():
-            for req in requirements:
-                req_id = req["id"]
-                sub_type = req["submission_type"]
-                # Generate realistic submitted_value per submission type
-                if sub_type == "github_profile":
-                    submitted_value = f"https://github.com/{github_username}"
-                elif sub_type == "profile_readme":
-                    submitted_value = (
-                        f"https://github.com/{github_username}/{github_username}"
-                    )
-                elif sub_type == "repo_fork" and req.get("required_repo"):
-                    repo_name = req["required_repo"].split("/")[-1]
-                    submitted_value = (
-                        f"https://github.com/{github_username}/{repo_name}"
-                    )
-                elif sub_type in (
-                    "devops_analysis",
-                    "security_scanning",
-                    "journal_api_verifier",
-                ):
-                    submitted_value = (
-                        f"https://github.com/{github_username}/journal-starter"
-                    )
-                elif sub_type == "pr_review":
-                    submitted_value = f"https://seed-data.example.com/{req_id}"
-                elif sub_type == "deployed_api":
-                    submitted_value = "https://journal-api.example.com"
-                else:
-                    submitted_value = f"https://seed-data.example.com/{req_id}"
+        async with engine.begin() as conn:
+            row = (
                 await conn.execute(
-                    """
-                    INSERT INTO submissions (
-                        user_id, requirement_id, attempt_number, submission_type,
-                        phase_id, submitted_value, is_validated, validated_at,
-                        verification_completed, created_at, updated_at
-                    )
-                    VALUES ($1, $2, 1, $3, $4, $5, true, $6, true, $6, $6)
-                    ON CONFLICT (user_id, requirement_id, attempt_number) DO UPDATE SET
-                        submitted_value = $5,
-                        is_validated = true,
-                        validated_at = $6,
-                        verification_completed = true,
-                        updated_at = $6
-                    """,
-                    user_id,
-                    req_id,
-                    sub_type,
-                    phase_id,
-                    submitted_value,
-                    now,
+                    text(
+                        "SELECT id, github_username FROM users "
+                        "WHERE github_username = :username"
+                    ),
+                    {"username": github_username},
                 )
-                sub_count += 1
-        print(f"Inserted {sub_count} submission records")
+            ).first()
+            if row is None:
+                print(f"ERROR: User '{github_username}' not found in the database.")
+                print("Make sure you've logged in at least once via the app.")
+                sys.exit(1)
 
-        print("\nDone! All progress seeded. You should now show as fully complete.")
+            user_id = row.id
+            print(f"Found user: {github_username} (id={user_id})")
 
+            now = datetime.now(UTC)
+
+            deleted = await conn.execute(
+                text("DELETE FROM step_progress WHERE user_id = :user_id"),
+                {"user_id": user_id},
+            )
+            print(f"Cleaned existing step_progress: {deleted.rowcount}")
+
+            step_count = 0
+            for phase in phases:
+                for topic in phase.topics:
+                    for step_order, step in enumerate(topic.learning_steps, 1):
+                        await conn.execute(
+                            text(
+                                """
+                                INSERT INTO step_progress (
+                                    user_id,
+                                    topic_id,
+                                    step_id,
+                                    phase_id,
+                                    step_order,
+                                    completed_at
+                                )
+                                VALUES (
+                                    :user_id, :topic_id, :step_id,
+                                    :phase_id, :step_order, :completed_at
+                                )
+                                ON CONFLICT (user_id, topic_id, step_id) DO NOTHING
+                                """
+                            ),
+                            {
+                                "user_id": user_id,
+                                "topic_id": topic.id,
+                                "step_id": step.id,
+                                "phase_id": phase.id,
+                                "step_order": step_order,
+                                "completed_at": now,
+                            },
+                        )
+                        step_count += 1
+            print(f"Inserted {step_count} step_progress records")
+
+            sub_count = 0
+            for phase in phases:
+                if phase.hands_on_verification is None:
+                    continue
+                for req in phase.hands_on_verification.requirements:
+                    sub_type = str(req.submission_type)
+                    required_repo = getattr(req, "required_repo", None)
+                    # Generate realistic submitted_value per submission type
+                    if sub_type == "github_profile":
+                        submitted_value = f"https://github.com/{github_username}"
+                    elif sub_type == "profile_readme":
+                        submitted_value = (
+                            f"https://github.com/{github_username}/{github_username}"
+                        )
+                    elif sub_type == "repo_fork" and required_repo:
+                        repo_name = required_repo.split("/")[-1]
+                        submitted_value = (
+                            f"https://github.com/{github_username}/{repo_name}"
+                        )
+                    elif sub_type in (
+                        "devops_analysis",
+                        "security_scanning",
+                        "journal_api_verifier",
+                    ):
+                        submitted_value = (
+                            f"https://github.com/{github_username}/journal-starter"
+                        )
+                    elif sub_type == "pr_review":
+                        submitted_value = f"https://seed-data.example.com/{req.id}"
+                    elif sub_type == "deployed_api":
+                        submitted_value = "https://journal-api.example.com"
+                    else:
+                        submitted_value = f"https://seed-data.example.com/{req.id}"
+
+                    await conn.execute(
+                        text(
+                            """
+                            INSERT INTO submissions (
+                                user_id, requirement_id, attempt_number,
+                                submission_type, phase_id, submitted_value,
+                                is_validated, validated_at,
+                                verification_completed, created_at, updated_at
+                            )
+                            VALUES (
+                                :user_id, :req_id, 1, :sub_type, :phase_id,
+                                :submitted_value, true, :now, true, :now, :now
+                            )
+                            ON CONFLICT (user_id, requirement_id, attempt_number)
+                            DO UPDATE SET
+                                submitted_value = :submitted_value,
+                                is_validated = true,
+                                validated_at = :now,
+                                verification_completed = true,
+                                updated_at = :now
+                            """
+                        ),
+                        {
+                            "user_id": user_id,
+                            "req_id": req.id,
+                            "sub_type": sub_type,
+                            "phase_id": phase.id,
+                            "submitted_value": submitted_value,
+                            "now": now,
+                        },
+                    )
+                    sub_count += 1
+            print(f"Inserted {sub_count} submission records")
+
+            print("\nDone! All progress seeded.")
     finally:
-        await conn.close()
+        await engine.dispose()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the loop on Phase C of #461. Public content reads now go through the DB tables populated by the deploy-time sync (#463), so YAML is no longer in the request path.

## Architecture

- New `content_yaml_loader.py` owns YAML loading + cross-file validators; only used by `content_sync` and the CI validator. Renames `get_all_phases` to `get_all_phases_from_yaml` so the source is explicit.
- `content_service.py` rewritten as a thin async wrapper over `content_db_loader`. Per-request DB reads, no caching (curriculum is ~466 indexed rows, 5 simple SELECTs).
- `verification/requirements.py` rewritten around a `RequirementIndex` dataclass. Hot paths build the index once from a single phase load to avoid redundant queries.

## Caller updates (all routes/services were already async)

- progress_service: loads phases once per request, builds index, derives totals from passed `phase` arg in `fetch_phase_progress`.
- dashboard_service: loads phases once and threads them to `fetch_user_progress`.
- pages_routes: awaits DB-backed helpers; topic page reuses `phase.topics` instead of a second lookup.
- htmx_routes: DbSession threaded into the three places that needed it (status card, submit, status poll).
- steps_service: `_resolve_step` async.
- submissions_service: `_check_submission_preconditions` does requirement lookups inside its existing read_session via `load_requirement_index`.
- verification_job_executor: hoists `get_requirement_by_id` inside the open `async with session_maker` block.
- main.py: dropped `_background_warmup` (cache it warmed is gone).
- scripts/seed_progress.py: SQLAlchemy + DB content (no longer asyncpg+YAML).
- deploy.yml: verification-functions smoke uses `get_all_phases_from_yaml` (right thing to check there).

## Tests

- Renamed `test_content_service.py` -> `test_content_yaml_loader.py`. Dropped the lookup-by-walking tests; `test_content_db_loader.py` covers the same behavior against the real schema.
- Rewrote `test_phase_requirements_service.py` around `RequirementIndex` + async helpers.
- Rewrote `test_submissions_service.py` to patch `load_requirement_index` returning a constructed index.
- Mock patches of async helpers all use `new_callable=AsyncMock`.
- Smoke tests patch route-module helpers to delegate to the YAML loader so the full ASGI stack still runs without a real DB.

## Verification

- 226 api tests, 464 shared tests (1 skipped) all green.
- ruff/format/ty all green for api, shared, verification-functions.
- End-to-end deploy path locally: alembic upgrade head -> alembic check -> sync = 7/42/272/135/10.
- API boots clean and serves / and /curriculum (200) from DB.

Closes part of #461. Remaining Phase C work merges into #464 follow-ups handled here.