### PR TITLE
docs(curriculum): document the domain model + migration patterns (Phase E)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -147,3 +147,25 @@ additive and the old code path doesn't break without the new schema
 (e.g., adding a nullable column that nothing reads yet).
 
 See [docs/migrations.md](migrations.md) for more on how migrations work.
+
+## Editing curriculum content
+
+Curriculum (phases, topics, steps, hands-on requirements) lives in
+packaged YAML under
+`packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/`.
+To change it:
+
+1. Edit the YAML files. The deploy syncs them into Postgres -- no
+   migration needed for content changes.
+2. Validate locally:
+   ```bash
+   cd packages/learn-to-cloud-shared
+   uv run python scripts/validate_content.py
+   ```
+3. Open a PR. CI runs the same validators.
+
+See [`docs/curriculum.md`](curriculum.md) for the full architecture
+(YAML-authoritative, deploy-time sync to Postgres, UUID FKs from
+user state to curriculum). Schema changes to the curriculum tables
+themselves are normal Alembic migrations; content changes go through
+the sync.

--- a/docs/curriculum.md
+++ b/docs/curriculum.md
@@ -1,0 +1,216 @@
+# Curriculum Domain Model
+
+This doc explains the architecture that powers Learn to Cloud's curriculum:
+phases, topics, learning steps, learning objectives, and hands-on
+verification requirements. If you're editing curriculum content or
+touching code that reads or writes user progress, start here.
+
+Context: this design landed across issues #461 through #466 (and the
+sub-issues #462 to #470). The high-level shape is YAML-authoritative
+content + deploy-time sync to Postgres + UUID FKs for user state.
+
+## The model
+
+```
+Phase ── Topic ── LearningStep
+       │       └─ LearningObjective
+       └─ HandsOnRequirement (per phase, hands-on verifications)
+```
+
+Each entity has two ids:
+
+- `uuid` — Postgres primary key. Used for foreign keys and as the stable
+  identity that survives YAML edits.
+- `legacy_id` — the human-readable id from YAML. For phases that's the
+  int (`0`, `1`, ...); for topics/steps/objectives/requirements it's the
+  kebab-case slug (`phase0-topic1`, `step-intro`, `github-profile`).
+  Used in URLs, templates, and seed scripts. Required for migration
+  backfills from the legacy string-keyed user state.
+
+Both ids are stored on every curriculum row. Loaders that hand a
+`HandsOnRequirement` (or any other Pydantic schema) to the rest of
+the app surface `id` for templates and `uuid` for repository writes.
+
+## The flow
+
+```
+YAML files  ──(deploy-time sync)──>  Postgres curriculum tables  ──>  app reads
+   ▲                                          ▲
+   │                                          │
+ authored                                user state
+ by editors                            (step_progress,
+                                       submissions,
+                                       verification_jobs)
+                                       references via UUID FK
+```
+
+### YAML is authoritative
+
+Curriculum lives under
+`packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/`.
+Each phase has a directory:
+
+```
+phase0/
+  _phase.yaml                  # phase metadata + topic/requirement slug lists
+  intro-to-the-cloud.yaml      # one file per topic, slug = filename stem
+  ...
+  requirements/
+    github-profile.yaml        # one file per hands-on requirement
+    ...
+```
+
+The `_phase.yaml` file owns the order of its topics and requirements via
+slug lists. Topic and requirement files must not carry an `order`
+field; loaders reject it (one source of truth, per #463).
+
+Editing curriculum is a normal YAML PR: change the files, push, let CI
+validate. The deploy then syncs your changes into Postgres.
+
+### Sync happens at deploy time
+
+The migrations job (Azure Container Apps Manual Job) runs
+`api/scripts/run_migrations.py` which:
+
+1. Runs `alembic upgrade head`.
+2. Runs `alembic current --check-heads` to fail loud if HEAD slipped.
+3. Runs `alembic check` to fail if the ORM disagrees with the DDL.
+4. Runs `python -m learn_to_cloud_shared.cli.sync_curriculum` against the
+   target database.
+
+The sync (`learn_to_cloud_shared.content_sync.sync_curriculum_to_db`):
+
+- Loads YAML via `content_yaml_loader.get_all_phases_from_yaml`.
+- Runs strict cross-file validators (`content_yaml_loader.validate_content`):
+  global UUID uniqueness, topic slug resolution, step order uniqueness,
+  requirement slug resolution, requirement id uniqueness.
+- Upserts each curriculum row by UUID.
+- Soft-deletes any active row whose UUID is no longer in the YAML
+  (`deleted_at` column, not a `DELETE`). This protects user state FKs.
+- Refuses to run if YAML loaded zero phases unless
+  `allow_empty=True` — a defense against accidentally wiping the
+  curriculum tables.
+
+### Runtime reads from Postgres
+
+Public entry point: `learn_to_cloud_shared.content_service`. The four
+functions return Pydantic shapes built from the DB tables:
+
+```python
+async def get_all_phases(db) -> tuple[Phase, ...]
+async def get_phase_by_slug(db, slug) -> Phase | None
+async def get_topic_by_id(db, topic_id) -> Topic | None       # legacy_id
+async def get_topic_by_slugs(db, phase_slug, topic_slug) -> Topic | None
+```
+
+`content_db_loader` does the actual work: 5 simple `SELECT ... WHERE
+deleted_at IS NULL ORDER BY order` queries (one per table) and
+in-Python grouping by parent UUID. Uncached by design — the
+curriculum is small (~466 active rows) and a process-level cache
+without invalidation creates a class of stale-data bugs we wanted
+to avoid (PR #476 / #474 discussion).
+
+The YAML loader (`content_yaml_loader`) is only imported from
+`content_sync` and `scripts/validate_content.py`. It must not be
+imported from request-serving code.
+
+### User state references curriculum via UUID FKs
+
+After Phase D (#465):
+
+| Table | FK to | Constraint |
+|---|---|---|
+| `step_progress.step_uuid` | `steps.uuid` | `ON DELETE RESTRICT` |
+| `submissions.requirement_uuid` | `requirements.uuid` | `ON DELETE RESTRICT` |
+| `verification_jobs.requirement_uuid` | `requirements.uuid` | `ON DELETE RESTRICT` |
+
+`ON DELETE RESTRICT` means curriculum rows can never be hard-deleted
+while user state references them. Soft-delete (`deleted_at` set) is
+the only delete mechanism the sync uses; the FK still resolves so
+historical submissions remain valid.
+
+`requirements.id` (the kebab-case slug) carries a partial unique
+index across active rows + a globally unique index ignoring
+`deleted_at`. The latter exists because the slug used to be
+denormalized into `submissions.requirement_id` and is still used as
+a public id in URLs and templates; duplicates across phases would
+break that.
+
+Repository APIs take and return UUIDs. The service layer translates
+to/from legacy ids at the boundary when templates need them.
+
+## Editing curriculum
+
+### Add a new step to a topic
+
+1. Edit the topic YAML file under
+   `content/phases/phase<N>/<topic-slug>.yaml`. Add the step to
+   `learning_steps` with a new `id`, `uuid` (generate a new one),
+   `title`, etc.
+2. (Optional but recommended) Run
+   `cd packages/learn-to-cloud-shared && uv run python scripts/validate_content.py`
+   locally.
+3. Open a PR. CI runs validators + the API test suite.
+4. After merge, the deploy job syncs your YAML into Postgres. No
+   migration needed for curriculum content changes.
+
+### Add a new hands-on requirement
+
+1. Create `content/phases/phase<N>/requirements/<slug>.yaml` with the
+   discriminated `type_config` for your submission type (see
+   `learn_to_cloud_shared.schemas.HandsOnRequirement`).
+2. Add the slug to the parent phase's `_phase.yaml`
+   `hands_on_verification.requirements:` list (position = display
+   order).
+3. Generate a UUID for the `uuid` field. Set `id` = filename stem.
+4. The requirement id must be globally unique across all phases —
+   it's used as a public submission key.
+5. Open a PR; CI validates; deploy syncs.
+
+### Soft-delete a requirement
+
+Remove the slug from `_phase.yaml`'s `requirements:` list and remove
+the per-requirement file. The sync sets `deleted_at` on the
+existing row. User state for the removed requirement stays intact
+(FK ON DELETE RESTRICT). The active read path
+(`get_all_phases`) filters out soft-deleted rows so the requirement
+disappears from the app, but historical submissions still resolve
+their `requirement_uuid` for display and accounting.
+
+## Adding a schema change to curriculum tables
+
+Phase B (#463) created the curriculum tables. Schema changes follow
+the normal Alembic flow described in
+[`docs/migrations.md`](./migrations.md). A few patterns specific to
+these tables:
+
+- The sync upserts by UUID, so adding a new column with a default is
+  trivially safe — the next deploy populates it for every row.
+- Adding a required column needs the standard "ADD nullable + backfill
+  + SET NOT NULL via CHECK-then-flip" pattern documented in
+  `docs/migrations.md`.
+- Soft-deletes use partial unique indexes (`postgresql_where=
+  text("deleted_at IS NULL")`) so collisions on active rows fail loud
+  while keeping the soft-deleted history intact.
+
+## Why this shape
+
+A few decisions worth knowing if you find yourself second-guessing
+them later:
+
+- **YAML over admin UI**: this is a learning curriculum maintained by
+  a small group of editors via PRs. A UI would be more work than the
+  audience justifies, and PR review on YAML diffs is genuinely useful.
+- **UUID PKs from day one**: lets us reorder, rename, or copy
+  curriculum content without breaking user state.
+- **`legacy_id` on every row**: humans look at URLs, templates, and
+  log lines. Forcing them to look up a UUID just to discuss "step 3
+  of topic 1" would be needlessly hostile. Carry the slug too.
+- **Per-request DB reads, no cache**: the curriculum is small enough
+  (~10 queries that hit indexes) that a request-scoped cache wouldn't
+  pay for itself. A process-level cache requires invalidation and the
+  sync needs to know about it.
+- **Sync over migrations for content**: schema changes go through
+  Alembic; content changes go through the sync. Mixing them would
+  make migrations harder to review and content changes harder to roll
+  back.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -212,3 +212,142 @@ cd api && uv run python scripts/lint_migration_sql.py
 
 This only checks new migrations (files added vs `origin/main`). If
 you're working on a branch with no new migrations, it exits cleanly.
+
+## Curriculum tables and the concurrent-friendly patterns
+
+Phases B through D of the curriculum refactor (#461) introduced
+patterns this repo now uses as a default for any non-trivial
+migration. They show up across `0028_step_progress_cleanup.py`,
+`0029_submissions_uuid_fk.py`, and `0030_verification_jobs_uuid_fk.py`
+if you need a worked example.
+
+### Standard preamble
+
+```python
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+```
+
+`lock_timeout` bounds how long any one statement waits for a lock
+before failing the deploy loudly. `statement_timeout` bounds total
+statement runtime.
+
+### `NOT NULL` without a long write lock
+
+Postgres's naive `ALTER TABLE ... SET NOT NULL` takes
+`ACCESS EXCLUSIVE` and scans the table to prove no NULLs exist. The
+safer pattern:
+
+```python
+# 1. Add a CHECK constraint NOT VALID -- fast, metadata-only.
+op.execute("""
+    DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'ck_foo_x_nn') THEN
+        ALTER TABLE foo ADD CONSTRAINT ck_foo_x_nn CHECK (x IS NOT NULL) NOT VALID;
+      END IF;
+    END $$;
+""")
+
+# 2. VALIDATE in its own transaction. Runs under SHARE UPDATE EXCLUSIVE
+#    so reads + writes keep flowing.
+with op.get_context().autocommit_block():
+    op.execute("""
+        DO $$ BEGIN
+          IF EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'ck_foo_x_nn' AND NOT convalidated
+          ) THEN
+            ALTER TABLE foo VALIDATE CONSTRAINT ck_foo_x_nn;
+          END IF;
+        END $$;
+    """)
+
+# 3. SET NOT NULL is now a metadata flip -- postgres uses the
+#    validated CHECK to skip the scan.
+op.alter_column("foo", "x", nullable=False)
+
+# 4. Drop the now-redundant CHECK.
+op.execute("ALTER TABLE foo DROP CONSTRAINT IF EXISTS ck_foo_x_nn")
+```
+
+### Foreign keys without a long write lock
+
+Same idea — `ADD CONSTRAINT ... NOT VALID` in one transaction, then
+`VALIDATE CONSTRAINT` in a separate transaction so the validation scan
+runs under the weaker lock:
+
+```python
+op.execute("""
+    DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_x') THEN
+        ALTER TABLE foo
+          ADD CONSTRAINT fk_x FOREIGN KEY (x) REFERENCES bar(id)
+          ON DELETE RESTRICT NOT VALID;
+      END IF;
+    END $$;
+""")
+
+with op.get_context().autocommit_block():
+    op.execute("""
+        DO $$ BEGIN
+          IF EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'fk_x' AND NOT convalidated
+          ) THEN
+            ALTER TABLE foo VALIDATE CONSTRAINT fk_x;
+          END IF;
+        END $$;
+    """)
+```
+
+### Indexes and unique constraints, concurrently
+
+```python
+with op.get_context().autocommit_block():
+    op.execute("""
+        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_foo_x
+            ON foo (x)
+    """)
+op.execute("""
+    DO $$ BEGIN
+      IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'uq_foo_x') THEN
+        ALTER TABLE foo ADD CONSTRAINT uq_foo_x UNIQUE USING INDEX uq_foo_x;
+      END IF;
+    END $$;
+""")
+```
+
+The `IF NOT EXISTS` / `convalidated` / `pg_constraint` checks make the
+operation idempotent so a partial-failure retry succeeds.
+
+### Squawk exclusions
+
+`api/.squawk.toml` excludes a few rules globally with documented
+reasons. The big ones for the curriculum migrations:
+
+- `ban-drop-column` — curriculum refactor explicitly accepts a brief
+  500s window during pod rollover while old pods still reference
+  dropped columns. Documented per-migration in the migration's
+  docstring.
+- `adding-not-nullable-field` — `SET NOT NULL` is in fact safe when
+  preceded by a validated `CHECK (col IS NOT NULL)` constraint
+  (squawk's static checker can't see the prior CHECK).
+
+## Curriculum content sync
+
+The curriculum tables (`phases`, `topics`, `steps`,
+`learning_objectives`, `requirements`) are populated by a separate
+sync step on every deploy. See
+[`docs/curriculum.md`](./curriculum.md) for the full flow. The
+short version:
+
+1. Migrations job runs `alembic upgrade head` and the usual checks.
+2. Same job then runs
+   `python -m learn_to_cloud_shared.cli.sync_curriculum`, which
+   upserts curriculum rows from packaged YAML.
+3. Sync soft-deletes (sets `deleted_at`) rather than hard-deletes
+   curriculum rows so user state FK references stay valid.
+
+Schema changes to curriculum tables are normal Alembic migrations;
+content changes go through the YAML sync.


### PR DESCRIPTION
**Closes Phase E of #461 / #466** with the items worth shipping. Items not shipped are called out with rationale.

## What ships

- **`docs/curriculum.md` (new, 216 lines)**: architecture overview for future contributors. YAML-authoritative content + deploy-time sync to Postgres + UUID FKs from user state to curriculum. Covers the model, the flow, repo conventions, naming (uuid + legacy_id), and a few decisions worth knowing (why YAML, why uncached, why `legacy_id`).
- **`docs/migrations.md`**: appends a 'Curriculum tables and the concurrent-friendly patterns' section showing the standard preamble, the CHECK-then-flip NOT NULL pattern, the NOT VALID + VALIDATE FK pattern, the concurrent index + ALTER TABLE USING INDEX pattern, and the rationale for the squawk rule exclusions. Plus a short pointer at the curriculum sync.
- **`docs/contributing.md`**: short 'Editing curriculum content' section pointing at `docs/curriculum.md` and the local validator script.

## What I audited but didn't change

- **Request-path YAML imports**: searched the codebase; the only consumers of `content_yaml_loader` are `content_sync` (deploy job) and `scripts/validate_content.py` (CI). All request paths go through `content_service` → `content_db_loader`. Nothing to remove.
- **`legacy_id` columns**: intentional, not transitional. Canonical human-readable id used in URLs, templates, log lines, seed scripts. Stay.
- **Defensive filter-at-read patterns** (e.g. `completed & valid_step_ids`): structural, not defensive. The UUID → legacy_id mapping happens at the service boundary; the intersections partition by topic. Stay.
- **`uq_user_requirement_attempt`**: dropped in D.2 already.

## Deferred (#466 item 7): drop YAML packaging from the API image

The migrations job uses the same container image as the API. Splitting would need either a second Dockerfile + wheel or YAML mounted from a release artifact — plus terraform output changes for a new image name. Cost (dual-image CI pipeline) outweighs benefit (~400KB saved on a ~200MB image) for the current curriculum size. Will revisit if `content/` grows materially.

## Trade-off accepted

None — docs-only PR.