### PR TITLE
Harden database integrity for issue 448

### DIFF
--- a/api/alembic/versions/0034_issue_448_integrity_hardening.py
+++ b/api/alembic/versions/0034_issue_448_integrity_hardening.py
@@ -1,0 +1,127 @@
+"""issue 448 database integrity hardening
+
+Revision ID: 0034_issue_448_integrity_hardening
+Revises: 0033_revoke_unused_fn_grants
+Create Date: 2026-05-25
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0034_issue_448_integrity_hardening"
+down_revision: str | None = "0033_revoke_unused_fn_grants"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_DROP_RESULT_SUBMISSION_FK = """
+DO $$
+DECLARE
+    existing_constraint_name text;
+BEGIN
+    SELECT constraint_row.conname
+    INTO existing_constraint_name
+    FROM pg_constraint constraint_row
+    JOIN pg_class source_table
+        ON source_table.oid = constraint_row.conrelid
+    JOIN pg_class target_table
+        ON target_table.oid = constraint_row.confrelid
+    JOIN pg_attribute source_column
+        ON source_column.attrelid = source_table.oid
+        AND source_column.attnum = ANY(constraint_row.conkey)
+    WHERE source_table.relname = 'verification_jobs'
+        AND target_table.relname = 'submissions'
+        AND source_column.attname = 'result_submission_id'
+        AND constraint_row.contype = 'f'
+    LIMIT 1;
+
+    IF existing_constraint_name IS NOT NULL THEN
+        EXECUTE format(
+            'ALTER TABLE verification_jobs DROP CONSTRAINT %I',
+            existing_constraint_name
+        );
+    END IF;
+END $$;
+"""
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
+
+    op.execute(
+        """
+        UPDATE submissions
+        SET validated_at = COALESCE(updated_at, created_at)
+        WHERE is_validated IS TRUE
+            AND validated_at IS NULL
+        """
+    )
+    op.execute(
+        """
+        UPDATE submissions
+        SET verification_completed = TRUE
+        WHERE is_validated IS TRUE
+            AND verification_completed IS NOT TRUE
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE submissions
+            ADD CONSTRAINT ck_submissions_validated_at_when_validated
+            CHECK (is_validated IS FALSE OR validated_at IS NOT NULL)
+            NOT VALID
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE submissions
+            ADD CONSTRAINT ck_submissions_completed_when_validated
+            CHECK (is_validated IS FALSE OR verification_completed IS TRUE)
+            NOT VALID
+        """
+    )
+
+    op.execute(_DROP_RESULT_SUBMISSION_FK)
+    op.execute(
+        """
+        ALTER TABLE verification_jobs
+            ADD CONSTRAINT fk_verification_jobs_result_submission_id
+            FOREIGN KEY (result_submission_id) REFERENCES submissions(id)
+            NOT VALID
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+
+    op.execute(_DROP_RESULT_SUBMISSION_FK)
+    op.execute(
+        """
+        ALTER TABLE verification_jobs
+            ADD CONSTRAINT verification_jobs_result_submission_id_fkey
+            FOREIGN KEY (result_submission_id) REFERENCES submissions(id)
+            ON DELETE SET NULL
+            NOT VALID
+        """
+    )
+
+    op.execute(
+        """
+        ALTER TABLE submissions
+            DROP CONSTRAINT IF EXISTS
+            ck_submissions_completed_when_validated
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE submissions
+            DROP CONSTRAINT IF EXISTS
+            ck_submissions_validated_at_when_validated
+        """
+    )

