### PR TITLE
feat: decouple Functions app from curriculum schema (fixes prod start failure)

### DIFF
--- a/api/alembic/versions/0033_revoke_unused_fn_grants.py
+++ b/api/alembic/versions/0033_revoke_unused_fn_grants.py
@@ -1,11 +1,11 @@
 """revoke Functions role grants on curriculum + users tables
 
-Phase E follow-up (#467): after the curriculum-decoupling refactor,
-the verification Functions app no longer reads ``users`` or any
-curriculum table -- the requirement definition and ``github_username``
-snapshot travel with the orchestration payload. Revoke the now-unused
-SELECT grants so the Functions role's effective surface matches what
-the code actually uses.
+After the curriculum-decoupling refactor, the verification Functions
+app no longer reads ``users`` or any curriculum table -- the
+requirement definition and ``github_username`` snapshot travel with
+the orchestration payload. Revoke the now-unused SELECT grants so
+the Functions role's effective surface matches what the code
+actually uses.
 
 The role name is read from ``POSTGRES_VERIFICATION_FUNCTIONS_ROLE`` at
 migration time. When the env var is missing (local dev with the

--- a/api/alembic/versions/0033_revoke_unused_fn_grants.py
+++ b/api/alembic/versions/0033_revoke_unused_fn_grants.py
@@ -1,0 +1,89 @@
+"""revoke Functions role grants on curriculum + users tables
+
+Phase E follow-up (#467): after the curriculum-decoupling refactor,
+the verification Functions app no longer reads ``users`` or any
+curriculum table -- the requirement definition and ``github_username``
+snapshot travel with the orchestration payload. Revoke the now-unused
+SELECT grants so the Functions role's effective surface matches what
+the code actually uses.
+
+The role name is read from ``POSTGRES_VERIFICATION_FUNCTIONS_ROLE`` at
+migration time. When the env var is missing (local dev with the
+``postgres`` superuser) or the role doesn't exist, the migration
+no-ops cleanly. Same idempotency story as the existing migrations.
+
+Schema effect:
+- REVOKE SELECT ON users, curriculum_phases, topics, steps,
+  learning_objectives, requirements FROM the Functions role.
+- Retains: SELECT/INSERT on submissions, SELECT/UPDATE on verification_jobs.
+
+Revision ID: 0033_revoke_unused_fn_grants
+Revises: 0032_feedback_json_jsonb
+Create Date: 2026-05-25
+"""
+
+import os
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0033_revoke_unused_fn_grants"
+down_revision: str | None = "0032_feedback_json_jsonb"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_REVOKE_TABLES = (
+    "users",
+    "curriculum_phases",
+    "topics",
+    "steps",
+    "learning_objectives",
+    "requirements",
+)
+
+
+def upgrade() -> None:
+    role = os.environ.get("POSTGRES_VERIFICATION_FUNCTIONS_ROLE")
+    if not role:
+        return
+    # Validate role name: PostgreSQL identifier rules. The migration job
+    # sets this from a Terraform local; defense in depth against a
+    # mistakenly-set env var.
+    if not all(c.isalnum() or c == "_" for c in role) or not role[0].isalpha():
+        raise RuntimeError(
+            f"POSTGRES_VERIFICATION_FUNCTIONS_ROLE is not a valid identifier: {role!r}"
+        )
+    tables = ", ".join(_REVOKE_TABLES)
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                REVOKE SELECT ON {tables} FROM "{role}";
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    role = os.environ.get("POSTGRES_VERIFICATION_FUNCTIONS_ROLE")
+    if not role:
+        return
+    if not all(c.isalnum() or c == "_" for c in role) or not role[0].isalpha():
+        raise RuntimeError(
+            f"POSTGRES_VERIFICATION_FUNCTIONS_ROLE is not a valid identifier: {role!r}"
+        )
+    tables = ", ".join(_REVOKE_TABLES)
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                GRANT SELECT ON {tables} TO "{role}";
+            END IF;
+        END $$;
+        """
+    )

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -35,6 +35,7 @@ from learn_to_cloud_shared.verification.url_derivation import (
     derive_submission_value,
     is_derivable,
 )
+from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 if TYPE_CHECKING:
@@ -431,23 +432,33 @@ async def _start_async_job_and_render(
 ) -> HTMLResponse:
     """Start a Durable orchestration for an async job and render the spinner.
 
-    The job's UUID *is* the Durable orchestration instance id (we always pass
-    ``instance_id=job.id`` to the starter), so we don't need to read it back
-    from ``VerificationJob.orchestration_instance_id`` — that column is dead
-    weight kept for old code mid-deploy and will be removed in PR4.
+    Builds the full :class:`PreparedVerificationJob` payload from the
+    validated requirement + github_username carried on
+    ``job_submission`` and posts it to the Functions starter. Functions
+    validates the immutable fields against the ``verification_jobs``
+    row before starting; the payload is trusted for the requirement
+    definition + username snapshot so Functions never needs to read
+    curriculum or users tables (#467 follow-up).
 
-    On the rare concurrent-submit case (``created=False``) the original submit
-    already kicked off Durable; we skip the start call and let the poller
-    discover the existing instance via ``job.id``. If that original start
-    never actually succeeded, the poller will see a 404 from Durable and
-    surface the error so the user can retry.
+    On the rare concurrent-submit case (``created=False``) the original
+    submit already kicked off Durable; we skip the start call and let
+    the poller discover the existing instance via ``job.id``. If that
+    original start never actually succeeded, the poller will see a 404
+    from Durable and surface the error so the user can retry.
 
-    On Durable start failure deletes the just-created row so the partial
-    unique index doesn't block the user's retry.
+    On Durable start failure deletes the just-created row so the
+    partial unique index doesn't block the user's retry.
     """
     try:
         if job_submission.created:
