### PR TITLE
feat: surface rubric feedback on passing submissions + JSONB column

### DIFF
--- a/api/alembic/versions/0032_feedback_json_jsonb.py
+++ b/api/alembic/versions/0032_feedback_json_jsonb.py
@@ -1,0 +1,75 @@
+"""convert submissions.feedback_json from TEXT to JSONB
+
+Issue #459: ``submissions.feedback_json`` was originally TEXT holding a
+JSON-serialized list of TaskResult records. Now that #425 surfaces
+rubric feedback for passing submissions too, every multi-task
+verification persists a feedback payload, so the column earns a real
+JSONB type: structured types in SQLAlchemy, smaller storage, no
+``json.dumps``/``json.loads`` boilerplate in app code, and future
+query-inside-the-JSON optionality.
+
+Schema effect:
+- ``submissions.feedback_json`` TEXT -> JSONB (using
+  ``feedback_json::jsonb`` cast).
+
+Safety:
+- The cast rejects malformed rows. Preflight on prod confirmed all
+  existing non-null rows parse (see PR body).
+- Idempotent via ``pg_typeof`` check.
+- Single ALTER TABLE under ACCESS EXCLUSIVE; the table is small
+  (one row per validation attempt) so the lock window is brief.
+
+Revision ID: 0032_feedback_json_jsonb
+Revises: 0031_drop_legacy_ids
+Create Date: 2026-05-24
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0032_feedback_json_jsonb"
+down_revision: str | None = "0031_drop_legacy_ids"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'submissions'
+                  AND column_name = 'feedback_json'
+                  AND data_type = 'text'
+            ) THEN
+                ALTER TABLE submissions
+                ALTER COLUMN feedback_json TYPE JSONB
+                USING feedback_json::jsonb;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'submissions'
+                  AND column_name = 'feedback_json'
+                  AND data_type = 'jsonb'
+            ) THEN
+                ALTER TABLE submissions
+                ALTER COLUMN feedback_json TYPE TEXT
+                USING feedback_json::text;
+            END IF;
+        END $$;
+        """
+    )

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -10,7 +10,6 @@ Routes should delegate submission business logic to this module.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -37,7 +36,6 @@ from learn_to_cloud_shared.verification.requirements import (
     get_prerequisite_phase,
     load_requirement_index,
 )
