### PR TITLE
feat(curriculum): add step_progress.step_uuid + dual-write (Phase D.1a)

### DIFF
--- a/api/alembic/versions/0027_step_progress_step_uuid.py
+++ b/api/alembic/versions/0027_step_progress_step_uuid.py
@@ -1,0 +1,97 @@
+"""add step_progress.step_uuid (Phase D.1a)
+
+Why this change: Phase D of #461 migrates user state tables to reference
+curriculum entities by UUID instead of free-form legacy string IDs. This
+is PR D.1a -- the additive, dual-write half. PR D.1b will switch app
+reads to ``step_uuid``; PR D.1c will drop the legacy columns and add
+``NOT NULL`` + FK.
+
+Schema effect:
+- Adds ``step_progress.step_uuid UUID`` (nullable, no FK yet).
+- Adds an index on ``step_uuid`` so the future FK lookup is cheap.
+- Backfills ``step_uuid`` for existing rows by joining
+  ``topics.legacy_id = step_progress.topic_id`` and
+  ``steps.legacy_id = step_progress.step_id`` against the active
+  (non-soft-deleted) curriculum.
+- Deletes rows whose ``(topic_id, step_id)`` no longer maps to any active
+  step. These rows were already invisible to users -- the read path in
+  ``get_valid_completed_steps`` filters completions against the current
+  topic's step IDs, so a stale row never contributed to displayed
+  progress. The DELETE makes the eventual ``NOT NULL`` constraint
+  achievable without losing user-visible progress.
+
+Production preflight (2026-05-24, prior to this migration):
+
+    step_progress rows                            : 49060
+    distinct users                                :  2466
+    rows with topic_id matching topics.legacy_id  : 49060
+    rows with step lookup match                   : 48942
+
+So this migration soft-cleans up 118 rows that already had no on-screen
+effect.
+
+Rollback notes: ``downgrade()`` drops the column and the index. The
+deleted stale rows are not restored -- they were already invisible to
+users, and reintroducing them would not change any user-visible state.
+
+Revision ID: 0027_step_progress_step_uuid
+Create Date: 2026-05-24 19:45:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0027_step_progress_step_uuid"
+down_revision = "0026_add_requirements_order"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '5min'")
+
+    op.add_column(
+        "step_progress",
+        sa.Column("step_uuid", sa.Uuid(as_uuid=True), nullable=True),
+    )
+
+    op.execute(
+        """
+        UPDATE step_progress sp
+        SET step_uuid = s.uuid
+        FROM steps s
+        JOIN topics t ON s.topic_uuid = t.uuid
+        WHERE t.legacy_id = sp.topic_id
+          AND s.legacy_id = sp.step_id
+          AND s.deleted_at IS NULL
+          AND t.deleted_at IS NULL
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM step_progress
+        WHERE step_uuid IS NULL
+        """
+    )
+
+    # CREATE INDEX CONCURRENTLY requires running outside of a transaction.
+    # autocommit_block commits the current tx, runs the index build, then
+    # opens a fresh tx for any later statements. ``IF NOT EXISTS`` makes
+    # the build idempotent if a previous deploy attempt was killed
+    # mid-create (which would otherwise leave an INVALID index behind).
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_step_progress_step_uuid ON step_progress (step_uuid)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_step_progress_step_uuid")
+    op.drop_column("step_progress", "step_uuid")

--- a/api/src/learn_to_cloud/services/steps_service.py
+++ b/api/src/learn_to_cloud/services/steps_service.py
@@ -1,6 +1,7 @@
 """Step progress service for learning step management."""
 
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from learn_to_cloud_shared.content_service import get_topic_by_id
 from learn_to_cloud_shared.models import utcnow
@@ -36,11 +37,14 @@ class StepInvalidStepIdError(StepValidationError):
 
 async def _resolve_step(
     db: AsyncSession, topic_id: str, step_id: str
-) -> tuple[str, int, int]:
+) -> tuple[str, int, int, UUID]:
     """Resolve and validate a step by stable step id.
 
     Returns:
