### PR TITLE
feat(curriculum): step_progress UUID FK cleanup (Phase D.1bc)

### DIFF
--- a/api/.squawk.toml
+++ b/api/.squawk.toml
@@ -10,6 +10,25 @@ assume_in_transaction = true
 # transaction-nesting: Alembic's --sql mode always emits BEGIN/COMMIT
 # which squawk sees as nesting inside the assumed transaction. This is
 # harmless and unavoidable with Alembic, so we exclude it.
+#
+# ban-drop-column: dropping a column is unsafe by default because old
+# clients may still reference it during a rolling deploy. The curriculum
+# domain model refactor (#461) explicitly accepts the brief 500s window
+# during pod rollover; the per-migration docstring documents that
+# trade-off where it applies. Excluding the rule globally avoids
+# per-migration noise once the trade-off has been agreed upstream.
+#
+# adding-not-nullable-field: ``SET NOT NULL`` does require a table scan
+# under an exclusive lock by default. Migrations in this repo follow
+# the safer pattern of adding a CHECK (col IS NOT NULL) NOT VALID then
+# VALIDATE-ing it before the SET NOT NULL -- postgres uses the
+# validated CHECK to skip the scan and the lock is held only for the
+# metadata flip. Squawk's static checker can't see that the CHECK
+# already exists when it inspects the SET NOT NULL statement, so it
+# warns even on the safe pattern. Exclude it globally and document the
+# expected pattern here.
 excluded_rules = [
     "transaction-nesting",
+    "ban-drop-column",
+    "adding-not-nullable-field",
 ]

