### PR TITLE
feat(curriculum): verification_jobs UUID FK + SubmissionData cleanup (Phase D.3)

### DIFF
--- a/api/alembic/versions/0030_verification_jobs_uuid_fk.py
+++ b/api/alembic/versions/0030_verification_jobs_uuid_fk.py
@@ -1,0 +1,230 @@
+"""verification_jobs UUID FK (Phase D.3)
+
+Closes Phase D of #461 / #465: ``verification_jobs`` now references
+the curriculum solely by ``requirement_uuid``. Same combined-PR shape
+as Phase D.2 (additive + cleanup in one migration) with the same
+accepted trade-off: a brief 500s window during pod rollover while
+old pods still reference the dropped columns.
+
+## Schema effect
+
+- Adds ``verification_jobs.requirement_uuid UUID``.
+- Backfills from ``requirements.id`` (lookup includes soft-deleted
+  rows so any in-flight job for a soft-deleted requirement still
+  gets a UUID).
+- DELETEs rows whose ``requirement_id`` matches no row in
+  ``requirements`` at all. Production preflight: 0 such rows.
+- Drops the legacy partial unique index
+  ``uq_verification_jobs_active_user_requirement_v2``. Replaces with
+  ``uq_verification_jobs_active_user_req_uuid`` -- same predicate
+  (``result_submission_id IS NULL``) on the new UUID column.
+- Drops ``ix_verification_jobs_user_req_created`` and replaces with
+  ``ix_verification_jobs_user_req_uuid_created`` covering the
+  same latest-per-(user, requirement) lookup.
+- Drops ``ix_verification_jobs_user_phase_active`` outright -- its
+  ``phase_id`` column is going away and no replacement is needed
+  (the in-flight per-user query is rare and covered by the
+  active partial unique index).
+- ``requirement_uuid`` SET NOT NULL via the CHECK-then-flip pattern
+  used in D.1/D.2; FK ``ON DELETE RESTRICT`` added NOT VALID then
+  VALIDATEd in a separate transaction.
+- Drops legacy columns: ``requirement_id``, ``phase_id``,
+  ``submission_type``.
+
+## Production preflight (2026-05-24, after D.2 deploy)
+
+    rows                                       : 246
+    rows where requirement_id resolves         : 246
+    unresolved requirement_ids                 : 0
+    in-flight (result_submission_id IS NULL)   : 0
+
+All rows backfill cleanly; nothing to delete. The 0 in-flight count
+also means the partial unique index swap touches no rows.
+
+Revision ID: 0030_verification_jobs_uuid_fk
+Create Date: 2026-05-24 21:05:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0030_verification_jobs_uuid_fk"
+down_revision = "0029_submissions_uuid_fk"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+
+    op.execute(
+        "ALTER TABLE verification_jobs ADD COLUMN IF NOT EXISTS requirement_uuid UUID"
+    )
+
+    op.execute(
+        """
+        UPDATE verification_jobs vj
+        SET requirement_uuid = r.uuid
+        FROM requirements r
+        WHERE r.id = vj.requirement_id
+        """
+    )
+
+    op.execute("DELETE FROM verification_jobs WHERE requirement_uuid IS NULL")
+
+    # ── NOT NULL via CHECK-then-flip ───────────────────────────────────
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'ck_verification_jobs_requirement_uuid_nn'
+          ) THEN
+            ALTER TABLE verification_jobs
+              ADD CONSTRAINT ck_verification_jobs_requirement_uuid_nn
+              CHECK (requirement_uuid IS NOT NULL) NOT VALID;
+          END IF;
+        END$$;
+        """
+    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DO $$
+            BEGIN
+              IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'ck_verification_jobs_requirement_uuid_nn'
+                  AND NOT convalidated
+              ) THEN
+                ALTER TABLE verification_jobs
+                  VALIDATE CONSTRAINT ck_verification_jobs_requirement_uuid_nn;
+              END IF;
+            END$$;
+            """
+        )
+    op.alter_column("verification_jobs", "requirement_uuid", nullable=False)
+    op.execute(
+        "ALTER TABLE verification_jobs "
+        "DROP CONSTRAINT IF EXISTS ck_verification_jobs_requirement_uuid_nn"
+    )
+
+    # ── FK NOT VALID then VALIDATE (separate transactions) ─────────────
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'fk_verification_jobs_requirement_uuid'
+          ) THEN
+            ALTER TABLE verification_jobs
+              ADD CONSTRAINT fk_verification_jobs_requirement_uuid
+              FOREIGN KEY (requirement_uuid) REFERENCES requirements(uuid)
+              ON DELETE RESTRICT NOT VALID;
+          END IF;
+        END$$;
+        """
+    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DO $$
+            BEGIN
+              IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'fk_verification_jobs_requirement_uuid'
+                  AND NOT convalidated
+              ) THEN
+                ALTER TABLE verification_jobs
+                  VALIDATE CONSTRAINT fk_verification_jobs_requirement_uuid;
+              END IF;
+            END$$;
+            """
+        )
+
+    # ── Drop legacy indexes concurrently ───────────────────────────────
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "uq_verification_jobs_active_user_requirement_v2"
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_verification_jobs_user_req_created"
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_verification_jobs_user_phase_active"
+        )
+
+    # ── New active partial unique + latest-per-req indexes ─────────────
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+            "uq_verification_jobs_active_user_req_uuid "
+            "ON verification_jobs (user_id, requirement_uuid) "
+            "WHERE result_submission_id IS NULL"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_verification_jobs_user_req_uuid_created "
+            "ON verification_jobs (user_id, requirement_uuid, created_at)"
+        )
+
+    # ── Drop legacy columns ────────────────────────────────────────────
+    op.execute("ALTER TABLE verification_jobs DROP COLUMN IF EXISTS submission_type")
+    op.execute("ALTER TABLE verification_jobs DROP COLUMN IF EXISTS phase_id")
+    op.execute("ALTER TABLE verification_jobs DROP COLUMN IF EXISTS requirement_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "verification_jobs",
+        sa.Column("requirement_id", sa.String(length=100), nullable=True),
+    )
+    op.add_column(
+        "verification_jobs",
+        sa.Column("phase_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "verification_jobs",
+        sa.Column("submission_type", sa.String(length=50), nullable=True),
+    )
+
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "ix_verification_jobs_user_req_uuid_created"
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "uq_verification_jobs_active_user_req_uuid"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_verification_jobs_user_phase_active "
+            "ON verification_jobs (user_id, phase_id) "
+            "WHERE result_submission_id IS NULL"
+        )
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_verification_jobs_user_req_created "
+            "ON verification_jobs (user_id, requirement_id, created_at)"
+        )
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+            "uq_verification_jobs_active_user_requirement_v2 "
+            "ON verification_jobs (user_id, requirement_id) "
+            "WHERE result_submission_id IS NULL"
+        )
+
+    op.drop_constraint(
+        "fk_verification_jobs_requirement_uuid",
+        "verification_jobs",
+        type_="foreignkey",
+    )
+    op.alter_column("verification_jobs", "requirement_uuid", nullable=True)

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -23,7 +23,11 @@ from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
-from learn_to_cloud_shared.schemas import SubmissionData, SubmissionResult
+from learn_to_cloud_shared.schemas import (
+    HandsOnRequirement,
+    SubmissionData,
+    SubmissionResult,
+)
 from learn_to_cloud_shared.verification.execution import (
     SubmissionAlreadyInFlightError,
 )
@@ -403,6 +407,7 @@ async def htmx_submit_verification(
     if isinstance(dispatch_result, SyncVerificationResult):
         return _render_sync_result(
             user_id=user_id,
+            requirement=requirement,
             result=dispatch_result.submission_result,
         )
 
@@ -418,6 +423,7 @@ async def htmx_submit_verification(
 def _render_sync_result(
     *,
     user_id: int,
+    requirement: HandsOnRequirement | None,
     result: SubmissionResult,
 ) -> HTMLResponse:
     """Render the response for a sync verification that already finished.
