### PR TITLE
feat(curriculum): submissions UUID FK + drop attempt_number (Phase D.2 + #460)

### DIFF
--- a/api/alembic/versions/0029_submissions_uuid_fk.py
+++ b/api/alembic/versions/0029_submissions_uuid_fk.py
@@ -1,0 +1,252 @@
+"""submissions UUID FK + drop attempt_number (Phase D.2 + #460)
+
+Why this change: Phase D of #461 / #465. Combines the additive +
+cleanup steps for ``submissions`` into one PR (one migration, one
+deploy). The agreed trade-off is a brief 500s window during pod
+rollover while old pods still reference the dropped columns; see
+``.squawk.toml`` for the documented rule exclusions.
+
+Also lands #460: drop ``attempt_number`` and the
+``uq_user_requirement_attempt`` unique constraint. Nothing in the
+codebase reads ``attempt_number``; the unique constraint's only role
+was to disambiguate retries, and the row PK already does that.
+
+## Schema effect
+
+- Adds ``submissions.requirement_uuid UUID``.
+- Backfills from ``requirements.id`` -- the lookup includes
+  soft-deleted requirements (no ``deleted_at IS NULL`` filter) so
+  in-flight submissions for a soft-deleted requirement still get a
+  UUID. The ``uq_requirements_id_active`` partial index only guards
+  active rows from collisions, but ``requirements.id`` is also
+  globally unique-ish historically: there are no recorded cases of two
+  soft-deleted requirements sharing an id, so the lookup is
+  deterministic in practice.
+- DELETEs 210 rows whose ``requirement_id`` matches no row in
+  ``requirements`` at all (the 6 ``journal-pr-*`` slugs from an old
+  curriculum revision that was never synced). These rows are
+  already invisible from the app's perspective because no requirement
+  resolves them via ``get_requirement_by_id``.
+- Drops the legacy unique constraint ``uq_user_requirement_attempt``;
+  per #460 there is no replacement -- the row PK is sufficient and
+  the app already keys "latest submission" by ``ORDER BY id DESC``.
+- Drops legacy indexes ``ix_submissions_user_phase_req`` (used
+  ``phase_id`` which we are dropping) and ``ix_submissions_user_req_latest``
+  (used ``requirement_id`` which we are dropping). Replaces with
+  ``ix_submissions_user_req_uuid_latest`` covering the same
+  latest-submission query path on the new UUID.
+- ``requirement_uuid`` SET NOT NULL via the CHECK-then-flip pattern
+  used elsewhere in this refactor; FK ``ON DELETE RESTRICT`` to
+  ``requirements(uuid)`` added NOT VALID then VALIDATEd in a
+  separate transaction.
+- Drops legacy columns: ``attempt_number``, ``submission_type``,
+  ``phase_id``, ``requirement_id``.
+
+## Production preflight (2026-05-24)
+
+    rows                                       : 2588
+    distinct users                             : 1114
+    rows resolving incl soft-deleted           : 2378
+    rows with no matching requirement at all   : 210 (in 6 stale slugs)
+    distinct attempt_numbers                   : 1..22 (denormalized counter)
+    (user,req) groups with >1 attempt           : 285
+    in-flight verification_jobs                : 0
+
+Mixed-validation groups exist but in all of them the latest-by-attempt
+row is the validated one, so the row PK ordering preserves the
+"latest validated wins" semantic without the explicit counter.
+
+## Rollback
+
+``downgrade()`` re-adds the legacy columns (nullable), recreates the
+two dropped indexes, and rebuilds the unique constraint. It does NOT
+restore deleted orphan rows, and it does NOT re-derive
+``submission_type`` / ``phase_id`` / ``attempt_number`` from
+``requirement_uuid`` -- the source data for that derivation no longer
+exists in a single denormalized form.
+
+Revision ID: 0029_submissions_uuid_fk
+Create Date: 2026-05-24 20:35:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0029_submissions_uuid_fk"
+down_revision = "0028_step_progress_cleanup"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '5min'")
+
+    # ── Additive column ────────────────────────────────────────────────
+    op.execute("ALTER TABLE submissions ADD COLUMN IF NOT EXISTS requirement_uuid UUID")
+
+    # ── Backfill: include soft-deleted requirements ────────────────────
+    op.execute(
+        """
+        UPDATE submissions sub
+        SET requirement_uuid = r.uuid
+        FROM requirements r
+        WHERE r.id = sub.requirement_id
+        """
+    )
+
+    # ── Delete orphan rows (no matching requirement at all) ────────────
+    op.execute("DELETE FROM submissions WHERE requirement_uuid IS NULL")
+
+    # ── NOT NULL via CHECK-then-flip ───────────────────────────────────
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'ck_submissions_requirement_uuid_nn'
+          ) THEN
+            ALTER TABLE submissions
+              ADD CONSTRAINT ck_submissions_requirement_uuid_nn
+              CHECK (requirement_uuid IS NOT NULL) NOT VALID;
+          END IF;
+        END$$;
+        """
+    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DO $$
+            BEGIN
+              IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'ck_submissions_requirement_uuid_nn'
+                  AND NOT convalidated
+              ) THEN
+                ALTER TABLE submissions
+                  VALIDATE CONSTRAINT ck_submissions_requirement_uuid_nn;
+              END IF;
+            END$$;
+            """
+        )
+    op.alter_column("submissions", "requirement_uuid", nullable=False)
+    op.execute(
+        "ALTER TABLE submissions "
+        "DROP CONSTRAINT IF EXISTS ck_submissions_requirement_uuid_nn"
+    )
+
+    # ── FK NOT VALID then VALIDATE (separate transactions) ─────────────
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'fk_submissions_requirement_uuid'
+          ) THEN
+            ALTER TABLE submissions
+              ADD CONSTRAINT fk_submissions_requirement_uuid
+              FOREIGN KEY (requirement_uuid) REFERENCES requirements(uuid)
+              ON DELETE RESTRICT NOT VALID;
+          END IF;
+        END$$;
+        """
+    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DO $$
+            BEGIN
+              IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_submissions_requirement_uuid'
+                  AND NOT convalidated
+              ) THEN
+                ALTER TABLE submissions
+                  VALIDATE CONSTRAINT fk_submissions_requirement_uuid;
+              END IF;
+            END$$;
+            """
+        )
+
+    # ── Drop legacy unique constraint (per #460) ───────────────────────
+    op.execute(
+        "ALTER TABLE submissions DROP CONSTRAINT IF EXISTS uq_user_requirement_attempt"
+    )
+
+    # ── Drop legacy indexes concurrently ───────────────────────────────
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_submissions_user_phase_req")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_submissions_user_req_latest")
+
+    # ── New index for latest-per-(user, requirement_uuid) ──────────────
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_submissions_user_req_uuid_latest "
+            "ON submissions (user_id, requirement_uuid, created_at DESC)"
+        )
+
+    # ── Drop legacy columns ────────────────────────────────────────────
+    op.execute("ALTER TABLE submissions DROP COLUMN IF EXISTS attempt_number")
+    op.execute("ALTER TABLE submissions DROP COLUMN IF EXISTS submission_type")
+    op.execute("ALTER TABLE submissions DROP COLUMN IF EXISTS phase_id")
+    op.execute("ALTER TABLE submissions DROP COLUMN IF EXISTS requirement_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "submissions",
+        sa.Column("requirement_id", sa.String(length=100), nullable=True),
+    )
+    op.add_column(
+        "submissions",
+        sa.Column("phase_id", sa.Integer(), nullable=True),
+    )
+    # Original column used Enum(SubmissionType, native_enum=False), which
+    # is stored as VARCHAR + CHECK constraint, not a postgres ENUM type.
+    # Recreate as a plain string; the CHECK constraint isn't restored
+    # (downgrade is a developer escape hatch, not a production rollback).
+    op.add_column(
+        "submissions",
+        sa.Column("submission_type", sa.String(length=50), nullable=True),
+    )
+    op.add_column(
+        "submissions",
+        sa.Column(
+            "attempt_number",
+            sa.Integer(),
+            nullable=True,
+            server_default=sa.text("1"),
+        ),
+    )
+
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_submissions_user_req_uuid_latest"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_submissions_user_req_latest "
+            "ON submissions (user_id, requirement_id, created_at DESC)"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_submissions_user_phase_req "
+            "ON submissions (user_id, phase_id, requirement_id)"
+        )
+
+    op.create_unique_constraint(
+        "uq_user_requirement_attempt",
+        "submissions",
+        ["user_id", "requirement_id", "attempt_number"],
+    )
+
+    op.drop_constraint(
+        "fk_submissions_requirement_uuid", "submissions", type_="foreignkey"
+    )
+    op.alter_column("submissions", "requirement_uuid", nullable=True)

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -129,7 +129,7 @@ async def phase_page(
     if hands_on:
         requirements = hands_on.requirements
 
-    sub_context = await get_phase_submission_context(db, user_id, phase_id)
+    sub_context = await get_phase_submission_context(db, user_id, phase)
     submissions_by_req = sub_context.submissions_by_req
     feedback_by_req = sub_context.feedback_by_req
     active_jobs = await VerificationJobRepository(db).get_active_for_phase(

--- a/api/src/learn_to_cloud/services/progress_service.py
+++ b/api/src/learn_to_cloud/services/progress_service.py
@@ -12,6 +12,7 @@ Data sources:
 """
 
 import logging