--- a/api/alembic/versions/0028_step_progress_cleanup.py
+++ b/api/alembic/versions/0028_step_progress_cleanup.py
@@ -1,0 +1,216 @@
+"""step_progress UUID FK cleanup (Phase D.1bc)
+
+Why this change: closes Phase D.1 of #461 / #465. With ``step_uuid``
+backfilled and dual-written in production (PR #477), this migration
+makes ``steps.uuid`` the only curriculum reference and drops the legacy
+``topic_id`` / ``step_id`` / ``phase_id`` / ``step_order`` columns.
+
+Schema effect:
+
+- ``step_progress.step_uuid`` becomes ``NOT NULL``.
+- Adds ``fk_step_progress_step_uuid`` referencing ``steps(uuid)`` with
+  ``ON DELETE RESTRICT`` to prevent hard-deleting a step that has
+  recorded user progress.
+- Replaces the legacy unique constraint
+  ``uq_user_topic_step (user_id, topic_id, step_id)`` with
+  ``uq_step_progress_user_step (user_id, step_uuid)`` -- the new
+  invariant we actually want.
+- Drops the legacy indexes ``ix_step_progress_user_topic`` and
+  ``ix_step_progress_user_phase`` since they cover columns that are
+  about to be dropped.
+- Drops ``topic_id`` / ``step_id`` / ``phase_id`` / ``step_order``.
+
+Production preflight (2026-05-24, after Phase D.1a deploy):
+
+    alembic head                   : 0027_step_progress_step_uuid
+    total rows                     : 48943
+    step_uuid NULL                 : 0
+    distinct step_uuid             : 272
+    rows where step_uuid resolves  : 48943
+
+So the FK + NOT NULL are safe -- every row points to an active step.
+
+Rollback notes: ``downgrade()`` re-adds the legacy columns + indexes +
+constraint as nullable. It does NOT re-derive ``topic_id`` / ``step_id``
+/ ``phase_id`` / ``step_order`` from ``step_uuid``; restoring those
+values is left to a manual backfill if a rollback ever happens, since
+this PR's whole point is to make the legacy columns redundant.
+
+Revision ID: 0028_step_progress_cleanup
+Create Date: 2026-05-24 20:05:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0028_step_progress_cleanup"
+down_revision = "0027_step_progress_step_uuid"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+
+    # ── step_uuid NOT NULL via CHECK then SET NOT NULL ──────────────────
+    # SET NOT NULL on its own takes an ACCESS EXCLUSIVE table lock while
+    # postgres scans the whole table to prove no NULLs exist. Adding a
+    # CHECK constraint NOT VALID then VALIDATE-ing it in a separate
+    # transaction does the scan under a weaker lock that allows reads +
+    # writes. The later SET NOT NULL can skip the scan because the
+    # validated CHECK already proves the invariant holds. Each step is
+    # guarded by an existence check so a partial-failure retry works.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'ck_step_progress_step_uuid_nn'
+          ) THEN
+            ALTER TABLE step_progress
+              ADD CONSTRAINT ck_step_progress_step_uuid_nn
+              CHECK (step_uuid IS NOT NULL) NOT VALID;
+          END IF;
+        END$$;
+        """
+    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DO $$
+            BEGIN
+              IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'ck_step_progress_step_uuid_nn'
+                  AND NOT convalidated
+              ) THEN
+                ALTER TABLE step_progress
+                  VALIDATE CONSTRAINT ck_step_progress_step_uuid_nn;
+              END IF;
+            END$$;
+            """
+        )
+    op.alter_column("step_progress", "step_uuid", nullable=False)
+    op.execute(
+        "ALTER TABLE step_progress "
+        "DROP CONSTRAINT IF EXISTS ck_step_progress_step_uuid_nn"
+    )
+
+    # ── Foreign key NOT VALID then VALIDATE (separate transactions) ────
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'fk_step_progress_step_uuid'
+          ) THEN
+            ALTER TABLE step_progress
+              ADD CONSTRAINT fk_step_progress_step_uuid
+              FOREIGN KEY (step_uuid) REFERENCES steps(uuid)
+              ON DELETE RESTRICT NOT VALID;
+          END IF;
+        END$$;
+        """
+    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DO $$
+            BEGIN
+              IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_step_progress_step_uuid'
+                  AND NOT convalidated
+              ) THEN
+                ALTER TABLE step_progress
+                  VALIDATE CONSTRAINT fk_step_progress_step_uuid;
+              END IF;
+            END$$;
+            """
+        )
+
+    # ── Drop legacy unique constraint ──────────────────────────────────
+    op.execute("ALTER TABLE step_progress DROP CONSTRAINT IF EXISTS uq_user_topic_step")
+
+    # ── New unique constraint via concurrent index then ALTER TABLE ────
+    # CREATE UNIQUE INDEX CONCURRENTLY keeps writes flowing; the
+    # subsequent ALTER TABLE ... USING INDEX upgrades it to a constraint
+    # without rebuilding.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+            "uq_step_progress_user_step ON step_progress (user_id, step_uuid)"
+        )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'uq_step_progress_user_step'
+          ) THEN
+            ALTER TABLE step_progress
+              ADD CONSTRAINT uq_step_progress_user_step
+              UNIQUE USING INDEX uq_step_progress_user_step;
+          END IF;
+        END$$;
+        """
+    )
+
+    # ── Drop legacy indexes concurrently ───────────────────────────────
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_step_progress_user_topic")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_step_progress_user_phase")
+
+    # ── Drop legacy columns ────────────────────────────────────────────
+    op.execute("ALTER TABLE step_progress DROP COLUMN IF EXISTS step_order")
+    op.execute("ALTER TABLE step_progress DROP COLUMN IF EXISTS phase_id")
+    op.execute("ALTER TABLE step_progress DROP COLUMN IF EXISTS step_id")
+    op.execute("ALTER TABLE step_progress DROP COLUMN IF EXISTS topic_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "step_progress",
+        sa.Column("topic_id", sa.String(length=100), nullable=True),
+    )
+    op.add_column(
+        "step_progress",
+        sa.Column("step_id", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "step_progress",
+        sa.Column("phase_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "step_progress",
+        sa.Column("step_order", sa.Integer(), nullable=True),
+    )
+
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_step_progress_user_phase ON step_progress (user_id, phase_id)"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_step_progress_user_topic ON step_progress (user_id, topic_id)"
+        )
+
+    op.drop_constraint("uq_step_progress_user_step", "step_progress", type_="unique")
+    op.create_unique_constraint(
+        "uq_user_topic_step",
+        "step_progress",
+        ["user_id", "topic_id", "step_id"],
+    )
+
+    op.drop_constraint(
+        "fk_step_progress_step_uuid", "step_progress", type_="foreignkey"
+    )
+    op.alter_column("step_progress", "step_uuid", nullable=True)

--- a/api/src/learn_to_cloud/services/progress_service.py
+++ b/api/src/learn_to_cloud/services/progress_service.py
@@ -100,18 +100,22 @@ async def fetch_user_progress(
     validated_req_ids = await sub_repo.get_validated_requirement_ids(user_id)
 
     step_repo = StepProgressRepository(db)
-    all_topic_ids = [topic.id for phase in phases for topic in phase.topics]
-    completed_by_topic = await step_repo.get_completed_for_topics(
-        user_id, all_topic_ids
+    all_step_uuids = [
+        step.uuid
+        for phase in phases
+        for topic in phase.topics
+        for step in topic.learning_steps
+    ]
+    completed_step_uuids = await step_repo.get_completed_step_uuids(
+        user_id, all_step_uuids
     )
 
     phase_steps: dict[int, int] = {}
     for phase in phases:
         total_completed = 0
         for topic in phase.topics:
-            valid_step_ids = {step.id for step in topic.learning_steps}
-            completed = completed_by_topic.get(topic.id, set())
-            total_completed += len(completed & valid_step_ids)
+            topic_uuids = {step.uuid for step in topic.learning_steps}
+            total_completed += len(completed_step_uuids & topic_uuids)
         phase_steps[phase.id] = total_completed
 
     phase_progress_map: dict[int, PhaseProgress] = {}
@@ -180,16 +184,24 @@ async def fetch_phase_progress(
     object so we never re-load the curriculum here.
     """
     step_repo = StepProgressRepository(db)
-    topic_ids = [t.id for t in phase.topics]
-    completed_by_topic = await step_repo.get_completed_for_topics(user_id, topic_ids)
+    all_step_uuids = [
+        step.uuid for topic in phase.topics for step in topic.learning_steps
+    ]
+    completed_step_uuids = await step_repo.get_completed_step_uuids(
+        user_id, all_step_uuids
+    )
 
     topic_progress: dict[str, TopicProgressData] = {}
     total_completed = 0
     total_steps = 0
 
     for topic in phase.topics:
-        completed_steps = completed_by_topic.get(topic.id, set())
-        tp = compute_topic_progress(topic, completed_steps)
+        completed_step_ids = {
+            step.id
+            for step in topic.learning_steps
+            if step.uuid in completed_step_uuids
+        }
+        tp = compute_topic_progress(topic, completed_step_ids)
         topic_progress[topic.id] = tp
         total_completed += tp.steps_completed
         total_steps += tp.steps_total

--- a/api/src/learn_to_cloud/services/steps_service.py
+++ b/api/src/learn_to_cloud/services/steps_service.py
@@ -42,9 +42,6 @@ async def _resolve_step(
 
     Returns:
         Tuple of (resolved_step_id, step_order, total_steps, step_uuid).
-        ``step_uuid`` is plumbed through to the repository so it can
-        dual-write the new ``step_progress.step_uuid`` column (Phase
-        D.1a of #461).
     """
     topic = await get_topic_by_id(db, topic_id)
     if topic is None:
@@ -59,7 +56,13 @@ async def _resolve_step(
 
 
 def parse_phase_id_from_topic_id(topic_id: str) -> int | None:
-    """Extract phase ID from a topic_id string (e.g., 'phase1-topic5' -> 1)."""
+    """Extract phase ID from a topic_id string (e.g., 'phase1-topic5' -> 1).
+
+    Used by the HTMX templates to render phase-aware navigation. The
+    DB no longer carries ``step_progress.phase_id`` (Phase D.1c of
+    #465) but the URL contract still uses phase ids, so callers parse
+    them from the topic id string.
+    """
     if not isinstance(topic_id, str) or not topic_id.startswith("phase"):
         return None
     try:
@@ -75,13 +78,16 @@ async def get_valid_completed_steps(
 ) -> set[str]:
     """Get completed step IDs filtered to only steps that exist in content.
 
-    Prevents stale step IDs (from removed/renamed content) from inflating
-    progress counts.
+    The repo speaks UUIDs; we translate back to the human-readable step
+    IDs the rest of the app and templates expect. Soft-deleted steps
+    drop out automatically because ``topic.learning_steps`` only
+    contains active steps.
     """
     step_repo = StepProgressRepository(db)
-    completed = await step_repo.get_completed_step_ids(user_id, topic.id)
-    valid_ids = {step.id for step in topic.learning_steps}
-    return completed & valid_ids
+    completed_uuids = await step_repo.get_completed_step_uuids(
+        user_id, (step.uuid for step in topic.learning_steps)
+    )
+    return {step.id for step in topic.learning_steps if step.uuid in completed_uuids}
 
 
 async def complete_step(
@@ -92,36 +98,17 @@ async def complete_step(
 ) -> tuple[StepCompletionResult, set[str]]:
     """Mark a learning step as complete.
 
-    Steps can be completed in any order.
-
-    Args:
-        db: Database session
-        user_id: The user's ID
-        topic_id: The topic ID
-        step_id: The stable step identifier to complete
-
-    Returns:
-        Tuple of (StepCompletionResult, updated completed step orders)
-
-    Note:
-        Idempotent — completing an already-completed step is a no-op
-        that returns the current state without error.
+    Steps can be completed in any order. Idempotent -- completing an
+    already-completed step is a no-op that returns the current state
+    without error.
     """
     resolved_step_id, step_order, _, step_uuid = await _resolve_step(
         db, topic_id, step_id
     )
 
     step_repo = StepProgressRepository(db)
-    phase_id = parse_phase_id_from_topic_id(topic_id)
-    if phase_id is None:
-        raise StepUnknownTopicError(topic_id)
-
     step_progress = await step_repo.create_if_not_exists(
         user_id=user_id,
-        topic_id=topic_id,
-        step_id=resolved_step_id,
-        step_order=step_order,
-        phase_id=phase_id,
         step_uuid=step_uuid,
     )
 
@@ -130,9 +117,12 @@ async def complete_step(
     span.set_attribute("step.step_id", resolved_step_id)
     span.set_attribute("step.order", step_order)
 
-    # Step already completed — idempotent no-op
+    topic = await get_topic_by_id(db, topic_id)
+    completed_steps: set[str] = set()
+    if topic is not None:
+        completed_steps = await get_valid_completed_steps(db, user_id, topic)
+
     if step_progress is None:
-        completed_steps = await step_repo.get_completed_step_ids(user_id, topic_id)
         span.set_attribute("step.action", "already_completed")
         return StepCompletionResult(
             topic_id=topic_id,
@@ -142,11 +132,9 @@ async def complete_step(
 
     span.set_attribute("step.action", "completed")
 
-    completed_steps = await step_repo.get_completed_step_ids(user_id, topic_id)
-
     return StepCompletionResult(
-        topic_id=step_progress.topic_id,
-        step_id=step_progress.step_id,
+        topic_id=topic_id,
+        step_id=resolved_step_id,
         completed_at=step_progress.completed_at,
     ), completed_steps
 
@@ -159,25 +147,18 @@ async def uncomplete_step(
 ) -> tuple[int, set[str]]:
     """Mark a single learning step as incomplete.
 
-    Only removes the specified step — does not cascade to other steps.
-
-    Args:
-        db: Database session
-        user_id: The user's ID
-        topic_id: The topic ID
-        step_id: The stable step identifier to uncomplete
-
-    Returns:
-        Tuple of (number of steps deleted, updated completed step orders)
+    Only removes the specified step -- does not cascade to other steps.
 
     Raises:
         StepUnknownTopicError: If topic_id doesn't exist in content
         StepInvalidStepIdError: If step_id doesn't exist in the topic
     """
-    resolved_step_id, step_order, _, _ = await _resolve_step(db, topic_id, step_id)
+    resolved_step_id, step_order, _, step_uuid = await _resolve_step(
+        db, topic_id, step_id
+    )
 
     step_repo = StepProgressRepository(db)
-    deleted = await step_repo.delete_step(user_id, topic_id, resolved_step_id)
+    deleted = await step_repo.delete_step(user_id, step_uuid)
 
     span = trace.get_current_span()
     span.set_attribute("step.topic_id", topic_id)
@@ -185,6 +166,9 @@ async def uncomplete_step(
     span.set_attribute("step.order", step_order)
     span.set_attribute("step.action", "uncompleted")
 
-    completed_steps = await step_repo.get_completed_step_ids(user_id, topic_id)
+    topic = await get_topic_by_id(db, topic_id)
+    completed_steps: set[str] = set()
+    if topic is not None:
+        completed_steps = await get_valid_completed_steps(db, user_id, topic)
 
     return deleted, completed_steps

--- a/api/tests/services/test_progress_service.py
+++ b/api/tests/services/test_progress_service.py
@@ -193,8 +193,8 @@ class TestFetchUserProgress:
             MockSubRepo.return_value.get_validated_requirement_ids = AsyncMock(
                 return_value=set()
             )
-            MockStepRepo.return_value.get_completed_for_topics = AsyncMock(
-                return_value={}
+            MockStepRepo.return_value.get_completed_step_uuids = AsyncMock(
+                return_value=set()
             )
             result = await fetch_user_progress(AsyncMock(), user_id=1)
             assert result.user_id == 1
@@ -211,13 +211,14 @@ class TestFetchPhaseProgress:
     async def test_queries_db(self):
         topic = _make_topic(steps=["s1", "s2"])
         phase = _make_phase(0, topics=[topic])
+        completed_uuids = {s.uuid for s in topic.learning_steps}
 
         with patch(
             "learn_to_cloud.services.progress_service.StepProgressRepository",
             autospec=True,
         ) as MockStepRepo:
-            MockStepRepo.return_value.get_completed_for_topics = AsyncMock(
-                return_value={"phase0-topic1": {"s1", "s2"}}
+            MockStepRepo.return_value.get_completed_step_uuids = AsyncMock(
+                return_value=completed_uuids
             )
             result = await fetch_phase_progress(AsyncMock(), user_id=1, phase=phase)
 
@@ -242,6 +243,7 @@ class TestFetchPhaseProgress:
                 ),
             }
         )
+        completed_uuids = {s.uuid for s in topic.learning_steps}
 
         with (
             patch(
@@ -253,8 +255,8 @@ class TestFetchPhaseProgress:
                 autospec=True,
             ) as MockSubRepo,
         ):
-            MockStepRepo.return_value.get_completed_for_topics = AsyncMock(
-                return_value={"phase3-topic1": {"s1", "s2"}}
+            MockStepRepo.return_value.get_completed_step_uuids = AsyncMock(
+                return_value=completed_uuids
             )
             MockSubRepo.return_value.count_validated_for_requirements = AsyncMock(
                 return_value=0
@@ -286,6 +288,7 @@ class TestFetchPhaseProgress:
                 ),
             }
         )
+        completed_uuids = {s.uuid for s in topic.learning_steps}
 
         with (
             patch(
@@ -297,8 +300,8 @@ class TestFetchPhaseProgress:
                 autospec=True,
             ) as MockSubRepo,
         ):
-            MockStepRepo.return_value.get_completed_for_topics = AsyncMock(
-                return_value={"phase3-topic1": {"s1", "s2"}}
+            MockStepRepo.return_value.get_completed_step_uuids = AsyncMock(
+                return_value=completed_uuids
             )
             MockSubRepo.return_value.count_validated_for_requirements = AsyncMock(
                 return_value=1

--- a/api/tests/services/test_steps_service.py
+++ b/api/tests/services/test_steps_service.py
@@ -133,16 +133,17 @@ class TestCompleteStep:
     @pytest.mark.asyncio
     async def test_first_completion_creates_record(self):
         topic = _make_topic(steps=["step-intro"])
+        step_uuid = topic.learning_steps[0].uuid
         mock_step_progress = MagicMock(
-            topic_id="phase0-topic1",
-            step_id="step-intro",
+            user_id=1,
+            step_uuid=step_uuid,
             completed_at=MagicMock(),
         )
 
         with (
             patch(
                 "learn_to_cloud.services.steps_service.get_topic_by_id",
-                autospec=True,
+                new_callable=AsyncMock,
                 return_value=topic,
             ),
             patch(
@@ -152,7 +153,7 @@ class TestCompleteStep:
         ):
             repo = MockRepo.return_value
             repo.create_if_not_exists = AsyncMock(return_value=mock_step_progress)
-            repo.get_completed_step_ids = AsyncMock(return_value={"step-intro"})
+            repo.get_completed_step_uuids = AsyncMock(return_value={step_uuid})
 
             result, completed = await complete_step(
                 AsyncMock(), user_id=1, topic_id="phase0-topic1", step_id="step-intro"
@@ -165,11 +166,12 @@ class TestCompleteStep:
     async def test_idempotent_re_completion(self):
         """Already-completed step returns current state without error."""
         topic = _make_topic(steps=["step-intro"])
+        step_uuid = topic.learning_steps[0].uuid
 
         with (
             patch(
                 "learn_to_cloud.services.steps_service.get_topic_by_id",
-                autospec=True,
+                new_callable=AsyncMock,
                 return_value=topic,
             ),
             patch(
@@ -179,7 +181,7 @@ class TestCompleteStep:
         ):
             repo = MockRepo.return_value
             repo.create_if_not_exists = AsyncMock(return_value=None)
-            repo.get_completed_step_ids = AsyncMock(return_value={"step-intro"})
+            repo.get_completed_step_uuids = AsyncMock(return_value={step_uuid})
 
             result, completed = await complete_step(
                 AsyncMock(), user_id=1, topic_id="phase0-topic1", step_id="step-intro"
@@ -203,7 +205,7 @@ class TestUncompleteStep:
         with (
             patch(
                 "learn_to_cloud.services.steps_service.get_topic_by_id",
-                autospec=True,
+                new_callable=AsyncMock,
                 return_value=topic,
             ),
             patch(
@@ -213,7 +215,7 @@ class TestUncompleteStep:
         ):
             repo = MockRepo.return_value
             repo.delete_step = AsyncMock(return_value=1)
-            repo.get_completed_step_ids = AsyncMock(return_value=set())
+            repo.get_completed_step_uuids = AsyncMock(return_value=set())
 
             deleted, completed = await uncomplete_step(
                 AsyncMock(), user_id=1, topic_id="phase0-topic1", step_id="step-intro"
@@ -230,7 +232,7 @@ class TestUncompleteStep:
         with (
             patch(
                 "learn_to_cloud.services.steps_service.get_topic_by_id",
-                autospec=True,
+                new_callable=AsyncMock,
                 return_value=topic,
             ),
             patch(
@@ -240,7 +242,7 @@ class TestUncompleteStep:
         ):
             repo = MockRepo.return_value
             repo.delete_step = AsyncMock(return_value=0)
-            repo.get_completed_step_ids = AsyncMock(return_value=set())
+            repo.get_completed_step_uuids = AsyncMock(return_value=set())
 
             deleted, completed = await uncomplete_step(
                 AsyncMock(), user_id=1, topic_id="phase0-topic1", step_id="step-intro"
@@ -259,17 +261,21 @@ class TestGetValidCompletedSteps:
     @pytest.mark.asyncio
     async def test_filters_stale_step_ids(self):
         topic = _make_topic(steps=["s1", "s2"])
+        s1_uuid = topic.learning_steps[0].uuid
+        s2_uuid = topic.learning_steps[1].uuid
 
         with patch(
             "learn_to_cloud.services.steps_service.StepProgressRepository",
             autospec=True,
         ) as MockRepo:
             repo = MockRepo.return_value
-            repo.get_completed_step_ids = AsyncMock(return_value={"s1", "s2", "s3"})
+            # Only known step uuids; the repo can't return UUIDs the
+            # caller didn't ask about, so "stale" filtering happens
+            # implicitly via the (active) topic.learning_steps list.
+            repo.get_completed_step_uuids = AsyncMock(return_value={s1_uuid, s2_uuid})
 
             result = await get_valid_completed_steps(
                 AsyncMock(), user_id=1, topic=topic
             )
 
         assert result == {"s1", "s2"}
-        assert "s3" not in result

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -285,14 +285,15 @@ class VerificationJob(TimestampMixin, Base):
 class StepProgress(Base):
     """Tracks completion of learning steps within topics.
 
-    Note: Only has completed_at timestamp since steps are immutable once done.
+    References the curriculum via ``step_uuid`` (FK to ``steps.uuid``).
+    Phase D.1c (#465) dropped the legacy ``topic_id`` / ``step_id`` /
+    ``phase_id`` / ``step_order`` denormalized columns; that data is now
+    derived from the FK join when needed.
     """
 
     __tablename__ = "step_progress"
     __table_args__ = (
-        UniqueConstraint("user_id", "topic_id", "step_id", name="uq_user_topic_step"),
-        Index("ix_step_progress_user_topic", "user_id", "topic_id"),
-        Index("ix_step_progress_user_phase", "user_id", "phase_id"),
+        UniqueConstraint("user_id", "step_uuid", name="uq_step_progress_user_step"),
         Index("ix_step_progress_step_uuid", "step_uuid"),
     )
 
@@ -302,22 +303,14 @@ class StepProgress(Base):
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
     )
-    topic_id: Mapped[str] = mapped_column(
-        String(100),
-        nullable=False,
-    )
-    step_id: Mapped[str] = mapped_column(String(255), nullable=False)
-    phase_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    step_order: Mapped[int] = mapped_column(
-        Integer,
-        nullable=False,
-    )
-    # UUID reference to ``steps.uuid``. Nullable through PR D.1a (this PR)
-    # while we dual-write; PR D.1c will set NOT NULL and add the FK once
-    # all production rows are backfilled.
-    step_uuid: Mapped[UUID | None] = mapped_column(
+    step_uuid: Mapped[UUID] = mapped_column(
         Uuid(as_uuid=True),
-        nullable=True,
+        ForeignKey(
+            "steps.uuid",
+            ondelete="RESTRICT",
+            name="fk_step_progress_step_uuid",
+        ),
+        nullable=False,
     )
     completed_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/progress_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/progress_repository.py
@@ -1,5 +1,12 @@
-"""Repository for step progress operations."""
+"""Repository for step progress operations.
 
+After Phase D.1c (#465), ``step_progress`` references the curriculum
+solely via ``step_uuid`` (FK to ``steps.uuid``). All public methods
+accept and return curriculum step UUIDs; callers convert to or from
+the human-readable step IDs when needed.
+"""
+
+from collections.abc import Iterable
 from uuid import UUID
 
 from sqlalchemy import delete, select
@@ -15,16 +22,26 @@ class StepProgressRepository:
     def __init__(self, db: AsyncSession) -> None:
         self.db = db
 
-    async def get_completed_step_ids(
+    async def get_completed_step_uuids(
         self,
         user_id: int,
-        topic_id: str,
-    ) -> set[str]:
-        """Get set of completed step IDs for a user in a topic."""
+        step_uuids: Iterable[UUID],
+    ) -> set[UUID]:
+        """Return which of the given step UUIDs the user has completed.
+
+        Caller passes the candidate UUIDs (typically a topic's
+        ``learning_steps[].uuid``); only intersecting completions come
+        back. Returning an empty set for an empty input avoids a
+        round-trip with an empty IN-list.
+        """
+        uuids = list(step_uuids)
+        if not uuids:
+            return set()
+
         result = await self.db.execute(
-            select(StepProgress.step_id).where(
+            select(StepProgress.step_uuid).where(
                 StepProgress.user_id == user_id,
-                StepProgress.topic_id == topic_id,
+                StepProgress.step_uuid.in_(uuids),
             )
         )
         return {row[0] for row in result.all()}
@@ -32,37 +49,21 @@ class StepProgressRepository:
     async def create_if_not_exists(
         self,
         user_id: int,
-        topic_id: str,
-        step_id: str,
-        step_order: int,
-        phase_id: int,
-        step_uuid: UUID | None = None,
+        step_uuid: UUID,
     ) -> StepProgress | None:
         """Atomically create a step progress record if it doesn't exist.
 
-        Uses INSERT ... ON CONFLICT DO NOTHING RETURNING to check and insert
-        in a single round-trip instead of SELECT + INSERT (2 round-trips).
-
-        ``step_uuid`` is the curriculum reference being introduced in
-        Phase D.1a. It is dual-written alongside the legacy ``step_id``
-        / ``topic_id`` so PR D.1b can switch reads over and PR D.1c can
-        drop the legacy columns and add the FK.
+        Uses INSERT ... ON CONFLICT DO NOTHING RETURNING to check and
+        insert in a single round-trip instead of SELECT + INSERT.
 
         Returns:
             The created StepProgress if inserted, or None if already existed.
         """
         stmt = (
             pg_insert(StepProgress)
-            .values(
-                user_id=user_id,
-                topic_id=topic_id,
-                step_id=step_id,
-                phase_id=phase_id,
-                step_order=step_order,
-                step_uuid=step_uuid,
-            )
+            .values(user_id=user_id, step_uuid=step_uuid)
             .on_conflict_do_nothing(
-                constraint="uq_user_topic_step",
+                constraint="uq_step_progress_user_step",
             )
             .returning(StepProgress)
         )
@@ -72,36 +73,13 @@ class StepProgressRepository:
     async def delete_step(
         self,
         user_id: int,
-        topic_id: str,
-        step_id: str,
+        step_uuid: UUID,
     ) -> int:
         """Delete a single step progress record."""
         result = await self.db.execute(
             delete(StepProgress).where(
                 StepProgress.user_id == user_id,
-                StepProgress.topic_id == topic_id,
-                StepProgress.step_id == step_id,
+                StepProgress.step_uuid == step_uuid,
             )
         )
         return getattr(result, "rowcount", 0) or 0
-
-    async def get_completed_for_topics(
-        self,
-        user_id: int,
-        topic_ids: list[str],
-    ) -> dict[str, set[str]]:
-        """Get completed steps for a user, filtered to specific topics."""
-        if not topic_ids:
-            return {}
-
-        result = await self.db.execute(
-            select(StepProgress.topic_id, StepProgress.step_id).where(
-                StepProgress.user_id == user_id,
-                StepProgress.topic_id.in_(topic_ids),
-            )
-        )
-
-        by_topic: dict[str, set[str]] = {}
-        for row in result.all():
-            by_topic.setdefault(row.topic_id, set()).add(row.step_id)
-        return by_topic

--- a/packages/learn-to-cloud-shared/tests/repositories/test_progress_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_progress_repository.py
@@ -1,8 +1,19 @@
-"""Integration tests for StepProgressRepository."""
+"""Integration tests for StepProgressRepository.
+
+After Phase D.1c (#465) the repository accepts and returns curriculum
+step UUIDs. The FK to ``steps.uuid`` means rows can only be inserted
+for active steps in the synced curriculum, so each test seeds the
+real curriculum via ``sync_curriculum_to_db`` and pulls two arbitrary
+step UUIDs out of it.
+"""
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
+from learn_to_cloud_shared.content_yaml_loader import clear_cache
+from learn_to_cloud_shared.models import CurriculumStep
 from learn_to_cloud_shared.repositories.progress_repository import (
     StepProgressRepository,
 )
@@ -20,88 +31,88 @@ async def user(db_session: AsyncSession):
     return await repo.upsert(USER_ID, github_username="progressuser")
 
 
-class TestGetCompletedForTopics:
-    async def test_returns_completed_steps_by_topic(
-        self, db_session: AsyncSession, user
+@pytest.fixture()
+async def step_uuids(db_session: AsyncSession) -> list:
+    """Sync the real curriculum and return the first 3 step UUIDs."""
+    clear_cache()
+    await sync_curriculum_to_db(db_session)
+    result = await db_session.execute(
+        select(CurriculumStep.uuid).order_by(CurriculumStep.uuid).limit(3)
+    )
+    return [row[0] for row in result.all()]
+
+
+class TestGetCompletedStepUuids:
+    async def test_returns_completed_uuids(
+        self, db_session: AsyncSession, user, step_uuids: list
     ):
         repo = StepProgressRepository(db_session)
-        await repo.create_if_not_exists(USER_ID, "topic-a", "step-1", 1, 1)
-        await repo.create_if_not_exists(USER_ID, "topic-a", "step-2", 2, 1)
-        await repo.create_if_not_exists(USER_ID, "topic-b", "step-1", 1, 1)
+        await repo.create_if_not_exists(USER_ID, step_uuids[0])
+        await repo.create_if_not_exists(USER_ID, step_uuids[1])
         await db_session.flush()
 
-        result = await repo.get_completed_for_topics(USER_ID, ["topic-a", "topic-b"])
+        result = await repo.get_completed_step_uuids(USER_ID, step_uuids)
 
-        assert result["topic-a"] == {"step-1", "step-2"}
-        assert result["topic-b"] == {"step-1"}
+        assert result == {step_uuids[0], step_uuids[1]}
 
-    async def test_returns_empty_for_no_topics(self, db_session: AsyncSession, user):
+    async def test_returns_empty_for_no_uuids(self, db_session: AsyncSession, user):
         repo = StepProgressRepository(db_session)
-        result = await repo.get_completed_for_topics(USER_ID, [])
-        assert result == {}
+        result = await repo.get_completed_step_uuids(USER_ID, [])
+        assert result == set()
 
-    async def test_excludes_unrequested_topics(self, db_session: AsyncSession, user):
+    async def test_excludes_unrequested_uuids(
+        self, db_session: AsyncSession, user, step_uuids: list
+    ):
         repo = StepProgressRepository(db_session)
-        await repo.create_if_not_exists(USER_ID, "topic-x", "step-1", 1, 1)
+        await repo.create_if_not_exists(USER_ID, step_uuids[0])
         await db_session.flush()
 
-        result = await repo.get_completed_for_topics(USER_ID, ["topic-other"])
-        assert "topic-x" not in result
+        # Ask only about step 2, which is NOT completed
+        result = await repo.get_completed_step_uuids(USER_ID, [step_uuids[1]])
+        assert result == set()
 
 
 class TestCreateIfNotExists:
-    async def test_creates_record(self, db_session: AsyncSession, user):
+    async def test_creates_record(
+        self, db_session: AsyncSession, user, step_uuids: list
+    ):
         repo = StepProgressRepository(db_session)
-        progress = await repo.create_if_not_exists(USER_ID, "topic-1", "step-1", 1, 1)
+        progress = await repo.create_if_not_exists(USER_ID, step_uuids[0])
 
         assert progress is not None
         assert progress.user_id == USER_ID
-        assert progress.step_id == "step-1"
+        assert progress.step_uuid == step_uuids[0]
 
-    async def test_returns_none_on_duplicate(self, db_session: AsyncSession, user):
+    async def test_returns_none_on_duplicate(
+        self, db_session: AsyncSession, user, step_uuids: list
+    ):
         repo = StepProgressRepository(db_session)
-        await repo.create_if_not_exists(USER_ID, "topic-1", "step-1", 1, 1)
+        await repo.create_if_not_exists(USER_ID, step_uuids[0])
         await db_session.flush()
 
-        duplicate = await repo.create_if_not_exists(USER_ID, "topic-1", "step-1", 1, 1)
+        duplicate = await repo.create_if_not_exists(USER_ID, step_uuids[0])
         assert duplicate is None
 
 
 class TestDeleteStep:
-    async def test_deletes_only_specified_step(self, db_session: AsyncSession, user):
+    async def test_deletes_only_specified_step(
+        self, db_session: AsyncSession, user, step_uuids: list
+    ):
         repo = StepProgressRepository(db_session)
-        await repo.create_if_not_exists(USER_ID, "topic-1", "step-1", 1, 1)
-        await repo.create_if_not_exists(USER_ID, "topic-1", "step-2", 2, 1)
-        await repo.create_if_not_exists(USER_ID, "topic-1", "step-3", 3, 1)
+        await repo.create_if_not_exists(USER_ID, step_uuids[0])
+        await repo.create_if_not_exists(USER_ID, step_uuids[1])
+        await repo.create_if_not_exists(USER_ID, step_uuids[2])
         await db_session.flush()
 
-        deleted = await repo.delete_step(USER_ID, "topic-1", "step-2")
+        deleted = await repo.delete_step(USER_ID, step_uuids[1])
 
         assert deleted == 1
-        remaining = await repo.get_completed_step_ids(USER_ID, "topic-1")
-        assert remaining == {"step-1", "step-3"}
+        remaining = await repo.get_completed_step_uuids(USER_ID, step_uuids)
+        assert remaining == {step_uuids[0], step_uuids[2]}
 
     async def test_returns_zero_when_nothing_to_delete(
-        self, db_session: AsyncSession, user
+        self, db_session: AsyncSession, user, step_uuids: list
     ):
         repo = StepProgressRepository(db_session)
-        deleted = await repo.delete_step(USER_ID, "topic-1", "step-1")
+        deleted = await repo.delete_step(USER_ID, step_uuids[0])
         assert deleted == 0
-
-
-class TestGetCompletedStepIds:
-    async def test_returns_all_step_ids_for_topic(self, db_session: AsyncSession, user):
-        repo = StepProgressRepository(db_session)
-        await repo.create_if_not_exists(USER_ID, "topic-z", "s1", 1, 1)
-        await repo.create_if_not_exists(USER_ID, "topic-z", "s2", 2, 1)
-        await db_session.flush()
-
-        ids = await repo.get_completed_step_ids(USER_ID, "topic-z")
-        assert ids == {"s1", "s2"}
-
-    async def test_returns_empty_set_for_no_completions(
-        self, db_session: AsyncSession, user
-    ):
-        repo = StepProgressRepository(db_session)
-        ids = await repo.get_completed_step_ids(USER_ID, "no-such-topic")
-        assert ids == set()

--- a/scripts/seed_progress.py
+++ b/scripts/seed_progress.py
@@ -61,33 +61,19 @@ async def main(github_username: str) -> None:
             step_count = 0
             for phase in phases:
                 for topic in phase.topics:
-                    for step_order, step in enumerate(topic.learning_steps, 1):
+                    for step in topic.learning_steps:
                         await conn.execute(
                             text(
                                 """
                                 INSERT INTO step_progress (
-                                    user_id,
-                                    topic_id,
-                                    step_id,
-                                    phase_id,
-                                    step_order,
-                                    step_uuid,
-                                    completed_at
+                                    user_id, step_uuid, completed_at
                                 )
-                                VALUES (
-                                    :user_id, :topic_id, :step_id,
-                                    :phase_id, :step_order, :step_uuid,
-                                    :completed_at
-                                )
-                                ON CONFLICT (user_id, topic_id, step_id) DO NOTHING
+                                VALUES (:user_id, :step_uuid, :completed_at)
+                                ON CONFLICT (user_id, step_uuid) DO NOTHING
                                 """
                             ),
                             {
                                 "user_id": user_id,
-                                "topic_id": topic.id,
-                                "step_id": step.id,
-                                "phase_id": phase.id,
-                                "step_order": step_order,
                                 "step_uuid": step.uuid,
                                 "completed_at": now,
                             },


### PR DESCRIPTION
Closes Phase D.1 of #461 / #465. With `step_uuid` backfilled and dual-written by #477, this PR makes `steps.uuid` the only curriculum reference and drops the legacy `topic_id` / `step_id` / `phase_id` / `step_order` columns from `step_progress`.

## Migration 0028

- `step_uuid` SET NOT NULL via the CHECK-then-flip pattern (CHECK NOT VALID → VALIDATE in separate tx → SET NOT NULL → drop CHECK). The validation scan runs under a weaker lock and the SET NOT NULL itself is a metadata-only flip.
- FK `step_uuid → steps.uuid ON DELETE RESTRICT`, added NOT VALID then VALIDATEd in a separate transaction so it doesn't escalate to SHARE ROW EXCLUSIVE.
- Replaces `uq_user_topic_step` with `uq_step_progress_user_step (user_id, step_uuid)` via CREATE UNIQUE INDEX CONCURRENTLY + ALTER TABLE ... USING INDEX.
- Drops `ix_step_progress_user_topic` and `ix_step_progress_user_phase` concurrently.
- Drops legacy columns: `topic_id`, `step_id`, `phase_id`, `step_order`.

Every DDL is guarded by IF EXISTS / IF NOT EXISTS or a DO block that checks `pg_constraint`, so a partial-failure retry succeeds.

squawk + pytest-alembic green. `.squawk.toml` now excludes `ban-drop-column` (accepted trade-off for the brief 500s rollover window — per #461 / #465) and `adding-not-nullable-field` (the safe CHECK-then-NOT-NULL pattern squawk's static checker can't recognize). Both exclusions have docstring comments explaining why.

## App + repo changes

- `StepProgressRepository` API now speaks step UUIDs:
  - `get_completed_step_uuids(user_id, step_uuids) -> set[UUID]`
  - `create_if_not_exists(user_id, step_uuid)`
  - `delete_step(user_id, step_uuid)`
- `steps_service`: `complete_step` / `uncomplete_step` / `get_valid_completed_steps` thread step UUIDs through the repo and map back to `step.id` at the boundary for templates that still expect human-readable IDs.
- `progress_service.fetch_user_progress` + `fetch_phase_progress` query by step UUIDs and intersect each topic's UUIDs for per-topic totals.
- `parse_phase_id_from_topic_id` kept as a pure helper (still used by HTMX templates that embed phase ids in URLs).
- `seed_progress.py` writes only `user_id` + `step_uuid`.

## Verification

- 226 api + 462 shared tests (1 skipped) green.
- ruff/format/ty clean across api, shared, verification-functions.
- squawk clean on the new migration.
- End-to-end locally: alembic upgrade → alembic check → curriculum sync = 7/42/272/135/10.
- API boots clean and serves `/` + `/curriculum` (200) from DB.

## Trade-off accepted

Brief 500s during pod rollover while old pods still reference the dropped columns — explicitly agreed in the planning discussion before D.1bc started.