### PR TITLE
chore(htmx): log inner exception cause on durable start failure

### DIFF
--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -466,12 +466,18 @@ async def _start_async_job_and_render(
         DurableVerificationStartError,
     ) as exc:
         record_span_exception(exc)
-        logger.warning(
+        logger.exception(
             "htmx.submit.durable_start_failed",
             extra={
                 "user_id": user_id,
                 "requirement_slug": requirement_slug,
                 "error_type": type(exc).__name__,
+                "error_message": str(exc),
+                "error_cause": (
+                    f"{type(exc.__cause__).__name__}: {exc.__cause__}"
+                    if exc.__cause__ is not None
+                    else None
+                ),
             },
         )
         # Delete the just-created row so the partial unique index doesn't


### PR DESCRIPTION
The `htmx.submit.durable_start_failed` warning previously logged only the exception class name (e.g. `DurableVerificationStartError`), hiding the actual reason — the HTTP status code, httpx connection error, or JSON-parse failure that caused the wrap.

Shipping this so we can diagnose the current prod failure on `journal-api-implementation` submits without round-tripping through App Insights.

Changes:
- `logger.warning` → `logger.exception` (captures the traceback)
- New `error_message` extra: `str(exc)` (e.g. "Durable starter returned HTTP 502")
- New `error_cause` extra: `f"{type(exc.__cause__).__name__}: {exc.__cause__}"` when the wrapped error has a `__cause__` (e.g. `ConnectError: ...` from httpx)

No behavior change.