--- a/api/alembic/versions/0035_validate_issue_448_constraints.py
+++ b/api/alembic/versions/0035_validate_issue_448_constraints.py
@@ -1,0 +1,43 @@
+"""validate issue 448 database constraints
+
+Revision ID: 0035_validate_issue_448_constraints
+Revises: 0034_issue_448_integrity_hardening
+Create Date: 2026-05-25
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0035_validate_issue_448_constraints"
+down_revision: str | None = "0034_issue_448_integrity_hardening"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+
+    op.execute(
+        """
+        ALTER TABLE submissions
+            VALIDATE CONSTRAINT ck_submissions_validated_at_when_validated
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE submissions
+            VALIDATE CONSTRAINT ck_submissions_completed_when_validated
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE verification_jobs
+            VALIDATE CONSTRAINT fk_verification_jobs_result_submission_id
+        """
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/infra/database.tf
+++ b/infra/database.tf
@@ -18,6 +18,22 @@ resource "azurerm_postgresql_flexible_server" "main" {
   }
 }
 
+resource "azurerm_postgresql_flexible_server_configuration" "extensions" {
+  name      = "azure.extensions"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "PG_STAT_STATEMENTS"
+}
+
+resource "azurerm_postgresql_flexible_server_configuration" "shared_preload_libraries" {
+  name      = "shared_preload_libraries"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "pg_stat_statements"
+
+  depends_on = [
+    azurerm_postgresql_flexible_server_configuration.extensions,
+  ]
+}
+
 resource "azurerm_postgresql_flexible_server_database" "main" {
   name      = "learntocloud"
   server_id = azurerm_postgresql_flexible_server.main.id

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 from sqlalchemy import (
     BigInteger,
     Boolean,
+    CheckConstraint,
     DateTime,
     ForeignKey,
     Index,
@@ -132,6 +133,14 @@ class Submission(TimestampMixin, Base):
 
     __tablename__ = "submissions"
     __table_args__ = (
+        CheckConstraint(
+            "is_validated IS FALSE OR validated_at IS NOT NULL",
+            name="ck_submissions_validated_at_when_validated",
+        ),
+        CheckConstraint(
+            "is_validated IS FALSE OR verification_completed IS TRUE",
+            name="ck_submissions_completed_when_validated",
+        ),
         Index(
             "ix_submissions_user_verified_updated",
             "user_id",
@@ -250,7 +259,7 @@ class VerificationJob(TimestampMixin, Base):
     cloud_provider: Mapped[str | None] = mapped_column(String(16), nullable=True)
     result_submission_id: Mapped[int | None] = mapped_column(
         Integer,
-        ForeignKey("submissions.id", ondelete="SET NULL"),
+        ForeignKey("submissions.id", name="fk_verification_jobs_result_submission_id"),
         nullable=True,
     )
     traceparent: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/packages/learn-to-cloud-shared/tests/repositories/test_submission_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_submission_repository.py
@@ -7,11 +7,12 @@ few real UUIDs the FK requires.
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
 from learn_to_cloud_shared.content_yaml_loader import clear_cache
-from learn_to_cloud_shared.models import CurriculumRequirement
+from learn_to_cloud_shared.models import CurriculumRequirement, Submission, utcnow
 from learn_to_cloud_shared.repositories.submission_repository import (
     SubmissionRepository,
 )
@@ -20,6 +21,14 @@ from learn_to_cloud_shared.repositories.user_repository import UserRepository
 pytestmark = pytest.mark.integration
 
 USER_ID = 80001
+
+
+def _constraint_name(error: IntegrityError) -> str | None:
+    cause = getattr(error.orig, "__cause__", None)
+    constraint_name = getattr(cause, "constraint_name", None)
+    if isinstance(constraint_name, str):
+        return constraint_name
+    return None
 
 
 @pytest.fixture()
@@ -92,6 +101,56 @@ class TestCreate:
         )
 
         assert sub1.id != sub2.id
+
+    async def test_validated_submission_requires_validated_at(
+        self, db_session: AsyncSession, user, req_uuids
+    ):
+        nested = await db_session.begin_nested()
+        try:
+            db_session.add(
+                Submission(
+                    user_id=USER_ID,
+                    requirement_uuid=req_uuids[0],
+                    submitted_value="https://github.com/testuser",
+                    extracted_username="testuser",
+                    is_validated=True,
+                    validated_at=None,
+                    verification_completed=True,
+                )
+            )
+
+            with pytest.raises(IntegrityError) as error:
+                await db_session.flush()
+        finally:
+            await nested.rollback()
+
+        expected = "ck_submissions_validated_at_when_validated"
+        assert _constraint_name(error.value) == expected
+
+    async def test_validated_submission_requires_completed_verification(
+        self, db_session: AsyncSession, user, req_uuids
+    ):
+        nested = await db_session.begin_nested()
+        try:
+            db_session.add(
+                Submission(
+                    user_id=USER_ID,
+                    requirement_uuid=req_uuids[0],
+                    submitted_value="https://github.com/testuser",
+                    extracted_username="testuser",
+                    is_validated=True,
+                    validated_at=utcnow(),
+                    verification_completed=False,
+                )
+            )
+
+            with pytest.raises(IntegrityError) as error:
+                await db_session.flush()
+        finally:
+            await nested.rollback()
+
+        expected = "ck_submissions_completed_when_validated"
+        assert _constraint_name(error.value) == expected
 
 
 class TestGetByUserAndRequirement:

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
@@ -3,13 +3,15 @@
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
 from learn_to_cloud_shared.content_yaml_loader import clear_cache
 from learn_to_cloud_shared.models import (
     CurriculumRequirement,
+    Submission,
     VerificationJob,
 )
 from learn_to_cloud_shared.repositories.submission_repository import (
@@ -292,6 +294,23 @@ class TestDeleteActive:
         loaded = await repo.get_by_id(job.id)
         assert loaded is not None
         assert loaded.result_submission_id == submission.id
+
+    async def test_linked_submission_delete_is_restricted(
+        self,
+        db_session: AsyncSession,
+        user,
+        req_uuid: UUID,
+    ):
+        repo = VerificationJobRepository(db_session)
+        job = await _create_job(repo, req_uuid)
+        submission = await _create_submission(db_session, req_uuid)
+        await repo.link_submission(job.id, submission.id)
+
+        with pytest.raises(IntegrityError):
+            await db_session.execute(
+                delete(Submission).where(Submission.id == submission.id)
+            )
+            await db_session.flush()
 
     async def test_unknown_id_returns_false(
         self,


### PR DESCRIPTION
## Summary
- Add submission integrity constraints and backfill existing mismatches before validation
- Change verification job result submission FK away from ON DELETE SET NULL so linked jobs cannot become active again
- Enable pg_stat_statements settings for Azure PostgreSQL and create the extension in migration

## Notes
- Part of #448. The typed submitted_value refactor remains a larger design item.
- shared_preload_libraries is a static PostgreSQL setting and may restart the flexible server when applied.

## Validation
- cd api && uv run ruff check . ../packages/learn-to-cloud-shared
- cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared
- cd api && uv run ty check --exclude scripts --exclude tests .
- cd packages/learn-to-cloud-shared && uv run ty check --exclude tests .
- cd api && uv run pytest tests/
- cd packages/learn-to-cloud-shared && uv run pytest tests/
- cd apps/verification-functions && uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run python -c "import function_app"
- terraform fmt -check infra/database.tf
- uv run squawk generated SQL for migrations 0034 and 0035