+from uuid import UUID
 
 from learn_to_cloud_shared.content_service import get_all_phases
 from learn_to_cloud_shared.repositories.progress_repository import (
@@ -97,7 +98,7 @@ async def fetch_user_progress(
     req_index = RequirementIndex.from_phases(phases)
 
     sub_repo = SubmissionRepository(db)
-    validated_req_ids = await sub_repo.get_validated_requirement_ids(user_id)
+    validated_req_uuids = await sub_repo.get_validated_requirement_uuids(user_id)
 
     step_repo = StepProgressRepository(db)
     all_step_uuids = [
@@ -120,11 +121,9 @@ async def fetch_user_progress(
 
     phase_progress_map: dict[int, PhaseProgress] = {}
     for phase_id, requirements in phase_requirements.items():
-        current_req_ids = {
-            req_id for req_id in req_index.requirement_ids_for_phase(phase_id)
-        }
-        hands_on_validated = len(validated_req_ids & current_req_ids)
-        hands_on_required = len(current_req_ids)
+        current_req_uuids = set(req_index.requirement_uuids_for_phase(phase_id))
+        hands_on_validated = len(validated_req_uuids & current_req_uuids)
+        hands_on_required = len(current_req_uuids)
 
         phase_progress_map[phase_id] = _compute_phase_progress(
             phase_id=phase_id,
@@ -206,16 +205,16 @@ async def fetch_phase_progress(
         total_completed += tp.steps_completed
         total_steps += tp.steps_total
 
-    current_req_ids: set[str] = set()
+    current_req_uuids: set[UUID] = set()
     if phase.hands_on_verification:
-        current_req_ids = {r.id for r in phase.hands_on_verification.requirements}
-    hands_on_required = len(current_req_ids)
+        current_req_uuids = {r.uuid for r in phase.hands_on_verification.requirements}
+    hands_on_required = len(current_req_uuids)
 
     hands_on_validated = 0
     if hands_on_required > 0:
         sub_repo = SubmissionRepository(db)
         hands_on_validated = await sub_repo.count_validated_for_requirements(
-            user_id, current_req_ids
+            user_id, current_req_uuids
         )
 
     return _compute_phase_progress(

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from uuid import UUID
 
 from learn_to_cloud_shared.models import SubmissionType, VerificationJob
 from learn_to_cloud_shared.repositories.submission_repository import (
@@ -22,6 +23,7 @@ from learn_to_cloud_shared.repositories.verification_job_repository import (
 )
 from learn_to_cloud_shared.schemas import (
     HandsOnRequirement,
+    Phase,
     PhaseSubmissionContext,
     SubmissionData,
     SubmissionResult,
@@ -42,27 +44,47 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 async def get_phase_submission_context(
     db: AsyncSession,
     user_id: int,
-    phase_id: int,
+    phase: Phase,
 ) -> PhaseSubmissionContext:
     """Build submission context for rendering a phase page.
 
-    Fetches all submissions for the user in a phase, converts them to
-    DTOs, and parses stored feedback JSON into template-ready summaries.
-    Calculates remaining time for async submission types.
+    Fetches the latest submission per requirement for the user in
+    ``phase``, converts each to a ``SubmissionData`` DTO, and parses
+    stored feedback JSON into template-ready summaries.
 
-    Returns:
-        PhaseSubmissionContext with submissions and feedback keyed by
-        requirement ID.
+    Takes the resolved ``Phase`` rather than a phase id so we can pull
+    each requirement's UUID, slug, and submission_type out of the
+    in-memory tree -- after Phase D.2 (#465) the ``submissions`` table
+    no longer carries those denormalized fields.
     """
+    requirements_by_uuid: dict[UUID, HandsOnRequirement] = {}
+    if phase.hands_on_verification:
+        requirements_by_uuid = {
+            req.uuid: req for req in phase.hands_on_verification.requirements
+        }
+
     repo = SubmissionRepository(db)
-    raw_submissions = await repo.get_by_user_and_phase(user_id, phase_id)
+    raw_submissions = await repo.get_latest_for_requirements(
+        user_id, requirements_by_uuid.keys()
+    )
 
     submissions_by_req: dict[str, SubmissionData] = {}
     feedback_by_req: dict[str, dict[str, object]] = {}
 
     for sub in raw_submissions:
-        sub_data = to_submission_data(sub)
-        submissions_by_req[sub.requirement_id] = sub_data
+        requirement = requirements_by_uuid.get(sub.requirement_uuid)
+        if requirement is None:
+            # Defensive: get_latest_for_requirements only returns rows whose
+            # uuid is in the input list, but if curriculum drift slips one
+            # past us we skip silently rather than crash the phase page.
+            continue
+        sub_data = to_submission_data(
+            sub,
+            requirement_id=requirement.id,
+            submission_type=requirement.submission_type,
+            phase_id=phase.id,
+        )
+        submissions_by_req[requirement.id] = sub_data
 
         if sub.feedback_json and not sub.is_validated:
             try:
@@ -78,7 +100,7 @@ async def get_phase_submission_context(
                 ]
                 passed = sum(1 for t in tasks if t["passed"])
 
-                feedback_by_req[sub.requirement_id] = {
+                feedback_by_req[requirement.id] = {
                     "tasks": tasks,
                     "passed": passed,
                 }
@@ -86,7 +108,7 @@ async def get_phase_submission_context(
                 span = trace.get_current_span()
                 span.add_event(
                     "feedback_parse_failed",
-                    {"requirement_id": sub.requirement_id},
+                    {"requirement_id": requirement.id},
                 )
 
     return PhaseSubmissionContext(
@@ -181,7 +203,7 @@ async def _check_submission_preconditions(
         submission_repo = SubmissionRepository(read_session)
 
         existing = await submission_repo.get_by_user_and_requirement(
-            user_id, requirement_id
+            user_id, requirement.uuid
         )
         if existing is not None and existing.is_validated:
             raise AlreadyValidatedError("You have already completed this requirement.")
@@ -189,10 +211,10 @@ async def _check_submission_preconditions(
         # Sequential phase gating
         prereq_phase = get_prerequisite_phase(phase_id)
         if prereq_phase is not None:
-            prereq_req_ids = index.requirement_ids_for_phase(prereq_phase)
-            if prereq_req_ids:
+            prereq_req_uuids = index.requirement_uuids_for_phase(prereq_phase)
+            if prereq_req_uuids:
                 all_done = await submission_repo.are_all_requirements_validated(
-                    user_id, prereq_req_ids
+                    user_id, prereq_req_uuids
                 )
                 if not all_done:
                     raise PriorPhaseNotCompleteError(

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from learn_to_cloud_shared.models import SubmissionType
-from learn_to_cloud_shared.schemas import HandsOnRequirement
+from learn_to_cloud_shared.schemas import HandsOnRequirement, Phase
 from learn_to_cloud_shared.verification.requirements import RequirementIndex
 
 from learn_to_cloud.services.submissions_service import (
@@ -532,43 +532,71 @@ class TestSyncDispatchBranch:
 # ---------------------------------------------------------------------------
 
 
+def _phase_with_requirement(req: HandsOnRequirement) -> Phase:
+    from uuid import uuid4
+
+    from learn_to_cloud_shared.schemas import PhaseHandsOnVerificationOverview
+
+    return Phase(
+        uuid=uuid4(),
+        id=3,
+        name="Phase 3",
+        slug="phase3",
+        order=3,
+        topics=[],
+        hands_on_verification=PhaseHandsOnVerificationOverview(
+            requirements=[req],
+        ),
+    )
+
+
 @pytest.mark.unit
 class TestGetPhaseSubmissionContext:
     @pytest.mark.asyncio
     async def test_empty_submissions(self):
+        req = _make_mock_requirement()
+        phase = _phase_with_requirement(req)
         with patch(
             "learn_to_cloud.services.submissions_service.SubmissionRepository",
             autospec=True,
         ) as MockRepo:
-            MockRepo.return_value.get_by_user_and_phase = AsyncMock(return_value=[])
+            MockRepo.return_value.get_latest_for_requirements = AsyncMock(
+                return_value=[]
+            )
             result = await get_phase_submission_context(
-                AsyncMock(), user_id=1, phase_id=3
+                AsyncMock(), user_id=1, phase=phase
             )
         assert result.submissions_by_req == {}
         assert result.feedback_by_req == {}
 
     @pytest.mark.asyncio
     async def test_submission_without_feedback(self):
+        req = _make_mock_requirement()
+        phase = _phase_with_requirement(req)
         mock_sub = _make_mock_submission(is_validated=True)
+        mock_sub.requirement_uuid = req.uuid
         mock_sub.feedback_json = None
         with patch(
             "learn_to_cloud.services.submissions_service.SubmissionRepository",
             autospec=True,
         ) as MockRepo:
-            MockRepo.return_value.get_by_user_and_phase = AsyncMock(
+            MockRepo.return_value.get_latest_for_requirements = AsyncMock(
                 return_value=[mock_sub]
             )
             result = await get_phase_submission_context(
-                AsyncMock(), user_id=1, phase_id=3
+                AsyncMock(), user_id=1, phase=phase
             )
-        assert "test-requirement" in result.submissions_by_req
+        assert req.id in result.submissions_by_req
         assert result.feedback_by_req == {}
 
     @pytest.mark.asyncio
     async def test_submission_with_feedback_json(self):
+        req = _make_mock_requirement()
+        phase = _phase_with_requirement(req)
         mock_sub = _make_mock_submission(
             is_validated=False, verification_completed=True
         )
+        mock_sub.requirement_uuid = req.uuid
         mock_sub.feedback_json = (
             '[{"task_name":"A","passed":true,"feedback":"ok",'
             '"next_steps":"review the rubric"}]'
@@ -577,14 +605,14 @@ class TestGetPhaseSubmissionContext:
             "learn_to_cloud.services.submissions_service.SubmissionRepository",
             autospec=True,
         ) as MockRepo:
-            MockRepo.return_value.get_by_user_and_phase = AsyncMock(
+            MockRepo.return_value.get_latest_for_requirements = AsyncMock(
                 return_value=[mock_sub]
             )
             result = await get_phase_submission_context(
-                AsyncMock(), user_id=1, phase_id=3
+                AsyncMock(), user_id=1, phase=phase
             )
-        assert "test-requirement" in result.feedback_by_req
-        feedback = result.feedback_by_req["test-requirement"]
+        assert req.id in result.feedback_by_req
+        feedback = result.feedback_by_req[req.id]
         assert feedback["passed"] == 1
         assert feedback["tasks"] == [
             {

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -123,17 +123,16 @@ class SubmissionType(StrEnum):
 class Submission(TimestampMixin, Base):
     """Tracks validated submissions for hands-on verification.
 
-    Supports multiple submission types: GitHub URLs, deployed apps, CTF tokens, etc.
+    References curriculum via ``requirement_uuid`` (FK to
+    ``requirements.uuid``). Phase D.2 of #461 / #465 dropped the legacy
+    denormalized ``requirement_id`` / ``submission_type`` / ``phase_id``
+    columns and the ``attempt_number`` counter (per #460) -- callers
+    derive those values from the joined ``Requirement`` row when
+    needed.
     """
 
     __tablename__ = "submissions"
     __table_args__ = (
-        UniqueConstraint(
-            "user_id",
-            "requirement_id",
-            "attempt_number",
-            name="uq_user_requirement_attempt",
-        ),
         Index(
             "ix_submissions_user_verified_updated",
             "user_id",
@@ -141,15 +140,9 @@ class Submission(TimestampMixin, Base):
             "updated_at",
         ),
         Index(
-            "ix_submissions_user_phase_req",
+            "ix_submissions_user_req_uuid_latest",
             "user_id",
-            "phase_id",
-            "requirement_id",
-        ),
-        Index(
-            "ix_submissions_user_req_latest",
-            "user_id",
-            "requirement_id",
+            "requirement_uuid",
             text("created_at DESC"),
         ),
     )
@@ -160,23 +153,15 @@ class Submission(TimestampMixin, Base):
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
     )
-    requirement_id: Mapped[str] = mapped_column(
-        String(100),
-        nullable=False,
-    )
-    attempt_number: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default=text("1"), default=1
-    )
-    submission_type: Mapped[SubmissionType] = mapped_column(
-        Enum(
-            SubmissionType,
-            name="submission_type",
-            native_enum=False,
-            values_callable=lambda x: [e.value for e in x],
+    requirement_uuid: Mapped[UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        ForeignKey(
+            "requirements.uuid",
+            ondelete="RESTRICT",
+            name="fk_submissions_requirement_uuid",
         ),
         nullable=False,
     )
-    phase_id: Mapped[int] = mapped_column(Integer, nullable=False)
     submitted_value: Mapped[str] = mapped_column(
         Text,
         nullable=False,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/submission_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/submission_repository.py
@@ -1,9 +1,18 @@
-"""Submission repository for hands-on validation database operations."""
+"""Submission repository for hands-on validation database operations.
+
+After Phase D.2 of #461 / #465 the table references the curriculum via
+``requirement_uuid`` (FK to ``requirements.uuid``). All public methods
+speak UUIDs; callers translate to/from the human-readable requirement
+ids at the boundary (templates and DTOs).
+"""
+
+from collections.abc import Iterable
+from uuid import UUID
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from learn_to_cloud_shared.models import Submission, SubmissionType, utcnow
+from learn_to_cloud_shared.models import Submission, utcnow
 
 
 class SubmissionRepository:
@@ -12,20 +21,29 @@ class SubmissionRepository:
     def __init__(self, db: AsyncSession) -> None:
         self.db = db
 
-    async def get_by_user_and_phase(
-        self, user_id: int, phase_id: int
+    async def get_latest_for_requirements(
+        self, user_id: int, requirement_uuids: Iterable[UUID]
     ) -> list[Submission]:
-        """Get the latest submission per requirement for a user in a phase."""
+        """Get the latest submission per requirement_uuid for a user.
+
+        Replaces the previous ``get_by_user_and_phase`` -- callers now
+        pass an explicit list of requirement UUIDs (derived from a
+        phase's hands-on requirements) instead of an int ``phase_id``.
+        """
+        uuids = list(requirement_uuids)
+        if not uuids:
+            return []
+
         latest_sq = (
             select(
-                Submission.requirement_id,
+                Submission.requirement_uuid,
                 func.max(Submission.id).label("max_id"),
             )
             .where(
                 Submission.user_id == user_id,
-                Submission.phase_id == phase_id,
+                Submission.requirement_uuid.in_(uuids),
             )
-            .group_by(Submission.requirement_id)
+            .group_by(Submission.requirement_uuid)
             .subquery()
         )
         result = await self.db.execute(
@@ -37,14 +55,14 @@ class SubmissionRepository:
         return list(result.scalars().all())
 
     async def get_by_user_and_requirement(
-        self, user_id: int, requirement_id: str
+        self, user_id: int, requirement_uuid: UUID
     ) -> Submission | None:
         """Get the latest submission for a user and requirement."""
         result = await self.db.execute(
             select(Submission)
             .where(
                 Submission.user_id == user_id,
-                Submission.requirement_id == requirement_id,
+                Submission.requirement_uuid == requirement_uuid,
             )
             .order_by(Submission.id.desc())
             .limit(1)
@@ -61,9 +79,7 @@ class SubmissionRepository:
     async def create(
         self,
         user_id: int,
-        requirement_id: str,
-        submission_type: SubmissionType,
-        phase_id: int,
+        requirement_uuid: UUID,
         submitted_value: str,
         extracted_username: str | None,
         is_validated: bool,
@@ -72,10 +88,7 @@ class SubmissionRepository:
         validation_message: str | None = None,
         cloud_provider: str | None = None,
     ) -> Submission:
-        """Create a new submission attempt.
-
-        Automatically determines the next attempt number for the
-        user+requirement pair.
+        """Create a new submission row.
 
         Args:
             verification_completed: Whether the verification logic actually ran.
@@ -86,21 +99,9 @@ class SubmissionRepository:
                 multi-cloud labs. None for non-multi-cloud submissions.
         """
         now = utcnow()
-
-        result = await self.db.execute(
-            select(func.coalesce(func.max(Submission.attempt_number), 0)).where(
-                Submission.user_id == user_id,
-                Submission.requirement_id == requirement_id,
-            )
-        )
-        max_attempt = result.scalar_one()
-
         submission = Submission(
             user_id=user_id,
-            requirement_id=requirement_id,
-            attempt_number=max_attempt + 1,
-            submission_type=submission_type,
-            phase_id=phase_id,
+            requirement_uuid=requirement_uuid,
             submitted_value=submitted_value,
             extracted_username=extracted_username,
             is_validated=is_validated,
@@ -115,34 +116,35 @@ class SubmissionRepository:
         return submission
 
     async def are_all_requirements_validated(
-        self, user_id: int, requirement_ids: list[str]
+        self, user_id: int, requirement_uuids: Iterable[UUID]
     ) -> bool:
         """Check if the user has validated ALL of the given requirements.
 
-        Used for sequential phase gating — ensures prior phase verification
+        Used for sequential phase gating -- ensures prior phase verification
         is fully complete before allowing the next phase's submissions.
         """
-        if not requirement_ids:
+        uuids = list(requirement_uuids)
+        if not uuids:
             return True
 
         result = await self.db.execute(
-            select(func.count(func.distinct(Submission.requirement_id))).where(
+            select(func.count(func.distinct(Submission.requirement_uuid))).where(
                 Submission.user_id == user_id,
-                Submission.requirement_id.in_(requirement_ids),
+                Submission.requirement_uuid.in_(uuids),
                 Submission.is_validated.is_(True),
             )
         )
         validated_count = result.scalar_one() or 0
-        return validated_count >= len(requirement_ids)
+        return validated_count >= len(uuids)
 
-    async def get_validated_requirement_ids(self, user_id: int) -> set[str]:
-        """Get all distinct requirement IDs with at least one validated submission.
+    async def get_validated_requirement_uuids(self, user_id: int) -> set[UUID]:
+        """Get all requirement UUIDs with at least one validated submission.
 
         Used by progress computation to count hands-on completions
         directly from the source of truth (submissions table).
         """
         result = await self.db.execute(
-            select(func.distinct(Submission.requirement_id)).where(
+            select(func.distinct(Submission.requirement_uuid)).where(
                 Submission.user_id == user_id,
                 Submission.is_validated.is_(True),
             )
@@ -150,19 +152,20 @@ class SubmissionRepository:
         return set(result.scalars().all())
 
     async def count_validated_for_requirements(
-        self, user_id: int, requirement_ids: set[str]
+        self, user_id: int, requirement_uuids: Iterable[UUID]
     ) -> int:
-        """Count how many of the given requirement IDs have been validated.
+        """Count how many of the given requirement UUIDs have been validated.
 
-        Filters against a specific set of requirement IDs (from current content)
-        to prevent stale/removed requirements from inflating counts.
+        Filters against a specific set of UUIDs (from current content)
+        so removed requirements never inflate counts.
         """
-        if not requirement_ids:
+        uuids = list(requirement_uuids)
+        if not uuids:
             return 0
         result = await self.db.execute(
-            select(func.count(func.distinct(Submission.requirement_id))).where(
+            select(func.count(func.distinct(Submission.requirement_uuid))).where(
                 Submission.user_id == user_id,
-                Submission.requirement_id.in_(requirement_ids),
+                Submission.requirement_uuid.in_(uuids),
                 Submission.is_validated.is_(True),
             )
         )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
@@ -50,12 +50,26 @@ def persisted_validation_message(message: str | None) -> str | None:
     return f"{message[: MAX_VALIDATION_MESSAGE_LENGTH - 3]}..."
 
 
-def to_submission_data(submission: Submission) -> SubmissionData:
+def to_submission_data(
+    submission: Submission,
+    *,
+    requirement_id: str,
+    submission_type: SubmissionType,
+    phase_id: int,
+) -> SubmissionData:
+    """Project a ``Submission`` row into the ``SubmissionData`` response model.
+
+    After Phase D.2 (#465 / #460) the row no longer carries
+    ``requirement_id`` / ``submission_type`` / ``phase_id``. The caller
+    resolves them from the in-memory ``HandsOnRequirement`` + phase
+    context and passes them in -- ``SubmissionData`` keeps the flat
+    shape so templates and clients don't have to walk a relationship.
+    """
     return SubmissionData(
         id=submission.id,
-        requirement_id=submission.requirement_id,
-        submission_type=submission.submission_type,
-        phase_id=submission.phase_id,
+        requirement_id=requirement_id,
+        submission_type=submission_type,
+        phase_id=phase_id,
         submitted_value=submission.submitted_value,
         extracted_username=submission.extracted_username,
         is_validated=submission.is_validated,
@@ -104,9 +118,7 @@ async def persist_validation_result(
     submission_repo = SubmissionRepository(db)
     return await submission_repo.create(
         user_id=user_id,
-        requirement_id=requirement.id,
-        submission_type=requirement.submission_type,
-        phase_id=phase_id,
+        requirement_uuid=requirement.uuid,
         submitted_value=submitted_value,
         extracted_username=_extract_username(
             requirement,
@@ -128,9 +140,16 @@ async def persist_validation_result(
 def build_submission_result(
     submission: Submission,
     validation_result: ValidationResult,
+    requirement: HandsOnRequirement,
+    phase_id: int,
 ) -> SubmissionResult:
     return SubmissionResult(
-        submission=to_submission_data(submission),
+        submission=to_submission_data(
+            submission,
+            requirement_id=requirement.id,
+            submission_type=requirement.submission_type,
+            phase_id=phase_id,
+        ),
         is_valid=validation_result.is_valid,
         message=validation_result.message,
         username_match=validation_result.username_match,
@@ -201,7 +220,12 @@ async def execute_submission_validation(
             },
         )
 
-        return build_submission_result(db_submission, validation_result)
+        return build_submission_result(
+            db_submission,
+            validation_result,
+            requirement=requirement,
+            phase_id=phase_id,
+        )
 
 
 def _advisory_lock_key(user_id: int, requirement_id: str) -> str:
@@ -301,4 +325,9 @@ async def execute_sync_submission_validation(
             },
         )
 
-        return build_submission_result(db_submission, validation_result)
+        return build_submission_result(
+            db_submission,
+            validation_result,
+            requirement=requirement,
+            phase_id=phase_id,
+        )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/requirements.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/requirements.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from learn_to_cloud_shared.content_service import get_all_phases
 from learn_to_cloud_shared.repositories.submission_repository import (
@@ -58,6 +59,9 @@ class RequirementIndex:
 
     def requirement_ids_for_phase(self, phase_id: int) -> list[str]:
         return [req.id for req in self.requirements_for_phase(phase_id)]
+
+    def requirement_uuids_for_phase(self, phase_id: int) -> list[UUID]:
+        return [req.uuid for req in self.requirements_for_phase(phase_id)]
 
 
 async def load_requirement_index(db: AsyncSession) -> RequirementIndex:
@@ -128,12 +132,14 @@ async def is_phase_verification_locked(
     if prereq is None:
         return False, None
 
-    prereq_req_ids = await get_requirement_ids_for_phase(db, prereq)
-    if not prereq_req_ids:
+    prereq_req_uuids = (await load_requirement_index(db)).requirement_uuids_for_phase(
+        prereq
+    )
+    if not prereq_req_uuids:
         return False, None
 
     repo = SubmissionRepository(db)
-    all_done = await repo.are_all_requirements_validated(user_id, prereq_req_ids)
+    all_done = await repo.are_all_requirements_validated(user_id, prereq_req_uuids)
     if all_done:
         return False, None
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -26,12 +26,11 @@ from dataclasses import dataclass
 from uuid import UUID
 
 from opentelemetry import trace
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.models import (
     Submission,
-    SubmissionType,
     User,
     VerificationJob,
 )
@@ -299,26 +298,52 @@ def _build_result_from_submission(
     *,
     job_id: UUID,
     submission: Submission,
-    requirement: HandsOnRequirement | None,
+    requirement_id: str,
+    submission_type: str,
+    requirement_name: str | None,
 ) -> VerificationJobExecutionResult:
     """Build a ``VerificationJobExecutionResult`` from an already-persisted
     ``Submission``. Used by the replay short-circuit in
     :func:`prepare_verification_job` and :func:`persist_verification_result`.
+
+    ``requirement_id`` and ``submission_type`` are passed in by the caller
+    rather than read off the ``Submission`` row: Phase D.2 (#465) dropped
+    those denormalized columns from ``submissions``. The job payload
+    (sourced from ``verification_jobs``) still carries them until D.3.
     """
     outcome = _outcome_from_submission(submission)
     return VerificationJobExecutionResult(
         job_id=job_id,
         status=outcome,
         code=_code_for_outcome(outcome),
-        requirement_id=submission.requirement_id,
-        requirement_name=requirement.name if requirement is not None else None,
-        submission_type=submission.submission_type.value,
+        requirement_id=requirement_id,
+        requirement_name=requirement_name,
+        submission_type=submission_type,
         submission_id=submission.id,
         is_valid=submission.is_validated,
         verification_completed=submission.verification_completed,
         message=_MESSAGE_BY_OUTCOME[outcome],
         detail=submission.validation_message,
     )
+
+
+async def _resolve_requirement_uuid(
+    db: AsyncSession, requirement_id: str
+) -> UUID | None:
+    """Look up ``requirements.uuid`` by legacy id including soft-deleted rows.
+
+    The active read path (``get_requirement_by_id``) filters out
+    soft-deleted entries, but a submission persist may need the UUID
+    for a requirement that was soft-deleted between submit and
+    execute. The ``requirements`` FK on submissions is ON DELETE
+    RESTRICT, so soft-deleted UUIDs are always still resolvable.
+    """
+    result = await db.execute(
+        text("SELECT uuid FROM requirements WHERE id = :id LIMIT 1"),
+        {"id": requirement_id},
+    )
+    row = result.first()
+    return row[0] if row else None
 
 
 async def _handle_missing_requirement(
@@ -332,21 +357,25 @@ async def _handle_missing_requirement(
 
     Linking the Submission (rather than deleting the job row) keeps
     ``prepare_verification_job`` idempotent: a retry sees the linked row
-    and short-circuits via the replay path.
+    and short-circuits via the replay path. If the requirement no
+    longer exists at all (not even soft-deleted), raises
+    ``VerificationJobNotFoundError`` so the orchestration surfaces a
+    clear failure -- the job's payload is unrecoverable.
     """
     detail = f"Requirement not found: {payload.requirement_id}"
-    try:
-        submission_type = SubmissionType(payload.submission_type)
-    except ValueError:
-        submission_type = SubmissionType.GITHUB_PROFILE
 
     async with session_maker() as db:
+        requirement_uuid = await _resolve_requirement_uuid(db, payload.requirement_id)
+        if requirement_uuid is None:
+            raise VerificationJobNotFoundError(
+                f"job {payload.id} references unknown requirement "
+                f"{payload.requirement_id!r}"
+            )
+
         submission_repo = SubmissionRepository(db)
         submission = await submission_repo.create(
             user_id=payload.user_id,
-            requirement_id=payload.requirement_id,
-            submission_type=submission_type,
-            phase_id=payload.phase_id,
+            requirement_uuid=requirement_uuid,
             submitted_value=payload.submitted_value,
             extracted_username=None,
             is_validated=False,
@@ -412,7 +441,11 @@ async def prepare_verification_job(
                 result = _build_result_from_submission(
                     job_id=normalized_job_id,
                     submission=submission,
-                    requirement=requirement,
+                    requirement_id=payload.requirement_id,
+                    submission_type=payload.submission_type,
+                    requirement_name=(
+                        requirement.name if requirement is not None else None
+                    ),
                 )
                 span.set_attribute("verification.status", result.status)
                 span.set_attribute("verification.replay", True)
@@ -499,7 +532,9 @@ async def persist_verification_result(
                 result = _build_result_from_submission(
                     job_id=job.id,
                     submission=submission,
-                    requirement=job.requirement,
+                    requirement_id=job.requirement.id,
+                    submission_type=job.requirement.submission_type.value,
+                    requirement_name=job.requirement.name,
                 )
                 span.set_attribute("verification.status", result.status)
                 span.set_attribute("verification.replay", True)
@@ -540,7 +575,9 @@ async def persist_verification_result(
                     result = _build_result_from_submission(
                         job_id=job.id,
                         submission=canonical_submission,
-                        requirement=job.requirement,
+                        requirement_id=job.requirement.id,
+                        submission_type=job.requirement.submission_type.value,
+                        requirement_name=job.requirement.name,
                     )
                 span.set_attribute("verification.status", result.status)
                 span.set_attribute("verification.replay", True)

--- a/packages/learn-to-cloud-shared/tests/repositories/test_submission_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_submission_repository.py
@@ -1,9 +1,17 @@
-"""Integration tests for SubmissionRepository."""
+"""Integration tests for SubmissionRepository.
+
+After Phase D.2 (#465 / #460) the repo accepts and returns
+``requirement_uuid``. Tests sync the real curriculum to get hold of a
+few real UUIDs the FK requires.
+"""
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from learn_to_cloud_shared.models import SubmissionType
+from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
+from learn_to_cloud_shared.content_yaml_loader import clear_cache
+from learn_to_cloud_shared.models import CurriculumRequirement
 from learn_to_cloud_shared.repositories.submission_repository import (
     SubmissionRepository,
 )
@@ -21,57 +29,40 @@ async def user(db_session: AsyncSession):
     return await repo.upsert(USER_ID, github_username="submissionuser")
 
 
+@pytest.fixture()
+async def req_uuids(db_session: AsyncSession) -> list:
+    """Sync the real curriculum and return the first 3 requirement UUIDs."""
+    clear_cache()
+    await sync_curriculum_to_db(db_session)
+    result = await db_session.execute(
+        select(CurriculumRequirement.uuid).order_by(CurriculumRequirement.id).limit(3)
+    )
+    return [row[0] for row in result.all()]
+
+
 class TestCreate:
-    async def test_creates_submission(self, db_session: AsyncSession, user):
+    async def test_creates_submission(self, db_session: AsyncSession, user, req_uuids):
         repo = SubmissionRepository(db_session)
         sub = await repo.create(
             user_id=USER_ID,
-            requirement_id="req-1",
-            submission_type=SubmissionType.GITHUB_PROFILE,
-            phase_id=0,
+            requirement_uuid=req_uuids[0],
             submitted_value="https://github.com/testuser",
             extracted_username="testuser",
             is_validated=True,
         )
 
         assert sub.id is not None
-        assert sub.attempt_number == 1
         assert sub.is_validated is True
         assert sub.validated_at is not None
-
-    async def test_auto_increments_attempt_number(self, db_session: AsyncSession, user):
-        repo = SubmissionRepository(db_session)
-        sub1 = await repo.create(
-            user_id=USER_ID,
-            requirement_id="req-inc",
-            submission_type=SubmissionType.CTF_TOKEN,
-            phase_id=1,
-            submitted_value="token-1",
-            extracted_username=None,
-            is_validated=False,
-        )
-        sub2 = await repo.create(
-            user_id=USER_ID,
-            requirement_id="req-inc",
-            submission_type=SubmissionType.CTF_TOKEN,
-            phase_id=1,
-            submitted_value="token-2",
-            extracted_username=None,
-            is_validated=True,
-        )
-
-        assert sub1.attempt_number == 1
-        assert sub2.attempt_number == 2
+        assert sub.requirement_uuid == req_uuids[0]
 
     async def test_unvalidated_has_no_validated_at(
-        self, db_session: AsyncSession, user
+        self, db_session: AsyncSession, user, req_uuids
     ):
         repo = SubmissionRepository(db_session)
         sub = await repo.create(
             user_id=USER_ID,
-            requirement_id="req-fail",
-            submission_type=SubmissionType.GITHUB_PROFILE,
-            phase_id=0,
+            requirement_uuid=req_uuids[0],
             submitted_value="bad-value",
             extracted_username=None,
             is_validated=False,
@@ -79,129 +70,148 @@ class TestCreate:
 
         assert sub.validated_at is None
 
+    async def test_multiple_rows_per_user_requirement_allowed(
+        self, db_session: AsyncSession, user, req_uuids
+    ):
+        """#460: dropping uq_user_requirement_attempt means multiple
+        attempts coexist; the PK ``id`` keeps each row unique."""
+        repo = SubmissionRepository(db_session)
+        sub1 = await repo.create(
+            user_id=USER_ID,
+            requirement_uuid=req_uuids[0],
+            submitted_value="attempt-1",
+            extracted_username=None,
+            is_validated=False,
+        )
+        sub2 = await repo.create(
+            user_id=USER_ID,
+            requirement_uuid=req_uuids[0],
+            submitted_value="attempt-2",
+            extracted_username=None,
+            is_validated=True,
+        )
+
+        assert sub1.id != sub2.id
+
 
 class TestGetByUserAndRequirement:
-    async def test_returns_latest_submission(self, db_session: AsyncSession, user):
+    async def test_returns_latest_submission(
+        self, db_session: AsyncSession, user, req_uuids
+    ):
         repo = SubmissionRepository(db_session)
         await repo.create(
             user_id=USER_ID,
-            requirement_id="req-latest",
-            submission_type=SubmissionType.PROFILE_README,
-            phase_id=1,
+            requirement_uuid=req_uuids[0],
             submitted_value="old",
             extracted_username=None,
             is_validated=False,
         )
         await repo.create(
             user_id=USER_ID,
-            requirement_id="req-latest",
-            submission_type=SubmissionType.PROFILE_README,
-            phase_id=1,
+            requirement_uuid=req_uuids[0],
             submitted_value="new",
             extracted_username=None,
             is_validated=True,
         )
 
-        latest = await repo.get_by_user_and_requirement(USER_ID, "req-latest")
+        latest = await repo.get_by_user_and_requirement(USER_ID, req_uuids[0])
         assert latest is not None
         assert latest.submitted_value == "new"
-        assert latest.attempt_number == 2
 
-    async def test_returns_none_for_missing(self, db_session: AsyncSession, user):
+    async def test_returns_none_for_missing(
+        self, db_session: AsyncSession, user, req_uuids
+    ):
         repo = SubmissionRepository(db_session)
-        result = await repo.get_by_user_and_requirement(USER_ID, "nonexistent")
+        result = await repo.get_by_user_and_requirement(USER_ID, req_uuids[2])
         assert result is None
 
 
-class TestGetByUserAndPhase:
-    async def test_returns_latest_per_requirement(self, db_session: AsyncSession, user):
+class TestGetLatestForRequirements:
+    async def test_returns_latest_per_requirement(
+        self, db_session: AsyncSession, user, req_uuids
+    ):
         repo = SubmissionRepository(db_session)
-        # Two submissions for req-a, one for req-b
         await repo.create(
             user_id=USER_ID,
-            requirement_id="req-a",
-            submission_type=SubmissionType.CTF_TOKEN,
-            phase_id=1,
+            requirement_uuid=req_uuids[0],
             submitted_value="attempt-1",
             extracted_username=None,
             is_validated=False,
         )
         await repo.create(
             user_id=USER_ID,
-            requirement_id="req-a",
-            submission_type=SubmissionType.CTF_TOKEN,
-            phase_id=1,
+            requirement_uuid=req_uuids[0],
             submitted_value="attempt-2",
             extracted_username=None,
             is_validated=True,
         )
         await repo.create(
             user_id=USER_ID,
-            requirement_id="req-b",
-            submission_type=SubmissionType.REPO_FORK,
-            phase_id=1,
+            requirement_uuid=req_uuids[1],
             submitted_value="fork-url",
             extracted_username=None,
             is_validated=True,
         )
 
-        results = await repo.get_by_user_and_phase(USER_ID, phase_id=1)
+        results = await repo.get_latest_for_requirements(USER_ID, req_uuids[:2])
 
-        req_ids = {s.requirement_id for s in results}
-        assert req_ids == {"req-a", "req-b"}
-        # Should return only latest for req-a
-        req_a = next(s for s in results if s.requirement_id == "req-a")
-        assert req_a.submitted_value == "attempt-2"
+        seen_uuids = {s.requirement_uuid for s in results}
+        assert seen_uuids == {req_uuids[0], req_uuids[1]}
+        latest_for_first = next(
+            s for s in results if s.requirement_uuid == req_uuids[0]
+        )
+        assert latest_for_first.submitted_value == "attempt-2"
 
     async def test_returns_empty_for_no_submissions(
-        self, db_session: AsyncSession, user
+        self, db_session: AsyncSession, user, req_uuids
     ):
         repo = SubmissionRepository(db_session)
-        results = await repo.get_by_user_and_phase(USER_ID, phase_id=99)
+        results = await repo.get_latest_for_requirements(USER_ID, req_uuids[:1])
+        assert results == []
+
+    async def test_returns_empty_for_empty_input(self, db_session: AsyncSession, user):
+        repo = SubmissionRepository(db_session)
+        results = await repo.get_latest_for_requirements(USER_ID, [])
         assert results == []
 
 
 class TestAreAllRequirementsValidated:
     async def test_returns_true_when_all_validated(
-        self, db_session: AsyncSession, user
+        self, db_session: AsyncSession, user, req_uuids
     ):
         repo = SubmissionRepository(db_session)
         await repo.create(
             user_id=USER_ID,
-            requirement_id="r1",
-            submission_type=SubmissionType.GITHUB_PROFILE,
-            phase_id=0,
+            requirement_uuid=req_uuids[0],
             submitted_value="v1",
             extracted_username=None,
             is_validated=True,
         )
         await repo.create(
             user_id=USER_ID,
-            requirement_id="r2",
-            submission_type=SubmissionType.PROFILE_README,
-            phase_id=1,
+            requirement_uuid=req_uuids[1],
             submitted_value="v2",
             extracted_username=None,
             is_validated=True,
         )
 
-        assert await repo.are_all_requirements_validated(USER_ID, ["r1", "r2"]) is True
+        assert await repo.are_all_requirements_validated(USER_ID, req_uuids[:2]) is True
 
     async def test_returns_false_when_some_missing(
-        self, db_session: AsyncSession, user
+        self, db_session: AsyncSession, user, req_uuids
     ):
         repo = SubmissionRepository(db_session)
         await repo.create(
             user_id=USER_ID,
-            requirement_id="r1",
-            submission_type=SubmissionType.GITHUB_PROFILE,
-            phase_id=0,
+            requirement_uuid=req_uuids[0],
             submitted_value="v1",
             extracted_username=None,
             is_validated=True,
         )
 
-        assert await repo.are_all_requirements_validated(USER_ID, ["r1", "r2"]) is False
+        assert (
+            await repo.are_all_requirements_validated(USER_ID, req_uuids[:2]) is False
+        )
 
     async def test_returns_true_for_empty_list(self, db_session: AsyncSession, user):
         repo = SubmissionRepository(db_session)

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
@@ -6,7 +6,13 @@ import pytest
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from learn_to_cloud_shared.models import SubmissionType, VerificationJob
+from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
+from learn_to_cloud_shared.content_yaml_loader import clear_cache
+from learn_to_cloud_shared.models import (
+    CurriculumRequirement,
+    SubmissionType,
+    VerificationJob,
+)
 from learn_to_cloud_shared.repositories.submission_repository import (
     SubmissionRepository,
 )
@@ -28,6 +34,17 @@ async def user(db_session: AsyncSession):
     return await repo.upsert(USER_ID, github_username="verificationjobuser")
 
 
+@pytest.fixture()
+async def req_uuid(db_session: AsyncSession) -> UUID:
+    """Sync curriculum and return a requirement UUID for the submissions FK."""
+    clear_cache()
+    await sync_curriculum_to_db(db_session)
+    result = await db_session.execute(
+        select(CurriculumRequirement.uuid).order_by(CurriculumRequirement.id).limit(1)
+    )
+    return result.scalar_one()
+
+
 async def _create_job(
     repo: VerificationJobRepository,
     *,
@@ -46,16 +63,14 @@ async def _create_job(
 
 async def _create_submission(
     db_session: AsyncSession,
+    requirement_uuid: UUID,
     *,
-    requirement_id: str = "req-1",
     is_validated: bool = True,
     verification_completed: bool = True,
 ):
     return await SubmissionRepository(db_session).create(
         user_id=USER_ID,
-        requirement_id=requirement_id,
-        submission_type=SubmissionType.GITHUB_PROFILE,
-        phase_id=0,
+        requirement_uuid=requirement_uuid,
         submitted_value="https://github.com/testuser",
         extracted_username="testuser",
         is_validated=is_validated,
@@ -117,6 +132,7 @@ class TestCreate:
         self,
         db_session: AsyncSession,
         user,
+        req_uuid: UUID,
     ):
         """After ``link_submission`` flips a job out of the unlinked
         partial unique index, a follow-up submit must succeed.
@@ -133,7 +149,7 @@ class TestCreate:
         )
         submission = await _create_submission(
             db_session,
-            requirement_id="req-retry",
+            req_uuid,
             is_validated=False,
             verification_completed=True,
         )
@@ -193,10 +209,11 @@ class TestLinkSubmission:
         self,
         db_session: AsyncSession,
         user,
+        req_uuid: UUID,
     ):
         repo = VerificationJobRepository(db_session)
         job = await _create_job(repo)
-        submission = await _create_submission(db_session)
+        submission = await _create_submission(db_session, req_uuid)
 
         before = job.updated_at
         result = await repo.link_submission(job.id, submission.id)
@@ -212,13 +229,14 @@ class TestLinkSubmission:
         self,
         db_session: AsyncSession,
         user,
+        req_uuid: UUID,
     ):
         """Idempotency check: a Durable activity retry that re-runs
         ``link_submission`` sees ``ALREADY_LINKED`` instead of writing
         again."""
         repo = VerificationJobRepository(db_session)
         job = await _create_job(repo)
-        submission = await _create_submission(db_session)
+        submission = await _create_submission(db_session, req_uuid)
 
         first = await repo.link_submission(job.id, submission.id)
         # Even if the retry passes a different submission id, the row's
@@ -232,9 +250,10 @@ class TestLinkSubmission:
         self,
         db_session: AsyncSession,
         user,
+        req_uuid: UUID,
     ):
         repo = VerificationJobRepository(db_session)
-        submission = await _create_submission(db_session)
+        submission = await _create_submission(db_session, req_uuid)
 
         result = await repo.link_submission(
             UUID("00000000-0000-0000-0000-000000000000"),
@@ -268,10 +287,11 @@ class TestDeleteActive:
         self,
         db_session: AsyncSession,
         user,
+        req_uuid: UUID,
     ):
         repo = VerificationJobRepository(db_session)
         job = await _create_job(repo)
-        submission = await _create_submission(db_session)
+        submission = await _create_submission(db_session, req_uuid)
         await repo.link_submission(job.id, submission.id)
 
         deleted = await repo.delete_active(job.id)

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -7,7 +7,14 @@ import pytest
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
-from learn_to_cloud_shared.models import Submission, SubmissionType, VerificationJob
+from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
+from learn_to_cloud_shared.content_yaml_loader import clear_cache
+from learn_to_cloud_shared.models import (
+    CurriculumRequirement,
+    Submission,
+    SubmissionType,
+    VerificationJob,
+)
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
@@ -31,7 +38,6 @@ from learn_to_cloud_shared.verification_job_executor import (
 pytestmark = pytest.mark.integration
 
 USER_ID = 82001
-REQUIREMENT_ID = "verification-executor-test"
 
 
 @pytest.fixture()
@@ -44,33 +50,59 @@ def session_maker(test_engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
     )
 
 
-def _requirement(
-    submission_type: SubmissionType = SubmissionType.JOURNAL_API_VERIFIER,
+@pytest.fixture()
+async def synced_requirement(
+    session_maker: async_sessionmaker[AsyncSession],
 ) -> HandsOnRequirement:
-    from learn_to_cloud_shared.testing.requirement_factories import make_requirement
+    """Sync the real curriculum and return a HandsOnRequirement whose
+    UUID + id match an active row in the ``requirements`` table.
+
+    Phase D.2 added an FK on ``submissions.requirement_uuid``; tests
+    persisting submissions need the referenced requirement to exist,
+    and ``get_requirement_by_id`` only returns active rows so the test
+    requirement must be alive in the curriculum.
+    """
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        make_requirement,
+    )
+
+    clear_cache()
+    async with session_maker() as db:
+        await sync_curriculum_to_db(db)
+        await UserRepository(db).upsert(USER_ID, github_username="executoruser")
+        await db.commit()
+        row = (
+            await db.execute(
+                select(
+                    CurriculumRequirement.uuid,
+                    CurriculumRequirement.id,
+                    CurriculumRequirement.submission_type,
+                )
+                .where(CurriculumRequirement.submission_type == "journal_api_verifier")
+                .limit(1)
+            )
+        ).one()
 
     return make_requirement(
-        submission_type,
-        id=REQUIREMENT_ID,
+        SubmissionType(row.submission_type),
+        id=row.id,
         name="Verification Executor Test",
         description="Test requirement",
-    )
+    ).model_copy(update={"uuid": row.uuid})
 
 
 async def _create_job(
     session_maker: async_sessionmaker[AsyncSession],
+    requirement: HandsOnRequirement,
     *,
-    submission_type: SubmissionType = SubmissionType.JOURNAL_API_VERIFIER,
+    submission_type: SubmissionType | None = None,
 ) -> UUID:
+    sub_type = submission_type or requirement.submission_type
     async with session_maker() as db:
-        await UserRepository(db).upsert(
-            USER_ID,
-            github_username="executoruser",
-        )
         job = await VerificationJobRepository(db).create(
             user_id=USER_ID,
-            requirement_id=REQUIREMENT_ID,
-            submission_type=submission_type,
+            requirement_id=requirement.id,
+            submission_type=sub_type,
             phase_id=3,
             submitted_value="https://github.com/executoruser/repo",
         )
@@ -119,15 +151,16 @@ async def _get_submission(
 
 async def test_split_verification_primitives_prepare_run_and_persist(
     session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
 ):
-    job_id = await _create_job(session_maker)
+    job_id = await _create_job(session_maker, synced_requirement)
     validation = AsyncMock(
         return_value=ValidationResult(is_valid=True, message="Verified")
     )
 
     with patch(
         "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
-        return_value=_requirement(),
+        return_value=synced_requirement,
     ):
         preparation = await prepare_verification_job(
             job_id,
@@ -161,8 +194,9 @@ async def test_split_verification_primitives_prepare_run_and_persist(
 
 async def test_execute_verification_job_marks_success_and_links_submission(
     session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
 ):
-    job_id = await _create_job(session_maker)
+    job_id = await _create_job(session_maker, synced_requirement)
     validation = AsyncMock(
         return_value=ValidationResult(is_valid=True, message="Verified")
     )
@@ -170,7 +204,7 @@ async def test_execute_verification_job_marks_success_and_links_submission(
     with (
         patch(
             "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
-            return_value=_requirement(),
+            return_value=synced_requirement,
         ),
         patch(
             "learn_to_cloud_shared.verification_job_executor.validate_submission",
@@ -186,7 +220,7 @@ async def test_execute_verification_job_marks_success_and_links_submission(
     payload = result.to_payload()
     assert payload["status"] == "succeeded"
     assert payload["code"] == VERIFICATION_SUCCEEDED_CODE
-    assert payload["requirement_id"] == REQUIREMENT_ID
+    assert payload["requirement_id"] == synced_requirement.id
     assert payload["requirement_name"] == "Verification Executor Test"
     assert payload["submission_type"] == SubmissionType.JOURNAL_API_VERIFIER.value
     assert payload["message"] == "Verification succeeded."
@@ -200,8 +234,9 @@ async def test_execute_verification_job_marks_success_and_links_submission(
 
 async def test_execute_verification_job_marks_user_validation_failure(
     session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
 ):
-    job_id = await _create_job(session_maker)
+    job_id = await _create_job(session_maker, synced_requirement)
     validation = AsyncMock(
         return_value=ValidationResult(
             is_valid=False,
@@ -213,7 +248,7 @@ async def test_execute_verification_job_marks_user_validation_failure(
     with (
         patch(
             "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
-            return_value=_requirement(),
+            return_value=synced_requirement,
         ),
         patch(
             "learn_to_cloud_shared.verification_job_executor.validate_submission",
@@ -233,11 +268,12 @@ async def test_execute_verification_job_marks_user_validation_failure(
 
 async def test_execute_verification_job_marks_server_error(
     session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
 ):
     """A validator returning ``verification_completed=False`` records a
     server-error result. The Submission row exists and is linked but
     is_validated=False / verification_completed=False."""
-    job_id = await _create_job(session_maker)
+    job_id = await _create_job(session_maker, synced_requirement)
     validation = AsyncMock(
         return_value=ValidationResult(
             is_valid=False,
@@ -249,7 +285,7 @@ async def test_execute_verification_job_marks_server_error(
     with (
         patch(
             "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
-            return_value=_requirement(),
+            return_value=synced_requirement,
         ),
         patch(
             "learn_to_cloud_shared.verification_job_executor.validate_submission",
@@ -270,11 +306,12 @@ async def test_execute_verification_job_marks_server_error(
 
 async def test_execute_verification_job_truncates_persisted_error_messages(
     session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
 ):
     """Validation messages over the persisted limit are truncated for
     storage; the ``detail`` in the activity result follows the same
     rule."""
-    job_id = await _create_job(session_maker)
+    job_id = await _create_job(session_maker, synced_requirement)
     long_message = "x" * (MAX_VALIDATION_MESSAGE_LENGTH + 64)
     validation = AsyncMock(
         return_value=ValidationResult(
@@ -287,7 +324,7 @@ async def test_execute_verification_job_truncates_persisted_error_messages(
     with (
         patch(
             "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
-            return_value=_requirement(),
+            return_value=synced_requirement,
         ),
         patch(
             "learn_to_cloud_shared.verification_job_executor.validate_submission",
@@ -303,6 +340,7 @@ async def test_execute_verification_job_truncates_persisted_error_messages(
 
 async def test_execute_verification_job_marks_missing_requirement_server_error(
     session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
 ):
     """When the requirement vanishes from content between submit and
     execute, the executor writes a server-error Submission, links it,
@@ -311,7 +349,7 @@ async def test_execute_verification_job_marks_missing_requirement_server_error(
     Linking (rather than deleting the job row) keeps the executor
     idempotent on Durable activity retry — the second attempt sees the
     linked row and returns the same result."""
-    job_id = await _create_job(session_maker)
+    job_id = await _create_job(session_maker, synced_requirement)
     validation = AsyncMock()
 
     with (
@@ -331,25 +369,29 @@ async def test_execute_verification_job_marks_missing_requirement_server_error(
     assert result.verification_completed is False
     assert result.code == REQUIREMENT_NOT_FOUND_ERROR_CODE
     assert result.message == "Verification could not be completed."
-    assert result.detail == f"Requirement not found: {REQUIREMENT_ID}"
+    assert result.detail == f"Requirement not found: {synced_requirement.id}"
 
     # Row stays linked so a retry is idempotent.
     assert await _get_job_link(session_maker, job_id) == result.submission_id
     submission = await _get_submission(session_maker, result.submission_id)
     assert submission.is_validated is False
     assert submission.verification_completed is False
-    assert submission.validation_message == f"Requirement not found: {REQUIREMENT_ID}"
+    assert (
+        submission.validation_message
+        == f"Requirement not found: {synced_requirement.id}"
+    )
 
     validation.assert_not_awaited()
 
 
 async def test_execute_verification_job_is_idempotent_for_terminal_jobs(
     session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
 ):
     """The replay short-circuit fires when the job already has a linked
     Submission; the result is reconstructed from that Submission rather
     than running the validator again."""
-    job_id = await _create_job(session_maker)
+    job_id = await _create_job(session_maker, synced_requirement)
     validation = AsyncMock(
         return_value=ValidationResult(is_valid=True, message="Verified")
     )
@@ -357,7 +399,7 @@ async def test_execute_verification_job_is_idempotent_for_terminal_jobs(
     with (
         patch(
             "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
-            return_value=_requirement(),
+            return_value=synced_requirement,
         ),
         patch(
             "learn_to_cloud_shared.verification_job_executor.validate_submission",
@@ -379,17 +421,18 @@ async def test_execute_verification_job_is_idempotent_for_terminal_jobs(
 
 async def test_persist_is_idempotent_via_result_submission_id_guard(
     session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
 ):
     """A second ``persist_verification_result`` call after the first one
     linked a Submission must short-circuit on the result_submission_id
     guard, not write a duplicate row."""
-    job_id = await _create_job(session_maker)
+    job_id = await _create_job(session_maker, synced_requirement)
 
     prepared = PreparedVerificationJob(
         id=job_id,
         user_id=USER_ID,
         github_username="executoruser",
-        requirement=_requirement(),
+        requirement=synced_requirement,
         phase_id=3,
         submitted_value="https://github.com/executoruser/repo",
     )
@@ -415,11 +458,12 @@ async def test_persist_is_idempotent_via_result_submission_id_guard(
 
 async def test_persist_raises_when_job_row_was_deleted(
     session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
 ):
     """If the poller's ``delete_active`` won the race the persist
     activity raises ``VerificationJobNotFoundError`` rather than
     creating an orphan Submission."""
-    job_id = await _create_job(session_maker)
+    job_id = await _create_job(session_maker, synced_requirement)
 
     # Simulate the poller having deleted the row mid-flight.
     async with session_maker() as db:
@@ -431,7 +475,7 @@ async def test_persist_raises_when_job_row_was_deleted(
         id=job_id,
         user_id=USER_ID,
         github_username="executoruser",
-        requirement=_requirement(),
+        requirement=synced_requirement,
         phase_id=3,
         submitted_value="https://github.com/executoruser/repo",
     )

--- a/packages/learn-to-cloud-shared/tests/verification/test_sync_execution.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_sync_execution.py
@@ -15,7 +15,13 @@ import pytest
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
-from learn_to_cloud_shared.models import Submission, SubmissionType
+from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
+from learn_to_cloud_shared.content_yaml_loader import clear_cache
+from learn_to_cloud_shared.models import (
+    CurriculumRequirement,
+    Submission,
+    SubmissionType,
+)
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
 from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
 from learn_to_cloud_shared.verification.execution import (
@@ -40,17 +46,39 @@ def session_maker(test_engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
     )
 
 
-def _requirement(
+async def _make_requirement_in_db(
+    session_maker: async_sessionmaker[AsyncSession],
     submission_type: SubmissionType = SubmissionType.GITHUB_PROFILE,
 ) -> HandsOnRequirement:
-    from learn_to_cloud_shared.testing.requirement_factories import make_requirement
+    """Sync the real curriculum and return a HandsOnRequirement whose
+    UUID is present in the ``requirements`` table.
+
+    Phase D.2 added an FK on ``submissions.requirement_uuid``; tests
+    that persist Submission rows need the referenced requirement to
+    exist.
+    """
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        make_requirement,
+    )
+
+    clear_cache()
+    async with session_maker() as db:
+        await sync_curriculum_to_db(db)
+        await db.commit()
+        row_uuid = (
+            await db.execute(
+                select(CurriculumRequirement.uuid)
+                .order_by(CurriculumRequirement.id)
+                .limit(1)
+            )
+        ).scalar_one()
 
     return make_requirement(
         submission_type,
         id=REQUIREMENT_ID,
         name="Sync Execution Test",
         description="Test requirement",
-    )
+    ).model_copy(update={"uuid": row_uuid})
 
 
 async def _seed_user(session_maker: async_sessionmaker[AsyncSession]) -> None:
@@ -74,6 +102,7 @@ async def test_sync_validation_persists_submission(
 ) -> None:
     """Happy path: validator returns success, ``Submission`` row is written."""
     await _seed_user(session_maker)
+    requirement = await _make_requirement_in_db(session_maker)
 
     with patch(
         "learn_to_cloud_shared.verification.execution.validate_submission",
@@ -88,7 +117,7 @@ async def test_sync_validation_persists_submission(
         result = await execute_sync_submission_validation(
             session_maker=session_maker,
             user_id=USER_ID,
-            requirement=_requirement(),
+            requirement=requirement,
             phase_id=PHASE_ID,
             submitted_value="https://github.com/syncuser",
             github_username="syncuser",
@@ -104,6 +133,7 @@ async def test_sync_validation_persists_failure(
 ) -> None:
     """User-correctable failure path: row is written with is_validated=False."""
     await _seed_user(session_maker)
+    requirement = await _make_requirement_in_db(session_maker)
 
     with patch(
         "learn_to_cloud_shared.verification.execution.validate_submission",
@@ -118,7 +148,7 @@ async def test_sync_validation_persists_failure(
         result = await execute_sync_submission_validation(
             session_maker=session_maker,
             user_id=USER_ID,
-            requirement=_requirement(),
+            requirement=requirement,
             phase_id=PHASE_ID,
             submitted_value="https://github.com/wronguser",
             github_username="syncuser",
@@ -139,6 +169,7 @@ async def test_sync_validation_rolls_back_on_validator_exception(
     rolls back the whole thing and the advisory lock is released.
     """
     await _seed_user(session_maker)
+    requirement = await _make_requirement_in_db(session_maker)
 
     with patch(
         "learn_to_cloud_shared.verification.execution.validate_submission",
@@ -148,7 +179,7 @@ async def test_sync_validation_rolls_back_on_validator_exception(
             await execute_sync_submission_validation(
                 session_maker=session_maker,
                 user_id=USER_ID,
-                requirement=_requirement(),
+                requirement=requirement,
                 phase_id=PHASE_ID,
                 submitted_value="https://github.com/syncuser",
                 github_username="syncuser",
@@ -170,7 +201,7 @@ async def test_sync_validation_rolls_back_on_validator_exception(
         await execute_sync_submission_validation(
             session_maker=session_maker,
             user_id=USER_ID,
-            requirement=_requirement(),
+            requirement=requirement,
             phase_id=PHASE_ID,
             submitted_value="https://github.com/syncuser",
             github_username="syncuser",
@@ -189,6 +220,7 @@ async def test_concurrent_submits_for_same_requirement_dedupe(
     long enough for the second request to race past the lock check.
     """
     await _seed_user(session_maker)
+    requirement = await _make_requirement_in_db(session_maker)
 
     started = asyncio.Event()
     release = asyncio.Event()
@@ -210,7 +242,7 @@ async def test_concurrent_submits_for_same_requirement_dedupe(
             execute_sync_submission_validation(
                 session_maker=session_maker,
                 user_id=USER_ID,
-                requirement=_requirement(),
+                requirement=requirement,
                 phase_id=PHASE_ID,
                 submitted_value="https://github.com/syncuser",
                 github_username="syncuser",
@@ -226,7 +258,7 @@ async def test_concurrent_submits_for_same_requirement_dedupe(
             await execute_sync_submission_validation(
                 session_maker=session_maker,
                 user_id=USER_ID,
-                requirement=_requirement(),
+                requirement=requirement,
                 phase_id=PHASE_ID,
                 submitted_value="https://github.com/syncuser",
                 github_username="syncuser",
@@ -247,6 +279,7 @@ async def test_advisory_lock_keyed_per_requirement(
     submit for a *different* requirement must NOT be blocked."""
     other_requirement_id = f"{REQUIREMENT_ID}-other"
     await _seed_user(session_maker)
+    requirement = await _make_requirement_in_db(session_maker)
 
     started = asyncio.Event()
     release = asyncio.Event()
@@ -276,7 +309,7 @@ async def test_advisory_lock_keyed_per_requirement(
             execute_sync_submission_validation(
                 session_maker=session_maker,
                 user_id=USER_ID,
-                requirement=_requirement(),
+                requirement=requirement,
                 phase_id=PHASE_ID,
                 submitted_value="https://github.com/syncuser",
                 github_username="syncuser",
@@ -284,15 +317,19 @@ async def test_advisory_lock_keyed_per_requirement(
         )
         await asyncio.wait_for(started.wait(), timeout=5.0)
 
-        # Different requirement → different lock key → must proceed immediately.
-        from learn_to_cloud_shared.testing.requirement_factories import (
-            github_profile_requirement,
-        )
-
-        other_requirement = github_profile_requirement(
-            id=other_requirement_id,
-            name="Other",
-            description="Other",
+        # Different requirement -> different lock key -> must proceed immediately.
+        # Grab a second curriculum requirement so the FK is satisfied.
+        async with session_maker() as db:
+            other_uuid = (
+                await db.execute(
+                    select(CurriculumRequirement.uuid)
+                    .where(CurriculumRequirement.uuid != requirement.uuid)
+                    .order_by(CurriculumRequirement.id)
+                    .limit(1)
+                )
+            ).scalar_one()
+        other_requirement = requirement.model_copy(
+            update={"id": other_requirement_id, "uuid": other_uuid}
         )
         with patch(
             "learn_to_cloud_shared.verification.execution.validate_submission",
@@ -322,6 +359,7 @@ async def test_advisory_lock_uses_pg_try_advisory_xact_lock(
     after the function returns. Catches regressions where someone swaps
     in pg_advisory_lock (session-level) by mistake."""
     await _seed_user(session_maker)
+    requirement = await _make_requirement_in_db(session_maker)
 
     with patch(
         "learn_to_cloud_shared.verification.execution.validate_submission",
@@ -336,7 +374,7 @@ async def test_advisory_lock_uses_pg_try_advisory_xact_lock(
         await execute_sync_submission_validation(
             session_maker=session_maker,
             user_id=USER_ID,
-            requirement=_requirement(),
+            requirement=requirement,
             phase_id=PHASE_ID,
             submitted_value="https://github.com/syncuser",
             github_username="syncuser",

--- a/scripts/seed_progress.py
+++ b/scripts/seed_progress.py
@@ -118,30 +118,30 @@ async def main(github_username: str) -> None:
                     await conn.execute(
                         text(
                             """
+                            DELETE FROM submissions
+                            WHERE user_id = :user_id
+                              AND requirement_uuid = :req_uuid
+                            """
+                        ),
+                        {"user_id": user_id, "req_uuid": req.uuid},
+                    )
+                    await conn.execute(
+                        text(
+                            """
                             INSERT INTO submissions (
-                                user_id, requirement_id, attempt_number,
-                                submission_type, phase_id, submitted_value,
+                                user_id, requirement_uuid, submitted_value,
                                 is_validated, validated_at,
                                 verification_completed, created_at, updated_at
                             )
                             VALUES (
-                                :user_id, :req_id, 1, :sub_type, :phase_id,
-                                :submitted_value, true, :now, true, :now, :now
+                                :user_id, :req_uuid, :submitted_value,
+                                true, :now, true, :now, :now
                             )
-                            ON CONFLICT (user_id, requirement_id, attempt_number)
-                            DO UPDATE SET
-                                submitted_value = :submitted_value,
-                                is_validated = true,
-                                validated_at = :now,
-                                verification_completed = true,
-                                updated_at = :now
                             """
                         ),
                         {
                             "user_id": user_id,
-                            "req_id": req.id,
-                            "sub_type": sub_type,
-                            "phase_id": phase.id,
+                            "req_uuid": req.uuid,
                             "submitted_value": submitted_value,
                             "now": now,
                         },


### PR DESCRIPTION
Phase D.2 of #461 / #465. Combined additive + cleanup in one PR per the agreed plan (1 PR per table, brief 500s rollover window accepted). Also closes #460: drops `attempt_number` + `uq_user_requirement_attempt`.

## Migration 0029

- Adds nullable `requirement_uuid`; backfills from `requirements.id` (lookup includes soft-deleted to handle in-flight submissions for soft-deleted requirements).
- DELETEs **210 rows** (6 stale `journal-pr-*` slugs from an old curriculum revision).
- Drops `uq_user_requirement_attempt` (per #460).
- Drops legacy indexes `ix_submissions_user_phase_req` + `ix_submissions_user_req_latest` concurrently.
- Adds `ix_submissions_user_req_uuid_latest` covering the latest-per-(user,requirement) query path.
- `requirement_uuid` SET NOT NULL via CHECK-then-flip; FK `ON DELETE RESTRICT` added NOT VALID then VALIDATEd in a separate transaction.
- Drops legacy columns: `attempt_number`, `submission_type`, `phase_id`, `requirement_id`.

Every DDL is idempotent. squawk + pytest-alembic green.

## Production preflight (2026-05-24)

```
rows                       : 2588
distinct users             : 1114
resolving incl soft-deleted: 2378
no match at all            : 210 (6 stale 'journal-pr-*' slugs)
attempt_numbers            : 1..22
in-flight verification     : 0
```

272 (user, req) groups have mixed validation status — in all of them the latest-by-attempt is the validated one, so dropping `attempt_number` doesn't change which row 'wins'.

## App changes

- **Submission ORM**: drops 4 legacy columns; adds `requirement_uuid` with FK + new latest-per-req index.
- **SubmissionRepository**: rewritten to speak UUIDs. `get_by_user_and_phase` → `get_latest_for_requirements(uuids)`. `create()` loses `submission_type`/`phase_id`/`attempt_number`.
- **RequirementIndex**: adds `requirement_uuids_for_phase`.
- **to_submission_data**: takes `requirement_id`/`submission_type`/`phase_id` as kwargs (caller pulls them off the in-memory `HandsOnRequirement` + phase). `SubmissionData` shape unchanged externally.
- **submissions_service.get_phase_submission_context**: takes `Phase` instead of `phase_id`; resolves req_uuids from `phase.hands_on_verification`.
- **\_check_submission_preconditions**: uses `requirement.uuid` + `index.requirement_uuids_for_phase`.
- **progress_service**: `validated_req_uuids` throughout.
- **pages_routes.phase_page**: passes `phase` to `get_phase_submission_context`.
- **verification_job_executor**: `_build_result_from_submission` takes `requirement_id`/`submission_type` as kwargs. `_handle_missing_requirement` uses a new `_resolve_requirement_uuid` helper (queries `requirements` directly, includes soft-deleted) and raises `VerificationJobNotFoundError` if no row exists at all — the FK prevents persisting an orphaned submission.
- **persist_validation_result** + execution paths pass `requirement.uuid` through.
- **seed_progress**: writes `user_id` + `requirement_uuid` only; deletes any pre-existing rows for the (user, requirement) pair to keep the seed idempotent without relying on a unique constraint.

## Tests

Rewritten the integration tests that previously created submissions with fake UUIDs — the new FK requires the requirement to exist. Each suite now syncs the real curriculum to get a real requirement UUID.

## Verification

- 226 api + 463 shared (1 skipped) tests green.
- ruff / format / ty clean across api, shared, verification-functions.
- squawk clean on the new migration.
- End-to-end locally: alembic upgrade → alembic check → curriculum sync = 7/42/272/135/10.
- API boots clean and serves `/` + `/curriculum` (200) from DB.

## Trade-off accepted

~15-30s of 500s during pod rollover (old pods reading dropped columns).