### PR TITLE
Fix typed value validation for stored attempts

### DIFF
--- a/api/alembic/versions/0036_typed_submitted_values.py
+++ b/api/alembic/versions/0036_typed_submitted_values.py
@@ -114,11 +114,11 @@ OR (
 _TYPED_VALUE_FORMAT_CHECK = """
 (
     github_url IS NULL
-    OR github_url ~* '^https://github[.]com/[^[:space:]]+$'
+    OR length(btrim(github_url)) > 0
 )
 AND (
     deployed_url IS NULL
-    OR deployed_url ~* '^https?://[^[:space:]]+$'
+    OR length(btrim(deployed_url)) > 0
 )
 AND (
     token_value IS NULL

--- a/api/alembic/versions/0037_validate_typed_submitted_value_constraints.py
+++ b/api/alembic/versions/0037_validate_typed_submitted_value_constraints.py
@@ -14,10 +14,32 @@ down_revision: str | None = "0036_typed_submitted_values"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+_TYPED_VALUE_FORMAT_CHECK = """
+(
+    github_url IS NULL
+    OR length(btrim(github_url)) > 0
+)
+AND (
+    deployed_url IS NULL
+    OR length(btrim(deployed_url)) > 0
+)
+AND (
+    token_value IS NULL
+    OR length(btrim(token_value)) > 0
+)
+AND (
+    text_value IS NULL
+    OR length(btrim(text_value)) > 0
+)
+"""
+
 
 def upgrade() -> None:
     op.execute("SET LOCAL lock_timeout = '5s'")
     op.execute("SET LOCAL statement_timeout = '2min'")
+
+    _replace_typed_value_format_constraint("submissions", "ck_submissions")
+    _replace_typed_value_format_constraint("verification_jobs", "ck_verification_jobs")
 
     for table, constraints in {
         "requirements": ("ck_requirements_submission_value_kind_matches_type",),
@@ -38,3 +60,16 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     pass
+
+
+def _replace_typed_value_format_constraint(table: str, prefix: str) -> None:
+    constraint = f"{prefix}_typed_value_format"
+    op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {constraint}")
+    op.execute(
+        f"""
+        ALTER TABLE {table}
+        ADD CONSTRAINT {constraint}
+        CHECK ({_TYPED_VALUE_FORMAT_CHECK})
+        NOT VALID
+        """
+    )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -192,11 +192,11 @@ class Submission(TimestampMixin, Base):
             """
             (
                 github_url IS NULL
-                OR github_url ~* '^https://github[.]com/[^[:space:]]+$'
+                OR length(btrim(github_url)) > 0
             )
             AND (
                 deployed_url IS NULL
-                OR deployed_url ~* '^https?://[^[:space:]]+$'
+                OR length(btrim(deployed_url)) > 0
             )
             AND (
                 token_value IS NULL
@@ -340,11 +340,11 @@ class VerificationJob(TimestampMixin, Base):
             """
             (
                 github_url IS NULL
-                OR github_url ~* '^https://github[.]com/[^[:space:]]+$'
+                OR length(btrim(github_url)) > 0
             )
             AND (
                 deployed_url IS NULL
-                OR deployed_url ~* '^https?://[^[:space:]]+$'
+                OR length(btrim(deployed_url)) > 0
             )
             AND (
                 token_value IS NULL

--- a/packages/learn-to-cloud-shared/tests/repositories/test_submission_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_submission_repository.py
@@ -92,6 +92,42 @@ class TestCreate:
 
         assert sub.validated_at is None
 
+    async def test_stores_invalid_github_attempts(
+        self, db_session: AsyncSession, user, req_uuids
+    ):
+        repo = SubmissionRepository(db_session)
+
+        sub = await repo.create(
+            user_id=USER_ID,
+            requirement_uuid=req_uuids[0],
+            submitted_value=_github_value("http://github.com/testuser"),
+            extracted_username=None,
+            is_validated=False,
+        )
+
+        assert sub.github_url == "http://github.com/testuser"
+        assert sub.is_validated is False
+
+    async def test_rejects_blank_typed_value(
+        self, db_session: AsyncSession, user, req_uuids
+    ):
+        repo = SubmissionRepository(db_session)
+        nested = await db_session.begin_nested()
+        try:
+            with pytest.raises(IntegrityError) as error:
+                await repo.create(
+                    user_id=USER_ID,
+                    requirement_uuid=req_uuids[0],
+                    submitted_value=_github_value(""),
+                    extracted_username=None,
+                    is_validated=False,
+                )
+        finally:
+            await nested.rollback()
+
+        expected = "ck_submissions_typed_value_format"
+        assert _constraint_name(error.value) == expected
+
     async def test_multiple_rows_per_user_requirement_allowed(
         self, db_session: AsyncSession, user, req_uuids
     ):


### PR DESCRIPTION
## Summary
- relax typed value database format checks to require nonblank values instead of semantically valid URLs
- update the validation migration to replace the previous strict format constraint before validating
- add repository coverage for storing invalid GitHub attempts while rejecting blank typed values

## Why
Production stores failed verification attempts too. Existing rows include invalid-looking GitHub URLs, and those rows should remain valid stored attempts. URL semantics belong in verification logic, not the database shape constraint.

## Production repair
The failed deploy left production at Alembic 0035 with partial 0036 columns and the value-kind index present. I removed those half-applied objects so the corrected migrations can rerun from the recorded 0035 state.

## Validation
- cd api && uv run ruff check . ../packages/learn-to-cloud-shared
- cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared
- cd api && uv run ty check --exclude scripts --exclude tests .
- cd api && uv run pytest tests/
- cd packages/learn-to-cloud-shared && uv run ty check --exclude tests .
- cd packages/learn-to-cloud-shared && uv run pytest tests/
- cd apps/verification-functions && uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run python -c "import function_app"