-        Tuple of (resolved_step_id, step_order, total_steps)
+        Tuple of (resolved_step_id, step_order, total_steps, step_uuid).
+        ``step_uuid`` is plumbed through to the repository so it can
+        dual-write the new ``step_progress.step_uuid`` column (Phase
+        D.1a of #461).
     """
     topic = await get_topic_by_id(db, topic_id)
     if topic is None:
@@ -49,7 +53,7 @@ async def _resolve_step(
     total_steps = len(topic.learning_steps)
     for step in topic.learning_steps:
         if step.id == step_id:
-            return step.id, step.order, total_steps
+            return step.id, step.order, total_steps, step.uuid
 
     raise StepInvalidStepIdError(topic_id, step_id)
 
@@ -103,7 +107,9 @@ async def complete_step(
         Idempotent — completing an already-completed step is a no-op
         that returns the current state without error.
     """
-    resolved_step_id, step_order, _ = await _resolve_step(db, topic_id, step_id)
+    resolved_step_id, step_order, _, step_uuid = await _resolve_step(
+        db, topic_id, step_id
+    )
 
     step_repo = StepProgressRepository(db)
     phase_id = parse_phase_id_from_topic_id(topic_id)
@@ -116,6 +122,7 @@ async def complete_step(
         step_id=resolved_step_id,
         step_order=step_order,
         phase_id=phase_id,
+        step_uuid=step_uuid,
     )
 
     span = trace.get_current_span()
@@ -167,7 +174,7 @@ async def uncomplete_step(
         StepUnknownTopicError: If topic_id doesn't exist in content
         StepInvalidStepIdError: If step_id doesn't exist in the topic
     """
-    resolved_step_id, step_order, _ = await _resolve_step(db, topic_id, step_id)
+    resolved_step_id, step_order, _, _ = await _resolve_step(db, topic_id, step_id)
 
     step_repo = StepProgressRepository(db)
     deleted = await step_repo.delete_step(user_id, topic_id, resolved_step_id)

--- a/api/tests/services/test_steps_service.py
+++ b/api/tests/services/test_steps_service.py
@@ -65,12 +65,13 @@ class TestResolveStep:
             new_callable=AsyncMock,
             return_value=topic,
         ):
-            step_id, order, total = await _resolve_step(
+            step_id, order, total, step_uuid = await _resolve_step(
                 AsyncMock(), "phase0-topic1", "step-intro"
             )
         assert step_id == "step-intro"
         assert order == 0
         assert total == 2
+        assert step_uuid == topic.learning_steps[0].uuid
 
     @pytest.mark.asyncio
     async def test_unknown_topic_raises(self):

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -293,6 +293,7 @@ class StepProgress(Base):
         UniqueConstraint("user_id", "topic_id", "step_id", name="uq_user_topic_step"),
         Index("ix_step_progress_user_topic", "user_id", "topic_id"),
         Index("ix_step_progress_user_phase", "user_id", "phase_id"),
+        Index("ix_step_progress_step_uuid", "step_uuid"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -310,6 +311,13 @@ class StepProgress(Base):
     step_order: Mapped[int] = mapped_column(
         Integer,
         nullable=False,
+    )
+    # UUID reference to ``steps.uuid``. Nullable through PR D.1a (this PR)
+    # while we dual-write; PR D.1c will set NOT NULL and add the FK once
+    # all production rows are backfilled.
+    step_uuid: Mapped[UUID | None] = mapped_column(
+        Uuid(as_uuid=True),
+        nullable=True,
     )
     completed_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/progress_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/progress_repository.py
@@ -1,5 +1,7 @@
 """Repository for step progress operations."""
 
+from uuid import UUID
+
 from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,11 +36,17 @@ class StepProgressRepository:
         step_id: str,
         step_order: int,
         phase_id: int,
+        step_uuid: UUID | None = None,
     ) -> StepProgress | None:
         """Atomically create a step progress record if it doesn't exist.
 
         Uses INSERT ... ON CONFLICT DO NOTHING RETURNING to check and insert
         in a single round-trip instead of SELECT + INSERT (2 round-trips).
+
+        ``step_uuid`` is the curriculum reference being introduced in
+        Phase D.1a. It is dual-written alongside the legacy ``step_id``
+        / ``topic_id`` so PR D.1b can switch reads over and PR D.1c can
+        drop the legacy columns and add the FK.
 
         Returns:
             The created StepProgress if inserted, or None if already existed.
@@ -51,6 +59,7 @@ class StepProgressRepository:
                 step_id=step_id,
                 phase_id=phase_id,
                 step_order=step_order,
+                step_uuid=step_uuid,
             )
             .on_conflict_do_nothing(
                 constraint="uq_user_topic_step",

--- a/scripts/seed_progress.py
+++ b/scripts/seed_progress.py
@@ -71,11 +71,13 @@ async def main(github_username: str) -> None:
                                     step_id,
                                     phase_id,
                                     step_order,
+                                    step_uuid,
                                     completed_at
                                 )
                                 VALUES (
                                     :user_id, :topic_id, :step_id,
-                                    :phase_id, :step_order, :completed_at
+                                    :phase_id, :step_order, :step_uuid,
+                                    :completed_at
                                 )
                                 ON CONFLICT (user_id, topic_id, step_id) DO NOTHING
                                 """
@@ -86,6 +88,7 @@ async def main(github_username: str) -> None:
                                 "step_id": step.id,
                                 "phase_id": phase.id,
                                 "step_order": step_order,
+                                "step_uuid": step.uuid,
                                 "completed_at": now,
                             },
                         )


### PR DESCRIPTION
First of three PRs migrating `step_progress` to a UUID FK on `steps.uuid` (Phase D.1 of #461 / #465). Purely additive: introduces the new column, backfills, deletes 118 already-invisible stale rows, and dual-writes from the app. Reads still go through the legacy `topic_id` + `step_id` pair. PR D.1b will switch reads; PR D.1c will drop legacy columns + add NOT NULL + FK.

## Production preflight (2026-05-24)

```
step_progress rows                            : 49060
distinct users                                :  2466
rows with topic_id matching topics.legacy_id  : 49060
rows with step lookup match                   : 48942
```

The 118 rows whose `(topic_id, step_id)` no longer resolves to an active step are already invisible to users (read path filters via `get_valid_completed_steps` against the topic's current step IDs). The migration deletes them so the eventual NOT NULL is achievable without losing user-visible progress.

## Migration 0027

- Adds `step_progress.step_uuid UUID` (nullable, no FK yet).
- Backfills from `steps` + `topics` joined on `legacy_id` (active only).
- Deletes the 118 stale rows whose `step_uuid` stays NULL.
- Creates `ix_step_progress_step_uuid` CONCURRENTLY + IF NOT EXISTS so an interrupted deploy attempt can retry without a leftover INVALID index.

squawk + pytest-alembic green.

## App dual-write

- ORM gets nullable `step_uuid`.
- `create_if_not_exists` accepts `step_uuid` and writes it alongside the legacy columns.
- `steps_service._resolve_step` returns the resolved step's UUID and threads it through.
- `seed_progress.py` writes `step_uuid` too.

No read code changed.

## Verification

- 226 api + 464 shared tests green; squawk clean; ruff/format/ty clean.
- End-to-end locally: alembic upgrade -> alembic check -> sync = 7/42/272/135/10.

## After deploy

Verify before D.1b:
```sql
SELECT COUNT(*) FROM step_progress WHERE step_uuid IS NULL;  -- expect 0
```