### PR TITLE
Split migration sync into separate image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -249,8 +249,10 @@ jobs:
       - name: Run curriculum YAML -> DB sync (simulates deploy-time job)
         working-directory: packages/learn-to-cloud-shared
         # Matches the subprocess invocation in api/scripts/run_migrations.py.
-        # Exercises the full deploy path so settings/packaging bugs surface
-        # in CI instead of in the production migration job.
+        # Production migration images set CONTENT_DIR explicitly because
+        # curriculum YAML is no longer package data in the shared wheel.
+        env:
+          CONTENT_DIR: ${{ github.workspace }}/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases
         run: uv run python -m learn_to_cloud_shared.cli.sync_curriculum
 
       - name: Run API tests with coverage
@@ -441,17 +443,6 @@ jobs:
           DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud" PYTHONPATH="$PWD/.python_packages/lib/site-packages" python - <<'PY'
           import asyncpg
           import function_app
-          from learn_to_cloud_shared.content_yaml_loader import (
-              get_all_phases_from_yaml,
-          )
-
-          phases = get_all_phases_from_yaml()
-          assert any(
-              req.slug == "journal-api-implementation"
-              for phase in phases
-              if phase.hands_on_verification
-              for req in phase.hands_on_verification.requirements
-          ), "journal-api-implementation requirement not found in packaged YAML"
           PY
 
       - name: Deploy verification Functions
@@ -464,23 +455,64 @@ jobs:
       - name: Log in to ACR
         run: az acr login --name ${{ needs.terraform.outputs.container_registry_name }}
 
-      - name: Build and Push API Image
+      - name: Build and Push Container Images
         run: |
-          CACHE_FLAGS=""
+          API_CACHE_FLAGS=""
+          MIGRATIONS_CACHE_FLAGS=""
           if [[ "${{ inputs.force_rebuild }}" == "true" ]]; then
-            CACHE_FLAGS="--no-cache --pull"
+            API_CACHE_FLAGS="--no-cache --pull"
+            MIGRATIONS_CACHE_FLAGS="--no-cache --pull"
           else
             docker pull ${{ needs.terraform.outputs.container_registry_endpoint }}/api:latest || true
-            CACHE_FLAGS="--cache-from=${{ needs.terraform.outputs.container_registry_endpoint }}/api:latest"
+            docker pull ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:latest || true
+            API_CACHE_FLAGS="--cache-from=${{ needs.terraform.outputs.container_registry_endpoint }}/api:latest"
+            MIGRATIONS_CACHE_FLAGS="--cache-from=${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:latest"
           fi
+
           docker build -f api/Dockerfile \
-            $CACHE_FLAGS \
+            --target api-runtime \
+            $API_CACHE_FLAGS \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --label git-commit=${{ github.sha }} \
             -t ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }} \
             -t ${{ needs.terraform.outputs.container_registry_endpoint }}/api:latest .
+
+          docker build -f api/Dockerfile \
+            --target migrations-runtime \
+            $MIGRATIONS_CACHE_FLAGS \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --label git-commit=${{ github.sha }} \
+            -t ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:${{ github.sha }} \
+            -t ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:latest .
+
+          docker run --rm -i ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }} python - <<'PY'
+          from importlib.resources import files
+          from pathlib import Path
+
+          phases_path = Path(
+              str(files("learn_to_cloud_shared").joinpath("content", "phases"))
+          )
+          assert not phases_path.exists(), f"API image contains YAML at {phases_path}"
+          PY
+
+          docker run --rm -i \
+            -e DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud" \
+            ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:${{ github.sha }} \
+            python - <<'PY'
+          from learn_to_cloud_shared.core.config import WorkerSettings, configure_settings
+
+          configure_settings(WorkerSettings)
+
+          from learn_to_cloud_shared.content_yaml_loader import get_all_phases_from_yaml
+
+          phases = get_all_phases_from_yaml()
+          assert phases, "Migration image did not load curriculum phases"
+          PY
+
           docker push ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }}
           docker push ${{ needs.terraform.outputs.container_registry_endpoint }}/api:latest
+          docker push ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:${{ github.sha }}
+          docker push ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:latest
 
       - name: Run database migrations
         env:
@@ -491,7 +523,7 @@ jobs:
           POSTGRES_HOST: ${{ needs.terraform.outputs.database_host }}
           POSTGRES_USER: ${{ needs.terraform.outputs.migration_postgres_role }}
           RESOURCE_GROUP: ${{ needs.terraform.outputs.resource_group_name }}
-          IMAGE: ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }}
+          IMAGE: ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:${{ github.sha }}
         run: |
           az config set extension.use_dynamic_install=yes_without_prompt
 