@@ -433,8 +439,10 @@ def _render_sync_result(
         extra={
             "user_id": user_id,
             "submission_id": result.submission.id,
-            "requirement_id": result.submission.requirement_id,
-            "submission_type": result.submission.submission_type.value,
+            "requirement_id": requirement.id if requirement is not None else None,
+            "submission_type": (
+                requirement.submission_type.value if requirement is not None else None
+            ),
             "is_valid": result.is_valid,
             "verification_completed": result.submission.verification_completed,
             "is_server_error": result.is_server_error,

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -132,22 +132,28 @@ async def phase_page(
     sub_context = await get_phase_submission_context(db, user_id, phase)
     submissions_by_req = sub_context.submissions_by_req
     feedback_by_req = sub_context.feedback_by_req
-    active_jobs = await VerificationJobRepository(db).get_active_for_phase(
+    requirements_by_uuid = {req.uuid: req for req in requirements}
+    active_jobs = await VerificationJobRepository(db).get_active_for_requirements(
         user_id,
-        phase_id,
+        requirements_by_uuid.keys(),
     )
-    active_jobs_by_req = {job.requirement_id: job for job in active_jobs}
+    active_jobs_by_req = {
+        requirements_by_uuid[job.requirement_uuid].id: job
+        for job in active_jobs
+        if job.requirement_uuid in requirements_by_uuid
+    }
     # The Durable orchestration instance id IS the job UUID — we always
     # pass ``instance_id=job.id`` to the starter, so we don't need to read
     # back the now-dead ``orchestration_instance_id`` column.
     verification_status_tokens_by_req = {
-        job.requirement_id: create_verification_status_token(
+        requirements_by_uuid[job.requirement_uuid].id: create_verification_status_token(
             user_id=user_id,
             job_id=job.id,
             instance_id=str(job.id),
-            requirement_id=job.requirement_id,
+            requirement_id=requirements_by_uuid[job.requirement_uuid].id,
         )
         for job in active_jobs
+        if job.requirement_uuid in requirements_by_uuid
     }
 
     # Pre-compute per-requirement derived URLs so the Jinja template never

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -78,12 +78,7 @@ async def get_phase_submission_context(
             # uuid is in the input list, but if curriculum drift slips one
             # past us we skip silently rather than crash the phase page.
             continue
-        sub_data = to_submission_data(
-            sub,
-            requirement_id=requirement.id,
-            submission_type=requirement.submission_type,
-            phase_id=phase.id,
-        )
+        sub_data = to_submission_data(sub)
         submissions_by_req[requirement.id] = sub_data
 
         if sub.feedback_json and not sub.is_validated:
@@ -277,7 +272,6 @@ async def create_verification_job(
             session_maker=session_maker,
             user_id=user_id,
             requirement=ctx.requirement,
-            phase_id=ctx.phase_id,
             submitted_value=submitted_value,
             github_username=github_username,
         )
@@ -287,9 +281,7 @@ async def create_verification_job(
         repo = VerificationJobRepository(write_session)
         job, created = await repo.create_or_get_active(
             user_id=user_id,
-            requirement_id=requirement_id,
-            submission_type=ctx.requirement.submission_type,
-            phase_id=ctx.phase_id,
+            requirement_uuid=ctx.requirement.uuid,
             submitted_value=submitted_value,
         )
         await write_session.commit()

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -220,7 +220,9 @@ class TestPhasePage:
             ),
             patch(
                 "learn_to_cloud.routes.pages_routes.VerificationJobRepository",
-                return_value=MagicMock(get_active_for_phase=AsyncMock(return_value=[])),
+                return_value=MagicMock(
+                    get_active_for_requirements=AsyncMock(return_value=[]),
+                ),
             ),
             patch(
                 "learn_to_cloud.routes.pages_routes.is_phase_verification_locked",

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -296,7 +296,9 @@ class TestAuthPageSmoke:
             ),
             patch(
                 "learn_to_cloud.routes.pages_routes.VerificationJobRepository",
-                return_value=MagicMock(get_active_for_phase=AsyncMock(return_value=[])),
+                return_value=MagicMock(
+                    get_active_for_requirements=AsyncMock(return_value=[])
+                ),
             ),
             patch(
                 "learn_to_cloud.routes.pages_routes.is_phase_verification_locked",

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -17,7 +17,7 @@ from learn_to_cloud_shared.core.config import WorkerSettings, configure_settings
 from learn_to_cloud_shared.core.database import create_engine, create_session_maker
 from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE, configure_logging
 from learn_to_cloud_shared.core.observability import configure_observability
-from learn_to_cloud_shared.models import SubmissionType, VerificationJob
+from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
@@ -39,6 +39,7 @@ from learn_to_cloud_shared.verification_job_executor import (
 from opentelemetry import context as otel_context
 from opentelemetry import trace as otel_trace
 from opentelemetry.propagate import extract
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from verification_agents import grade_evidence
 
@@ -221,7 +222,6 @@ def _set_prepared_job_span_attributes(job: PreparedVerificationJob) -> None:
         job_id=str(job.id),
         user_id=job.user_id,
         github_username=job.github_username,
-        phase_id=job.phase_id,
         requirement_id=job.requirement.id,
         submission_type=job.requirement.submission_type.value,
     )
@@ -260,7 +260,6 @@ def _log_verification_job_completed(
             "job_id": result.get("job_id"),
             "user_id": job.user_id,
             "github_username": job.github_username,
-            "phase_id": job.phase_id,
             "requirement_id": job.requirement.id,
             "submission_type": job.requirement.submission_type.value,
             "status": result.get("status"),
@@ -272,9 +271,19 @@ def _log_verification_job_completed(
     )
 
 
-def _orchestrator_name_for_job(job: VerificationJob) -> str:
+def _orchestrator_name_for_submission_type(submission_type: str) -> str:
+    """Pick the Durable orchestrator for a verification's submission type.
+
+    Phase D.3 dropped ``submission_type`` from ``verification_jobs``;
+    callers resolve it via the linked requirement (see
+    :func:`start_verification_job`).
+    """
+    try:
+        enum_value = SubmissionType(submission_type)
+    except ValueError:
+        return _DEFAULT_ORCHESTRATOR_NAME
     return _ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE.get(
-        job.submission_type,
+        enum_value,
         _DEFAULT_ORCHESTRATOR_NAME,
     )
 
@@ -287,7 +296,6 @@ def _job_custom_status(
     return {
         "step": step,
         "job_id": job_id,
-        "phase_id": job.phase_id,
         "requirement_id": job.requirement.id,
         "submission_type": job.requirement.submission_type.value,
     }
@@ -645,10 +653,27 @@ async def start_verification_job(
         job_id = str(job_uuid)
         async with _get_session_maker()() as session:
             job = await VerificationJobRepository(session).get_by_id(job_uuid)
-        if job is None:
-            return _json_response({"error": "job_not_found"}, status_code=404)
+            if job is None:
+                return _json_response({"error": "job_not_found"}, status_code=404)
 
-        orchestrator_name = _orchestrator_name_for_job(job)
+            # verification_jobs no longer carries submission_type/requirement_id
+            # (Phase D.3). Resolve them via a direct lookup against the
+            # requirements table -- this includes soft-deleted rows because
+            # the FK is ON DELETE RESTRICT, so the row always still exists.
+            requirement_row = (
+                await session.execute(
+                    text(
+                        "SELECT id, submission_type FROM requirements "
+                        "WHERE uuid = :uuid LIMIT 1"
+                    ),
+                    {"uuid": job.requirement_uuid},
+                )
+            ).first()
+        if requirement_row is None:
+            return _json_response({"error": "requirement_not_found"}, status_code=404)
+        requirement_id, submission_type_str = requirement_row[0], requirement_row[1]
+
+        orchestrator_name = _orchestrator_name_for_submission_type(submission_type_str)
         _set_verification_span_attributes(job_id=job_id)
         instance_id = await client.start_new(
             orchestrator_name,
@@ -661,9 +686,8 @@ async def start_verification_job(
                 "job_id": job_id,
                 "instance_id": instance_id,
                 "orchestrator_name": orchestrator_name,
-                "phase_id": job.phase_id,
-                "requirement_id": job.requirement_id,
-                "submission_type": job.submission_type.value,
+                "requirement_id": requirement_id,
+                "submission_type": submission_type_str,
             },
         )
         return client.create_check_status_response(req, instance_id)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -8,7 +8,6 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     DateTime,
-    Enum,
     ForeignKey,
     Index,
     Integer,
@@ -210,22 +209,16 @@ class VerificationJob(TimestampMixin, Base):
     __tablename__ = "verification_jobs"
     __table_args__ = (
         Index(
-            "ix_verification_jobs_user_req_created",
+            "ix_verification_jobs_user_req_uuid_created",
             "user_id",
-            "requirement_id",
+            "requirement_uuid",
             "created_at",
         ),
         Index(
-            "uq_verification_jobs_active_user_requirement_v2",
+            "uq_verification_jobs_active_user_req_uuid",
             "user_id",
-            "requirement_id",
+            "requirement_uuid",
             unique=True,
-            postgresql_where=text("result_submission_id IS NULL"),
-        ),
-        Index(
-            "ix_verification_jobs_user_phase_active",
-            "user_id",
-            "phase_id",
             postgresql_where=text("result_submission_id IS NULL"),
         ),
     )
@@ -240,14 +233,12 @@ class VerificationJob(TimestampMixin, Base):
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
     )
-    requirement_id: Mapped[str] = mapped_column(String(100), nullable=False)
-    phase_id: Mapped[int] = mapped_column(Integer, nullable=False)
-    submission_type: Mapped[SubmissionType] = mapped_column(
-        Enum(
-            SubmissionType,
-            name="submission_type",
-            native_enum=False,
-            values_callable=lambda x: [e.value for e in x],
+    requirement_uuid: Mapped[UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        ForeignKey(
+            "requirements.uuid",
+            ondelete="RESTRICT",
+            name="fk_verification_jobs_requirement_uuid",
         ),
         nullable=False,
     )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
@@ -1,15 +1,22 @@
 """Repository for verification job records.
 
-PR4 stripped the legacy status enum and the ``mark_*`` lifecycle methods.
-``VerificationJob`` is now a thin work-queue marker: a row exists during
-in-flight verification work, gets linked to a ``Submission`` via
-:meth:`VerificationJobRepository.link_submission` when the persist
-activity completes, and is deleted by the poller on Durable terminal
-failure via :meth:`VerificationJobRepository.delete_active`.
+After Phase D.3 (#465) the table references the curriculum solely via
+``requirement_uuid`` (FK to ``requirements.uuid``). Repo methods speak
+UUIDs; callers translate to/from human-readable requirement ids at
+the boundary.
+
+PR4 stripped the legacy status enum and the ``mark_*`` lifecycle
+methods. ``VerificationJob`` is now a thin work-queue marker: a row
+exists during in-flight verification work, gets linked to a
+``Submission`` via :meth:`VerificationJobRepository.link_submission`
+when the persist activity completes, and is deleted by the poller on
+Durable terminal failure via
+:meth:`VerificationJobRepository.delete_active`.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from enum import StrEnum
 from uuid import UUID, uuid4
 
@@ -17,11 +24,7 @@ from sqlalchemy import delete, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from learn_to_cloud_shared.models import (
-    SubmissionType,
-    VerificationJob,
-    utcnow,
-)
+from learn_to_cloud_shared.models import VerificationJob, utcnow
 
 ACTIVE_JOB_UNLINKED_PREDICATE = "result_submission_id IS NULL"
 
@@ -44,9 +47,7 @@ class VerificationJobRepository:
         self,
         *,
         user_id: int,
-        requirement_id: str,
-        submission_type: SubmissionType,
-        phase_id: int,
+        requirement_uuid: UUID,
         submitted_value: str,
         extracted_username: str | None = None,
         cloud_provider: str | None = None,
@@ -56,9 +57,7 @@ class VerificationJobRepository:
         job = VerificationJob(
             id=uuid4(),
             user_id=user_id,
-            requirement_id=requirement_id,
-            phase_id=phase_id,
-            submission_type=submission_type,
+            requirement_uuid=requirement_uuid,
             submitted_value=submitted_value,
             extracted_username=extracted_username,
             cloud_provider=cloud_provider,
@@ -72,9 +71,7 @@ class VerificationJobRepository:
         self,
         *,
         user_id: int,
-        requirement_id: str,
-        submission_type: SubmissionType,
-        phase_id: int,
+        requirement_uuid: UUID,
         submitted_value: str,
         extracted_username: str | None = None,
         cloud_provider: str | None = None,
@@ -83,8 +80,8 @@ class VerificationJobRepository:
         """Create a queued job, or return the active one for the requirement.
 
         The partial unique index
-        ``uq_verification_jobs_active_user_requirement_v2`` ensures only
-        one row per ``(user_id, requirement_id)`` may be unlinked at a
+        ``uq_verification_jobs_active_user_req_uuid`` ensures only one
+        row per ``(user_id, requirement_uuid)`` may be unlinked at a
         time. A brand-new row has ``result_submission_id=NULL`` so it
         falls under the predicate; once the persist activity links a
         Submission the row exits and a follow-up submit succeeds.
@@ -96,9 +93,7 @@ class VerificationJobRepository:
                 .values(
                     id=uuid4(),
                     user_id=user_id,
-                    requirement_id=requirement_id,
-                    phase_id=phase_id,
-                    submission_type=submission_type,
+                    requirement_uuid=requirement_uuid,
                     submitted_value=submitted_value,
                     extracted_username=extracted_username,
                     cloud_provider=cloud_provider,
@@ -107,7 +102,7 @@ class VerificationJobRepository:
                     updated_at=now,
                 )
                 .on_conflict_do_nothing(
-                    index_elements=["user_id", "requirement_id"],
+                    index_elements=["user_id", "requirement_uuid"],
                     index_where=text(ACTIVE_JOB_UNLINKED_PREDICATE),
                 )
                 .returning(VerificationJob)
@@ -117,7 +112,9 @@ class VerificationJobRepository:
             if job is not None:
                 return job, True
 
-            active_job = await self.get_active_for_requirement(user_id, requirement_id)
+            active_job = await self.get_active_for_requirement(
+                user_id, requirement_uuid
+            )
             if active_job is not None:
                 return active_job, False
 
@@ -133,14 +130,14 @@ class VerificationJobRepository:
     async def get_active_for_requirement(
         self,
         user_id: int,
-        requirement_id: str,
+        requirement_uuid: UUID,
     ) -> VerificationJob | None:
         """Get the active (unlinked) job for a user and requirement, if any."""
         result = await self.db.execute(
             select(VerificationJob)
             .where(
                 VerificationJob.user_id == user_id,
-                VerificationJob.requirement_id == requirement_id,
+                VerificationJob.requirement_uuid == requirement_uuid,
                 VerificationJob.result_submission_id.is_(None),
             )
             .order_by(VerificationJob.created_at.desc())
@@ -148,17 +145,26 @@ class VerificationJobRepository:
         )
         return result.scalar_one_or_none()
 
-    async def get_active_for_phase(
+    async def get_active_for_requirements(
         self,
         user_id: int,
-        phase_id: int,
+        requirement_uuids: Iterable[UUID],
     ) -> list[VerificationJob]:
-        """Get active (unlinked) jobs for a user in a phase."""
+        """Get active (unlinked) jobs for a user across a set of requirements.
+
+        Replaces ``get_active_for_phase`` -- callers now resolve a phase
+        to its requirement UUIDs (typically from the in-memory phase
+        tree) and pass them explicitly.
+        """
+        uuids = list(requirement_uuids)
+        if not uuids:
+            return []
+
         result = await self.db.execute(
             select(VerificationJob)
             .where(
                 VerificationJob.user_id == user_id,
-                VerificationJob.phase_id == phase_id,
+                VerificationJob.requirement_uuid.in_(uuids),
                 VerificationJob.result_submission_id.is_(None),
             )
             .order_by(VerificationJob.created_at.desc())
@@ -168,14 +174,14 @@ class VerificationJobRepository:
     async def get_latest_for_requirement(
         self,
         user_id: int,
-        requirement_id: str,
+        requirement_uuid: UUID,
     ) -> VerificationJob | None:
         """Get the latest job for a user and requirement."""
         result = await self.db.execute(
             select(VerificationJob)
             .where(
                 VerificationJob.user_id == user_id,
-                VerificationJob.requirement_id == requirement_id,
+                VerificationJob.requirement_uuid == requirement_uuid,
             )
             .order_by(VerificationJob.created_at.desc())
             .limit(1)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -509,12 +509,17 @@ class UserProgress(FrozenModel):
 
 
 class SubmissionData(FrozenModel):
-    """Submission data (service-layer response model)."""
+    """Submission data (service-layer response model).
+
+    After Phase D.2 + D.3 of #461 / #465 the denormalized
+    ``requirement_id`` / ``submission_type`` / ``phase_id`` columns
+    are gone from the underlying ``submissions`` table and nothing
+    in the app reads them off ``SubmissionData`` either -- callers
+    that need them have the corresponding ``HandsOnRequirement``
+    in scope.
+    """
 
     id: int
-    requirement_id: str
-    submission_type: SubmissionType
-    phase_id: int
     submitted_value: str
     extracted_username: str | None = None
     is_validated: bool

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
@@ -50,26 +50,16 @@ def persisted_validation_message(message: str | None) -> str | None:
     return f"{message[: MAX_VALIDATION_MESSAGE_LENGTH - 3]}..."
 
 
-def to_submission_data(
-    submission: Submission,
-    *,
-    requirement_id: str,
-    submission_type: SubmissionType,
-    phase_id: int,
-) -> SubmissionData:
+def to_submission_data(submission: Submission) -> SubmissionData:
     """Project a ``Submission`` row into the ``SubmissionData`` response model.
 
-    After Phase D.2 (#465 / #460) the row no longer carries
-    ``requirement_id`` / ``submission_type`` / ``phase_id``. The caller
-    resolves them from the in-memory ``HandsOnRequirement`` + phase
-    context and passes them in -- ``SubmissionData`` keeps the flat
-    shape so templates and clients don't have to walk a relationship.
+    Phase D.2 + D.3 (#461 / #465) removed the denormalized
+    ``requirement_id`` / ``submission_type`` / ``phase_id`` fields from
+    both the table and the schema -- callers that need them work off
+    the in-memory ``HandsOnRequirement`` directly.
     """
     return SubmissionData(
         id=submission.id,
-        requirement_id=requirement_id,
-        submission_type=submission_type,
-        phase_id=phase_id,
         submitted_value=submission.submitted_value,
         extracted_username=submission.extracted_username,
         is_validated=submission.is_validated,
@@ -109,7 +99,6 @@ async def persist_validation_result(
     *,
     user_id: int,
     requirement: HandsOnRequirement,
-    phase_id: int,
     submitted_value: str,
     github_username: str | None,
     validation_result: ValidationResult,
@@ -140,16 +129,9 @@ async def persist_validation_result(
 def build_submission_result(
     submission: Submission,
     validation_result: ValidationResult,
-    requirement: HandsOnRequirement,
-    phase_id: int,
 ) -> SubmissionResult:
     return SubmissionResult(
-        submission=to_submission_data(
-            submission,
-            requirement_id=requirement.id,
-            submission_type=requirement.submission_type,
-            phase_id=phase_id,
-        ),
+        submission=to_submission_data(submission),
         is_valid=validation_result.is_valid,
         message=validation_result.message,
         username_match=validation_result.username_match,
@@ -163,7 +145,6 @@ async def execute_submission_validation(
     session_maker: async_sessionmaker[AsyncSession],
     user_id: int,
     requirement: HandsOnRequirement,
-    phase_id: int,
     submitted_value: str,
     github_username: str | None,
     after_persist: SubmissionPersistHook | None = None,
@@ -188,7 +169,6 @@ async def execute_submission_validation(
                 write_session,
                 user_id=user_id,
                 requirement=requirement,
-                phase_id=phase_id,
                 submitted_value=submitted_value,
                 github_username=github_username,
                 validation_result=validation_result,
@@ -208,7 +188,6 @@ async def execute_submission_validation(
             extra={
                 "user_id": user_id,
                 "requirement_id": requirement.id,
-                "phase_id": phase_id,
                 "submission_type": requirement.submission_type,
                 "is_valid": validation_result.is_valid,
                 "verification_completed": validation_result.verification_completed,
@@ -220,12 +199,7 @@ async def execute_submission_validation(
             },
         )
 
-        return build_submission_result(
-            db_submission,
-            validation_result,
-            requirement=requirement,
-            phase_id=phase_id,
-        )
+        return build_submission_result(db_submission, validation_result)
 
 
 def _advisory_lock_key(user_id: int, requirement_id: str) -> str:
@@ -242,7 +216,6 @@ async def execute_sync_submission_validation(
     session_maker: async_sessionmaker[AsyncSession],
     user_id: int,
     requirement: HandsOnRequirement,
-    phase_id: int,
     submitted_value: str,
     github_username: str | None,
 ) -> SubmissionResult:
@@ -295,7 +268,6 @@ async def execute_sync_submission_validation(
                 session,
                 user_id=user_id,
                 requirement=requirement,
-                phase_id=phase_id,
                 submitted_value=submitted_value,
                 github_username=github_username,
                 validation_result=validation_result,
@@ -312,7 +284,6 @@ async def execute_sync_submission_validation(
             extra={
                 "user_id": user_id,
                 "requirement_id": requirement.id,
-                "phase_id": phase_id,
                 "submission_type": requirement.submission_type,
                 "is_valid": validation_result.is_valid,
                 "verification_completed": validation_result.verification_completed,
@@ -325,9 +296,4 @@ async def execute_sync_submission_validation(
             },
         )
 
-        return build_submission_result(
-            db_submission,
-            validation_result,
-            requirement=requirement,
-            phase_id=phase_id,
-        )
+        return build_submission_result(db_submission, validation_result)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -51,7 +51,7 @@ from learn_to_cloud_shared.verification.execution import (
     persist_validation_result,
     persisted_validation_message,
 )
-from learn_to_cloud_shared.verification.requirements import get_requirement_by_id
+from learn_to_cloud_shared.verification.requirements import load_requirement_index
 
 tracer = trace.get_tracer(__name__)
 
@@ -125,7 +125,6 @@ class PreparedVerificationJob:
     user_id: int
     github_username: str | None
     requirement: HandsOnRequirement
-    phase_id: int
     submitted_value: str
 
     def to_payload(self) -> dict[str, object]:
@@ -135,7 +134,6 @@ class PreparedVerificationJob:
             "user_id": self.user_id,
             "github_username": self.github_username,
             "requirement": self.requirement.model_dump(mode="json"),
-            "phase_id": self.phase_id,
             "submitted_value": self.submitted_value,
         }
 
@@ -154,7 +152,6 @@ class PreparedVerificationJob:
             requirement=HandsOnRequirementAdapter.validate_python(
                 payload["requirement"]
             ),
-            phase_id=_expect_int(payload["phase_id"], "phase_id"),
             submitted_value=_expect_str(payload["submitted_value"], "submitted_value"),
         )
 
@@ -208,10 +205,8 @@ class _VerificationJobPayload:
     id: UUID
     user_id: int
     github_username: str | None
-    requirement_id: str
-    phase_id: int
+    requirement_uuid: UUID
     submitted_value: str
-    submission_type: str
     result_submission_id: int | None
 
 
@@ -262,10 +257,8 @@ async def _load_job_payload(
         id=job.id,
         user_id=job.user_id,
         github_username=github_username,
-        requirement_id=job.requirement_id,
-        phase_id=job.phase_id,
+        requirement_uuid=job.requirement_uuid,
         submitted_value=job.submitted_value,
-        submission_type=job.submission_type.value,
         result_submission_id=job.result_submission_id,
     )
 
@@ -298,20 +291,26 @@ def _build_result_from_submission(
     *,
     job_id: UUID,
     submission: Submission,
-    requirement_id: str,
-    submission_type: str,
-    requirement_name: str | None,
+    requirement: HandsOnRequirement | None,
+    requirement_id_fallback: str | None = None,
 ) -> VerificationJobExecutionResult:
     """Build a ``VerificationJobExecutionResult`` from an already-persisted
     ``Submission``. Used by the replay short-circuit in
     :func:`prepare_verification_job` and :func:`persist_verification_result`.
 
-    ``requirement_id`` and ``submission_type`` are passed in by the caller
-    rather than read off the ``Submission`` row: Phase D.2 (#465) dropped
-    those denormalized columns from ``submissions``. The job payload
-    (sourced from ``verification_jobs``) still carries them until D.3.
+    When ``requirement`` is None (active lookup didn't find it -- the
+    requirement was soft-deleted), the caller passes the legacy
+    ``requirement_id_fallback`` so the result payload still surfaces
+    something useful in templates.
     """
     outcome = _outcome_from_submission(submission)
+    requirement_id = (
+        requirement.id if requirement is not None else (requirement_id_fallback or "")
+    )
+    submission_type = (
+        requirement.submission_type.value if requirement is not None else None
+    )
+    requirement_name = requirement.name if requirement is not None else None
     return VerificationJobExecutionResult(
         job_id=job_id,
         status=outcome,
@@ -327,23 +326,41 @@ def _build_result_from_submission(
     )
 
 
-async def _resolve_requirement_uuid(
-    db: AsyncSession, requirement_id: str
-) -> UUID | None:
-    """Look up ``requirements.uuid`` by legacy id including soft-deleted rows.
+async def _load_requirement_metadata(
+    db: AsyncSession, requirement_uuid: UUID
+) -> tuple[str, str] | None:
+    """Return ``(requirement_id, submission_type)`` for a requirement by UUID,
+    even if it has been soft-deleted.
 
-    The active read path (``get_requirement_by_id``) filters out
-    soft-deleted entries, but a submission persist may need the UUID
-    for a requirement that was soft-deleted between submit and
-    execute. The ``requirements`` FK on submissions is ON DELETE
-    RESTRICT, so soft-deleted UUIDs are always still resolvable.
+    Used by the missing-requirement path to fill in the legacy fields on
+    a server-error result when the active ``get_requirement_by_id``
+    lookup returns None.
     """
     result = await db.execute(
-        text("SELECT uuid FROM requirements WHERE id = :id LIMIT 1"),
-        {"id": requirement_id},
+        text("SELECT id, submission_type FROM requirements WHERE uuid = :uuid LIMIT 1"),
+        {"uuid": requirement_uuid},
     )
     row = result.first()
-    return row[0] if row else None
+    return (row[0], row[1]) if row else None
+
+
+async def _find_requirement_by_uuid(
+    db: AsyncSession, requirement_uuid: UUID
+) -> HandsOnRequirement | None:
+    """Return the active ``HandsOnRequirement`` matching the given UUID.
+
+    Walks the loaded curriculum tree -- the curriculum is small enough
+    (~10 requirements) that an explicit lookup map per call is cheaper
+    than a JOIN through ``requirements``. Soft-deleted requirements
+    return None here; callers fall back to ``_load_requirement_metadata``
+    for the legacy id/submission_type when they need to render a
+    server-error result.
+    """
+    index = await load_requirement_index(db)
+    for req in index.by_id.values():
+        if req.uuid == requirement_uuid:
+            return req
+    return None
 
 
 async def _handle_missing_requirement(
@@ -352,30 +369,29 @@ async def _handle_missing_requirement(
     payload: _VerificationJobPayload,
 ) -> VerificationJobExecutionResult:
     """Record a server-error ``Submission`` for a job whose requirement was
-    removed from content, link the job to it, and return the resulting
-    execution result.
+    soft-deleted from content, link the job to it, and return the
+    resulting execution result.
 
     Linking the Submission (rather than deleting the job row) keeps
-    ``prepare_verification_job`` idempotent: a retry sees the linked row
-    and short-circuits via the replay path. If the requirement no
-    longer exists at all (not even soft-deleted), raises
-    ``VerificationJobNotFoundError`` so the orchestration surfaces a
-    clear failure -- the job's payload is unrecoverable.
+    ``prepare_verification_job`` idempotent: a retry sees the linked
+    row and short-circuits via the replay path. The FK on
+    ``verification_jobs.requirement_uuid`` is ON DELETE RESTRICT, so
+    the requirement row always still exists in the ``requirements``
+    table -- the active read just filters out soft-deleted entries.
+    The fallback metadata lookup below pulls ``id`` and
+    ``submission_type`` even from soft-deleted rows for the
+    server-error payload.
     """
-    detail = f"Requirement not found: {payload.requirement_id}"
-
     async with session_maker() as db:
-        requirement_uuid = await _resolve_requirement_uuid(db, payload.requirement_id)
-        if requirement_uuid is None:
-            raise VerificationJobNotFoundError(
-                f"job {payload.id} references unknown requirement "
-                f"{payload.requirement_id!r}"
-            )
+        metadata = await _load_requirement_metadata(db, payload.requirement_uuid)
+        requirement_id_fallback = metadata[0] if metadata is not None else ""
+        submission_type_fallback = metadata[1] if metadata is not None else None
+        detail = f"Requirement not found: {requirement_id_fallback}"
 
         submission_repo = SubmissionRepository(db)
         submission = await submission_repo.create(
             user_id=payload.user_id,
-            requirement_uuid=requirement_uuid,
+            requirement_uuid=payload.requirement_uuid,
             submitted_value=payload.submitted_value,
             extracted_username=None,
             is_validated=False,
@@ -394,9 +410,9 @@ async def _handle_missing_requirement(
         job_id=payload.id,
         status=_OUTCOME_SERVER_ERROR,
         code=REQUIREMENT_NOT_FOUND_ERROR_CODE,
-        requirement_id=payload.requirement_id,
+        requirement_id=requirement_id_fallback,
         requirement_name=None,
-        submission_type=payload.submission_type,
+        submission_type=submission_type_fallback,
         submission_id=submission.id,
         is_valid=False,
         verification_completed=False,
@@ -430,6 +446,8 @@ async def prepare_verification_job(
             if payload is None:
                 raise VerificationJobNotFoundError(str(normalized_job_id))
 
+            requirement = await _find_requirement_by_uuid(db, payload.requirement_uuid)
+
             if payload.result_submission_id is not None:
                 submission = await db.get(Submission, payload.result_submission_id)
                 if submission is None:
@@ -437,21 +455,21 @@ async def prepare_verification_job(
                         f"job {normalized_job_id} references missing submission "
                         f"{payload.result_submission_id}"
                     )
-                requirement = await get_requirement_by_id(db, payload.requirement_id)
+                fallback = None
+                if requirement is None:
+                    metadata = await _load_requirement_metadata(
+                        db, payload.requirement_uuid
+                    )
+                    fallback = metadata[0] if metadata is not None else None
                 result = _build_result_from_submission(
                     job_id=normalized_job_id,
                     submission=submission,
-                    requirement_id=payload.requirement_id,
-                    submission_type=payload.submission_type,
-                    requirement_name=(
-                        requirement.name if requirement is not None else None
-                    ),
+                    requirement=requirement,
+                    requirement_id_fallback=fallback,
                 )
                 span.set_attribute("verification.status", result.status)
                 span.set_attribute("verification.replay", True)
                 return VerificationJobPreparation(terminal_result=result)
-
-            requirement = await get_requirement_by_id(db, payload.requirement_id)
 
         if requirement is None:
             result = await _handle_missing_requirement(
@@ -467,7 +485,6 @@ async def prepare_verification_job(
                 user_id=payload.user_id,
                 github_username=payload.github_username,
                 requirement=requirement,
-                phase_id=payload.phase_id,
                 submitted_value=payload.submitted_value,
             )
         )
@@ -532,9 +549,7 @@ async def persist_verification_result(
                 result = _build_result_from_submission(
                     job_id=job.id,
                     submission=submission,
-                    requirement_id=job.requirement.id,
-                    submission_type=job.requirement.submission_type.value,
-                    requirement_name=job.requirement.name,
+                    requirement=job.requirement,
                 )
                 span.set_attribute("verification.status", result.status)
                 span.set_attribute("verification.replay", True)
@@ -544,7 +559,6 @@ async def persist_verification_result(
                 db,
                 user_id=job.user_id,
                 requirement=job.requirement,
-                phase_id=job.phase_id,
                 submitted_value=job.submitted_value,
                 github_username=job.github_username,
                 validation_result=validation_result,
@@ -575,9 +589,7 @@ async def persist_verification_result(
                     result = _build_result_from_submission(
                         job_id=job.id,
                         submission=canonical_submission,
-                        requirement_id=job.requirement.id,
-                        submission_type=job.requirement.submission_type.value,
-                        requirement_name=job.requirement.name,
+                        requirement=job.requirement,
                     )
                 span.set_attribute("verification.status", result.status)
                 span.set_attribute("verification.replay", True)

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
@@ -1,6 +1,6 @@
 """Integration tests for VerificationJobRepository."""
 
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import func, select
@@ -10,7 +10,6 @@ from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
 from learn_to_cloud_shared.content_yaml_loader import clear_cache
 from learn_to_cloud_shared.models import (
     CurriculumRequirement,
-    SubmissionType,
     VerificationJob,
 )
 from learn_to_cloud_shared.repositories.submission_repository import (
@@ -47,14 +46,11 @@ async def req_uuid(db_session: AsyncSession) -> UUID:
 
 async def _create_job(
     repo: VerificationJobRepository,
-    *,
-    requirement_id: str = "req-1",
+    requirement_uuid: UUID,
 ):
     return await repo.create(
         user_id=USER_ID,
-        requirement_id=requirement_id,
-        submission_type=SubmissionType.GITHUB_PROFILE,
-        phase_id=0,
+        requirement_uuid=requirement_uuid,
         submitted_value="https://github.com/testuser",
         extracted_username="testuser",
         traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
@@ -83,15 +79,15 @@ class TestCreate:
         self,
         db_session: AsyncSession,
         user,
+        req_uuid: UUID,
     ):
         repo = VerificationJobRepository(db_session)
 
-        job = await _create_job(repo)
+        job = await _create_job(repo, req_uuid)
 
         assert isinstance(job.id, UUID)
         assert job.user_id == USER_ID
-        assert job.requirement_id == "req-1"
-        assert job.submission_type == SubmissionType.GITHUB_PROFILE
+        assert job.requirement_uuid == req_uuid
         assert job.traceparent is not None
         assert job.created_at is not None
         assert job.result_submission_id is None
@@ -100,21 +96,18 @@ class TestCreate:
         self,
         db_session: AsyncSession,
         user,
+        req_uuid: UUID,
     ):
         repo = VerificationJobRepository(db_session)
 
         first, first_created = await repo.create_or_get_active(
             user_id=USER_ID,
-            requirement_id="req-active",
-            submission_type=SubmissionType.CTF_TOKEN,
-            phase_id=1,
+            requirement_uuid=req_uuid,
             submitted_value="token-1",
         )
         second, second_created = await repo.create_or_get_active(
             user_id=USER_ID,
-            requirement_id="req-active",
-            submission_type=SubmissionType.CTF_TOKEN,
-            phase_id=1,
+            requirement_uuid=req_uuid,
             submitted_value="token-2",
         )
 
@@ -142,9 +135,7 @@ class TestCreate:
 
         first, first_created = await repo.create_or_get_active(
             user_id=USER_ID,
-            requirement_id="req-retry",
-            submission_type=SubmissionType.CTF_TOKEN,
-            phase_id=1,
+            requirement_uuid=req_uuid,
             submitted_value="token-1",
         )
         submission = await _create_submission(
@@ -158,9 +149,7 @@ class TestCreate:
 
         second, second_created = await repo.create_or_get_active(
             user_id=USER_ID,
-            requirement_id="req-retry",
-            submission_type=SubmissionType.CTF_TOKEN,
-            phase_id=1,
+            requirement_uuid=req_uuid,
             submitted_value="token-2",
         )
 
@@ -175,15 +164,16 @@ class TestFind:
         self,
         db_session: AsyncSession,
         user,
+        req_uuid: UUID,
     ):
         repo = VerificationJobRepository(db_session)
-        first = await _create_job(repo, requirement_id="req-latest")
+        first = await _create_job(repo, req_uuid)
         deleted = await repo.delete_active(first.id)
         assert deleted is True
-        second = await _create_job(repo, requirement_id="req-latest")
+        second = await _create_job(repo, req_uuid)
 
-        active = await repo.get_active_for_requirement(USER_ID, "req-latest")
-        latest = await repo.get_latest_for_requirement(USER_ID, "req-latest")
+        active = await repo.get_active_for_requirement(USER_ID, req_uuid)
+        latest = await repo.get_latest_for_requirement(USER_ID, req_uuid)
 
         assert active is not None
         assert active.id == second.id
@@ -194,10 +184,11 @@ class TestFind:
         self,
         db_session: AsyncSession,
         user,
+        req_uuid: UUID,
     ):
         repo = VerificationJobRepository(db_session)
 
-        result = await repo.get_latest_for_requirement(USER_ID, "missing")
+        result = await repo.get_latest_for_requirement(USER_ID, uuid4())
 
         assert result is None
 
@@ -212,7 +203,7 @@ class TestLinkSubmission:
         req_uuid: UUID,
     ):
         repo = VerificationJobRepository(db_session)
-        job = await _create_job(repo)
+        job = await _create_job(repo, req_uuid)
         submission = await _create_submission(db_session, req_uuid)
 
         before = job.updated_at
@@ -235,7 +226,7 @@ class TestLinkSubmission:
         ``link_submission`` sees ``ALREADY_LINKED`` instead of writing
         again."""
         repo = VerificationJobRepository(db_session)
-        job = await _create_job(repo)
+        job = await _create_job(repo, req_uuid)
         submission = await _create_submission(db_session, req_uuid)
 
         first = await repo.link_submission(job.id, submission.id)
@@ -270,9 +261,10 @@ class TestDeleteActive:
         self,
         db_session: AsyncSession,
         user,
+        req_uuid: UUID,
     ):
         repo = VerificationJobRepository(db_session)
-        job = await _create_job(repo)
+        job = await _create_job(repo, req_uuid)
 
         deleted = await repo.delete_active(job.id)
         await db_session.commit()
@@ -290,7 +282,7 @@ class TestDeleteActive:
         req_uuid: UUID,
     ):
         repo = VerificationJobRepository(db_session)
-        job = await _create_job(repo)
+        job = await _create_job(repo, req_uuid)
         submission = await _create_submission(db_session, req_uuid)
         await repo.link_submission(job.id, submission.id)
 
@@ -305,6 +297,7 @@ class TestDeleteActive:
         self,
         db_session: AsyncSession,
         user,
+        req_uuid: UUID,
     ):
         repo = VerificationJobRepository(db_session)
 

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -94,16 +94,11 @@ async def synced_requirement(
 async def _create_job(
     session_maker: async_sessionmaker[AsyncSession],
     requirement: HandsOnRequirement,
-    *,
-    submission_type: SubmissionType | None = None,
 ) -> UUID:
-    sub_type = submission_type or requirement.submission_type
     async with session_maker() as db:
         job = await VerificationJobRepository(db).create(
             user_id=USER_ID,
-            requirement_id=requirement.id,
-            submission_type=sub_type,
-            phase_id=3,
+            requirement_uuid=requirement.uuid,
             submitted_value="https://github.com/executoruser/repo",
         )
         await db.commit()
@@ -159,7 +154,7 @@ async def test_split_verification_primitives_prepare_run_and_persist(
     )
 
     with patch(
-        "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
+        "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
         return_value=synced_requirement,
     ):
         preparation = await prepare_verification_job(
@@ -203,7 +198,7 @@ async def test_execute_verification_job_marks_success_and_links_submission(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
+            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
             return_value=synced_requirement,
         ),
         patch(
@@ -247,7 +242,7 @@ async def test_execute_verification_job_marks_user_validation_failure(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
+            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
             return_value=synced_requirement,
         ),
         patch(
@@ -284,7 +279,7 @@ async def test_execute_verification_job_marks_server_error(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
+            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
             return_value=synced_requirement,
         ),
         patch(
@@ -323,7 +318,7 @@ async def test_execute_verification_job_truncates_persisted_error_messages(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
+            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
             return_value=synced_requirement,
         ),
         patch(
@@ -354,7 +349,7 @@ async def test_execute_verification_job_marks_missing_requirement_server_error(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
+            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
             return_value=None,
         ),
         patch(
@@ -398,7 +393,7 @@ async def test_execute_verification_job_is_idempotent_for_terminal_jobs(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor.get_requirement_by_id",
+            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
             return_value=synced_requirement,
         ),
         patch(
@@ -433,7 +428,6 @@ async def test_persist_is_idempotent_via_result_submission_id_guard(
         user_id=USER_ID,
         github_username="executoruser",
         requirement=synced_requirement,
-        phase_id=3,
         submitted_value="https://github.com/executoruser/repo",
     )
     run_result = VerificationRunResult(
@@ -476,7 +470,6 @@ async def test_persist_raises_when_job_row_was_deleted(
         user_id=USER_ID,
         github_username="executoruser",
         requirement=synced_requirement,
-        phase_id=3,
         submitted_value="https://github.com/executoruser/repo",
     )
     run_result = VerificationRunResult(

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_payload_roundtrip.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_payload_roundtrip.py
@@ -29,7 +29,6 @@ class TestPreparedVerificationJobRoundTrip:
             user_id=42,
             github_username="alice",
             requirement=repo_fork_requirement(id="my-fork", required_repo="owner/repo"),
-            phase_id=1,
             submitted_value="https://github.com/alice/repo",
         )
         payload = job.to_payload()
@@ -44,7 +43,6 @@ class TestPreparedVerificationJobRoundTrip:
             user_id=1,
             github_username="bob",
             requirement=github_profile_requirement(id="profile"),
-            phase_id=0,
             submitted_value="https://github.com/bob",
         )
         payload = job.to_payload()
@@ -60,7 +58,6 @@ class TestPreparedVerificationJobRoundTrip:
             requirement=deployed_api_requirement(
                 id="deployed", placeholder="https://your-api.example.com"
             ),
-            phase_id=4,
             submitted_value="https://api.example.com",
         )
         payload = job.to_payload()

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -42,7 +42,6 @@ def _run_result(is_valid: bool = True) -> VerificationRunResult:
             user_id=1,
             github_username="learner",
             requirement=requirement,
-            phase_id=6,
             submitted_value="https://github.com/learner/journal",
         ),
         validation_result=ValidationResult(
@@ -76,7 +75,6 @@ def _phase3_run_result(is_valid: bool = True) -> VerificationRunResult:
             user_id=1,
             github_username="learner",
             requirement=requirement,
-            phase_id=3,
             submitted_value="https://github.com/learner/journal-starter",
         ),
         validation_result=ValidationResult(

--- a/packages/learn-to-cloud-shared/tests/verification/test_sync_execution.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_sync_execution.py
@@ -118,7 +118,6 @@ async def test_sync_validation_persists_submission(
             session_maker=session_maker,
             user_id=USER_ID,
             requirement=requirement,
-            phase_id=PHASE_ID,
             submitted_value="https://github.com/syncuser",
             github_username="syncuser",
         )
@@ -149,7 +148,6 @@ async def test_sync_validation_persists_failure(
             session_maker=session_maker,
             user_id=USER_ID,
             requirement=requirement,
-            phase_id=PHASE_ID,
             submitted_value="https://github.com/wronguser",
             github_username="syncuser",
         )
@@ -180,7 +178,6 @@ async def test_sync_validation_rolls_back_on_validator_exception(
                 session_maker=session_maker,
                 user_id=USER_ID,
                 requirement=requirement,
-                phase_id=PHASE_ID,
                 submitted_value="https://github.com/syncuser",
                 github_username="syncuser",
             )
@@ -202,7 +199,6 @@ async def test_sync_validation_rolls_back_on_validator_exception(
             session_maker=session_maker,
             user_id=USER_ID,
             requirement=requirement,
-            phase_id=PHASE_ID,
             submitted_value="https://github.com/syncuser",
             github_username="syncuser",
         )
@@ -243,7 +239,6 @@ async def test_concurrent_submits_for_same_requirement_dedupe(
                 session_maker=session_maker,
                 user_id=USER_ID,
                 requirement=requirement,
-                phase_id=PHASE_ID,
                 submitted_value="https://github.com/syncuser",
                 github_username="syncuser",
             )
@@ -259,7 +254,6 @@ async def test_concurrent_submits_for_same_requirement_dedupe(
                 session_maker=session_maker,
                 user_id=USER_ID,
                 requirement=requirement,
-                phase_id=PHASE_ID,
                 submitted_value="https://github.com/syncuser",
                 github_username="syncuser",
             )
@@ -310,7 +304,6 @@ async def test_advisory_lock_keyed_per_requirement(
                 session_maker=session_maker,
                 user_id=USER_ID,
                 requirement=requirement,
-                phase_id=PHASE_ID,
                 submitted_value="https://github.com/syncuser",
                 github_username="syncuser",
             )
@@ -339,7 +332,6 @@ async def test_advisory_lock_keyed_per_requirement(
                 session_maker=session_maker,
                 user_id=USER_ID,
                 requirement=other_requirement,
-                phase_id=PHASE_ID,
                 submitted_value="https://github.com/syncuser",
                 github_username="syncuser",
             )
@@ -375,7 +367,6 @@ async def test_advisory_lock_uses_pg_try_advisory_xact_lock(
             session_maker=session_maker,
             user_id=USER_ID,
             requirement=requirement,
-            phase_id=PHASE_ID,
             submitted_value="https://github.com/syncuser",
             github_username="syncuser",
         )


### PR DESCRIPTION
**Closes Phase D of #461 / #465.** verification_jobs now references the curriculum solely by `requirement_uuid`; SubmissionData drops its denormalized fields (zero readers anywhere).

## Migration 0030

- Adds nullable `requirement_uuid`; backfills from `requirements.id` (includes soft-deleted).
- DELETEs unresolvable rows (production preflight: **0**).
- Drops `uq_verification_jobs_active_user_requirement_v2`; replaces with `uq_verification_jobs_active_user_req_uuid` (same predicate).
- Drops `ix_verification_jobs_user_req_created`; replaces with `ix_verification_jobs_user_req_uuid_created`.
- Drops `ix_verification_jobs_user_phase_active` outright (per-user in-flight covered by the partial unique).
- `requirement_uuid` SET NOT NULL via CHECK-then-flip; FK `ON DELETE RESTRICT` added NOT VALID then VALIDATEd separately.
- Drops legacy columns: `requirement_id`, `phase_id`, `submission_type`.

Every DDL idempotent. squawk + pytest-alembic green.

## Production preflight (2026-05-24, after D.2)

```
rows: 246    resolves: 246    unresolved: 0    in-flight: 0
```

## App changes

- **VerificationJob ORM** + **VerificationJobRepository** speak `requirement_uuid`.
- **\_VerificationJobPayload**: `requirement_uuid` only.
- **PreparedVerificationJob**: drops `phase_id` (no readers).
- **\_build_result_from_submission** takes `HandsOnRequirement` directly with a soft-delete fallback via `_load_requirement_metadata`.
- **\_handle_missing_requirement**: simpler — FK guarantees the row exists in `requirements` (active or soft-deleted).
- **\_find_requirement_by_uuid** walks the loaded curriculum tree (small N).
- **submissions_service** / **pages_routes** / **htmx_routes** updated to thread UUIDs through.
- **apps/verification-functions**: `_orchestrator_name_for_submission_type` + `start_verification_job` resolves `submission_type` via a direct `requirements` lookup (FK guarantees the row). Span/log fields drop `phase_id`.

### SubmissionData cleanup (coupled simplification)

`SubmissionData.requirement_id / .submission_type / .phase_id` had zero template/API readers — templates use `requirement` directly; the only Python reader was one log line. Dropped from the schema and upstream signatures (`to_submission_data`, `build_submission_result`, `persist_validation_result`, `execute_*_submission_validation`). The denormalized-field plumbing finally goes away end-to-end.

## Verification

- 226 api + 463 shared (1 skipped) tests green.
- ruff / format / ty clean across api, shared, verification-functions.
- squawk clean on the new migration.
- End-to-end locally: alembic upgrade → alembic check → curriculum sync = 7/42/272/135/10.
- API boots clean and serves `/` + `/curriculum` (200) from DB.

## Trade-off accepted

~15-30s of 500s during pod rollover (old pods reading dropped columns) — consistent with D.1bc and D.2.

## After this merges

Phase D is **complete**. All user state tables reference curriculum via UUID FKs. Next up: **Phase E (#466)** cleanup — drop YAML packaging from the API container, then sweep any dead helpers.