### PR TITLE
Fix Azure PostgreSQL extension migration

### DIFF
--- a/api/alembic/versions/0034_issue_448_integrity_hardening.py
+++ b/api/alembic/versions/0034_issue_448_integrity_hardening.py
@@ -50,8 +50,6 @@ def upgrade() -> None:
     op.execute("SET LOCAL lock_timeout = '5s'")
     op.execute("SET LOCAL statement_timeout = '2min'")
 
-    op.execute("CREATE EXTENSION IF NOT EXISTS pg_stat_statements")
-
     op.execute(
         """
         UPDATE submissions


### PR DESCRIPTION
## Summary
- remove pg_stat_statements extension creation from Alembic migration 0034
- keep Azure PostgreSQL extension allow-list and preload settings managed by Terraform/admin setup
- unblock production migrations that run as the normal migration role instead of azure_pg_admin

## Why
Azure Database for PostgreSQL Flexible Server rejects CREATE EXTENSION pg_stat_statements for non-azure_pg_admin roles, even with IF NOT EXISTS. The migration role should own application schema changes, not Azure-admin extension setup.

## Validation
- cd api && uv run ruff check . ../packages/learn-to-cloud-shared
- cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared
- cd api && uv run ty check --exclude scripts --exclude tests .
- cd api && uv run pytest tests/
- cd packages/learn-to-cloud-shared && uv run ty check --exclude tests .
- cd packages/learn-to-cloud-shared && uv run pytest tests/
- cd apps/verification-functions && uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run python -c "import function_app"