@@ -508,6 +540,7 @@ jobs:
                 POSTGRES_USER="$POSTGRES_USER" \
                 POSTGRES_DATABASE="$POSTGRES_DATABASE" \
                 AZURE_CLIENT_ID="$MIGRATION_CLIENT_ID" \
+                CONTENT_DIR="/app/content/phases" \
               --registry-identity "$MIGRATION_IDENTITY_ID" \
               --query name \
               --output tsv

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -32,8 +32,8 @@ COPY api/src/learn_to_cloud/static/css/input.css ./static/css/input.css
 COPY api/src/learn_to_cloud/templates/ ./templates/
 RUN npx @tailwindcss/cli -i static/css/input.css -o static/css/styles.css --minify
 
-# Production stage - minimal runtime
-FROM python:3.13-slim AS runtime
+# Shared production base for API and migration images
+FROM python:3.13-slim AS runtime-base
 
 WORKDIR /app
 
@@ -57,14 +57,33 @@ ENV PYTHONPATH="/app/src"
 # Enable Python fault handler for debugging
 ENV PYTHONFAULTHANDLER=1
 
-# Copy application code from api/
+# Use tini as init process for proper signal handling and zombie reaping
+ENTRYPOINT ["tini", "-g", "--"]
+
+# Switch to non-root user
+USER appuser
+
+# Migration stage - Alembic plus curriculum YAML sync
+FROM runtime-base AS migrations-runtime
+
+COPY --chown=appuser:appuser api/alembic.ini .
+COPY --chown=appuser:appuser api/alembic/ ./alembic/
+COPY --chown=appuser:appuser api/scripts/run_migrations.py ./scripts/run_migrations.py
+COPY --chown=appuser:appuser packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases /app/content/phases
+
+ENV CONTENT_DIR="/app/content/phases"
+
+CMD ["python", "scripts/run_migrations.py"]
+
+# API stage - request-serving runtime
+FROM runtime-base AS api-runtime
+
+# Copy application code from api/. The shared package is already installed in
+# the virtual environment, without curriculum YAML package data.
 COPY --chown=appuser:appuser api/ .
 
 # Copy Tailwind-generated CSS from build stage
 COPY --from=tailwind --chown=appuser:appuser /build/static/css/styles.css /app/src/learn_to_cloud/static/css/styles.css
-
-# Switch to non-root user
-USER appuser
 
 # Expose port
 EXPOSE 8000