-            await start_verification_orchestration(job_submission.job.id)
+            prepared = PreparedVerificationJob(
+                id=job_submission.job.id,
+                user_id=user_id,
+                github_username=job_submission.github_username,
+                requirement=job_submission.requirement,
+                submitted_value=job_submission.job.submitted_value,
+            )
+            await start_verification_orchestration(prepared)
 
         status_token = create_verification_status_token(
             user_id=user_id,

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -438,7 +438,7 @@ async def _start_async_job_and_render(
     validates the immutable fields against the ``verification_jobs``
     row before starting; the payload is trusted for the requirement
     definition + username snapshot so Functions never needs to read
-    curriculum or users tables (#467 follow-up).
+    curriculum or users tables.
 
     On the rare concurrent-submit case (``created=False``) the original
     submit already kicked off Durable; we skip the start call and let

--- a/api/src/learn_to_cloud/services/durable_verification_client.py
+++ b/api/src/learn_to_cloud/services/durable_verification_client.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from uuid import UUID
+from typing import Any
 
 import httpx
 from learn_to_cloud_shared.core.config import get_web_settings
+from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
 
 
 class DurableVerificationConfigError(Exception):
@@ -33,8 +34,19 @@ class DurableStatusResult:
     custom_status: object | None = None
 
 
-async def start_verification_orchestration(job_id: UUID) -> DurableStartResult:
-    """Start the Durable orchestration for a persisted verification job."""
+async def start_verification_orchestration(
+    prepared: PreparedVerificationJob,
+) -> DurableStartResult:
+    """Start the Durable orchestration for a persisted verification job.
+
+    Posts the full :class:`PreparedVerificationJob` payload to the
+    Functions starter so the orchestration has everything it needs to
+    run without reading curriculum tables. The Functions side still
+    validates the immutable fields (``user_id``, ``requirement_uuid``,
+    ``submitted_value``) against the ``verification_jobs`` row before
+    starting -- the payload is trusted only for the requirement
+    *definition* and ``github_username`` snapshot.
+    """
     settings = get_web_settings()
     base_url = settings.verification_functions_base_url.rstrip("/")
     function_key = settings.verification_functions_key
@@ -44,12 +56,13 @@ async def start_verification_orchestration(job_id: UUID) -> DurableStartResult:
             "Verification Functions endpoint is not configured."
         )
 
-    url = f"{base_url}/api/verification/jobs/{job_id}/start"
+    url = f"{base_url}/api/verification/jobs/{prepared.id}/start"
     headers = {"x-functions-key": function_key}
+    body: dict[str, Any] = prepared.to_payload()
 
     try:
         async with httpx.AsyncClient(timeout=settings.external_api_timeout) as client:
-            response = await client.post(url, headers=headers)
+            response = await client.post(url, headers=headers, json=body)
     except httpx.HTTPError as exc:
         raise DurableVerificationStartError("Durable starter request failed.") from exc
 

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -137,10 +137,18 @@ class _PreValidationContext:
 
 @dataclass(frozen=True, slots=True)
 class VerificationJobSubmission:
-    """Result of creating or reusing a verification job (async Durable path)."""
+    """Result of creating or reusing a verification job (async Durable path).
+
+    Carries the validated requirement (and the github_username used at
+    submit time) so the route can build a complete
+    ``PreparedVerificationJob`` payload for the Durable starter without
+    re-deriving anything from the request.
+    """
 
     job: VerificationJob
     created: bool
+    requirement: HandsOnRequirement
+    github_username: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -278,4 +286,9 @@ async def create_verification_job(
         )
         await write_session.commit()
 
-    return VerificationJobSubmission(job=job, created=created)
+    return VerificationJobSubmission(
+        job=job,
+        created=created,
+        requirement=ctx.requirement,
+        github_username=github_username,
+    )

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -43,6 +43,20 @@ from learn_to_cloud.services.users_service import UserNotFoundError
 from learn_to_cloud.services.verification_status_tokens import VerificationStatusToken
 
 
+def _async_requirement():
+    """A real HandsOnRequirement for tests that need to build a
+    PreparedVerificationJob payload alongside a VerificationJobSubmission."""
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        journal_api_verifier_requirement,
+    )
+
+    return journal_api_verifier_requirement(
+        slug="journal-api-implementation",
+        name="Journal API",
+        description="Test",
+    )
+
+
 def _mock_request(*, session: dict | None = None) -> MagicMock:
     """Build mock Request with session support."""
     request = MagicMock()
@@ -197,8 +211,17 @@ class TestHtmxSubmitVerification:
         """Successful submission starts Durable and returns processing card."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = SimpleNamespace(id=uuid4(), orchestration_instance_id=None)
-        job_submission = SimpleNamespace(job=job, created=True)
+        job = SimpleNamespace(
+            id=uuid4(),
+            orchestration_instance_id=None,
+            submitted_value="test",
+        )
+        job_submission = SimpleNamespace(
+            job=job,
+            created=True,
+            requirement=_async_requirement(),
+            github_username="user",
+        )
         start_result = SimpleNamespace(instance_id=str(job.id))
         write_session = AsyncMock()
         request.app.state.session_maker.return_value.__aenter__.return_value = (
@@ -242,7 +265,7 @@ class TestHtmxSubmitVerification:
         # Should return a processing card, not a final result
         assert result is not None
         mock_create_job.assert_awaited_once()
-        mock_start.assert_awaited_once_with(job.id)
+        mock_start.assert_awaited_once()
 
     async def test_submit_unexpected_error_renders_server_error(self):
         """Unexpected exceptions render a server error card."""
@@ -282,10 +305,14 @@ class TestHtmxSubmitVerification:
         partial unique index so the user can retry immediately."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = SimpleNamespace(id=uuid4(), orchestration_instance_id=None)
+        job = SimpleNamespace(
+            id=uuid4(), orchestration_instance_id=None, submitted_value="test"
+        )
         async_result = VerificationJobSubmission(
             job=cast(VerificationJob, job),
             created=True,
+            requirement=_async_requirement(),
+            github_username="user",
         )
         write_session = AsyncMock()
         request.app.state.session_maker.return_value.__aenter__.return_value = (
@@ -446,10 +473,14 @@ class TestHtmxSubmitVerification:
         VerificationJobSubmission spinner-and-poll path."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = SimpleNamespace(id=uuid4(), orchestration_instance_id=None)
+        job = SimpleNamespace(
+            id=uuid4(), orchestration_instance_id=None, submitted_value="test"
+        )
         async_result = VerificationJobSubmission(
             job=cast(VerificationJob, job),
             created=True,
+            requirement=_async_requirement(),
+            github_username="user",
         )
         start_result = SimpleNamespace(instance_id=str(job.id))
         write_session = AsyncMock()
@@ -492,7 +523,11 @@ class TestHtmxSubmitVerification:
             )
 
         assert isinstance(result, HTMLResponse)
-        mock_start.assert_awaited_once_with(job.id)
+        mock_start.assert_awaited_once()
+        await_args = mock_start.await_args
+        assert await_args is not None
+        (call_arg,) = await_args.args
+        assert call_arg.id == job.id
 
     async def test_duplicate_submit_skips_durable_start(self):
         """When ``create_verification_job`` returns ``created=False``
@@ -502,10 +537,14 @@ class TestHtmxSubmitVerification:
         with the same instance id would error."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = SimpleNamespace(id=uuid4(), orchestration_instance_id=None)
+        job = SimpleNamespace(
+            id=uuid4(), orchestration_instance_id=None, submitted_value="test"
+        )
         async_result = VerificationJobSubmission(
             job=cast(VerificationJob, job),
             created=False,
+            requirement=_async_requirement(),
+            github_username="user",
         )
 
         with (

--- a/api/tests/services/test_durable_verification_client.py
+++ b/api/tests/services/test_durable_verification_client.py
@@ -6,6 +6,10 @@ from uuid import uuid4
 
 import httpx
 import pytest
+from learn_to_cloud_shared.testing.requirement_factories import (
+    github_profile_requirement,
+)
+from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
 
 from learn_to_cloud.services.durable_verification_client import (
     DurableVerificationConfigError,
@@ -30,6 +34,16 @@ def _settings(
     )
 
 
+def _prepared(job_id=None) -> PreparedVerificationJob:
+    return PreparedVerificationJob(
+        id=job_id or uuid4(),
+        user_id=42,
+        github_username="testuser",
+        requirement=github_profile_requirement(),
+        submitted_value="https://github.com/testuser",
+    )
+
+
 def _async_client(response: httpx.Response | Exception):
     client = MagicMock()
     if isinstance(response, Exception):
@@ -45,8 +59,8 @@ def _async_client(response: httpx.Response | Exception):
     return client, context_manager
 
 
-async def test_starts_orchestration_with_function_key_header():
-    job_id = uuid4()
+async def test_starts_orchestration_with_function_key_header_and_payload():
+    prepared = _prepared()
     client, context_manager = _async_client(httpx.Response(202, json={"id": "abc"}))
 
     with (
@@ -59,13 +73,14 @@ async def test_starts_orchestration_with_function_key_header():
             return_value=context_manager,
         ) as async_client,
     ):
-        result = await start_verification_orchestration(job_id)
+        result = await start_verification_orchestration(prepared)
 
     assert result.instance_id == "abc"
     async_client.assert_called_once_with(timeout=3.0)
     client.post.assert_awaited_once_with(
-        f"http://localhost:7071/api/verification/jobs/{job_id}/start",
+        f"http://localhost:7071/api/verification/jobs/{prepared.id}/start",
         headers={"x-functions-key": "function-key"},
+        json=prepared.to_payload(),
     )
 
 
@@ -80,7 +95,7 @@ async def test_missing_config_fails_before_http_call():
         ) as async_client,
         pytest.raises(DurableVerificationConfigError),
     ):
-        await start_verification_orchestration(uuid4())
+        await start_verification_orchestration(_prepared())
 
     async_client.assert_not_called()
 
@@ -99,7 +114,7 @@ async def test_http_error_status_raises_start_error():
         ),
         pytest.raises(DurableVerificationStartError, match="HTTP 500"),
     ):
-        await start_verification_orchestration(uuid4())
+        await start_verification_orchestration(_prepared())
 
 
 async def test_transport_error_raises_start_error():
