### PR TITLE
feat: type verification submitted values

### DIFF
--- a/api/alembic/versions/0036_typed_submitted_values.py
+++ b/api/alembic/versions/0036_typed_submitted_values.py
@@ -245,12 +245,30 @@ def upgrade() -> None:
     op.alter_column("submissions", "submission_value_kind", nullable=False)
     op.alter_column("verification_jobs", "submission_value_kind", nullable=False)
 
-    op.create_unique_constraint(
-        "uq_requirements_uuid_value_kind",
-        "requirements",
-        ["uuid", "submission_value_kind"],
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+            uq_requirements_uuid_value_kind
+            ON requirements (uuid, submission_value_kind)
+            """
+        )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'uq_requirements_uuid_value_kind'
+            ) THEN
+                ALTER TABLE requirements
+                ADD CONSTRAINT uq_requirements_uuid_value_kind
+                UNIQUE USING INDEX uq_requirements_uuid_value_kind;
+            END IF;
+        END $$
+        """
     )
-    op.create_check_constraint(
+    _add_check_constraint_not_valid(
         "ck_requirements_submission_value_kind_matches_type",
         "requirements",
         _REQUIREMENT_KIND_CHECK,
@@ -350,12 +368,12 @@ def _backfill_typed_values(table: str) -> None:
 
 
 def _add_typed_value_constraints(table: str, prefix: str) -> None:
-    op.create_check_constraint(
+    _add_check_constraint_not_valid(
         f"{prefix}_typed_value_shape",
         table,
         _TYPED_VALUE_SHAPE_CHECK,
     )
-    op.create_check_constraint(
+    _add_check_constraint_not_valid(
         f"{prefix}_typed_value_format",
         table,
         _TYPED_VALUE_FORMAT_CHECK,
@@ -368,13 +386,26 @@ def _drop_typed_value_constraints(table: str, prefix: str) -> None:
 
 
 def _add_value_kind_fk(table: str, name: str) -> None:
-    op.create_foreign_key(
-        name,
-        table,
-        "requirements",
-        ["requirement_uuid", "submission_value_kind"],
-        ["uuid", "submission_value_kind"],
-        ondelete="RESTRICT",
+    op.execute(
+        f"""
+        ALTER TABLE {table}
+        ADD CONSTRAINT {name}
+        FOREIGN KEY (requirement_uuid, submission_value_kind)
+        REFERENCES requirements (uuid, submission_value_kind)
+        ON DELETE RESTRICT
+        NOT VALID
+        """
+    )
+
+
+def _add_check_constraint_not_valid(name: str, table: str, condition: str) -> None:
+    op.execute(
+        f"""
+        ALTER TABLE {table}
+        ADD CONSTRAINT {name}
+        CHECK ({condition})
+        NOT VALID
+        """
     )
 
 

--- a/api/alembic/versions/0036_typed_submitted_values.py
+++ b/api/alembic/versions/0036_typed_submitted_values.py
@@ -1,0 +1,397 @@
+"""type submitted verification values
+
+Revision ID: 0036_typed_submitted_values
+Revises: 0035_validate_issue_448_constraints
+Create Date: 2026-05-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0036_typed_submitted_values"
+down_revision: str | None = "0035_validate_issue_448_constraints"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_VALUE_KIND_CASE = """
+CASE
+    WHEN requirements.submission_type IN (
+        'github_profile',
+        'profile_readme',
+        'repo_fork',
+        'pr_review',
+        'journal_api_verifier',
+        'devops_analysis',
+        'security_scanning',
+        'ci_status'
+    ) THEN 'github_url'
+    WHEN requirements.submission_type IN (
+        'ctf_token',
+        'networking_token',
+        'iac_token'
+    ) THEN 'token'
+    WHEN requirements.submission_type = 'deployed_api' THEN 'deployed_url'
+    WHEN requirements.submission_type IN (
+        'journal_api_response',
+        'code_analysis'
+    ) THEN 'text'
+END
+"""
+
+_REQUIREMENT_KIND_CHECK = """
+(
+    submission_type IN (
+        'github_profile',
+        'profile_readme',
+        'repo_fork',
+        'pr_review',
+        'journal_api_verifier',
+        'devops_analysis',
+        'security_scanning',
+        'ci_status'
+    )
+    AND submission_value_kind = 'github_url'
+)
+OR (
+    submission_type IN (
+        'ctf_token',
+        'networking_token',
+        'iac_token'
+    )
+    AND submission_value_kind = 'token'
+)
+OR (
+    submission_type = 'deployed_api'
+    AND submission_value_kind = 'deployed_url'
+)
+OR (
+    submission_type IN (
+        'journal_api_response',
+        'code_analysis'
+    )
+    AND submission_value_kind = 'text'
+)
+"""
+
+_TYPED_VALUE_SHAPE_CHECK = """
+(
+    submission_value_kind = 'github_url'
+    AND github_url IS NOT NULL
+    AND token_value IS NULL
+    AND deployed_url IS NULL
+    AND text_value IS NULL
+    AND submitted_value = github_url
+)
+OR (
+    submission_value_kind = 'token'
+    AND token_value IS NOT NULL
+    AND github_url IS NULL
+    AND deployed_url IS NULL
+    AND text_value IS NULL
+    AND submitted_value = token_value
+)
+OR (
+    submission_value_kind = 'deployed_url'
+    AND deployed_url IS NOT NULL
+    AND github_url IS NULL
+    AND token_value IS NULL
+    AND text_value IS NULL
+    AND submitted_value = deployed_url
+)
+OR (
+    submission_value_kind = 'text'
+    AND text_value IS NOT NULL
+    AND github_url IS NULL
+    AND token_value IS NULL
+    AND deployed_url IS NULL
+    AND submitted_value = text_value
+)
+"""
+
+_TYPED_VALUE_FORMAT_CHECK = """
+(
+    github_url IS NULL
+    OR github_url ~* '^https://github[.]com/[^[:space:]]+$'
+)
+AND (
+    deployed_url IS NULL
+    OR deployed_url ~* '^https?://[^[:space:]]+$'
+)
+AND (
+    token_value IS NULL
+    OR length(btrim(token_value)) > 0
+)
+AND (
+    text_value IS NULL
+    OR length(btrim(text_value)) > 0
+)
+"""
+
+_CREATE_TRIGGER_FUNCTION = """
+CREATE OR REPLACE FUNCTION set_typed_submitted_value()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    expected_kind text;
+BEGIN
+    SELECT submission_value_kind
+    INTO expected_kind
+    FROM requirements
+    WHERE uuid = NEW.requirement_uuid;
+
+    IF expected_kind IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    NEW.submission_value_kind = COALESCE(
+        NEW.submission_value_kind,
+        expected_kind
+    );
+
+    IF NEW.submission_value_kind = 'github_url'
+        AND NEW.github_url IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.github_url = NEW.submitted_value;
+    ELSIF NEW.submission_value_kind = 'token'
+        AND NEW.token_value IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.token_value = NEW.submitted_value;
+    ELSIF NEW.submission_value_kind = 'deployed_url'
+        AND NEW.deployed_url IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.deployed_url = NEW.submitted_value;
+    ELSIF NEW.submission_value_kind = 'text'
+        AND NEW.text_value IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.text_value = NEW.submitted_value;
+    END IF;
+
+    RETURN NEW;
+END
+$$
+"""
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+
+    op.add_column(
+        "requirements",
+        sa.Column("submission_value_kind", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "submissions",
+        sa.Column("submission_value_kind", sa.Text(), nullable=True),
+    )
+    op.add_column("submissions", sa.Column("github_url", sa.Text(), nullable=True))
+    op.add_column("submissions", sa.Column("token_value", sa.Text(), nullable=True))
+    op.add_column("submissions", sa.Column("deployed_url", sa.Text(), nullable=True))
+    op.add_column("submissions", sa.Column("text_value", sa.Text(), nullable=True))
+    op.add_column(
+        "verification_jobs",
+        sa.Column("submission_value_kind", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "verification_jobs",
+        sa.Column("github_url", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "verification_jobs",
+        sa.Column("token_value", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "verification_jobs",
+        sa.Column("deployed_url", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "verification_jobs",
+        sa.Column("text_value", sa.Text(), nullable=True),
+    )
+
+    op.execute(
+        f"""
+        UPDATE requirements
+        SET submission_value_kind = {_VALUE_KIND_CASE}
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            bad_count bigint;
+        BEGIN
+            SELECT count(*)
+            INTO bad_count
+            FROM requirements
+            WHERE submission_value_kind IS NULL;
+
+            IF bad_count > 0 THEN
+                RAISE EXCEPTION
+                    'requirements have unsupported submission_type values';
+            END IF;
+        END $$;
+        """
+    )
+
+    _backfill_typed_values("submissions")
+    _backfill_typed_values("verification_jobs")
+
+    op.alter_column("requirements", "submission_value_kind", nullable=False)
+    op.alter_column("submissions", "submission_value_kind", nullable=False)
+    op.alter_column("verification_jobs", "submission_value_kind", nullable=False)
+
+    op.create_unique_constraint(
+        "uq_requirements_uuid_value_kind",
+        "requirements",
+        ["uuid", "submission_value_kind"],
+    )
+    op.create_check_constraint(
+        "ck_requirements_submission_value_kind_matches_type",
+        "requirements",
+        _REQUIREMENT_KIND_CHECK,
+    )
+    _add_typed_value_constraints("submissions", "ck_submissions")
+    _add_typed_value_constraints("verification_jobs", "ck_verification_jobs")
+    _add_value_kind_fk("submissions", "fk_submissions_requirement_value_kind")
+    _add_value_kind_fk(
+        "verification_jobs",
+        "fk_verification_jobs_requirement_value_kind",
+    )
+
+    op.execute(_CREATE_TRIGGER_FUNCTION)
+    _create_trigger("submissions", "trg_submissions_set_typed_submitted_value")
+    _create_trigger(
+        "verification_jobs",
+        "trg_verification_jobs_set_typed_submitted_value",
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_verification_jobs_set_typed_submitted_value "
+        "ON verification_jobs"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_submissions_set_typed_submitted_value "
+        "ON submissions"
+    )
+    op.execute("DROP FUNCTION IF EXISTS set_typed_submitted_value()")
+
+    op.drop_constraint(
+        "fk_verification_jobs_requirement_value_kind",
+        "verification_jobs",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "fk_submissions_requirement_value_kind",
+        "submissions",
+        type_="foreignkey",
+    )
+    _drop_typed_value_constraints("verification_jobs", "ck_verification_jobs")
+    _drop_typed_value_constraints("submissions", "ck_submissions")
+    op.drop_constraint(
+        "ck_requirements_submission_value_kind_matches_type",
+        "requirements",
+        type_="check",
+    )
+    op.drop_constraint(
+        "uq_requirements_uuid_value_kind",
+        "requirements",
+        type_="unique",
+    )
+
+    for table in ("verification_jobs", "submissions"):
+        for column in (
+            "text_value",
+            "deployed_url",
+            "token_value",
+            "github_url",
+            "submission_value_kind",
+        ):
+            op.drop_column(table, column)
+    op.drop_column("requirements", "submission_value_kind")
+
+
+def _backfill_typed_values(table: str) -> None:
+    op.execute(
+        f"""
+        UPDATE {table}
+        SET
+            submission_value_kind = requirements.submission_value_kind,
+            github_url = CASE
+                WHEN requirements.submission_value_kind = 'github_url'
+                THEN btrim({table}.submitted_value)
+            END,
+            token_value = CASE
+                WHEN requirements.submission_value_kind = 'token'
+                THEN btrim({table}.submitted_value)
+            END,
+            deployed_url = CASE
+                WHEN requirements.submission_value_kind = 'deployed_url'
+                THEN btrim({table}.submitted_value)
+            END,
+            text_value = CASE
+                WHEN requirements.submission_value_kind = 'text'
+                THEN btrim({table}.submitted_value)
+            END,
+            submitted_value = btrim({table}.submitted_value)
+        FROM requirements
+        WHERE {table}.requirement_uuid = requirements.uuid
+        """
+    )
+
+
+def _add_typed_value_constraints(table: str, prefix: str) -> None:
+    op.create_check_constraint(
+        f"{prefix}_typed_value_shape",
+        table,
+        _TYPED_VALUE_SHAPE_CHECK,
+    )
+    op.create_check_constraint(
+        f"{prefix}_typed_value_format",
+        table,
+        _TYPED_VALUE_FORMAT_CHECK,
+    )
+
+
+def _drop_typed_value_constraints(table: str, prefix: str) -> None:
+    op.drop_constraint(f"{prefix}_typed_value_format", table, type_="check")
+    op.drop_constraint(f"{prefix}_typed_value_shape", table, type_="check")
+
+
+def _add_value_kind_fk(table: str, name: str) -> None:
+    op.create_foreign_key(
+        name,
+        table,
+        "requirements",
+        ["requirement_uuid", "submission_value_kind"],
+        ["uuid", "submission_value_kind"],
+        ondelete="RESTRICT",
+    )
+
+
+def _create_trigger(table: str, name: str) -> None:
+    op.execute(
+        f"""
+        CREATE TRIGGER {name}
+        BEFORE INSERT OR UPDATE OF
+            requirement_uuid,
+            submitted_value,
+            submission_value_kind,
+            github_url,
+            token_value,
+            deployed_url,
+            text_value
+        ON {table}
+        FOR EACH ROW
+        EXECUTE FUNCTION set_typed_submitted_value()
+        """
+    )

--- a/api/alembic/versions/0037_validate_typed_submitted_value_constraints.py
+++ b/api/alembic/versions/0037_validate_typed_submitted_value_constraints.py
@@ -1,0 +1,40 @@
+"""validate typed submitted value constraints
+
+Revision ID: 0037_validate_typed_submitted_value_constraints
+Revises: 0036_typed_submitted_values
+Create Date: 2026-05-25
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0037_validate_typed_submitted_value_constraints"
+down_revision: str | None = "0036_typed_submitted_values"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+
+    for table, constraints in {
+        "requirements": ("ck_requirements_submission_value_kind_matches_type",),
+        "submissions": (
+            "ck_submissions_typed_value_shape",
+            "ck_submissions_typed_value_format",
+            "fk_submissions_requirement_value_kind",
+        ),
+        "verification_jobs": (
+            "ck_verification_jobs_typed_value_shape",
+            "ck_verification_jobs_typed_value_format",
+            "fk_verification_jobs_requirement_value_kind",
+        ),
+    }.items():
+        for constraint in constraints:
+            op.execute(f"ALTER TABLE {table} VALIDATE CONSTRAINT {constraint}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -27,6 +27,7 @@ from learn_to_cloud_shared.schemas import (
     SubmissionData,
     SubmissionResult,
 )
+from learn_to_cloud_shared.submission_values import submission_value_from_columns
 from learn_to_cloud_shared.verification.execution import (
     SubmissionAlreadyInFlightError,
 )
@@ -64,6 +65,7 @@ from learn_to_cloud.services.steps_service import (
 from learn_to_cloud.services.submissions_service import (
     AlreadyValidatedError,
     GitHubUsernameRequiredError,
+    InvalidSubmittedValueError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
     SyncVerificationResult,
@@ -88,6 +90,7 @@ logger = logging.getLogger(__name__)
 _USER_FACING_ERRORS = (
     AlreadyValidatedError,
     GitHubUsernameRequiredError,
+    InvalidSubmittedValueError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
     SubmissionAlreadyInFlightError,
@@ -456,7 +459,7 @@ async def _start_async_job_and_render(
                 user_id=user_id,
                 github_username=job_submission.github_username,
                 requirement=job_submission.requirement,
-                submitted_value=job_submission.job.submitted_value,
+                submitted_value=submission_value_from_columns(job_submission.job),
             )
             await start_verification_orchestration(prepared)
 

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -27,6 +27,7 @@ from learn_to_cloud_shared.schemas import (
     SubmissionData,
     SubmissionResult,
 )
+from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.verification.dispatcher import is_sync_verifiable
 from learn_to_cloud_shared.verification.execution import (
     execute_sync_submission_validation,
@@ -109,6 +110,10 @@ class RequirementNotFoundError(Exception):
 
 
 class GitHubUsernameRequiredError(Exception):
+    pass
+
+
+class InvalidSubmittedValueError(Exception):
     pass
 
 
@@ -266,13 +271,17 @@ async def create_verification_job(
         github_username,
         submitted_value,
     )
+    try:
+        typed_value = SubmittedValue.from_raw(ctx.requirement, submitted_value)
+    except ValueError as exc:
+        raise InvalidSubmittedValueError(str(exc)) from exc
 
     if is_sync_verifiable(ctx.requirement.submission_type):
         submission_result = await execute_sync_submission_validation(
             session_maker=session_maker,
             user_id=user_id,
             requirement=ctx.requirement,
-            submitted_value=submitted_value,
+            submitted_value=typed_value.as_text,
             github_username=github_username,
         )
         return SyncVerificationResult(submission_result=submission_result)
@@ -282,7 +291,7 @@ async def create_verification_job(
         job, created = await repo.create_or_get_active(
             user_id=user_id,
             requirement_uuid=ctx.requirement.uuid,
-            submitted_value=submitted_value,
+            submitted_value=typed_value,
         )
         await write_session.commit()
 

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi.responses import HTMLResponse
-from learn_to_cloud_shared.models import VerificationJob
+from learn_to_cloud_shared.models import SubmissionValueKind, VerificationJob
 from learn_to_cloud_shared.schemas import SubmissionResult
 
 from learn_to_cloud.core.auth import AuthenticatedUser
@@ -54,6 +54,19 @@ def _async_requirement():
         slug="journal-api-implementation",
         name="Journal API",
         description="Test",
+    )
+
+
+def _mock_job(value: str = "https://github.com/user/repo") -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(),
+        orchestration_instance_id=None,
+        submitted_value=value,
+        submission_value_kind=SubmissionValueKind.GITHUB_URL.value,
+        github_url=value,
+        token_value=None,
+        deployed_url=None,
+        text_value=None,
     )
 
 
@@ -211,11 +224,7 @@ class TestHtmxSubmitVerification:
         """Successful submission starts Durable and returns processing card."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = SimpleNamespace(
-            id=uuid4(),
-            orchestration_instance_id=None,
-            submitted_value="test",
-        )
+        job = _mock_job()
         job_submission = SimpleNamespace(
             job=job,
             created=True,
@@ -237,7 +246,7 @@ class TestHtmxSubmitVerification:
             patch(
                 "learn_to_cloud.routes.htmx_routes.derive_submission_value",
                 autospec=True,
-                return_value="test",
+                return_value="https://github.com/user/repo",
             ),
             patch(
                 "learn_to_cloud.routes.htmx_routes.create_verification_job",
@@ -259,7 +268,7 @@ class TestHtmxSubmitVerification:
                 AsyncMock(),
                 current_user,
                 requirement_slug="req-1",
-                submitted_value="test",
+                submitted_value="https://github.com/user/repo",
             )
 
         # Should return a processing card, not a final result
@@ -305,9 +314,7 @@ class TestHtmxSubmitVerification:
         partial unique index so the user can retry immediately."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = SimpleNamespace(
-            id=uuid4(), orchestration_instance_id=None, submitted_value="test"
-        )
+        job = _mock_job()
         async_result = VerificationJobSubmission(
             job=cast(VerificationJob, job),
             created=True,
@@ -473,9 +480,7 @@ class TestHtmxSubmitVerification:
         VerificationJobSubmission spinner-and-poll path."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = SimpleNamespace(
-            id=uuid4(), orchestration_instance_id=None, submitted_value="test"
-        )
+        job = _mock_job()
         async_result = VerificationJobSubmission(
             job=cast(VerificationJob, job),
             created=True,
@@ -537,9 +542,7 @@ class TestHtmxSubmitVerification:
         with the same instance id would error."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = SimpleNamespace(
-            id=uuid4(), orchestration_instance_id=None, submitted_value="test"
-        )
+        job = _mock_job()
         async_result = VerificationJobSubmission(
             job=cast(VerificationJob, job),
             created=False,

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -11,7 +11,7 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from learn_to_cloud_shared.models import SubmissionType
+from learn_to_cloud_shared.models import SubmissionType, SubmissionValueKind
 from learn_to_cloud_shared.schemas import HandsOnRequirement, Phase
 from learn_to_cloud_shared.verification.requirements import RequirementIndex
 
@@ -54,6 +54,11 @@ def _make_mock_submission(
         submission_type=submission_type,
         phase_id=3,
         submitted_value="https://github.com/user/repo",
+        submission_value_kind=SubmissionValueKind.GITHUB_URL.value,
+        github_url="https://github.com/user/repo",
+        token_value=None,
+        deployed_url=None,
+        text_value=None,
         extracted_username="user",
         is_validated=is_validated,
         validated_at=datetime.now(UTC) if is_validated else None,

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -21,20 +21,29 @@ from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
+from learn_to_cloud_shared.submission_values import submission_value_from_columns
 from learn_to_cloud_shared.verification.llm_grading import (
     LLMGradingDecisionPayload,
     LLMGradingRequest,
-    apply_llm_grading_decisions as apply_llm_decisions,
-    collect_llm_grading_requests as collect_llm_requests,
     llm_grading_unavailable_result,
+)
+from learn_to_cloud_shared.verification.llm_grading import (
+    apply_llm_grading_decisions as apply_llm_decisions,
+)
+from learn_to_cloud_shared.verification.llm_grading import (
+    collect_llm_grading_requests as collect_llm_requests,
 )
 from learn_to_cloud_shared.verification_job_executor import (
     PreparedVerificationJob,
     VerificationJobNotFoundError,
     VerificationRunResult,
-    persist_verification_result as persist_prepared_verification_result,
-    prepare_verification_job as prepare_persisted_verification_job,
     run_verification,
+)
+from learn_to_cloud_shared.verification_job_executor import (
+    persist_verification_result as persist_prepared_verification_result,
+)
+from learn_to_cloud_shared.verification_job_executor import (
+    prepare_verification_job as prepare_persisted_verification_job,
 )
 from opentelemetry import context as otel_context
 from opentelemetry import trace as otel_trace
@@ -86,7 +95,9 @@ _ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE = {
     SubmissionType.JOURNAL_API_RESPONSE: "verify_phase3_journal_api_orchestrator",
     SubmissionType.CODE_ANALYSIS: "verify_phase3_journal_api_orchestrator",
     SubmissionType.PR_REVIEW: "verify_phase3_pr_review_orchestrator",
-    SubmissionType.JOURNAL_API_VERIFIER: "verify_phase3_journal_api_verifier_orchestrator",
+    SubmissionType.JOURNAL_API_VERIFIER: (
+        "verify_phase3_journal_api_verifier_orchestrator"
+    ),
     SubmissionType.DEPLOYED_API: "verify_phase4_deployed_api_orchestrator",
     SubmissionType.DEVOPS_ANALYSIS: "verify_phase5_devops_orchestrator",
     SubmissionType.SECURITY_SCANNING: "verify_phase6_security_orchestrator",
@@ -713,7 +724,7 @@ async def start_verification_job(
             if (
                 job.user_id != prepared.user_id
                 or job.requirement_uuid != prepared.requirement.uuid
-                or job.submitted_value != prepared.submitted_value
+                or submission_value_from_columns(job) != prepared.typed_submitted_value
             ):
                 return _json_response(
                     {"error": "payload_does_not_match_job"},

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
@@ -51,6 +51,7 @@ from learn_to_cloud_shared.models import (
     CurriculumTopic,
 )
 from learn_to_cloud_shared.schemas import Phase
+from learn_to_cloud_shared.submission_values import value_kind_for_submission_type
 
 
 class _CurriculumRowProtocol(Protocol):
@@ -128,6 +129,7 @@ _REQUIREMENT_UPDATE_FIELDS = (
     "name",
     "description",
     "submission_type",
+    "submission_value_kind",
     "order",
     "type_config",
     "deleted_at",
@@ -225,6 +227,9 @@ def _build_requirement_rows(phase: Phase, now: datetime) -> Iterable[dict[str, A
             "name": req.name,
             "description": req.description,
             "submission_type": req.submission_type.value,
+            "submission_value_kind": value_kind_for_submission_type(
+                req.submission_type
+            ).value,
             # Position in _phase.yaml's requirement slug list = display order.
             # Mirrors the topic-order convention from #470: one source of truth.
             "order": idx + 1,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     CheckConstraint,
     DateTime,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
     Integer,
     String,
@@ -120,6 +121,15 @@ class SubmissionType(StrEnum):
     SECURITY_SCANNING = "security_scanning"
 
 
+class SubmissionValueKind(StrEnum):
+    """Storage shape for a submitted verification value."""
+
+    GITHUB_URL = "github_url"
+    TOKEN = "token"
+    DEPLOYED_URL = "deployed_url"
+    TEXT = "text"
+
+
 class Submission(TimestampMixin, Base):
     """Tracks validated submissions for hands-on verification.
 
@@ -140,6 +150,70 @@ class Submission(TimestampMixin, Base):
         CheckConstraint(
             "is_validated IS FALSE OR verification_completed IS TRUE",
             name="ck_submissions_completed_when_validated",
+        ),
+        CheckConstraint(
+            """
+            (
+                submission_value_kind = 'github_url'
+                AND github_url IS NOT NULL
+                AND token_value IS NULL
+                AND deployed_url IS NULL
+                AND text_value IS NULL
+                AND submitted_value = github_url
+            )
+            OR (
+                submission_value_kind = 'token'
+                AND token_value IS NOT NULL
+                AND github_url IS NULL
+                AND deployed_url IS NULL
+                AND text_value IS NULL
+                AND submitted_value = token_value
+            )
+            OR (
+                submission_value_kind = 'deployed_url'
+                AND deployed_url IS NOT NULL
+                AND github_url IS NULL
+                AND token_value IS NULL
+                AND text_value IS NULL
+                AND submitted_value = deployed_url
+            )
+            OR (
+                submission_value_kind = 'text'
+                AND text_value IS NOT NULL
+                AND github_url IS NULL
+                AND token_value IS NULL
+                AND deployed_url IS NULL
+                AND submitted_value = text_value
+            )
+            """,
+            name="ck_submissions_typed_value_shape",
+        ),
+        CheckConstraint(
+            """
+            (
+                github_url IS NULL
+                OR github_url ~* '^https://github[.]com/[^[:space:]]+$'
+            )
+            AND (
+                deployed_url IS NULL
+                OR deployed_url ~* '^https?://[^[:space:]]+$'
+            )
+            AND (
+                token_value IS NULL
+                OR length(btrim(token_value)) > 0
+            )
+            AND (
+                text_value IS NULL
+                OR length(btrim(text_value)) > 0
+            )
+            """,
+            name="ck_submissions_typed_value_format",
+        ),
+        ForeignKeyConstraint(
+            ["requirement_uuid", "submission_value_kind"],
+            ["requirements.uuid", "requirements.submission_value_kind"],
+            name="fk_submissions_requirement_value_kind",
+            ondelete="RESTRICT",
         ),
         Index(
             "ix_submissions_user_verified_updated",
@@ -174,6 +248,11 @@ class Submission(TimestampMixin, Base):
         Text,
         nullable=False,
     )
+    submission_value_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    github_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    token_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    deployed_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    text_value: Mapped[str | None] = mapped_column(Text, nullable=True)
     extracted_username: Mapped[str | None] = mapped_column(
         String(255),
         nullable=True,
@@ -220,6 +299,70 @@ class VerificationJob(TimestampMixin, Base):
 
     __tablename__ = "verification_jobs"
     __table_args__ = (
+        CheckConstraint(
+            """
+            (
+                submission_value_kind = 'github_url'
+                AND github_url IS NOT NULL
+                AND token_value IS NULL
+                AND deployed_url IS NULL
+                AND text_value IS NULL
+                AND submitted_value = github_url
+            )
+            OR (
+                submission_value_kind = 'token'
+                AND token_value IS NOT NULL
+                AND github_url IS NULL
+                AND deployed_url IS NULL
+                AND text_value IS NULL
+                AND submitted_value = token_value
+            )
+            OR (
+                submission_value_kind = 'deployed_url'
+                AND deployed_url IS NOT NULL
+                AND github_url IS NULL
+                AND token_value IS NULL
+                AND text_value IS NULL
+                AND submitted_value = deployed_url
+            )
+            OR (
+                submission_value_kind = 'text'
+                AND text_value IS NOT NULL
+                AND github_url IS NULL
+                AND token_value IS NULL
+                AND deployed_url IS NULL
+                AND submitted_value = text_value
+            )
+            """,
+            name="ck_verification_jobs_typed_value_shape",
+        ),
+        CheckConstraint(
+            """
+            (
+                github_url IS NULL
+                OR github_url ~* '^https://github[.]com/[^[:space:]]+$'
+            )
+            AND (
+                deployed_url IS NULL
+                OR deployed_url ~* '^https?://[^[:space:]]+$'
+            )
+            AND (
+                token_value IS NULL
+                OR length(btrim(token_value)) > 0
+            )
+            AND (
+                text_value IS NULL
+                OR length(btrim(text_value)) > 0
+            )
+            """,
+            name="ck_verification_jobs_typed_value_format",
+        ),
+        ForeignKeyConstraint(
+            ["requirement_uuid", "submission_value_kind"],
+            ["requirements.uuid", "requirements.submission_value_kind"],
+            name="fk_verification_jobs_requirement_value_kind",
+            ondelete="RESTRICT",
+        ),
         Index(
             "ix_verification_jobs_user_req_uuid_created",
             "user_id",
@@ -255,6 +398,11 @@ class VerificationJob(TimestampMixin, Base):
         nullable=False,
     )
     submitted_value: Mapped[str] = mapped_column(Text, nullable=False)
+    submission_value_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    github_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    token_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    deployed_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    text_value: Mapped[str | None] = mapped_column(Text, nullable=True)
     extracted_username: Mapped[str | None] = mapped_column(String(255), nullable=True)
     cloud_provider: Mapped[str | None] = mapped_column(String(16), nullable=True)
     result_submission_id: Mapped[int | None] = mapped_column(
@@ -458,6 +606,43 @@ class CurriculumRequirement(TimestampMixin, Base):
 
     __tablename__ = "requirements"
     __table_args__ = (
+        CheckConstraint(
+            """
+            (
+                submission_type IN (
+                    'github_profile',
+                    'profile_readme',
+                    'repo_fork',
+                    'pr_review',
+                    'journal_api_verifier',
+                    'devops_analysis',
+                    'security_scanning',
+                    'ci_status'
+                )
+                AND submission_value_kind = 'github_url'
+            )
+            OR (
+                submission_type IN (
+                    'ctf_token',
+                    'networking_token',
+                    'iac_token'
+                )
+                AND submission_value_kind = 'token'
+            )
+            OR (
+                submission_type = 'deployed_api'
+                AND submission_value_kind = 'deployed_url'
+            )
+            OR (
+                submission_type IN (
+                    'journal_api_response',
+                    'code_analysis'
+                )
+                AND submission_value_kind = 'text'
+            )
+            """,
+            name="ck_requirements_submission_value_kind_matches_type",
+        ),
         Index(
             "uq_requirements_phase_slug_active",
             "phase_uuid",
@@ -476,6 +661,11 @@ class CurriculumRequirement(TimestampMixin, Base):
             unique=True,
             postgresql_where=text("deleted_at IS NULL"),
         ),
+        UniqueConstraint(
+            "uuid",
+            "submission_value_kind",
+            name="uq_requirements_uuid_value_kind",
+        ),
     )
 
     uuid: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
@@ -492,6 +682,7 @@ class CurriculumRequirement(TimestampMixin, Base):
     name: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
     submission_type: Mapped[str] = mapped_column(Text, nullable=False)
+    submission_value_kind: Mapped[str] = mapped_column(Text, nullable=False)
     order: Mapped[int] = mapped_column(
         BigInteger,
         nullable=False,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/submission_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/submission_repository.py
@@ -13,6 +13,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from learn_to_cloud_shared.models import Submission, utcnow
+from learn_to_cloud_shared.submission_values import SubmittedValue
 
 
 class SubmissionRepository:
@@ -80,7 +81,7 @@ class SubmissionRepository:
         self,
         user_id: int,
         requirement_uuid: UUID,
-        submitted_value: str,
+        submitted_value: SubmittedValue,
         extracted_username: str | None,
         is_validated: bool,
         verification_completed: bool = True,
@@ -100,10 +101,11 @@ class SubmissionRepository:
                 multi-cloud labs. None for non-multi-cloud submissions.
         """
         now = utcnow()
+        value_columns = submitted_value.to_columns()
         submission = Submission(
             user_id=user_id,
             requirement_uuid=requirement_uuid,
-            submitted_value=submitted_value,
+            **value_columns,
             extracted_username=extracted_username,
             is_validated=is_validated,
             validated_at=now if is_validated else None,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
@@ -25,6 +25,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from learn_to_cloud_shared.models import VerificationJob, utcnow
+from learn_to_cloud_shared.submission_values import SubmittedValue
 
 ACTIVE_JOB_UNLINKED_PREDICATE = "result_submission_id IS NULL"
 
@@ -48,17 +49,18 @@ class VerificationJobRepository:
         *,
         user_id: int,
         requirement_uuid: UUID,
-        submitted_value: str,
+        submitted_value: SubmittedValue,
         extracted_username: str | None = None,
         cloud_provider: str | None = None,
         traceparent: str | None = None,
     ) -> VerificationJob:
         """Create a verification job and let DB constraints enforce uniqueness."""
+        value_columns = submitted_value.to_columns()
         job = VerificationJob(
             id=uuid4(),
             user_id=user_id,
             requirement_uuid=requirement_uuid,
-            submitted_value=submitted_value,
+            **value_columns,
             extracted_username=extracted_username,
             cloud_provider=cloud_provider,
             traceparent=traceparent,
@@ -72,7 +74,7 @@ class VerificationJobRepository:
         *,
         user_id: int,
         requirement_uuid: UUID,
-        submitted_value: str,
+        submitted_value: SubmittedValue,
         extracted_username: str | None = None,
         cloud_provider: str | None = None,
         traceparent: str | None = None,
@@ -94,7 +96,7 @@ class VerificationJobRepository:
                     id=uuid4(),
                     user_id=user_id,
                     requirement_uuid=requirement_uuid,
-                    submitted_value=submitted_value,
+                    **submitted_value.to_columns(),
                     extracted_username=extracted_username,
                     cloud_provider=cloud_provider,
                     traceparent=traceparent,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
@@ -1,0 +1,245 @@
+"""Typed storage helpers for submitted verification values."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.parse import urlparse
+
+from learn_to_cloud_shared.models import SubmissionType, SubmissionValueKind
+from learn_to_cloud_shared.schemas import HandsOnRequirement
+
+_GITHUB_URL_TYPES = {
+    SubmissionType.GITHUB_PROFILE.value,
+    SubmissionType.PROFILE_README.value,
+    SubmissionType.REPO_FORK.value,
+    SubmissionType.PR_REVIEW.value,
+    SubmissionType.JOURNAL_API_VERIFIER.value,
+    SubmissionType.DEVOPS_ANALYSIS.value,
+    SubmissionType.SECURITY_SCANNING.value,
+    "ci_status",
+}
+_TOKEN_TYPES = {
+    SubmissionType.CTF_TOKEN.value,
+    SubmissionType.NETWORKING_TOKEN.value,
+    "iac_token",
+}
+_DEPLOYED_URL_TYPES = {SubmissionType.DEPLOYED_API.value}
+_TEXT_TYPES = {
+    SubmissionType.JOURNAL_API_RESPONSE.value,
+    SubmissionType.CODE_ANALYSIS.value,
+}
+
+
+class SubmittedValueColumns(Protocol):
+    submission_value_kind: str
+    github_url: str | None
+    token_value: str | None
+    deployed_url: str | None
+    text_value: str | None
+    submitted_value: str
+
+
+@dataclass(frozen=True, slots=True)
+class SubmittedValue:
+    """A submitted value normalized into its database storage shape."""
+
+    kind: SubmissionValueKind
+    github_url: str | None = None
+    token_value: str | None = None
+    deployed_url: str | None = None
+    text_value: str | None = None
+
+    @property
+    def as_text(self) -> str:
+        match self.kind:
+            case SubmissionValueKind.GITHUB_URL:
+                value = self.github_url
+            case SubmissionValueKind.TOKEN:
+                value = self.token_value
+            case SubmissionValueKind.DEPLOYED_URL:
+                value = self.deployed_url
+            case SubmissionValueKind.TEXT:
+                value = self.text_value
+        if value is None:
+            raise ValueError(f"Missing value for {self.kind.value}")
+        return value
+
+    def to_columns(self) -> dict[str, str | None]:
+        return {
+            "submitted_value": self.as_text,
+            "submission_value_kind": self.kind.value,
+            "github_url": self.github_url,
+            "token_value": self.token_value,
+            "deployed_url": self.deployed_url,
+            "text_value": self.text_value,
+        }
+
+    def to_payload(self) -> dict[str, str | None]:
+        return self.to_columns()
+
+    @classmethod
+    def from_payload(cls, payload: object) -> SubmittedValue:
+        if not isinstance(payload, Mapping):
+            raise TypeError("Expected submission_value payload object")
+        payload_map: dict[str, object] = {}
+        for key, value in payload.items():
+            if not isinstance(key, str):
+                raise TypeError("Expected string submission_value payload keys")
+            payload_map[key] = value
+        kind = payload_map.get("submission_value_kind")
+        if not isinstance(kind, str):
+            raise TypeError("Expected submission_value_kind payload field")
+        return cls.from_columns(
+            kind=kind,
+            github_url=_optional_str(payload_map.get("github_url"), "github_url"),
+            token_value=_optional_str(payload_map.get("token_value"), "token_value"),
+            deployed_url=_optional_str(
+                payload_map.get("deployed_url"),
+                "deployed_url",
+            ),
+            text_value=_optional_str(payload_map.get("text_value"), "text_value"),
+            legacy_value=_optional_str(
+                payload_map.get("submitted_value"),
+                "submitted_value",
+            ),
+        )
+
+    @classmethod
+    def from_raw(
+        cls,
+        requirement: HandsOnRequirement,
+        raw_value: str,
+    ) -> SubmittedValue:
+        kind = value_kind_for_submission_type(requirement.submission_type)
+        value = raw_value.strip()
+        if not value:
+            raise ValueError("Submitted value cannot be empty.")
+
+        match kind:
+            case SubmissionValueKind.GITHUB_URL:
+                _validate_github_url(value)
+                return cls(kind=kind, github_url=value)
+            case SubmissionValueKind.TOKEN:
+                return cls(kind=kind, token_value=value)
+            case SubmissionValueKind.DEPLOYED_URL:
+                _validate_http_url(value, field_name="deployed API URL")
+                return cls(kind=kind, deployed_url=value)
+            case SubmissionValueKind.TEXT:
+                return cls(kind=kind, text_value=value)
+
+    @classmethod
+    def from_columns(
+        cls,
+        *,
+        kind: str | SubmissionValueKind,
+        github_url: str | None,
+        token_value: str | None,
+        deployed_url: str | None,
+        text_value: str | None,
+        legacy_value: str | None = None,
+    ) -> SubmittedValue:
+        normalized_kind = (
+            kind if isinstance(kind, SubmissionValueKind) else SubmissionValueKind(kind)
+        )
+        value = _single_value_for_kind(
+            normalized_kind,
+            github_url=github_url,
+            token_value=token_value,
+            deployed_url=deployed_url,
+            text_value=text_value,
+        )
+        if legacy_value is not None and legacy_value != value:
+            raise ValueError("Legacy submitted_value does not match typed value")
+        return cls(
+            kind=normalized_kind,
+            github_url=github_url,
+            token_value=token_value,
+            deployed_url=deployed_url,
+            text_value=text_value,
+        )
+
+
+def value_kind_for_submission_type(
+    submission_type: SubmissionType | str,
+) -> SubmissionValueKind:
+    raw_type = (
+        submission_type.value
+        if isinstance(submission_type, SubmissionType)
+        else submission_type
+    )
+    if raw_type in _GITHUB_URL_TYPES:
+        return SubmissionValueKind.GITHUB_URL
+    if raw_type in _TOKEN_TYPES:
+        return SubmissionValueKind.TOKEN
+    if raw_type in _DEPLOYED_URL_TYPES:
+        return SubmissionValueKind.DEPLOYED_URL
+    if raw_type in _TEXT_TYPES:
+        return SubmissionValueKind.TEXT
+    raise ValueError(f"Unknown submission_type for submitted value: {raw_type!r}")
+
+
+def submission_value_from_columns(row: SubmittedValueColumns) -> SubmittedValue:
+    return SubmittedValue.from_columns(
+        kind=row.submission_value_kind,
+        github_url=row.github_url,
+        token_value=row.token_value,
+        deployed_url=row.deployed_url,
+        text_value=row.text_value,
+        legacy_value=row.submitted_value,
+    )
+
+
+def _optional_str(value: object, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"Expected string payload field: {field_name}")
+    return value
+
+
+def _single_value_for_kind(
+    kind: SubmissionValueKind,
+    *,
+    github_url: str | None,
+    token_value: str | None,
+    deployed_url: str | None,
+    text_value: str | None,
+) -> str:
+    values = {
+        SubmissionValueKind.GITHUB_URL: github_url,
+        SubmissionValueKind.TOKEN: token_value,
+        SubmissionValueKind.DEPLOYED_URL: deployed_url,
+        SubmissionValueKind.TEXT: text_value,
+    }
+    value = values[kind]
+    other_values = [item for item_kind, item in values.items() if item_kind != kind]
+    if value is None or any(item is not None for item in other_values):
+        raise ValueError(f"Invalid typed value columns for {kind.value}")
+    return value
+
+
+def _validate_github_url(value: str) -> None:
+    parsed = urlparse(value)
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc.lower() != "github.com"
+        or not parsed.path.strip("/")
+        or _has_whitespace(value)
+    ):
+        raise ValueError("Submitted value must be a GitHub URL.")
+
+
+def _validate_http_url(value: str, *, field_name: str) -> None:
+    parsed = urlparse(value)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or _has_whitespace(value)
+    ):
+        raise ValueError(f"Submitted value must be a valid {field_name}.")
+
+
+def _has_whitespace(value: str) -> bool:
+    return any(character.isspace() for character in value)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
@@ -19,6 +19,10 @@ from learn_to_cloud_shared.schemas import (
     SubmissionResult,
     ValidationResult,
 )
+from learn_to_cloud_shared.submission_values import (
+    SubmittedValue,
+    submission_value_from_columns,
+)
 from learn_to_cloud_shared.verification.dispatcher import validate_submission
 from learn_to_cloud_shared.verification.github_profile import parse_github_url
 
@@ -59,7 +63,7 @@ def to_submission_data(submission: Submission) -> SubmissionData:
     """
     return SubmissionData(
         id=submission.id,
-        submitted_value=submission.submitted_value,
+        submitted_value=submission_value_from_columns(submission).as_text,
         extracted_username=submission.extracted_username,
         is_validated=submission.is_validated,
         validated_at=submission.validated_at,
@@ -98,7 +102,7 @@ async def persist_validation_result(
     *,
     user_id: int,
     requirement: HandsOnRequirement,
-    submitted_value: str,
+    submitted_value: SubmittedValue,
     github_username: str | None,
     validation_result: ValidationResult,
 ) -> Submission:
@@ -110,7 +114,7 @@ async def persist_validation_result(
         submitted_value=submitted_value,
         extracted_username=_extract_username(
             requirement,
-            submitted_value,
+            submitted_value.as_text,
             github_username,
         ),
         is_validated=validation_result.is_valid,
@@ -149,6 +153,7 @@ async def execute_submission_validation(
     after_persist: SubmissionPersistHook | None = None,
 ) -> SubmissionResult:
     """Run validation without holding a DB session, then persist the result."""
+    typed_value = SubmittedValue.from_raw(requirement, submitted_value)
     with tracer.start_as_current_span(
         "execute_submission_validation",
         attributes={
@@ -159,7 +164,7 @@ async def execute_submission_validation(
     ) as span:
         validation_result = await validate_submission(
             requirement=requirement,
-            submitted_value=submitted_value,
+            submitted_value=typed_value.as_text,
             expected_username=github_username,
         )
 
@@ -168,7 +173,7 @@ async def execute_submission_validation(
                 write_session,
                 user_id=user_id,
                 requirement=requirement,
-                submitted_value=submitted_value,
+                submitted_value=typed_value,
                 github_username=github_username,
                 validation_result=validation_result,
             )
@@ -235,6 +240,7 @@ async def execute_sync_submission_validation(
     stays negligible.
     """
     lock_key = _advisory_lock_key(user_id, requirement.slug)
+    typed_value = SubmittedValue.from_raw(requirement, submitted_value)
 
     with tracer.start_as_current_span(
         "execute_sync_submission_validation",
@@ -259,7 +265,7 @@ async def execute_sync_submission_validation(
 
             validation_result = await validate_submission(
                 requirement=requirement,
-                submitted_value=submitted_value,
+                submitted_value=typed_value.as_text,
                 expected_username=github_username,
             )
 
@@ -267,7 +273,7 @@ async def execute_sync_submission_validation(
                 session,
                 user_id=user_id,
                 requirement=requirement,
-                submitted_value=submitted_value,
+                submitted_value=typed_value,
                 github_username=github_username,
                 validation_result=validation_result,
             )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -130,7 +130,7 @@ async def _collect_phase6_requests(
 
     expected_name = _expected_fork_name(run_result.job.requirement)
     repo_result = validate_repo_url(
-        run_result.job.submitted_value,
+        run_result.job.typed_submitted_value.as_text,
         github_username,
         expected_name,
     )
@@ -176,7 +176,7 @@ async def _collect_phase3_requests(
 
     expected_name = _expected_fork_name(run_result.job.requirement)
     repo_result = validate_repo_url(
-        run_result.job.submitted_value,
+        run_result.job.typed_submitted_value.as_text,
         github_username,
         expected_name,
     )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -44,6 +44,10 @@ from learn_to_cloud_shared.schemas import (
     HandsOnRequirementAdapter,
     ValidationResult,
 )
+from learn_to_cloud_shared.submission_values import (
+    SubmittedValue,
+    submission_value_from_columns,
+)
 from learn_to_cloud_shared.verification.dispatcher import validate_submission
 from learn_to_cloud_shared.verification.execution import (
     persist_validation_result,
@@ -122,7 +126,15 @@ class PreparedVerificationJob:
     user_id: int
     github_username: str | None
     requirement: HandsOnRequirement
-    submitted_value: str
+    submitted_value: SubmittedValue | str
+
+    def __post_init__(self) -> None:
+        if isinstance(self.submitted_value, str):
+            object.__setattr__(
+                self,
+                "submitted_value",
+                SubmittedValue.from_raw(self.requirement, self.submitted_value),
+            )
 
     def to_payload(self) -> dict[str, object]:
         """Return a JSON-serializable activity payload."""
@@ -131,8 +143,15 @@ class PreparedVerificationJob:
             "user_id": self.user_id,
             "github_username": self.github_username,
             "requirement": self.requirement.model_dump(mode="json"),
-            "submitted_value": self.submitted_value,
+            "submitted_value": self.typed_submitted_value.as_text,
+            "submission_value": self.typed_submitted_value.to_payload(),
         }
+
+    @property
+    def typed_submitted_value(self) -> SubmittedValue:
+        if isinstance(self.submitted_value, str):
+            return SubmittedValue.from_raw(self.requirement, self.submitted_value)
+        return self.submitted_value
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, object]) -> PreparedVerificationJob:
@@ -149,7 +168,14 @@ class PreparedVerificationJob:
             requirement=HandsOnRequirementAdapter.validate_python(
                 payload["requirement"]
             ),
-            submitted_value=_expect_str(payload["submitted_value"], "submitted_value"),
+            submitted_value=(
+                SubmittedValue.from_payload(payload["submission_value"])
+                if "submission_value" in payload
+                else SubmittedValue.from_raw(
+                    HandsOnRequirementAdapter.validate_python(payload["requirement"]),
+                    _expect_str(payload["submitted_value"], "submitted_value"),
+                )
+            ),
         )
 
 
@@ -202,7 +228,7 @@ class _VerificationJobPayload:
     id: UUID
     user_id: int
     requirement_uuid: UUID
-    submitted_value: str
+    submitted_value: SubmittedValue
     result_submission_id: int | None
 
 
@@ -325,7 +351,7 @@ async def prepare_verification_job(
             if (
                 payload.user_id != prepared_input.user_id
                 or payload.requirement_uuid != prepared_input.requirement.uuid
-                or payload.submitted_value != prepared_input.submitted_value
+                or payload.submitted_value != prepared_input.typed_submitted_value
             ):
                 raise VerificationJobNotFoundError(
                     f"prepared payload does not match verification_jobs "
@@ -378,7 +404,7 @@ async def _load_job_state(
         id=job.id,
         user_id=job.user_id,
         requirement_uuid=job.requirement_uuid,
-        submitted_value=job.submitted_value,
+        submitted_value=submission_value_from_columns(job),
         result_submission_id=job.result_submission_id,
     )
 
@@ -397,7 +423,7 @@ async def run_verification(
     ) as span:
         validation_result = await validate_submission(
             requirement=job.requirement,
-            submitted_value=job.submitted_value,
+            submitted_value=job.typed_submitted_value.as_text,
             expected_username=job.github_username,
         )
         span.set_attribute("verification.is_valid", validation_result.is_valid)
@@ -452,7 +478,7 @@ async def persist_verification_result(
                 db,
                 user_id=job.user_id,
                 requirement=job.requirement,
-                submitted_value=job.submitted_value,
+                submitted_value=job.typed_submitted_value,
                 github_username=job.github_username,
                 validation_result=validation_result,
             )

--- a/packages/learn-to-cloud-shared/tests/repositories/test_submission_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_submission_repository.py
@@ -12,11 +12,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
 from learn_to_cloud_shared.content_yaml_loader import clear_cache
-from learn_to_cloud_shared.models import CurriculumRequirement, Submission, utcnow
+from learn_to_cloud_shared.models import (
+    CurriculumRequirement,
+    Submission,
+    SubmissionValueKind,
+    utcnow,
+)
 from learn_to_cloud_shared.repositories.submission_repository import (
     SubmissionRepository,
 )
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
+from learn_to_cloud_shared.submission_values import SubmittedValue
 
 pytestmark = pytest.mark.integration
 
@@ -31,6 +37,10 @@ def _constraint_name(error: IntegrityError) -> str | None:
     return None
 
 
+def _github_value(value: str) -> SubmittedValue:
+    return SubmittedValue(kind=SubmissionValueKind.GITHUB_URL, github_url=value)
+
+
 @pytest.fixture()
 async def user(db_session: AsyncSession):
     """Create a test user for FK constraints."""
@@ -40,11 +50,14 @@ async def user(db_session: AsyncSession):
 
 @pytest.fixture()
 async def req_uuids(db_session: AsyncSession) -> list:
-    """Sync the real curriculum and return the first 3 requirement UUIDs."""
+    """Sync the curriculum and return GitHub URL requirement UUIDs."""
     clear_cache()
     await sync_curriculum_to_db(db_session)
     result = await db_session.execute(
-        select(CurriculumRequirement.uuid).order_by(CurriculumRequirement.slug).limit(3)
+        select(CurriculumRequirement.uuid)
+        .where(CurriculumRequirement.submission_value_kind == "github_url")
+        .order_by(CurriculumRequirement.slug)
+        .limit(3)
     )
     return [row[0] for row in result.all()]
 
@@ -55,7 +68,7 @@ class TestCreate:
         sub = await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[0],
-            submitted_value="https://github.com/testuser",
+            submitted_value=_github_value("https://github.com/testuser"),
             extracted_username="testuser",
             is_validated=True,
         )
@@ -72,7 +85,7 @@ class TestCreate:
         sub = await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[0],
-            submitted_value="bad-value",
+            submitted_value=_github_value("https://github.com/testuser/bad"),
             extracted_username=None,
             is_validated=False,
         )
@@ -88,14 +101,14 @@ class TestCreate:
         sub1 = await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[0],
-            submitted_value="attempt-1",
+            submitted_value=_github_value("https://github.com/testuser/attempt-1"),
             extracted_username=None,
             is_validated=False,
         )
         sub2 = await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[0],
-            submitted_value="attempt-2",
+            submitted_value=_github_value("https://github.com/testuser/attempt-2"),
             extracted_username=None,
             is_validated=True,
         )
@@ -112,6 +125,8 @@ class TestCreate:
                     user_id=USER_ID,
                     requirement_uuid=req_uuids[0],
                     submitted_value="https://github.com/testuser",
+                    submission_value_kind=SubmissionValueKind.GITHUB_URL.value,
+                    github_url="https://github.com/testuser",
                     extracted_username="testuser",
                     is_validated=True,
                     validated_at=None,
@@ -137,6 +152,8 @@ class TestCreate:
                     user_id=USER_ID,
                     requirement_uuid=req_uuids[0],
                     submitted_value="https://github.com/testuser",
+                    submission_value_kind=SubmissionValueKind.GITHUB_URL.value,
+                    github_url="https://github.com/testuser",
                     extracted_username="testuser",
                     is_validated=True,
                     validated_at=utcnow(),
@@ -161,21 +178,21 @@ class TestGetByUserAndRequirement:
         await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[0],
-            submitted_value="old",
+            submitted_value=_github_value("https://github.com/testuser/old"),
             extracted_username=None,
             is_validated=False,
         )
         await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[0],
-            submitted_value="new",
+            submitted_value=_github_value("https://github.com/testuser/new"),
             extracted_username=None,
             is_validated=True,
         )
 
         latest = await repo.get_by_user_and_requirement(USER_ID, req_uuids[0])
         assert latest is not None
-        assert latest.submitted_value == "new"
+        assert latest.submitted_value == "https://github.com/testuser/new"
 
     async def test_returns_none_for_missing(
         self, db_session: AsyncSession, user, req_uuids
@@ -193,21 +210,21 @@ class TestGetLatestForRequirements:
         await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[0],
-            submitted_value="attempt-1",
+            submitted_value=_github_value("https://github.com/testuser/attempt-1"),
             extracted_username=None,
             is_validated=False,
         )
         await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[0],
-            submitted_value="attempt-2",
+            submitted_value=_github_value("https://github.com/testuser/attempt-2"),
             extracted_username=None,
             is_validated=True,
         )
         await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[1],
-            submitted_value="fork-url",
+            submitted_value=_github_value("https://github.com/testuser/fork-url"),
             extracted_username=None,
             is_validated=True,
         )
@@ -219,7 +236,9 @@ class TestGetLatestForRequirements:
         latest_for_first = next(
             s for s in results if s.requirement_uuid == req_uuids[0]
         )
-        assert latest_for_first.submitted_value == "attempt-2"
+        assert (
+            latest_for_first.submitted_value == "https://github.com/testuser/attempt-2"
+        )
 
     async def test_returns_empty_for_no_submissions(
         self, db_session: AsyncSession, user, req_uuids
@@ -242,14 +261,14 @@ class TestAreAllRequirementsValidated:
         await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[0],
-            submitted_value="v1",
+            submitted_value=_github_value("https://github.com/testuser/v1"),
             extracted_username=None,
             is_validated=True,
         )
         await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[1],
-            submitted_value="v2",
+            submitted_value=_github_value("https://github.com/testuser/v2"),
             extracted_username=None,
             is_validated=True,
         )
@@ -263,7 +282,7 @@ class TestAreAllRequirementsValidated:
         await repo.create(
             user_id=USER_ID,
             requirement_uuid=req_uuids[0],
-            submitted_value="v1",
+            submitted_value=_github_value("https://github.com/testuser/v1"),
             extracted_username=None,
             is_validated=True,
         )

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
@@ -12,6 +12,7 @@ from learn_to_cloud_shared.content_yaml_loader import clear_cache
 from learn_to_cloud_shared.models import (
     CurriculumRequirement,
     Submission,
+    SubmissionValueKind,
     VerificationJob,
 )
 from learn_to_cloud_shared.repositories.submission_repository import (
@@ -22,10 +23,15 @@ from learn_to_cloud_shared.repositories.verification_job_repository import (
     LinkResult,
     VerificationJobRepository,
 )
+from learn_to_cloud_shared.submission_values import SubmittedValue
 
 pytestmark = pytest.mark.integration
 
 USER_ID = 81001
+
+
+def _github_value(value: str) -> SubmittedValue:
+    return SubmittedValue(kind=SubmissionValueKind.GITHUB_URL, github_url=value)
 
 
 @pytest.fixture()
@@ -37,11 +43,14 @@ async def user(db_session: AsyncSession):
 
 @pytest.fixture()
 async def req_uuid(db_session: AsyncSession) -> UUID:
-    """Sync curriculum and return a requirement UUID for the submissions FK."""
+    """Sync curriculum and return a GitHub URL requirement UUID."""
     clear_cache()
     await sync_curriculum_to_db(db_session)
     result = await db_session.execute(
-        select(CurriculumRequirement.uuid).order_by(CurriculumRequirement.slug).limit(1)
+        select(CurriculumRequirement.uuid)
+        .where(CurriculumRequirement.submission_value_kind == "github_url")
+        .order_by(CurriculumRequirement.slug)
+        .limit(1)
     )
     return result.scalar_one()
 
@@ -53,7 +62,7 @@ async def _create_job(
     return await repo.create(
         user_id=USER_ID,
         requirement_uuid=requirement_uuid,
-        submitted_value="https://github.com/testuser",
+        submitted_value=_github_value("https://github.com/testuser"),
         extracted_username="testuser",
         traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     )
@@ -69,7 +78,7 @@ async def _create_submission(
     return await SubmissionRepository(db_session).create(
         user_id=USER_ID,
         requirement_uuid=requirement_uuid,
-        submitted_value="https://github.com/testuser",
+        submitted_value=_github_value("https://github.com/testuser"),
         extracted_username="testuser",
         is_validated=is_validated,
         verification_completed=verification_completed,
@@ -105,18 +114,18 @@ class TestCreate:
         first, first_created = await repo.create_or_get_active(
             user_id=USER_ID,
             requirement_uuid=req_uuid,
-            submitted_value="token-1",
+            submitted_value=_github_value("https://github.com/testuser/token-1"),
         )
         second, second_created = await repo.create_or_get_active(
             user_id=USER_ID,
             requirement_uuid=req_uuid,
-            submitted_value="token-2",
+            submitted_value=_github_value("https://github.com/testuser/token-2"),
         )
 
         assert first_created is True
         assert second_created is False
         assert second.id == first.id
-        assert second.submitted_value == "token-1"
+        assert second.submitted_value == "https://github.com/testuser/token-1"
 
         count = await db_session.scalar(
             select(func.count()).select_from(VerificationJob)
@@ -138,7 +147,7 @@ class TestCreate:
         first, first_created = await repo.create_or_get_active(
             user_id=USER_ID,
             requirement_uuid=req_uuid,
-            submitted_value="token-1",
+            submitted_value=_github_value("https://github.com/testuser/token-1"),
         )
         submission = await _create_submission(
             db_session,
@@ -152,13 +161,13 @@ class TestCreate:
         second, second_created = await repo.create_or_get_active(
             user_id=USER_ID,
             requirement_uuid=req_uuid,
-            submitted_value="token-2",
+            submitted_value=_github_value("https://github.com/testuser/token-2"),
         )
 
         assert first_created is True
         assert second_created is True
         assert second.id != first.id
-        assert second.submitted_value == "token-2"
+        assert second.submitted_value == "https://github.com/testuser/token-2"
 
 
 class TestFind:

--- a/packages/learn-to-cloud-shared/tests/services/test_content_db_loader.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_db_loader.py
@@ -319,6 +319,7 @@ async def test_requirement_rehydrates_to_correct_subclass(
         name="Test Fork",
         description="desc",
         submission_type="repo_fork",
+        submission_value_kind="github_url",
         order=1,
         type_config={"required_repo": "owner/repo"},
         deleted_at=None,

--- a/packages/learn-to-cloud-shared/tests/services/test_content_sync.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_sync.py
@@ -157,6 +157,8 @@ async def test_first_sync_inserts_all_rows(
     phase = (await db_session.execute(select(CurriculumPhase))).scalar_one()
     assert phase.slug == "phase0"
     assert phase.deleted_at is None
+    requirement = (await db_session.execute(select(CurriculumRequirement))).scalar_one()
+    assert requirement.submission_value_kind == "github_url"
 
 
 async def test_second_sync_is_idempotent(

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -13,6 +13,7 @@ from learn_to_cloud_shared.models import (
     CurriculumRequirement,
     Submission,
     SubmissionType,
+    SubmissionValueKind,
     VerificationJob,
 )
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
@@ -20,6 +21,7 @@ from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
 from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
+from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.verification.execution import MAX_VALIDATION_MESSAGE_LENGTH
 from learn_to_cloud_shared.verification_job_executor import (
     VALIDATION_FAILED_ERROR_CODE,
@@ -37,6 +39,10 @@ from learn_to_cloud_shared.verification_job_executor import (
 pytestmark = pytest.mark.integration
 
 USER_ID = 82001
+
+
+def _github_value(value: str) -> SubmittedValue:
+    return SubmittedValue(kind=SubmissionValueKind.GITHUB_URL, github_url=value)
 
 
 @pytest.fixture()
@@ -98,7 +104,7 @@ async def _create_job(
         job = await VerificationJobRepository(db).create(
             user_id=USER_ID,
             requirement_uuid=requirement.uuid,
-            submitted_value="https://github.com/executoruser/repo",
+            submitted_value=_github_value("https://github.com/executoruser/repo"),
         )
         await db.commit()
         return job.id
@@ -111,7 +117,7 @@ def _prepared(job_id: UUID, requirement: HandsOnRequirement) -> PreparedVerifica
         user_id=USER_ID,
         github_username="executoruser",
         requirement=requirement,
-        submitted_value="https://github.com/executoruser/repo",
+        submitted_value=_github_value("https://github.com/executoruser/repo"),
     )
 
 

--- a/packages/learn-to-cloud-shared/tests/test_submission_values.py
+++ b/packages/learn-to-cloud-shared/tests/test_submission_values.py
@@ -1,0 +1,107 @@
+"""Tests for typed submitted-value storage helpers."""
+
+import pytest
+
+from learn_to_cloud_shared.models import SubmissionType, SubmissionValueKind
+from learn_to_cloud_shared.submission_values import (
+    SubmittedValue,
+    value_kind_for_submission_type,
+)
+from learn_to_cloud_shared.testing.requirement_factories import (
+    ctf_token_requirement,
+    deployed_api_requirement,
+    github_profile_requirement,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("submission_type", "expected"),
+    [
+        (SubmissionType.GITHUB_PROFILE, SubmissionValueKind.GITHUB_URL),
+        (SubmissionType.JOURNAL_API_VERIFIER, SubmissionValueKind.GITHUB_URL),
+        (SubmissionType.CTF_TOKEN, SubmissionValueKind.TOKEN),
+        (SubmissionType.DEPLOYED_API, SubmissionValueKind.DEPLOYED_URL),
+        (SubmissionType.JOURNAL_API_RESPONSE, SubmissionValueKind.TEXT),
+        ("ci_status", SubmissionValueKind.GITHUB_URL),
+        ("iac_token", SubmissionValueKind.TOKEN),
+    ],
+)
+def test_value_kind_for_submission_type(
+    submission_type: SubmissionType | str,
+    expected: SubmissionValueKind,
+) -> None:
+    assert value_kind_for_submission_type(submission_type) is expected
+
+
+@pytest.mark.unit
+def test_github_url_value_uses_github_column() -> None:
+    value = SubmittedValue.from_raw(
+        github_profile_requirement(),
+        " https://github.com/user ",
+    )
+
+    assert value.kind is SubmissionValueKind.GITHUB_URL
+    assert value.github_url == "https://github.com/user"
+    assert value.to_columns() == {
+        "submitted_value": "https://github.com/user",
+        "submission_value_kind": "github_url",
+        "github_url": "https://github.com/user",
+        "token_value": None,
+        "deployed_url": None,
+        "text_value": None,
+    }
+
+
+@pytest.mark.unit
+def test_token_value_uses_token_column() -> None:
+    value = SubmittedValue.from_raw(ctf_token_requirement(), " token-123 ")
+
+    assert value.kind is SubmissionValueKind.TOKEN
+    assert value.token_value == "token-123"
+    assert value.as_text == "token-123"
+
+
+@pytest.mark.unit
+def test_deployed_url_value_uses_deployed_url_column() -> None:
+    value = SubmittedValue.from_raw(
+        deployed_api_requirement(),
+        " https://api.example.com ",
+    )
+
+    assert value.kind is SubmissionValueKind.DEPLOYED_URL
+    assert value.deployed_url == "https://api.example.com"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw_value",
+    ["not-a-url", "https://example.com/user", "https://github.com/user name"],
+)
+def test_github_url_requires_github_url(raw_value: str) -> None:
+    with pytest.raises(ValueError, match="GitHub URL"):
+        SubmittedValue.from_raw(github_profile_requirement(), raw_value)
+
+
+@pytest.mark.unit
+def test_deployed_url_rejects_whitespace() -> None:
+    with pytest.raises(ValueError, match="deployed API URL"):
+        SubmittedValue.from_raw(
+            deployed_api_requirement(),
+            "https://api.example.com/bad path",
+        )
+
+
+@pytest.mark.unit
+def test_payload_round_trip_rejects_legacy_mismatch() -> None:
+    payload = {
+        "submission_value_kind": "github_url",
+        "github_url": "https://github.com/user",
+        "token_value": None,
+        "deployed_url": None,
+        "text_value": None,
+        "submitted_value": "https://github.com/other",
+    }
+
+    with pytest.raises(ValueError, match="Legacy submitted_value"):
+        SubmittedValue.from_payload(payload)

--- a/packages/learn-to-cloud-shared/tests/verification/test_sync_execution.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_sync_execution.py
@@ -24,6 +24,7 @@ from learn_to_cloud_shared.models import (
 )
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
 from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
+from learn_to_cloud_shared.submission_values import value_kind_for_submission_type
 from learn_to_cloud_shared.verification.execution import (
     SubmissionAlreadyInFlightError,
     execute_sync_submission_validation,
@@ -68,6 +69,10 @@ async def _make_requirement_in_db(
         row_uuid = (
             await db.execute(
                 select(CurriculumRequirement.uuid)
+                .where(
+                    CurriculumRequirement.submission_value_kind
+                    == value_kind_for_submission_type(submission_type).value
+                )
                 .order_by(CurriculumRequirement.slug)
                 .limit(1)
             )
@@ -317,6 +322,7 @@ async def test_advisory_lock_keyed_per_requirement(
                 await db.execute(
                     select(CurriculumRequirement.uuid)
                     .where(CurriculumRequirement.uuid != requirement.uuid)
+                    .where(CurriculumRequirement.submission_value_kind == "github_url")
                     .order_by(CurriculumRequirement.slug)
                     .limit(1)
                 )


### PR DESCRIPTION
## Summary
- add typed submitted-value storage for verification requirements
- keep legacy submitted_value compatibility during rolling deploys
- update API, shared repositories, Durable payloads, and Functions validation to use typed values

## Validation
- prek run --all-files
- cd api && uv run pytest tests/ -x --tb=short
- cd packages/learn-to-cloud-shared && uv run pytest tests/ -x --tb=short
- cd apps/verification-functions && uv run python -c "import function_app"

Closes #488