-from opentelemetry import trace
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
@@ -81,30 +79,24 @@ async def get_phase_submission_context(
         sub_data = to_submission_data(sub)
         submissions_by_req[requirement.slug] = sub_data
 
-        if sub.feedback_json and not sub.is_validated:
-            try:
-                raw_tasks = json.loads(sub.feedback_json)
-                tasks = [
-                    {
-                        "name": t.get("task_name", ""),
-                        "passed": t.get("passed", False),
-                        "message": t.get("feedback", ""),
-                        "next_steps": t.get("next_steps", ""),
-                    }
-                    for t in raw_tasks
-                ]
-                passed = sum(1 for t in tasks if t["passed"])
-
-                feedback_by_req[requirement.slug] = {
-                    "tasks": tasks,
-                    "passed": passed,
+        # Surface rubric feedback for both passing and failing submissions
+        # (#425). Stored as JSONB (#459) so the rows arrive as a list of
+        # TaskResult dicts and we don't need json.loads / try / except.
+        if sub.feedback_json:
+            tasks = [
+                {
+                    "name": t.get("task_name", ""),
+                    "passed": t.get("passed", False),
+                    "message": t.get("feedback", ""),
+                    "next_steps": t.get("next_steps", ""),
                 }
-            except (json.JSONDecodeError, TypeError):
-                span = trace.get_current_span()
-                span.add_event(
-                    "feedback_parse_failed",
-                    {"requirement_slug": requirement.slug},
-                )
+                for t in sub.feedback_json
+            ]
+            passed = sum(1 for t in tasks if t["passed"])
+            feedback_by_req[requirement.slug] = {
+                "tasks": tasks,
+                "passed": passed,
+            }
 
     return PhaseSubmissionContext(
         submissions_by_req=submissions_by_req,

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -7,6 +7,7 @@ Tests cover:
 
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -591,17 +592,56 @@ class TestGetPhaseSubmissionContext:
         assert result.feedback_by_req == {}
 
     @pytest.mark.asyncio
-    async def test_submission_with_feedback_json(self):
+    async def test_passing_submission_with_feedback_renders_for_pass(self):
+        """#425: rubric feedback persists for passing submissions too."""
+        req = _make_mock_requirement()
+        phase = _phase_with_requirement(req)
+        mock_sub = _make_mock_submission(is_validated=True, verification_completed=True)
+        mock_sub.requirement_uuid = req.uuid
+        mock_sub.feedback_json = [
+            {
+                "task_name": "rubric-check-1",
+                "passed": True,
+                "feedback": "great job",
+                "next_steps": "",
+            },
+            {
+                "task_name": "rubric-check-2",
+                "passed": True,
+                "feedback": "also good",
+                "next_steps": "",
+            },
+        ]
+        with patch(
+            "learn_to_cloud.services.submissions_service.SubmissionRepository",
+            autospec=True,
+        ) as MockRepo:
+            MockRepo.return_value.get_latest_for_requirements = AsyncMock(
+                return_value=[mock_sub]
+            )
+            result = await get_phase_submission_context(
+                AsyncMock(), user_id=1, phase=phase
+            )
+        assert req.slug in result.feedback_by_req
+        feedback = result.feedback_by_req[req.slug]
+        assert feedback["passed"] == 2
+        tasks = cast(list[dict[str, object]], feedback["tasks"])
+        assert len(tasks) == 2
+        assert all(t["passed"] is True for t in tasks)
         req = _make_mock_requirement()
         phase = _phase_with_requirement(req)
         mock_sub = _make_mock_submission(
             is_validated=False, verification_completed=True
         )
         mock_sub.requirement_uuid = req.uuid
-        mock_sub.feedback_json = (
-            '[{"task_name":"A","passed":true,"feedback":"ok",'
-            '"next_steps":"review the rubric"}]'
-        )
+        mock_sub.feedback_json = [
+            {
+                "task_name": "A",
+                "passed": True,
+                "feedback": "ok",
+                "next_steps": "review the rubric",
+            }
+        ]
         with patch(
             "learn_to_cloud.services.submissions_service.SubmissionRepository",
             autospec=True,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -177,9 +177,12 @@ class Submission(TimestampMixin, Base):
     # True when verification logic actually ran (not blocked by server error).
     # Only count completed verification attempts.
     verification_completed: Mapped[bool] = mapped_column(Boolean, default=False)
-    # JSON-serialized task feedback for multi-task verification submissions
-    # Stores list of TaskResult dicts so feedback persists across page reloads
-    feedback_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Structured per-task feedback for multi-task verification
+    # submissions, stored as JSONB. Each element is a TaskResult shape
+    # (``task_name``, ``passed``, ``feedback``, ``next_steps``). Now that
+    # we surface rubric feedback for passing submissions too (#425),
+    # every multi-task verification persists a payload.
+    feedback_json: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
     # User-facing validation error message (persists across page reloads)
     validation_message: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     # Cloud provider for multi-cloud labs ("aws", "azure", "gcp", or None)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/submission_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/submission_repository.py
@@ -84,7 +84,7 @@ class SubmissionRepository:
         extracted_username: str | None,
         is_validated: bool,
         verification_completed: bool = True,
-        feedback_json: str | None = None,
+        feedback_json: list[dict] | None = None,
         validation_message: str | None = None,
         cloud_provider: str | None = None,
     ) -> Submission:
@@ -94,7 +94,8 @@ class SubmissionRepository:
             verification_completed: Whether the verification logic actually ran.
                 Set to False when blocked by server errors (e.g., GitHub API down).
                 Only completed verifications count toward the daily cap.
-            feedback_json: JSON-serialized task feedback for multi-task submissions.
+            feedback_json: Structured per-task feedback for multi-task
+                submissions (list of TaskResult dicts). Persisted as JSONB.
             cloud_provider: Cloud provider slug ("aws", "azure", "gcp") for
                 multi-cloud labs. None for non-multi-cloud submissions.
         """

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -692,7 +692,7 @@ class SubmissionData(FrozenModel):
     is_validated: bool
     validated_at: datetime | None = None
     verification_completed: bool = False
-    feedback_json: str | None = None
+    feedback_json: list[dict] | None = None
     validation_message: str | None = None
     cloud_provider: str | None = None
     created_at: datetime

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Awaitable, Callable
 
@@ -88,10 +87,10 @@ def _extract_username(
     return parsed.username if parsed.is_valid else None
 
 
-def _feedback_json(validation_result: ValidationResult) -> str | None:
+def _feedback_json(validation_result: ValidationResult) -> list[dict] | None:
     if not validation_result.task_results:
         return None
-    return json.dumps([task.model_dump() for task in validation_result.task_results])
+    return [task.model_dump() for task in validation_result.task_results]
 
 
 async def persist_validation_result(


### PR DESCRIPTION
Resolves #425 and #459 together — the #459 body explicitly suggested doing them as a pair, and the work fits naturally in one PR.

## #425 — surface rubric feedback on passing submissions

The current behavior: `submissions_service.get_phase_submission_context` gates feedback rendering on `not sub.is_validated`, so a learner who passes a multi-task verification sees an "✓ Verified" pill and nothing else — no detail on *why* they passed.

Fix: drop the guard. Both pass and fail paths render through the existing `verification_feedback.html` partial, which already implements an "All checks passed" header variant (green band, ✓ icon) for the all-passed case. Zero template changes needed.

## #459 — `feedback_json` TEXT → JSONB

Now that every multi-task verification persists a payload (instead of only failed ones), the column earns its real type. Standalone, the issue body itself flagged this as "refactor for refactor's sake"; paired with #425 the storage shape matches the runtime shape.

**Schema (migration 0032):**
- `ALTER COLUMN feedback_json TYPE JSONB USING feedback_json::jsonb`. Single statement, wrapped in a `DO` block keyed on `information_schema.columns.data_type` so re-runs are no-ops. Squawk-clean.
- The cast rejects malformed rows. Preflight on prod (`SELECT id FROM submissions WHERE feedback_json IS NOT NULL AND NOT (feedback_json::jsonb IS NOT NULL)`) needs to confirm zero affected rows before the deploy can drain.

**App:**
- `models.Submission.feedback_json` → `Mapped[list[dict] | None]` on `JSONB`.
- `verification.execution._feedback_json` returns a raw list (not `json.dumps(...)`).
- `SubmissionRepository.create` parameter type updated.
- `submissions_service.get_phase_submission_context` drops the `json.loads` call + `JSONDecodeError/TypeError` try/except — the cast guarantees structured input. Unused `json` + `opentelemetry.trace` imports go too.
- `schemas.SubmissionData.feedback_json` → `list[dict] | None`.

## Validation

- 476 shared + 205 API tests pass.
- New `test_passing_submission_with_feedback_renders_for_pass` covers the #425 behavior change.
- Existing `test_submission_with_feedback_json` updated to use the structured shape.
- Migration applies cleanly against the local DB; `test_migration_chain` (up + down round-trip + model parity) passes.
- Squawk-clean on the new migration.

## Rollout note

This is a single-PR migration + app cutover, same shape as the recent Phase D/E PRs. Brief HTMX 500 window during pod rollover is the same trade-off you've accepted on those: old pods that read `sub.feedback_json` as a `str` will get a `list` back from SQLAlchemy after the migration runs and the model class is reloaded, but those pods are mid-replacement and get drained within the rolling deploy window.

If the prod preflight finds any unparseable rows, null them out manually before deploying so the cast doesn't reject them.