@@ -72,8 +91,5 @@ EXPOSE 8000
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"
-
-# Use tini as init process for proper signal handling and zombie reaping
-ENTRYPOINT ["tini", "-g", "--"]
 
 CMD ["python", "-m", "uvicorn", "learn_to_cloud.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/api/scripts/run_migrations.py
+++ b/api/scripts/run_migrations.py
@@ -12,7 +12,8 @@ Runs the full deploy-gate sequence:
    (autogenerate dry-run). Catches model fields added without
    corresponding migrations.
 4. ``python -m learn_to_cloud_shared.cli.sync_curriculum`` — populate
-   curriculum DB tables from packaged YAML (issue #463 / Phase B).
+   curriculum DB tables from the migration image's copied YAML directory
+   (issue #463 / Phase B).
    Runs as a subprocess so its settings singleton starts fresh as
    ``WorkerSettings``; sharing the Alembic process would lock it to
    ``DatabaseSettings``.
@@ -22,11 +23,11 @@ process, so the ``DefaultAzureCredential`` token cache is hit for the
 second and third calls — only one IMDS roundtrip happens per job.
 
 The sync CLI lives inside the installed package
-(``learn_to_cloud_shared.cli.sync_curriculum``) rather than a
-filesystem script, because the runtime container does not copy the
-package source tree -- only the installed wheel ends up in
-``/app/.venv``. ``python -m`` finds the module via the wheel's import
-path, which is portable across local devcontainer, CI, and production.
+(``learn_to_cloud_shared.cli.sync_curriculum``) rather than a filesystem
+script. The migration image copies curriculum YAML separately and points
+``CONTENT_DIR`` at that path, so the API image does not need to ship YAML.
+``python -m`` finds the module via the wheel's import path, which is
+portable across local devcontainer, CI, and production.
 """
 
 from __future__ import annotations

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -86,7 +86,7 @@ def _fake_dashboard() -> DashboardData:
 @pytest_asyncio.fixture
 async def _patched_content():
     """Route smoke tests don't run against a real DB; redirect content reads
-    to the packaged YAML loader so routes get a real curriculum tree."""
+    to the authored YAML loader so routes get a real curriculum tree."""
     from learn_to_cloud_shared.content_yaml_loader import (
         get_all_phases_from_yaml,
     )

--- a/infra/migrations.tf
+++ b/infra/migrations.tf
@@ -25,7 +25,7 @@ resource "azurerm_container_app_job" "migrations" {
   template {
     container {
       name    = "migrations"
-      image   = "${azurerm_container_registry.main.login_server}/api:latest"
+      image   = "${azurerm_container_registry.main.login_server}/migrations:latest"
       command = ["python"]
       args    = ["scripts/run_migrations.py"]
       cpu     = 0.5
@@ -54,6 +54,11 @@ resource "azurerm_container_app_job" "migrations" {
       env {
         name  = "POSTGRES_VERIFICATION_FUNCTIONS_ROLE"
         value = local.verification_functions_postgres_role
+      }
+
+      env {
+        name  = "CONTENT_DIR"
+        value = "/app/content/phases"
       }
     }
   }

--- a/packages/learn-to-cloud-shared/pyproject.toml
+++ b/packages/learn-to-cloud-shared/pyproject.toml
@@ -2,12 +2,12 @@
 requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+include-package-data = false
+
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["learn_to_cloud_shared*"]
-
-[tool.setuptools.package-data]
-learn_to_cloud_shared = ["content/phases/**/*.yaml", "content/phases/**/*.yml"]
 
 [project]
 name = "learn-to-cloud-shared"

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/cli/sync_curriculum.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/cli/sync_curriculum.py
@@ -6,7 +6,8 @@ the settings singleton starts fresh as WorkerSettings (Alembic uses
 DatabaseSettings; sharing the same process can lock the singleton to
 the wrong profile).
 
-Usage (anywhere the ``learn-to-cloud-shared`` wheel is installed)::
+Usage (anywhere the ``learn-to-cloud-shared`` wheel is installed and
+``CONTENT_DIR`` points at ``content/phases``)::
 
     python -m learn_to_cloud_shared.cli.sync_curriculum
 
@@ -15,9 +16,9 @@ Exit codes:
     1  Sync aborted (validation error, collision, or other ContentSyncError).
     2  Unexpected exception.
 
-Lives inside the installed package (not in ``scripts/``) so the
-production runtime container has it via the wheel -- the runtime image
-does not copy the source tree (see ``api/Dockerfile``).
+Lives inside the installed package (not in ``scripts/``) so the migration
+image can run the CLI from the wheel while owning the copied YAML directory
+separately (see ``api/Dockerfile``).
 
 Wired into ``api/scripts/run_migrations.py`` as a subprocess that runs
 after ``alembic upgrade head`` in the Container Apps migration job.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
@@ -1,11 +1,11 @@
 """Deploy-time sync from YAML curriculum to DB tables (issue #463).
 
-Reads the packaged curriculum YAML, runs the strict cross-file
-validators, and upserts every curriculum entity into its corresponding
-DB table. Entities no longer present in YAML are soft-deleted; entities
-that reappear (same UUID) have their ``deleted_at`` cleared. Idempotent
-re-runs leave ``updated_at`` untouched unless something actually
-changed.
+Reads the authored curriculum YAML from ``CONTENT_DIR`` in production,
+runs the strict cross-file validators, and upserts every curriculum entity
+into its corresponding DB table. Entities no longer present in YAML are
+soft-deleted; entities that reappear (same UUID) have their ``deleted_at``
+cleared. Idempotent re-runs leave ``updated_at`` untouched unless something
+actually changed.
 
 This module does NOT load on app startup. It's intended to run once
 per deploy via ``python -m learn_to_cloud_shared.cli.sync_curriculum``

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
@@ -1,11 +1,11 @@
-"""YAML-backed curriculum loader (legacy source of truth).
+"""YAML-backed curriculum loader (authoring source of truth).
 
-This module loads the curriculum tree from the packaged YAML files. After
+This module loads the curriculum tree from the authored YAML files. After
 Phase C (issue #461), runtime reads in the API go through the DB loader in
-``content_db_loader.py`` via the public ``content_service`` module. The
-YAML loader is still authoritative -- it remains the source of truth for
-the deploy-time YAML to DB sync (``content_sync.py``) and for the strict
-cross-file validators run in CI.
+``content_db_loader.py`` via the public ``content_service`` module. The YAML
+loader is still authoritative for deploy-time YAML to DB sync
+(``content_sync.py``) and for the strict cross-file validators run in CI.
+Production migration jobs provide the YAML path through ``CONTENT_DIR``.
 
 Do not import from this module in request-serving code paths. Use
 ``learn_to_cloud_shared.content_service`` (async, DB-backed) instead.
@@ -207,7 +207,7 @@ def _load_phase(phase_slug: str) -> Phase | None:
 
 @lru_cache(maxsize=1)
 def get_all_phases_from_yaml() -> tuple[Phase, ...]:
-    """Get all phases in order from packaged YAML files.
+    """Get all phases in order from authored YAML files.
 
     Results are cached for performance. Dynamically discovers phase
     directories (phase0, phase1, ...). Used by ``content_sync.py``

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
@@ -113,12 +113,21 @@ class WorkerSettings(DatabaseSettings):
 
     @cached_property
     def content_dir_path(self) -> Path:
-        """Defaults to packaged content/phases if CONTENT_DIR not set."""
+        """Resolve authored curriculum YAML for sync and validation jobs."""
         if self.content_dir:
             return Path(self.content_dir)
 
-        packaged_content = files("learn_to_cloud_shared").joinpath("content", "phases")
-        return Path(str(packaged_content))
+        source_content = Path(
+            str(files("learn_to_cloud_shared").joinpath("content", "phases"))
+        )
+        if source_content.exists():
+            return source_content
+
+        raise RuntimeError(
+            "CONTENT_DIR is required because curriculum YAML is not packaged "
+            "with learn-to-cloud-shared. Set CONTENT_DIR to the copied "
+            "content/phases directory in jobs that sync or validate YAML."
+        )
 
 
 class WebSettings(WorkerSettings):

--- a/packages/learn-to-cloud-shared/tests/services/test_content_db_loader.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_db_loader.py
@@ -42,7 +42,7 @@ pytestmark = pytest.mark.integration
 
 
 async def _seed_with_real_content(db: AsyncSession) -> None:
-    """Run the real sync against the packaged YAML content."""
+    """Run the real sync against the authored YAML content."""
     clear_cache()
     await sync_curriculum_to_db(db)
 
@@ -52,13 +52,13 @@ async def _seed_with_real_content(db: AsyncSession) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def test_db_loader_matches_yaml_loader_for_packaged_content(
+async def test_db_loader_matches_yaml_loader_for_authored_content(
     db_session: AsyncSession,
 ) -> None:
     """The DB loader returns the same shape as the YAML loader.
 
-    Runs the real ``sync_curriculum_to_db`` against the packaged YAML
-    (the same content the production app would see), then compares
+    Runs the real ``sync_curriculum_to_db`` against the authored YAML
+    (the same content the migration image syncs), then compares
     ``load_all_phases_from_db`` output against ``get_all_phases``.
 
     Uses ``model_dump(mode='json')`` so equality failures produce a

--- a/packages/learn-to-cloud-shared/tests/services/test_content_yaml_loader.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_yaml_loader.py
@@ -245,7 +245,7 @@ learning_steps:
 
 @pytest.mark.unit
 class TestGetAllPhases:
-    def test_packaged_content_contains_journal_requirement(self):
+    def test_authored_content_contains_journal_requirement(self):
         requirements = [
             requirement
             for phase in get_all_phases()


### PR DESCRIPTION
## Summary

- Build separate `api` and `migrations` image targets from `api/Dockerfile`.
- Remove curriculum YAML from the `learn-to-cloud-shared` wheel so the API image no longer receives `content/phases` through package data.
- Copy curriculum YAML only into the migration image and set `CONTENT_DIR=/app/content/phases` for migration sync.
- Update Terraform and the deploy workflow so the migration Container Apps Job runs the `migrations:${sha}` image while the web app runs `api:${sha}`.
- Add deploy-time image checks that fail if the API image contains YAML or if the migration image cannot load phases.

## Validation

- `terraform -chdir=infra fmt -check`
- `cd api && uv run ruff check . ../packages/learn-to-cloud-shared`
- `cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared`
- `cd api && uv run ty check --exclude scripts --exclude tests .`
- `cd packages/learn-to-cloud-shared && uv run ty check --exclude tests .`
- `cd api && uv run pytest tests/`
- `cd packages/learn-to-cloud-shared && uv run pytest tests/`
- `cd apps/verification-functions && uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run python -c "import function_app"`
- Built the shared wheel locally and verified it does not contain `learn_to_cloud_shared/content/phases`.
- Verified `get_all_phases_from_yaml()` loads phases when `CONTENT_DIR` points at the source `content/phases` directory.

Docker CLI is not installed in this devcontainer, so local image builds could not run here. The deploy workflow now performs the API-image and migration-image content checks during CI.

Closes #490.