@@ -117,7 +132,7 @@ async def test_transport_error_raises_start_error():
         ),
         pytest.raises(DurableVerificationStartError, match="request failed"),
     ):
-        await start_verification_orchestration(uuid4())
+        await start_verification_orchestration(_prepared())
 
 
 async def test_gets_orchestration_status_with_function_key_header():

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -39,7 +39,6 @@ from learn_to_cloud_shared.verification_job_executor import (
 from opentelemetry import context as otel_context
 from opentelemetry import trace as otel_trace
 from opentelemetry.propagate import extract
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from verification_agents import grade_evidence
 
@@ -317,16 +316,31 @@ def _result_custom_status(
 
 
 def _run_verification_orchestration(context: df.DurableOrchestrationContext):
-    """Run one verification job wor
-    kflow."""
-    job_id = context.get_input()
-    if isinstance(job_id, str):
-        _set_verification_span_attributes(job_id=job_id)
+    """Run one verification job workflow.
+
+    Input shape:
+    - **New**: a :class:`PreparedVerificationJob` payload dict (with
+      ``id``, ``requirement``, ``submitted_value`` etc.). This is what
+      the HTTP starter sends after the curriculum-decoupling refactor.
+    - **Legacy**: a bare job_id string. Accepted for one deploy cycle
+      so in-flight orchestrations from before the deploy still execute;
+      the activity falls back to the DB-loading path. Remove once no
+      legacy instances remain.
+    """
+    raw_input = context.get_input()
+    if isinstance(raw_input, str):
+        job_id = raw_input
+    elif isinstance(raw_input, Mapping):
+        job_id_obj = raw_input.get("id")
+        job_id = job_id_obj if isinstance(job_id_obj, str) else str(job_id_obj)
+    else:
+        job_id = str(raw_input)
+    _set_verification_span_attributes(job_id=job_id)
     context.set_custom_status({"step": "preparing", "job_id": job_id})
     preparation = yield context.call_activity_with_retry(
         "prepare_verification_job",
         _TRANSIENT_RETRY_OPTIONS,
-        job_id,
+        raw_input,
     )
 
     terminal_result = preparation.get("terminal_result")
@@ -497,18 +511,39 @@ def verify_phase6_security_orchestrator(context: df.DurableOrchestrationContext)
     return (yield from _run_verification_orchestration(context))
 
 
-@app.activity_trigger(input_name="job_id")
+@app.activity_trigger(input_name="input_payload")
 async def prepare_verification_job(
-    job_id: str,
+    input_payload,
     context: func.Context,
 ) -> dict[str, object]:
-    """Load and mark the persisted verification job as running."""
+    """Load and mark the persisted verification job as running.
+
+    Accepts either:
+    - a bare job_id string (legacy in-flight orchestrations) — falls
+      back to the DB-load path that reads curriculum tables; or
+    - a full :class:`PreparedVerificationJob` payload dict — the new
+      shape, where the requirement definition + github_username
+      snapshot travel with the orchestration so this activity never
+      reads curriculum or users tables.
+    """
     with _attached_invocation_context(context):
+        if isinstance(input_payload, str):
+            job_id = input_payload
+            prepared_input = None
+        elif isinstance(input_payload, Mapping):
+            prepared_input = PreparedVerificationJob.from_payload(input_payload)
+            job_id = str(prepared_input.id)
+        else:
+            raise TypeError(
+                f"prepare_verification_job: expected str or Mapping input, "
+                f"got {type(input_payload).__name__}"
+            )
         _set_verification_span_attributes(job_id=job_id)
         try:
             preparation = await prepare_persisted_verification_job(
                 job_id,
                 session_maker=_get_session_maker(),
+                prepared_input=prepared_input,
             )
         except VerificationJobNotFoundError:
             logger.warning("verification.job.not_found", extra={"job_id": job_id})
@@ -641,7 +676,18 @@ async def start_verification_job(
     client: df.DurableOrchestrationClient,
     context: func.Context,
 ) -> func.HttpResponse:
-    """Start the verification orchestration for an existing job."""
+    """Start the verification orchestration for an existing job.
+
+    The API posts a full :class:`PreparedVerificationJob` payload as
+    the request body. We validate the immutable fields against the
+    ``verification_jobs`` row (route ``job_id``, ``user_id``,
+    ``requirement_uuid``, ``submitted_value``) so a leaked function
+    key or API bug can't make us run validation against a forged
+    user/requirement pair. The requirement *definition* and the
+    ``github_username`` snapshot are trusted from the payload -- which
+    is what lets the Functions role drop curriculum/users grants
+    entirely.
+    """
     with _attached_invocation_context(context):
         raw_job_id = req.route_params.get("job_id")
         if raw_job_id is None:
@@ -652,35 +698,45 @@ async def start_verification_job(
         except ValueError:
             return _json_response({"error": "invalid_job_id"}, status_code=400)
 
+        try:
+            body = req.get_json()
+        except ValueError:
+            return _json_response({"error": "invalid_json_body"}, status_code=400)
+
+        try:
+            prepared = PreparedVerificationJob.from_payload(body)
+        except (KeyError, ValueError, TypeError) as exc:
+            return _json_response(
+                {"error": "invalid_payload", "detail": str(exc)},
+                status_code=400,
+            )
+
+        if prepared.id != job_uuid:
+            return _json_response({"error": "payload_job_id_mismatch"}, status_code=400)
+
         job_id = str(job_uuid)
         async with _get_session_maker()() as session:
             job = await VerificationJobRepository(session).get_by_id(job_uuid)
             if job is None:
                 return _json_response({"error": "job_not_found"}, status_code=404)
 
-            # verification_jobs no longer carries submission_type/requirement_slug
-            # (Phase D.3). Resolve them via a direct lookup against the
-            # requirements table -- this includes soft-deleted rows because
-            # the FK is ON DELETE RESTRICT, so the row always still exists.
-            requirement_row = (
-                await session.execute(
-                    text(
-                        "SELECT slug, submission_type FROM requirements "
-                        "WHERE uuid = :uuid LIMIT 1"
-                    ),
-                    {"uuid": job.requirement_uuid},
+            if (
+                job.user_id != prepared.user_id
+                or job.requirement_uuid != prepared.requirement.uuid
+                or job.submitted_value != prepared.submitted_value
+            ):
+                return _json_response(
+                    {"error": "payload_does_not_match_job"},
+                    status_code=400,
                 )
-            ).first()
-        if requirement_row is None:
-            return _json_response({"error": "requirement_not_found"}, status_code=404)
-        requirement_slug, submission_type_str = requirement_row[0], requirement_row[1]
 
+        submission_type_str = prepared.requirement.submission_type.value
         orchestrator_name = _orchestrator_name_for_submission_type(submission_type_str)
         _set_verification_span_attributes(job_id=job_id)
         instance_id = await client.start_new(
             orchestrator_name,
             instance_id=job_id,
-            client_input=job_id,
+            client_input=prepared.to_payload(),
         )
         logger.info(
             "verification.orchestration.started",
@@ -688,7 +744,7 @@ async def start_verification_job(
                 "job_id": job_id,
                 "instance_id": instance_id,
                 "orchestrator_name": orchestrator_name,
-                "requirement_slug": requirement_slug,
+                "requirement_slug": prepared.requirement.slug,
                 "submission_type": submission_type_str,
             },
         )

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -321,7 +321,7 @@ def _run_verification_orchestration(context: df.DurableOrchestrationContext):
     Input is a :class:`PreparedVerificationJob` payload dict (with
     ``id``, ``requirement``, ``submitted_value`` etc.) -- the HTTP
     starter always builds and posts one. Functions never reads
-    curriculum or users tables (#467 follow-up).
+    curriculum or users tables.
     """
     input_payload = context.get_input()
     if not isinstance(input_payload, Mapping):
@@ -512,12 +512,13 @@ async def prepare_verification_job(
     input_payload,
     context: func.Context,
 ) -> dict[str, object]:
-    """Load and mark the persisted verification job as running.
+    """Validate the persisted verification job and return the prepared
+    work item for the orchestrator to run.
 
     Input is the :class:`PreparedVerificationJob` payload dict carried
     by the orchestration. The requirement definition + github_username
     snapshot travel with the orchestration so this activity never
-    reads curriculum or users tables (#467 follow-up).
+    reads curriculum or users tables.
     """
     with _attached_invocation_context(context):
         if not isinstance(input_payload, Mapping):

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -318,29 +318,25 @@ def _result_custom_status(
 def _run_verification_orchestration(context: df.DurableOrchestrationContext):
     """Run one verification job workflow.
 
-    Input shape:
-    - **New**: a :class:`PreparedVerificationJob` payload dict (with
-      ``id``, ``requirement``, ``submitted_value`` etc.). This is what
-      the HTTP starter sends after the curriculum-decoupling refactor.
-    - **Legacy**: a bare job_id string. Accepted for one deploy cycle
-      so in-flight orchestrations from before the deploy still execute;
-      the activity falls back to the DB-loading path. Remove once no
-      legacy instances remain.
+    Input is a :class:`PreparedVerificationJob` payload dict (with
+    ``id``, ``requirement``, ``submitted_value`` etc.) -- the HTTP
+    starter always builds and posts one. Functions never reads
+    curriculum or users tables (#467 follow-up).
     """
-    raw_input = context.get_input()
-    if isinstance(raw_input, str):
-        job_id = raw_input
-    elif isinstance(raw_input, Mapping):
-        job_id_obj = raw_input.get("id")
-        job_id = job_id_obj if isinstance(job_id_obj, str) else str(job_id_obj)
-    else:
-        job_id = str(raw_input)
+    input_payload = context.get_input()
+    if not isinstance(input_payload, Mapping):
+        raise TypeError(
+            f"verification orchestration: expected Mapping input, "
+            f"got {type(input_payload).__name__}"
+        )
+    job_id_obj = input_payload.get("id")
+    job_id = job_id_obj if isinstance(job_id_obj, str) else str(job_id_obj)
     _set_verification_span_attributes(job_id=job_id)
     context.set_custom_status({"step": "preparing", "job_id": job_id})
     preparation = yield context.call_activity_with_retry(
         "prepare_verification_job",
         _TRANSIENT_RETRY_OPTIONS,
-        raw_input,
+        input_payload,
     )
 
     terminal_result = preparation.get("terminal_result")
@@ -518,26 +514,19 @@ async def prepare_verification_job(
 ) -> dict[str, object]:
     """Load and mark the persisted verification job as running.
 
-    Accepts either:
-    - a bare job_id string (legacy in-flight orchestrations) — falls
-      back to the DB-load path that reads curriculum tables; or
-    - a full :class:`PreparedVerificationJob` payload dict — the new
-      shape, where the requirement definition + github_username
-      snapshot travel with the orchestration so this activity never
-      reads curriculum or users tables.
+    Input is the :class:`PreparedVerificationJob` payload dict carried
+    by the orchestration. The requirement definition + github_username
+    snapshot travel with the orchestration so this activity never
+    reads curriculum or users tables (#467 follow-up).
     """
     with _attached_invocation_context(context):
-        if isinstance(input_payload, str):
-            job_id = input_payload
-            prepared_input = None
-        elif isinstance(input_payload, Mapping):
-            prepared_input = PreparedVerificationJob.from_payload(input_payload)
-            job_id = str(prepared_input.id)
-        else:
+        if not isinstance(input_payload, Mapping):
             raise TypeError(
-                f"prepare_verification_job: expected str or Mapping input, "
+                f"prepare_verification_job: expected Mapping input, "
                 f"got {type(input_payload).__name__}"
             )
+        prepared_input = PreparedVerificationJob.from_payload(input_payload)
+        job_id = str(prepared_input.id)
         _set_verification_span_attributes(job_id=job_id)
         try:
             preparation = await prepare_persisted_verification_job(

--- a/infra/migrations.tf
+++ b/infra/migrations.tf
@@ -50,6 +50,11 @@ resource "azurerm_container_app_job" "migrations" {
         name  = "AZURE_CLIENT_ID"
         value = azurerm_user_assigned_identity.migrations.client_id
       }
+
+      env {
+        name  = "POSTGRES_VERIFICATION_FUNCTIONS_ROLE"
+        value = local.verification_functions_postgres_role
+      }
     }
   }
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -427,6 +427,7 @@ async def prepare_verification_job(
     job_id: UUID | str,
     *,
     session_maker: async_sessionmaker[AsyncSession],
+    prepared_input: PreparedVerificationJob | None = None,
 ) -> VerificationJobPreparation:
     """Load a verification job and dispatch to the right execution path.
 
@@ -435,20 +436,49 @@ async def prepare_verification_job(
        prepare after the persist activity already finished), return the
        same execution result from the linked Submission.
     2. If the requirement was removed from content between submit and
-       execute, record a server-error Submission and short-circuit.
+       execute and we have no ``prepared_input`` snapshot, record a
+       server-error Submission and short-circuit.
+
+    Args:
+        prepared_input: When the orchestration was started with a full
+            :class:`PreparedVerificationJob` payload (the post-#467
+            decoupling path), the requirement definition and
+            ``github_username`` snapshot travel with the orchestration
+            and we skip the curriculum / users reads. The DB row is
+            still loaded so we can validate immutable identity fields
+            against the payload (defense against a forged start
+            request) and check the replay short-circuit. Pass ``None``
+            for legacy in-flight orchestrations whose ``client_input``
+            is a bare job_id string.
     """
     normalized_job_id = _coerce_job_id(job_id)
 
     with tracer.start_as_current_span(
         "prepare_verification_job",
-        attributes={"verification.job_id": str(normalized_job_id)},
+        attributes={"verification.job.id": str(normalized_job_id)},
     ) as span:
         async with session_maker() as db:
-            payload = await _load_job_payload(db, normalized_job_id)
-            if payload is None:
-                raise VerificationJobNotFoundError(str(normalized_job_id))
-
-            requirement = await _find_requirement_by_uuid(db, payload.requirement_uuid)
+            if prepared_input is None:
+                payload = await _load_job_payload(db, normalized_job_id)
+                if payload is None:
+                    raise VerificationJobNotFoundError(str(normalized_job_id))
+                requirement = await _find_requirement_by_uuid(
+                    db, payload.requirement_uuid
+                )
+            else:
+                payload = await _load_job_state(db, normalized_job_id)
+                if payload is None:
+                    raise VerificationJobNotFoundError(str(normalized_job_id))
+                if (
+                    payload.user_id != prepared_input.user_id
+                    or payload.requirement_uuid != prepared_input.requirement.uuid
+                    or payload.submitted_value != prepared_input.submitted_value
+                ):
+                    raise VerificationJobNotFoundError(
+                        f"prepared payload does not match verification_jobs "
+                        f"row for job {normalized_job_id}"
+                    )
+                requirement = prepared_input.requirement
 
             if payload.result_submission_id is not None:
                 submission = await db.get(Submission, payload.result_submission_id)
@@ -485,11 +515,40 @@ async def prepare_verification_job(
             job=PreparedVerificationJob(
                 id=payload.id,
                 user_id=payload.user_id,
-                github_username=payload.github_username,
+                github_username=(
+                    prepared_input.github_username
+                    if prepared_input is not None
+                    else payload.github_username
+                ),
                 requirement=requirement,
                 submitted_value=payload.submitted_value,
             )
         )
+
+
+async def _load_job_state(
+    db: AsyncSession,
+    job_id: UUID,
+) -> _VerificationJobPayload | None:
+    """Load verification_jobs identity + replay state without joining users.
+
+    Used by the new payload-driven prepare path: ``github_username``
+    comes from the orchestration payload, not the DB row, so the
+    Functions role doesn't need ``SELECT ON users``. The returned
+    dataclass's ``github_username`` field is set to ``None`` and
+    callers must read it from the payload instead.
+    """
+    job = await db.get(VerificationJob, job_id)
+    if job is None:
+        return None
+    return _VerificationJobPayload(
+        id=job.id,
+        user_id=job.user_id,
+        github_username=None,
+        requirement_uuid=job.requirement_uuid,
+        submitted_value=job.submitted_value,
+        result_submission_id=job.result_submission_id,
+    )
 
 
 async def run_verification(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -26,16 +26,11 @@ from dataclasses import dataclass
 from uuid import UUID
 
 from opentelemetry import trace
-from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.models import (
     Submission,
-    User,
     VerificationJob,
-)
-from learn_to_cloud_shared.repositories.submission_repository import (
-    SubmissionRepository,
 )
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     LinkResult,
@@ -50,9 +45,6 @@ from learn_to_cloud_shared.verification.dispatcher import validate_submission
 from learn_to_cloud_shared.verification.execution import (
     persist_validation_result,
     persisted_validation_message,
-)
-from learn_to_cloud_shared.verification.requirements import (
-    get_requirement_by_uuid,
 )
 
 tracer = trace.get_tracer(__name__)
@@ -206,7 +198,6 @@ class VerificationRunResult:
 class _VerificationJobPayload:
     id: UUID
     user_id: int
-    github_username: str | None
     requirement_uuid: UUID
     submitted_value: str
     result_submission_id: int | None
@@ -241,30 +232,6 @@ def _coerce_job_id(job_id: UUID | str) -> UUID:
     return UUID(job_id)
 
 
-async def _load_job_payload(
-    db: AsyncSession,
-    job_id: UUID,
-) -> _VerificationJobPayload | None:
-    result = await db.execute(
-        select(VerificationJob, User.github_username)
-        .join(User, VerificationJob.user_id == User.id)
-        .where(VerificationJob.id == job_id)
-    )
-    row = result.one_or_none()
-    if row is None:
-        return None
-
-    job, github_username = row
-    return _VerificationJobPayload(
-        id=job.id,
-        user_id=job.user_id,
-        github_username=github_username,
-        requirement_uuid=job.requirement_uuid,
-        submitted_value=job.submitted_value,
-        result_submission_id=job.result_submission_id,
-    )
-
-
 def _outcome_for(validation_result: ValidationResult) -> str:
     if validation_result.is_valid:
         return _OUTCOME_SUCCEEDED
@@ -293,35 +260,23 @@ def _build_result_from_submission(
     *,
     job_id: UUID,
     submission: Submission,
-    requirement: HandsOnRequirement | None,
-    requirement_slug_fallback: str | None = None,
+    requirement: HandsOnRequirement,
 ) -> VerificationJobExecutionResult:
     """Build a ``VerificationJobExecutionResult`` from an already-persisted
     ``Submission``. Used by the replay short-circuit in
     :func:`prepare_verification_job` and :func:`persist_verification_result`.
 
-    When ``requirement`` is None (active lookup didn't find it -- the
-    requirement was soft-deleted), the caller passes the legacy
-    ``requirement_slug_fallback`` so the result payload still surfaces
-    something useful in templates.
+    The requirement is always available (carried on the orchestration
+    payload after #467) so we don't need a soft-delete fallback shape.
     """
     outcome = _outcome_from_submission(submission)
-    requirement_slug = (
-        requirement.slug
-        if requirement is not None
-        else (requirement_slug_fallback or "")
-    )
-    submission_type = (
-        requirement.submission_type.value if requirement is not None else None
-    )
-    requirement_name = requirement.name if requirement is not None else None
     return VerificationJobExecutionResult(
         job_id=job_id,
         status=outcome,
         code=_code_for_outcome(outcome),
-        requirement_slug=requirement_slug,
-        requirement_name=requirement_name,
-        submission_type=submission_type,
+        requirement_slug=requirement.slug,
+        requirement_name=requirement.name,
+        submission_type=requirement.submission_type.value,
         submission_id=submission.id,
         is_valid=submission.is_validated,
         verification_completed=submission.verification_completed,
@@ -330,126 +285,29 @@ def _build_result_from_submission(
     )
 
 
-async def _load_requirement_metadata(
-    db: AsyncSession, requirement_uuid: UUID
-) -> tuple[str, str] | None:
-    """Return ``(requirement_slug, submission_type)`` for a requirement by UUID,
-    even if it has been soft-deleted.
-
-    Used by the missing-requirement path to fill in the slug field on
-    a server-error result when the active ``get_requirement_by_slug``
-    lookup returns None.
-    """
-    result = await db.execute(
-        text(
-            "SELECT slug, submission_type FROM requirements WHERE uuid = :uuid LIMIT 1"
-        ),
-        {"uuid": requirement_uuid},
-    )
-    row = result.first()
-    return (row[0], row[1]) if row else None
-
-
-async def _find_requirement_by_uuid(
-    db: AsyncSession, requirement_uuid: UUID
-) -> HandsOnRequirement | None:
-    """Return the active ``HandsOnRequirement`` matching the given UUID.
-
-    Walks the loaded curriculum tree -- the curriculum is small enough
-    (~10 requirements) that an explicit lookup map per call is cheaper
-    than a JOIN through ``requirements``. Soft-deleted requirements
-    return None here; callers fall back to ``_load_requirement_metadata``
-    for the legacy id/submission_type when they need to render a
-    server-error result.
-    """
-    return await get_requirement_by_uuid(db, requirement_uuid)
-
-
-async def _handle_missing_requirement(
-    *,
-    session_maker: async_sessionmaker[AsyncSession],
-    payload: _VerificationJobPayload,
-) -> VerificationJobExecutionResult:
-    """Record a server-error ``Submission`` for a job whose requirement was
-    soft-deleted from content, link the job to it, and return the
-    resulting execution result.
-
-    Linking the Submission (rather than deleting the job row) keeps
-    ``prepare_verification_job`` idempotent: a retry sees the linked
-    row and short-circuits via the replay path. The FK on
-    ``verification_jobs.requirement_uuid`` is ON DELETE RESTRICT, so
-    the requirement row always still exists in the ``requirements``
-    table -- the active read just filters out soft-deleted entries.
-    The fallback metadata lookup below pulls ``id`` and
-    ``submission_type`` even from soft-deleted rows for the
-    server-error payload.
-    """
-    async with session_maker() as db:
-        metadata = await _load_requirement_metadata(db, payload.requirement_uuid)
-        requirement_slug_fallback = metadata[0] if metadata is not None else ""
-        submission_type_fallback = metadata[1] if metadata is not None else None
-        detail = f"Requirement not found: {requirement_slug_fallback}"
-
-        submission_repo = SubmissionRepository(db)
-        submission = await submission_repo.create(
-            user_id=payload.user_id,
-            requirement_uuid=payload.requirement_uuid,
-            submitted_value=payload.submitted_value,
-            extracted_username=None,
-            is_validated=False,
-            verification_completed=False,
-            validation_message=detail,
-        )
-        link = await VerificationJobRepository(db).link_submission(
-            payload.id,
-            submission.id,
-        )
-        if link is LinkResult.MISSING:
-            raise VerificationJobNotFoundError(str(payload.id))
-        await db.commit()
-
-    return VerificationJobExecutionResult(
-        job_id=payload.id,
-        status=_OUTCOME_SERVER_ERROR,
-        code=REQUIREMENT_NOT_FOUND_ERROR_CODE,
-        requirement_slug=requirement_slug_fallback,
-        requirement_name=None,
-        submission_type=submission_type_fallback,
-        submission_id=submission.id,
-        is_valid=False,
-        verification_completed=False,
-        message=_MESSAGE_BY_OUTCOME[_OUTCOME_SERVER_ERROR],
-        detail=detail,
-    )
-
-
 async def prepare_verification_job(
     job_id: UUID | str,
     *,
     session_maker: async_sessionmaker[AsyncSession],
-    prepared_input: PreparedVerificationJob | None = None,
+    prepared_input: PreparedVerificationJob,
 ) -> VerificationJobPreparation:
-    """Load a verification job and dispatch to the right execution path.
+    """Validate a verification job and dispatch to the right execution path.
 
-    Replay-safe short-circuits:
-    1. If the job is already linked to a ``Submission`` (Durable retried
-       prepare after the persist activity already finished), return the
-       same execution result from the linked Submission.
-    2. If the requirement was removed from content between submit and
-       execute and we have no ``prepared_input`` snapshot, record a
-       server-error Submission and short-circuit.
+    The orchestration always carries a full ``PreparedVerificationJob``
+    payload (post-#467 curriculum decoupling). This activity:
 
-    Args:
-        prepared_input: When the orchestration was started with a full
-            :class:`PreparedVerificationJob` payload (the post-#467
-            decoupling path), the requirement definition and
-            ``github_username`` snapshot travel with the orchestration
-            and we skip the curriculum / users reads. The DB row is
-            still loaded so we can validate immutable identity fields
-            against the payload (defense against a forged start
-            request) and check the replay short-circuit. Pass ``None``
-            for legacy in-flight orchestrations whose ``client_input``
-            is a bare job_id string.
+    1. Loads the ``verification_jobs`` row and validates the immutable
+       identity fields (``user_id``, ``requirement_uuid``,
+       ``submitted_value``) against the payload, so a forged start
+       request can't make us run validation against an arbitrary user
+       or requirement.
+    2. If the job is already linked to a ``Submission`` (Durable
+       retried prepare after the persist activity already finished),
+       returns the same execution result from the linked Submission.
+    3. Otherwise returns the prepared job for the orchestrator to run.
+
+    The Functions role only needs ``SELECT`` on ``verification_jobs``
+    + ``submissions`` here -- no curriculum or users reads.
     """
     normalized_job_id = _coerce_job_id(job_id)
 
@@ -458,27 +316,19 @@ async def prepare_verification_job(
         attributes={"verification.job.id": str(normalized_job_id)},
     ) as span:
         async with session_maker() as db:
-            if prepared_input is None:
-                payload = await _load_job_payload(db, normalized_job_id)
-                if payload is None:
-                    raise VerificationJobNotFoundError(str(normalized_job_id))
-                requirement = await _find_requirement_by_uuid(
-                    db, payload.requirement_uuid
+            payload = await _load_job_state(db, normalized_job_id)
+            if payload is None:
+                raise VerificationJobNotFoundError(str(normalized_job_id))
+            if (
+                payload.user_id != prepared_input.user_id
+                or payload.requirement_uuid != prepared_input.requirement.uuid
+                or payload.submitted_value != prepared_input.submitted_value
+            ):
+                raise VerificationJobNotFoundError(
+                    f"prepared payload does not match verification_jobs "
+                    f"row for job {normalized_job_id}"
                 )
-            else:
-                payload = await _load_job_state(db, normalized_job_id)
-                if payload is None:
-                    raise VerificationJobNotFoundError(str(normalized_job_id))
-                if (
-                    payload.user_id != prepared_input.user_id
-                    or payload.requirement_uuid != prepared_input.requirement.uuid
-                    or payload.submitted_value != prepared_input.submitted_value
-                ):
-                    raise VerificationJobNotFoundError(
-                        f"prepared payload does not match verification_jobs "
-                        f"row for job {normalized_job_id}"
-                    )
-                requirement = prepared_input.requirement
+            requirement = prepared_input.requirement
 
             if payload.result_submission_id is not None:
                 submission = await db.get(Submission, payload.result_submission_id)
@@ -487,39 +337,20 @@ async def prepare_verification_job(
                         f"job {normalized_job_id} references missing submission "
                         f"{payload.result_submission_id}"
                     )
-                fallback = None
-                if requirement is None:
-                    metadata = await _load_requirement_metadata(
-                        db, payload.requirement_uuid
-                    )
-                    fallback = metadata[0] if metadata is not None else None
                 result = _build_result_from_submission(
                     job_id=normalized_job_id,
                     submission=submission,
                     requirement=requirement,
-                    requirement_slug_fallback=fallback,
                 )
                 span.set_attribute("verification.status", result.status)
                 span.set_attribute("verification.replay", True)
                 return VerificationJobPreparation(terminal_result=result)
 
-        if requirement is None:
-            result = await _handle_missing_requirement(
-                session_maker=session_maker,
-                payload=payload,
-            )
-            span.set_attribute("verification.status", result.status)
-            return VerificationJobPreparation(terminal_result=result)
-
         return VerificationJobPreparation(
             job=PreparedVerificationJob(
                 id=payload.id,
                 user_id=payload.user_id,
-                github_username=(
-                    prepared_input.github_username
-                    if prepared_input is not None
-                    else payload.github_username
-                ),
+                github_username=prepared_input.github_username,
                 requirement=requirement,
                 submitted_value=payload.submitted_value,
             )
@@ -530,13 +361,11 @@ async def _load_job_state(
     db: AsyncSession,
     job_id: UUID,
 ) -> _VerificationJobPayload | None:
-    """Load verification_jobs identity + replay state without joining users.
+    """Load verification_jobs identity + replay state.
 
-    Used by the new payload-driven prepare path: ``github_username``
-    comes from the orchestration payload, not the DB row, so the
-    Functions role doesn't need ``SELECT ON users``. The returned
-    dataclass's ``github_username`` field is set to ``None`` and
-    callers must read it from the payload instead.
+    No JOIN: ``github_username`` comes from the orchestration payload
+    after the #467 curriculum-decoupling refactor, so the Functions
+    role doesn't need ``SELECT ON users``.
     """
     job = await db.get(VerificationJob, job_id)
     if job is None:
@@ -544,7 +373,6 @@ async def _load_job_state(
     return _VerificationJobPayload(
         id=job.id,
         user_id=job.user_id,
-        github_username=None,
         requirement_uuid=job.requirement_uuid,
         submitted_value=job.submitted_value,
         result_submission_id=job.result_submission_id,
@@ -596,7 +424,7 @@ async def persist_verification_result(
         attributes={"verification.job_id": str(job.id)},
     ) as span:
         async with session_maker() as db:
-            payload = await _load_job_payload(db, job.id)
+            payload = await _load_job_state(db, job.id)
             if payload is None:
                 raise VerificationJobNotFoundError(str(job.id))
 
@@ -638,7 +466,7 @@ async def persist_verification_result(
                 # reload the canonical Submission and return its result.
                 await db.rollback()
                 async with session_maker() as fresh_db:
-                    canonical = await _load_job_payload(fresh_db, job.id)
+                    canonical = await _load_job_state(fresh_db, job.id)
                     if canonical is None or canonical.result_submission_id is None:
                         raise VerificationJobNotFoundError(str(job.id))
                     canonical_submission = await fresh_db.get(
@@ -682,6 +510,7 @@ async def execute_verification_job(
     job_id: UUID | str,
     *,
     session_maker: async_sessionmaker[AsyncSession],
+    prepared_input: PreparedVerificationJob,
 ) -> VerificationJobExecutionResult:
     """Run one persisted verification job end-to-end."""
     normalized_job_id = _coerce_job_id(job_id)
@@ -693,6 +522,7 @@ async def execute_verification_job(
         preparation = await prepare_verification_job(
             normalized_job_id,
             session_maker=session_maker,
+            prepared_input=prepared_input,
         )
         if preparation.terminal_result is not None:
             span.set_attribute(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -5,18 +5,21 @@ writes. A verification job is now identified by the presence of its row
 in ``verification_jobs``; the outcome lives entirely in the linked
 ``Submission``. The executor:
 
-1. ``prepare_verification_job`` loads the job and, if it already has a
-   linked Submission (Durable replay after a successful prior run),
-   returns the same execution result without doing more work.
+1. ``prepare_verification_job`` validates the persisted job against the
+   orchestration's ``PreparedVerificationJob`` payload and, if the job
+   already has a linked Submission (Durable replay after a successful
+   prior run), returns the same execution result without doing more
+   work.
 2. ``run_verification`` runs the validator (no DB writes).
 3. ``persist_verification_result`` writes the ``Submission`` and links
    it to the job via ``VerificationJobRepository.link_submission``.
    Idempotent against retries via the ``ALREADY_LINKED`` short-circuit.
 
-The missing-requirement edge case writes a server-error ``Submission``
-and links it, so ``prepare`` stays idempotent on retry — the row exists,
-the link exists, and ``preparation.terminal_result`` is reconstructed
-from the linked Submission.
+After the curriculum-decoupling refactor, the requirement definition
+and ``github_username`` snapshot travel with the orchestration payload
+so the executor never reads ``users`` or any curriculum table. Any
+soft-delete of the requirement between submit and execute is invisible
+here -- validation runs against the submit-time snapshot.
 """
 
 from __future__ import annotations
@@ -267,7 +270,7 @@ def _build_result_from_submission(
     :func:`prepare_verification_job` and :func:`persist_verification_result`.
 
     The requirement is always available (carried on the orchestration
-    payload after #467) so we don't need a soft-delete fallback shape.
+    payload) so we don't need a soft-delete fallback shape.
     """
     outcome = _outcome_from_submission(submission)
     return VerificationJobExecutionResult(
@@ -294,7 +297,7 @@ async def prepare_verification_job(
     """Validate a verification job and dispatch to the right execution path.
 
     The orchestration always carries a full ``PreparedVerificationJob``
-    payload (post-#467 curriculum decoupling). This activity:
+    payload (curriculum-decoupling refactor). This activity:
 
     1. Loads the ``verification_jobs`` row and validates the immutable
        identity fields (``user_id``, ``requirement_uuid``,
@@ -364,8 +367,8 @@ async def _load_job_state(
     """Load the verification_jobs row's identity + replay state.
 
     No JOIN against ``users`` -- the ``github_username`` snapshot
-    travels with the orchestration payload after the #467
-    curriculum-decoupling refactor, so the Functions role doesn't need
+    travels with the orchestration payload after the curriculum-
+    decoupling refactor, so the Functions role doesn't need
     ``SELECT ON users`` and this query is one indexed PK lookup.
     """
     job = await db.get(VerificationJob, job_id)
@@ -462,7 +465,7 @@ async def persist_verification_result(
                 raise VerificationJobNotFoundError(str(job.id))
             if link is LinkResult.ALREADY_LINKED:
                 # Another activity attempt linked a Submission between our
-                # _load_job_payload and the link_submission UPDATE. Roll
+                # _load_job_state and the link_submission UPDATE. Roll
                 # back our duplicate insert by aborting the transaction;
                 # reload the canonical Submission and return its result.
                 await db.rollback()

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -361,11 +361,12 @@ async def _load_job_state(
     db: AsyncSession,
     job_id: UUID,
 ) -> _VerificationJobPayload | None:
-    """Load verification_jobs identity + replay state.
+    """Load the verification_jobs row's identity + replay state.
 
-    No JOIN: ``github_username`` comes from the orchestration payload
-    after the #467 curriculum-decoupling refactor, so the Functions
-    role doesn't need ``SELECT ON users``.
+    No JOIN against ``users`` -- the ``github_username`` snapshot
+    travels with the orchestration payload after the #467
+    curriculum-decoupling refactor, so the Functions role doesn't need
+    ``SELECT ON users`` and this query is one indexed PK lookup.
     """
     job = await db.get(VerificationJob, job_id)
     if job is None:

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -22,7 +22,6 @@ from learn_to_cloud_shared.repositories.verification_job_repository import (
 from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
 from learn_to_cloud_shared.verification.execution import MAX_VALIDATION_MESSAGE_LENGTH
 from learn_to_cloud_shared.verification_job_executor import (
-    REQUIREMENT_NOT_FOUND_ERROR_CODE,
     VALIDATION_FAILED_ERROR_CODE,
     VERIFICATION_INCOMPLETE_ERROR_CODE,
     VERIFICATION_SUCCEEDED_CODE,
@@ -105,6 +104,17 @@ async def _create_job(
         return job.id
 
 
+def _prepared(job_id: UUID, requirement: HandsOnRequirement) -> PreparedVerificationJob:
+    """Build the PreparedVerificationJob the orchestration would carry."""
+    return PreparedVerificationJob(
+        id=job_id,
+        user_id=USER_ID,
+        github_username="executoruser",
+        requirement=requirement,
+        submitted_value="https://github.com/executoruser/repo",
+    )
+
+
 async def _get_job_link(
     session_maker: async_sessionmaker[AsyncSession],
     job_id: UUID,
@@ -152,15 +162,11 @@ async def test_split_verification_primitives_prepare_run_and_persist(
     validation = AsyncMock(
         return_value=ValidationResult(is_valid=True, message="Verified")
     )
-
-    with patch(
-        "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
-        return_value=synced_requirement,
-    ):
-        preparation = await prepare_verification_job(
-            job_id,
-            session_maker=session_maker,
-        )
+    preparation = await prepare_verification_job(
+        job_id,
+        session_maker=session_maker,
+        prepared_input=_prepared(job_id, synced_requirement),
+    )
 
     assert preparation.terminal_result is None
     assert preparation.job is not None
@@ -198,15 +204,15 @@ async def test_execute_verification_job_marks_success_and_links_submission(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
-            return_value=synced_requirement,
-        ),
-        patch(
             "learn_to_cloud_shared.verification_job_executor.validate_submission",
             validation,
         ),
     ):
-        result = await execute_verification_job(job_id, session_maker=session_maker)
+        result = await execute_verification_job(
+            job_id,
+            session_maker=session_maker,
+            prepared_input=_prepared(job_id, synced_requirement),
+        )
 
     assert result.status == "succeeded"
     assert result.submission_id is not None
@@ -242,15 +248,15 @@ async def test_execute_verification_job_marks_user_validation_failure(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
-            return_value=synced_requirement,
-        ),
-        patch(
             "learn_to_cloud_shared.verification_job_executor.validate_submission",
             validation,
         ),
     ):
-        result = await execute_verification_job(job_id, session_maker=session_maker)
+        result = await execute_verification_job(
+            job_id,
+            session_maker=session_maker,
+            prepared_input=_prepared(job_id, synced_requirement),
+        )
 
     assert result.status == "failed"
     assert result.code == VALIDATION_FAILED_ERROR_CODE
@@ -279,15 +285,15 @@ async def test_execute_verification_job_marks_server_error(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
-            return_value=synced_requirement,
-        ),
-        patch(
             "learn_to_cloud_shared.verification_job_executor.validate_submission",
             validation,
         ),
     ):
-        result = await execute_verification_job(job_id, session_maker=session_maker)
+        result = await execute_verification_job(
+            job_id,
+            session_maker=session_maker,
+            prepared_input=_prepared(job_id, synced_requirement),
+        )
 
     assert result.status == "server_error"
     assert result.code == VERIFICATION_INCOMPLETE_ERROR_CODE
@@ -318,65 +324,51 @@ async def test_execute_verification_job_truncates_persisted_error_messages(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
-            return_value=synced_requirement,
-        ),
-        patch(
             "learn_to_cloud_shared.verification_job_executor.validate_submission",
             validation,
         ),
     ):
-        result = await execute_verification_job(job_id, session_maker=session_maker)
+        result = await execute_verification_job(
+            job_id,
+            session_maker=session_maker,
+            prepared_input=_prepared(job_id, synced_requirement),
+        )
 
     assert result.status == "failed"
     assert result.detail is not None
     assert len(result.detail) <= MAX_VALIDATION_MESSAGE_LENGTH
 
 
-async def test_execute_verification_job_marks_missing_requirement_server_error(
+async def test_execute_verification_job_rejects_payload_mismatch(
     session_maker: async_sessionmaker[AsyncSession],
     synced_requirement: HandsOnRequirement,
 ):
-    """When the requirement vanishes from content between submit and
-    execute, the executor writes a server-error Submission, links it,
-    and short-circuits via the terminal_result path.
+    """A forged payload (whose ``requirement.uuid`` or ``user_id`` does
+    not match the persisted ``verification_jobs`` row) is rejected via
+    ``VerificationJobNotFoundError`` so the orchestration cannot run
+    validation against an arbitrary user/requirement pair.
 
-    Linking (rather than deleting the job row) keeps the executor
-    idempotent on Durable activity retry — the second attempt sees the
-    linked row and returns the same result."""
+    Replaces the old soft-deleted-requirement test: after #467 the
+    requirement definition travels with the orchestration, so the
+    missing-requirement scenario no longer applies. The new failure
+    mode the validation guards against is payload tampering.
+    """
     job_id = await _create_job(session_maker, synced_requirement)
-    validation = AsyncMock()
-
-    with (
-        patch(
-            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
-            return_value=None,
-        ),
-        patch(
-            "learn_to_cloud_shared.verification_job_executor.validate_submission",
-            validation,
-        ),
-    ):
-        result = await execute_verification_job(job_id, session_maker=session_maker)
-
-    assert result.status == "server_error"
-    assert result.submission_id is not None
-    assert result.verification_completed is False
-    assert result.code == REQUIREMENT_NOT_FOUND_ERROR_CODE
-    assert result.message == "Verification could not be completed."
-    assert result.detail == f"Requirement not found: {synced_requirement.slug}"
-
-    # Row stays linked so a retry is idempotent.
-    assert await _get_job_link(session_maker, job_id) == result.submission_id
-    submission = await _get_submission(session_maker, result.submission_id)
-    assert submission.is_validated is False
-    assert submission.verification_completed is False
-    assert (
-        submission.validation_message
-        == f"Requirement not found: {synced_requirement.slug}"
+    forged = _prepared(job_id, synced_requirement)
+    # Forge by replacing user_id; requirement.uuid + submitted_value
+    # still match the DB row, but the start-time identity does not.
+    forged = PreparedVerificationJob(
+        id=forged.id,
+        user_id=forged.user_id + 1,
+        github_username=forged.github_username,
+        requirement=forged.requirement,
+        submitted_value=forged.submitted_value,
     )
 
-    validation.assert_not_awaited()
+    with pytest.raises(VerificationJobNotFoundError, match="does not match"):
+        await execute_verification_job(
+            job_id, session_maker=session_maker, prepared_input=forged
+        )
 
 
 async def test_execute_verification_job_is_idempotent_for_terminal_jobs(
@@ -393,19 +385,23 @@ async def test_execute_verification_job_is_idempotent_for_terminal_jobs(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor._find_requirement_by_uuid",
-            return_value=synced_requirement,
-        ),
-        patch(
             "learn_to_cloud_shared.verification_job_executor.validate_submission",
             validation,
         ),
     ):
-        first = await execute_verification_job(job_id, session_maker=session_maker)
+        first = await execute_verification_job(
+            job_id,
+            session_maker=session_maker,
+            prepared_input=_prepared(job_id, synced_requirement),
+        )
         # Reset the validator so the retry would clearly be observable
         # if the short-circuit weren't in place.
         validation.reset_mock()
-        second = await execute_verification_job(job_id, session_maker=session_maker)
+        second = await execute_verification_job(
+            job_id,
+            session_maker=session_maker,
+            prepared_input=_prepared(job_id, synced_requirement),
+        )
 
     assert first.status == "succeeded"
     assert second.status == "succeeded"


### PR DESCRIPTION
## What's broken

`Verification could not be started` errors in prod on `journal-api-implementation` submits. Root cause from prod App Insights:

```
ProgrammingError: <asyncpg.exceptions.InsufficientPrivilegeError>: permission denied for table requirements
[SQL: SELECT slug, submission_type FROM requirements WHERE uuid = $1 LIMIT 1]
```

The Functions DB role has `SELECT/INSERT` on `submissions`, `SELECT/UPDATE` on `verification_jobs`, `SELECT` on `users`, but no grants on the 5 curriculum tables. PR #480 dropped the denormalized `submission_type` from `verification_jobs`, and the Functions starter started joining curriculum to recover it. The grant was never added; the failure surfaced tonight when phase-3 submits were retried.

## Why I'm not adding more grants

The smell isn't 'missing grant.' It's that **Functions reads curriculum at all**. Content (curriculum) belongs to the API/sync. Execution (Functions) is an orchestration engine — it should receive what it needs as input, not reach back into content storage. Granting more privileges papers over a coupling that shouldn't exist.

## What ships

### API → Functions over the wire

The start request body becomes the full `PreparedVerificationJob` payload (job_id, user_id, github_username, requirement, submitted_value). The API builds it from data already in scope post-validation.

### Functions side

- `start_verification_job` parses the body via `PreparedVerificationJob.from_payload`, validates the immutable fields (`route job_id == payload.id`, `verification_jobs.user_id == payload.user_id`, `requirement_uuid` and `submitted_value` match) against the DB row, and starts the orchestration with the full payload as input.
- `_run_verification_orchestration` expects the payload dict as input; raises TypeError otherwise.
- `prepare_verification_job` activity parses + validates the same way; no curriculum or users reads.
- Drops the `sqlalchemy.text` import (no more raw SQL needed).

### Shared executor

- `prepare_verification_job` requires a `prepared_input` keyword; loads only `verification_jobs` (`_load_job_state` helper, no JOIN), validates immutable identity, uses the payload requirement.
- Replay short-circuit unchanged: still reads `verification_jobs.result_submission_id` and `submissions` row.
- Deletes `_load_job_payload` (the users JOIN variant), `_find_requirement_by_uuid`, `_handle_missing_requirement`, `_load_requirement_metadata` — all dead after the decoupling.
- `_build_result_from_submission` now requires `requirement` (no fallback shape).
- Drops `github_username` field from `_VerificationJobPayload` (always None now; comes from the payload).
- Cleans up unused imports: `User`, `SubmissionRepository`, `get_requirement_by_uuid`.

### Migration 0033 — revoke now-unused grants

`REVOKE SELECT ON users, curriculum_phases, topics, steps, learning_objectives, requirements FROM ltc_verification_functions_dev`. The Functions role keeps SELECT/INSERT on `submissions` + SELECT/UPDATE on `verification_jobs` — what the code actually uses.

- Reads `POSTGRES_VERIFICATION_FUNCTIONS_ROLE` env var
- No-ops when the env var is missing (local dev) or the role doesn't exist (bootstrap safety)
- Validates the role name against PostgreSQL identifier rules
- Idempotent up + down, squawk-clean
- `infra/migrations.tf` adds the env var to the migrations container so the role name is available in prod

## Security boundary preserved (rubber-duck catch)

A leaked function key or API bug can NOT forge submissions for arbitrary users. The Functions starter validates:
- route `job_id` matches `payload.id`
- `verification_jobs.user_id == payload.user_id`
- `verification_jobs.requirement_uuid == payload.requirement.uuid`
- `verification_jobs.submitted_value == payload.submitted_value`

The payload is trusted ONLY for the requirement *definition* and the `github_username` snapshot — both validated by the API at submit time.

## Why no backwards-compat for in-flight orchestrations

Verification has been broken in prod for hours — every start fails on the grant gap, so there are no in-flight orchestrations to migrate. Phase 3-6 jobs complete in 30-90s anyway. Dual-shape compatibility branches would protect a window that doesn't exist; single-shape code is cleaner and removes the rarely-hit-branch bug surface.

## Stale-requirement semantics (intentional change)

If a requirement is soft-deleted between submit and execute, the orchestration now validates against the submit-time snapshot in the payload instead of writing a server-error `Submission`. Defensible: the user submitted while the requirement was active; a soft-delete milliseconds later shouldn't invalidate their attempt.

## Validation

- 205 API + 476 shared tests pass
- Migration 0033 applies cleanly; up + down round-trip in `test_migration_chain`
- Squawk-clean on the new migration
- Rubber-duck review caught 5 design issues; all addressed before implementation
- Tests updated: dropped the `_find_requirement_by_uuid` mocking pattern, added `test_execute_verification_job_rejects_payload_mismatch` to exercise the new payload-validation defense