### PR TITLE
Refactor settings into composed config models

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,7 +151,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     env:
-      DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud
+      DATABASE__URL: postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -249,10 +249,10 @@ jobs:
       - name: Run curriculum YAML -> DB sync (simulates deploy-time job)
         working-directory: packages/learn-to-cloud-shared
         # Matches the subprocess invocation in api/scripts/run_migrations.py.
-        # Production migration images set CONTENT_DIR explicitly because
+        # Production migration images set CONTENT__DIR explicitly because
         # curriculum YAML is no longer package data in the shared wheel.
         env:
-          CONTENT_DIR: ${{ github.workspace }}/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases
+          CONTENT__DIR: ${{ github.workspace }}/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases
         run: uv run python -m learn_to_cloud_shared.cli.sync_curriculum
 
       - name: Run API tests with coverage
@@ -472,7 +472,7 @@ jobs:
             --python "$(which python)" \
             --target .python_packages/lib/site-packages \
             -r /tmp/verification-functions-requirements.txt
-          DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud" PYTHONPATH="$PWD/.python_packages/lib/site-packages" python - <<'PY'
+          DATABASE__URL="postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud" PYTHONPATH="$PWD/.python_packages/lib/site-packages" python - <<'PY'
           import asyncpg
           import function_app
           PY
@@ -528,13 +528,9 @@ jobs:
           PY
 
           docker run --rm -i \
-            -e DATABASE_URL="postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud" \
+            -e DATABASE__URL="postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud" \
             ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:${{ github.sha }} \
             python - <<'PY'
-          from learn_to_cloud_shared.core.config import WorkerSettings, configure_settings
-
-          configure_settings(WorkerSettings)
-
           from learn_to_cloud_shared.content_yaml_loader import get_all_phases_from_yaml
 
           phases = get_all_phases_from_yaml()
@@ -551,9 +547,9 @@ jobs:
           MIGRATION_JOB_NAME: ${{ needs.terraform.outputs.migration_job_name }}
           MIGRATION_CLIENT_ID: ${{ needs.terraform.outputs.migration_identity_client_id }}
           MIGRATION_IDENTITY_ID: ${{ needs.terraform.outputs.migration_identity_id }}
-          POSTGRES_DATABASE: ${{ needs.terraform.outputs.database_name }}
-          POSTGRES_HOST: ${{ needs.terraform.outputs.database_host }}
-          POSTGRES_USER: ${{ needs.terraform.outputs.migration_postgres_role }}
+          DATABASE_NAME: ${{ needs.terraform.outputs.database_name }}
+          DATABASE_HOST: ${{ needs.terraform.outputs.database_host }}
+          DATABASE_USER: ${{ needs.terraform.outputs.migration_postgres_role }}
           RESOURCE_GROUP: ${{ needs.terraform.outputs.resource_group_name }}
           IMAGE: ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:${{ github.sha }}
         run: |
@@ -568,11 +564,11 @@ jobs:
               --command python \
               --args scripts/run_migrations.py \
               --env-vars \
-                POSTGRES_HOST="$POSTGRES_HOST" \
-                POSTGRES_USER="$POSTGRES_USER" \
-                POSTGRES_DATABASE="$POSTGRES_DATABASE" \
+                DATABASE__HOST="$DATABASE_HOST" \
+                DATABASE__USER="$DATABASE_USER" \
+                DATABASE__NAME="$DATABASE_NAME" \
                 AZURE_CLIENT_ID="$MIGRATION_CLIENT_ID" \
-                CONTENT_DIR="/app/content/phases" \
+                CONTENT__DIR="/app/content/phases" \
               --registry-identity "$MIGRATION_IDENTITY_ID" \
               --query name \
               --output tsv

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,5 +1,5 @@
 # API environment variables
-DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud
+DATABASE__URL=postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud
 
 # Runtime environment: 'development' or 'production'.
 # 'development' relaxes web-only validation so the app starts without
@@ -7,30 +7,30 @@ DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud
 # in deployed environments (Container Apps sets this).
 ENVIRONMENT=development
 
-# GitHub OAuth (Authlib) — create an OAuth App at https://github.com/settings/developers
-# GITHUB_CLIENT_ID=your_github_client_id
-# GITHUB_CLIENT_SECRET=your_github_client_secret
+# GitHub OAuth. Create an OAuth App at https://github.com/settings/developers
+# OAUTH__CLIENT_ID=your_github_client_id
+# OAUTH__CLIENT_SECRET=your_github_client_secret
 
 # Session cookie signing key (generate: python -c "import secrets; print(secrets.token_hex(32))")
-# SESSION_SECRET_KEY=change-me-in-production
+# SESSION__SECRET_KEY=change-me-in-production
 
-# GitHub API token (optional — for higher rate limits on verification)
-# GITHUB_TOKEN=ghp_xxx
+# GitHub API token (optional, for higher rate limits on verification)
+# GITHUB__TOKEN=ghp_xxx
 
 # Labs verification secret (required for CTF/networking labs)
-# LABS_VERIFICATION_SECRET=your_secret_here
+# LABS__VERIFICATION_SECRET=your_secret_here
 
 # Durable verification Functions starter (required for verification submissions)
-# VERIFICATION_FUNCTIONS_BASE_URL=http://localhost:7071
-# VERIFICATION_FUNCTIONS_KEY=your_function_key
+# VERIFICATION_FUNCTIONS__BASE_URL=http://localhost:7071
+# VERIFICATION_FUNCTIONS__KEY=your_function_key
 
-# Database debug logging (very verbose — logs every SQL query)
-# DB_ECHO=false
+# Database debug logging (very verbose, logs every SQL query)
+# DATABASE__ECHO=false
 
-# Azure Monitor (optional — only needed for Azure deployment)
+# Azure Monitor (optional, only needed for Azure deployment)
 # APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=xxx
-# FRONTEND_APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=xxx
-# FRONTEND_TELEMETRY_SAMPLING_PERCENTAGE=100
+# FRONTEND_TELEMETRY__APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=xxx;IngestionEndpoint=xxx
+# FRONTEND_TELEMETRY__SAMPLING_PERCENTAGE=100
 
 # Local observability with Aspire Dashboard (devcontainer/docker-compose service)
 # Uncomment the lines below and restart the API:

--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -31,20 +31,12 @@ from logging.config import fileConfig
 from azure.identity import DefaultAzureCredential
 from learn_to_cloud_shared.core.azure_auth import AZURE_PG_SCOPE
 from learn_to_cloud_shared.core.config import (
-    DatabaseSettings,
-    configure_settings,
-    get_database_settings,
+    get_migration_settings,
 )
 from learn_to_cloud_shared.core.database import Base
 from sqlalchemy import create_engine
 
 from alembic import context
-
-# Alembic only needs DB config. Calling configure_settings before any
-# get_*_settings() call keeps env.py honest about its profile and skips
-# the web-only validation that would otherwise demand OAuth credentials
-# the migration runner has no business knowing about.
-configure_settings(DatabaseSettings)
 
 # Import models so Base.metadata is populated for autogenerate.
 import_module("learn_to_cloud_shared.models")
@@ -93,16 +85,16 @@ def _get_sync_database_url() -> str:
     Sync driver lets alembic run without an asyncio event loop. The
     runtime app uses asyncpg; the two URLs are intentionally separate.
     """
-    settings = get_database_settings()
+    settings = get_migration_settings().database
     if settings.use_azure_postgres:
         token = _get_azure_token_with_retry()
         return (
-            f"postgresql+psycopg2://{settings.postgres_user}:{token}"
-            f"@{settings.postgres_host}:{settings.postgres_port}/{settings.postgres_database}"
+            f"postgresql+psycopg2://{settings.user}:{token}"
+            f"@{settings.host}:{settings.port}/{settings.name}"
             f"?sslmode=require"
         )
 
-    url = settings.database_url
+    url = settings.url
     if "+asyncpg" in url:
         url = url.replace("+asyncpg", "+psycopg2")
     return url

--- a/api/scripts/reset_local_submissions.py
+++ b/api/scripts/reset_local_submissions.py
@@ -17,6 +17,7 @@ import argparse
 import asyncio
 import logging
 
+from learn_to_cloud_shared.core.config import get_web_settings
 from learn_to_cloud_shared.core.database import create_engine
 from sqlalchemy import text
 
@@ -37,7 +38,7 @@ async def reset_submissions(
 
     Returns number of deleted rows.
     """
-    engine = create_engine()
+    engine = create_engine(get_web_settings().database)
     try:
         async with engine.begin() as conn:
             where_clauses = ["requirement_id = ANY(:requirement_ids)"]

--- a/api/scripts/run_migrations.py
+++ b/api/scripts/run_migrations.py
@@ -14,9 +14,7 @@ Runs the full deploy-gate sequence:
 4. ``python -m learn_to_cloud_shared.cli.sync_curriculum`` — populate
    curriculum DB tables from the migration image's copied YAML directory
    (issue #463 / Phase B).
-   Runs as a subprocess so its settings singleton starts fresh as
-   ``WorkerSettings``; sharing the Alembic process would lock it to
-   ``DatabaseSettings``.
+   Runs as a subprocess so migration and sync concerns stay isolated.
 
 Steps 1-3 share the same ``Config`` instance and run in the same Python
 process, so the ``DefaultAzureCredential`` token cache is hit for the
@@ -45,11 +43,8 @@ logger = logging.getLogger(__name__)
 def _run_curriculum_sync() -> None:
     """Run the curriculum YAML -> DB sync as a separate subprocess.
 
-    Settings-singleton isolation: this entry point's process has already
-    instantiated ``DatabaseSettings`` via Alembic. The sync needs
-    ``WorkerSettings`` (for ``content_dir_path``), so it must run in a
-    fresh interpreter where ``configure_settings(WorkerSettings)`` can
-    fire before any other code touches the settings tree.
+    The sync has separate runtime concerns from Alembic, so keep it in a
+    fresh interpreter and fail this deploy gate if sync fails.
     """
     logger.info("Running curriculum sync via subprocess")
     result = subprocess.run(

--- a/api/src/learn_to_cloud/core/auth.py
+++ b/api/src/learn_to_cloud/core/auth.py
@@ -18,7 +18,7 @@ from typing import Annotated
 
 from authlib.integrations.starlette_client import OAuth
 from fastapi import Depends, HTTPException, Request
-from learn_to_cloud_shared.core.config import get_web_settings
+from learn_to_cloud_shared.core.config import OAuthConfig
 
 logger = logging.getLogger(__name__)
 
@@ -34,14 +34,13 @@ class AuthenticatedUser:
     github_username: str | None
 
 
-def init_oauth() -> None:
+def init_oauth(settings: OAuthConfig) -> None:
     """Register GitHub as an OAuth provider.
 
     Call once at app startup (in lifespan). Uses Authlib's built-in
     GitHub integration which knows the authorize/token/userinfo URLs.
     """
-    settings = get_web_settings()
-    if not settings.github_client_id:
+    if not settings.client_id:
         logger.warning(
             "auth.github_oauth_disabled",
             extra={"reason": "github_client_id_not_configured"},
@@ -50,8 +49,8 @@ def init_oauth() -> None:
 
     oauth.register(
         name="github",
-        client_id=settings.github_client_id,
-        client_secret=settings.github_client_secret,
+        client_id=settings.client_id,
+        client_secret=settings.client_secret,
         access_token_url="https://github.com/login/oauth/access_token",
         authorize_url="https://github.com/login/oauth/authorize",
         api_base_url="https://api.github.com/",

--- a/api/src/learn_to_cloud/core/ratelimit.py
+++ b/api/src/learn_to_cloud/core/ratelimit.py
@@ -20,7 +20,7 @@ def _get_request_identifier(request: Request) -> str:
 
 
 def _get_storage_uri() -> str:
-    return get_web_settings().ratelimit_storage_uri
+    return get_web_settings().rate_limit.storage_uri
 
 
 limiter = Limiter(

--- a/api/src/learn_to_cloud/core/templates.py
+++ b/api/src/learn_to_cloud/core/templates.py
@@ -53,15 +53,15 @@ def _static_url_context(request: Request) -> dict[str, object]:
 
 def _frontend_telemetry_context(request: Request) -> dict[str, object]:
     """Inject browser telemetry config when frontend telemetry is enabled."""
-    conn_str = get_web_settings().frontend_applicationinsights_connection_string
+    settings = get_web_settings()
+    conn_str = settings.frontend_telemetry.applicationinsights_connection_string
     if not conn_str:
         return {"frontend_telemetry": None}
 
-    settings = get_web_settings()
     return {
         "frontend_telemetry": {
             "connection_string": conn_str,
-            "sampling_percentage": settings.frontend_telemetry_sampling_percentage,
+            "sampling_percentage": settings.frontend_telemetry.sampling_percentage,
         }
     }
 

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -110,17 +110,18 @@ async def validation_exception_handler(
 @asynccontextmanager
 async def lifespan(app: fastapi.FastAPI):
     """Create DB engine at startup, dispose on shutdown."""
-    app.state.engine = create_engine()
+    app.state.settings = get_web_settings()
+    app.state.engine = create_engine(app.state.settings.database)
     app.state.session_maker = create_session_maker(app.state.engine)
 
     app.state.init_done = False
     app.state.init_error = None
 
     try:
-        settings = get_web_settings()
+        settings = app.state.settings
         async with asyncio.timeout(settings.startup_timeout):
-            oauth_task = asyncio.to_thread(init_oauth)
-            db_task = init_db(app.state.engine)
+            oauth_task = asyncio.to_thread(init_oauth, settings.oauth)
+            db_task = init_db(app.state.engine, settings.database)
             await asyncio.gather(oauth_task, db_task)
 
         app.state.init_done = True
@@ -147,7 +148,7 @@ async def lifespan(app: fastapi.FastAPI):
     finally:
         await close_github_client()
         await dispose_engine(app.state.engine)
-        if get_web_settings().use_azure_postgres:
+        if app.state.settings.database.use_azure_postgres:
             await close_credential()
 
 
@@ -157,10 +158,20 @@ app = fastapi.FastAPI(
     title="Learn to Cloud API",
     version="1.0.0",
     lifespan=lifespan,
-    docs_url="/docs" if _settings.enable_docs or _settings.is_development else None,
-    redoc_url="/redoc" if _settings.enable_docs or _settings.is_development else None,
+    docs_url=(
+        "/docs"
+        if _settings.web_security.enable_docs or _settings.is_development
+        else None
+    ),
+    redoc_url=(
+        "/redoc"
+        if _settings.web_security.enable_docs or _settings.is_development
+        else None
+    ),
     openapi_url=(
-        "/openapi.json" if _settings.enable_docs or _settings.is_development else None
+        "/openapi.json"
+        if _settings.web_security.enable_docs or _settings.is_development
+        else None
     ),
 )
 
@@ -173,11 +184,11 @@ app.add_exception_handler(Exception, global_exception_handler)
 app.add_middleware(UserTrackingMiddleware)
 app.add_middleware(
     SessionMiddleware,
-    secret_key=_settings.session_secret_key,
+    secret_key=_settings.session.secret_key,
     session_cookie="session",
     max_age=60 * 60 * 24 * 30,
     same_site="lax",
-    https_only=_settings.require_https,
+    https_only=_settings.web_security.require_https,
 )
 
 app.add_middleware(GZipMiddleware, minimum_size=500)

--- a/api/src/learn_to_cloud/routes/auth_routes.py
+++ b/api/src/learn_to_cloud/routes/auth_routes.py
@@ -47,7 +47,9 @@ async def login(request: Request) -> RedirectResponse:
     redirect_uri = str(request.url_for("auth_callback"))
     # Azure Container Apps terminates TLS at the load balancer; ensure
     # the redirect URI uses https so it matches the GitHub OAuth config.
-    if get_web_settings().require_https and redirect_uri.startswith("http://"):
+    if get_web_settings().web_security.require_https and redirect_uri.startswith(
+        "http://"
+    ):
         redirect_uri = redirect_uri.replace("http://", "https://", 1)
     return await github.authorize_redirect(request, redirect_uri)
 

--- a/api/src/learn_to_cloud/routes/health_routes.py
+++ b/api/src/learn_to_cloud/routes/health_routes.py
@@ -53,7 +53,10 @@ async def ready(request: Request) -> HealthResponse:
         )
 
     try:
-        await check_db_connection(request.app.state.engine)
+        await check_db_connection(
+            request.app.state.engine,
+            request.app.state.settings.database,
+        )
     except Exception as e:
         logger.warning("health.ready.db_unavailable", extra={"error": str(e)})
         raise HTTPException(

--- a/api/src/learn_to_cloud/services/durable_verification_client.py
+++ b/api/src/learn_to_cloud/services/durable_verification_client.py
@@ -48,8 +48,8 @@ async def start_verification_orchestration(
     *definition* and ``github_username`` snapshot.
     """
     settings = get_web_settings()
-    base_url = settings.verification_functions_base_url.rstrip("/")
-    function_key = settings.verification_functions_key
+    base_url = settings.verification_functions.base_url.rstrip("/")
+    function_key = settings.verification_functions.key
 
     if not base_url or not function_key:
         raise DurableVerificationConfigError(
@@ -60,8 +60,9 @@ async def start_verification_orchestration(
     headers = {"x-functions-key": function_key}
     body: dict[str, Any] = prepared.to_payload()
 
+    timeout = settings.http.external_api_timeout
     try:
-        async with httpx.AsyncClient(timeout=settings.external_api_timeout) as client:
+        async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.post(url, headers=headers, json=body)
     except httpx.HTTPError as exc:
         raise DurableVerificationStartError("Durable starter request failed.") from exc
@@ -92,8 +93,8 @@ async def get_verification_orchestration_status(
 ) -> DurableStatusResult:
     """Fetch Durable orchestration status through the Function app proxy."""
     settings = get_web_settings()
-    base_url = settings.verification_functions_base_url.rstrip("/")
-    function_key = settings.verification_functions_key
+    base_url = settings.verification_functions.base_url.rstrip("/")
+    function_key = settings.verification_functions.key
 
     if not base_url or not function_key:
         raise DurableVerificationConfigError(
@@ -103,8 +104,9 @@ async def get_verification_orchestration_status(
     url = f"{base_url}/api/verification/jobs/{instance_id}/status"
     headers = {"x-functions-key": function_key}
 
+    timeout = settings.http.external_api_timeout
     try:
-        async with httpx.AsyncClient(timeout=settings.external_api_timeout) as client:
+        async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.get(url, headers=headers)
     except httpx.HTTPError as exc:
         raise DurableVerificationStatusError("Durable status request failed.") from exc

--- a/api/src/learn_to_cloud/services/verification_status_tokens.py
+++ b/api/src/learn_to_cloud/services/verification_status_tokens.py
@@ -26,7 +26,8 @@ class VerificationStatusToken:
 
 def _serializer() -> URLSafeTimedSerializer:
     return URLSafeTimedSerializer(
-        get_web_settings().session_secret_key, salt=_TOKEN_SALT
+        get_web_settings().session.secret_key,
+        salt=_TOKEN_SALT,
     )
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -26,7 +26,17 @@ from collections.abc import AsyncGenerator
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI
-from learn_to_cloud_shared.core.config import Environment, WebSettings
+from learn_to_cloud_shared.core.config import (
+    CorsConfig,
+    DatabaseConfig,
+    Environment,
+    GitHubConfig,
+    LabsConfig,
+    OAuthConfig,
+    SessionConfig,
+    WebSecurityConfig,
+    WebSettings,
+)
 from learn_to_cloud_shared.core.database import Base
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import (
@@ -71,15 +81,17 @@ def test_settings() -> WebSettings:
     Uses the same PostgreSQL instance from docker-compose but a separate database.
     """
     return WebSettings(
-        database_url=TEST_DATABASE_URL,
+        database=DatabaseConfig(url=TEST_DATABASE_URL),
         environment=Environment.DEVELOPMENT,
-        require_https=False,
-        github_client_id="test_github_client_id",
-        github_client_secret="test_github_client_secret",
-        session_secret_key="test_session_secret_key_for_testing",
-        github_token="test_github_token",
-        labs_verification_secret="test_ctf_secret_must_be_32_chars!",
-        cors_allowed_origins="",
+        web_security=WebSecurityConfig(require_https=False),
+        oauth=OAuthConfig(
+            client_id="test_github_client_id",
+            client_secret="test_github_client_secret",
+        ),
+        session=SessionConfig(secret_key="test_session_secret_key_for_testing"),
+        github=GitHubConfig(token="test_github_token"),
+        labs=LabsConfig(verification_secret="test_ctf_secret_must_be_32_chars!"),
+        cors=CorsConfig(allowed_origins=""),
     )
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -14,11 +14,11 @@ Architecture follows best practices from:
 import os
 
 os.environ.setdefault(
-    "DATABASE_URL",
+    "DATABASE__URL",
     "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud",
 )
-os.environ.setdefault("GITHUB_TOKEN", "test_github_token")
-os.environ.setdefault("LABS_VERIFICATION_SECRET", "test_ctf_secret_must_be_32_chars!")
+os.environ.setdefault("GITHUB__TOKEN", "test_github_token")
+os.environ.setdefault("LABS__VERIFICATION_SECRET", "test_ctf_secret_must_be_32_chars!")
 os.environ.setdefault("ENVIRONMENT", "development")
 
 from collections.abc import AsyncGenerator
@@ -53,7 +53,7 @@ from sqlalchemy.pool import NullPool
 
 
 def _build_test_database_url() -> tuple[str, str, int]:
-    """Derive test DB URL from DATABASE_URL env var.
+    """Derive test DB URL from the configured database env var.
 
     Returns (test_url, host, port). The test database is always
     'test_learn_to_cloud' regardless of what DATABASE_URL specifies.
@@ -61,8 +61,11 @@ def _build_test_database_url() -> tuple[str, str, int]:
     from sqlalchemy.engine import make_url
 
     raw = os.environ.get(
-        "DATABASE_URL",
-        "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud",
+        "DATABASE__URL",
+        os.environ.get(
+            "DATABASE_URL",
+            "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud",
+        ),
     )
     url = make_url(raw)
     host = url.host or "localhost"

--- a/api/tests/core/test_auth.py
+++ b/api/tests/core/test_auth.py
@@ -7,10 +7,11 @@ Tests session-based authentication utilities:
 - init_oauth registers GitHub OAuth provider
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException, Request
+from learn_to_cloud_shared.core.config import OAuthConfig
 
 from learn_to_cloud.core.auth import (
     AuthenticatedUser,
@@ -200,28 +201,19 @@ class TestOptionalAuthenticatedUser:
 class TestInitOauth:
     """Test init_oauth registers GitHub provider."""
 
-    @patch("learn_to_cloud.core.auth.get_web_settings", autospec=True)
-    def test_registers_github_when_client_id_set(self, mock_get_settings):
-        mock_settings = MagicMock()
-        mock_settings.github_client_id = "test-client-id"
-        mock_settings.github_client_secret = "test-client-secret"
-        mock_get_settings.return_value = mock_settings
-
+    def test_registers_github_when_client_id_set(self):
         # Clear any existing registration
         oauth._clients.pop("github", None)
 
-        init_oauth()
+        init_oauth(
+            OAuthConfig(client_id="test-client-id", client_secret="test-client-secret")
+        )
 
         assert "github" in oauth._clients
 
-    @patch("learn_to_cloud.core.auth.get_web_settings", autospec=True)
-    def test_skips_registration_when_client_id_empty(self, mock_get_settings):
-        mock_settings = MagicMock()
-        mock_settings.github_client_id = ""
-        mock_get_settings.return_value = mock_settings
-
+    def test_skips_registration_when_client_id_empty(self):
         oauth._clients.pop("github", None)
 
-        init_oauth()
+        init_oauth(OAuthConfig(client_id=""))
 
         assert "github" not in oauth._clients

--- a/api/tests/routes/test_auth_routes.py
+++ b/api/tests/routes/test_auth_routes.py
@@ -60,7 +60,7 @@ class TestLoginRoute:
                 "learn_to_cloud.routes.auth_routes.get_web_settings"
             ) as mock_settings,
         ):
-            mock_settings.return_value.require_https = False
+            mock_settings.return_value.web_security.require_https = False
             mock_oauth.create_client.return_value = mock_github
 
             result = await login(request)
@@ -87,7 +87,7 @@ class TestLoginRoute:
                 "learn_to_cloud.routes.auth_routes.get_web_settings"
             ) as mock_settings,
         ):
-            mock_settings.return_value.require_https = True
+            mock_settings.return_value.web_security.require_https = True
             mock_oauth.create_client.return_value = mock_github
 
             await login(request)
@@ -107,7 +107,7 @@ class TestLoginRoute:
                 "learn_to_cloud.routes.auth_routes.get_web_settings"
             ) as mock_settings,
         ):
-            mock_settings.return_value.require_https = False
+            mock_settings.return_value.web_security.require_https = False
             mock_oauth.create_client.return_value = None
 
             result = await login(request)

--- a/api/tests/routes/test_health_routes.py
+++ b/api/tests/routes/test_health_routes.py
@@ -37,7 +37,10 @@ class TestReadyEndpoint:
 
         assert result.status == "ready"
         assert result.service == "learn-to-cloud-api"
-        mock_check.assert_awaited_once_with(request.app.state.engine)
+        mock_check.assert_awaited_once_with(
+            request.app.state.engine,
+            request.app.state.settings.database,
+        )
 
     async def test_ready_returns_503_when_init_error(self):
         """Ready returns 503 when init_error is set."""

--- a/api/tests/services/test_durable_verification_client.py
+++ b/api/tests/services/test_durable_verification_client.py
@@ -28,9 +28,8 @@ def _settings(
     key: str = "function-key",
 ) -> SimpleNamespace:
     return SimpleNamespace(
-        verification_functions_base_url=base_url,
-        verification_functions_key=key,
-        external_api_timeout=3.0,
+        verification_functions=SimpleNamespace(base_url=base_url, key=key),
+        http=SimpleNamespace(external_api_timeout=3.0),
     )
 
 

--- a/api/tests/services/test_verification_status_tokens.py
+++ b/api/tests/services/test_verification_status_tokens.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.unit
 
 def _settings() -> SimpleNamespace:
     return SimpleNamespace(
-        session_secret_key="test-status-token-secret",
+        session=SimpleNamespace(secret_key="test-status-token-secret"),
         verification_wait_timeout=60,
     )
 

--- a/api/tests/test_alembic_env.py
+++ b/api/tests/test_alembic_env.py
@@ -64,11 +64,11 @@ def test_get_sync_database_url_converts_asyncpg_to_psycopg2(
     env = _load_env_module(monkeypatch)
 
     fake_settings = MagicMock()
-    fake_settings.use_azure_postgres = False
-    fake_settings.database_url = (
+    fake_settings.database.use_azure_postgres = False
+    fake_settings.database.url = (
         "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud"
     )
-    monkeypatch.setattr(env, "get_database_settings", lambda: fake_settings)
+    monkeypatch.setattr(env, "get_migration_settings", lambda: fake_settings)
 
     url = env._get_sync_database_url()
 

--- a/api/tests/test_alembic_env_regression.py
+++ b/api/tests/test_alembic_env_regression.py
@@ -137,9 +137,9 @@ def _write_fixture_project(root: Path, db_path: Path) -> None:
 def _run_alembic_upgrade(project: Path) -> subprocess.CompletedProcess[str]:
     """Run ``alembic upgrade head`` against the fixture project."""
     env_overrides = {
-        "DATABASE_URL": f"sqlite:///{project / 'test.db'}",
-        "GITHUB_TOKEN": "test_github_token",
-        "LABS_VERIFICATION_SECRET": "test_ctf_secret_must_be_32_chars!",
+        "DATABASE__URL": f"sqlite:///{project / 'test.db'}",
+        "GITHUB__TOKEN": "test_github_token",
+        "LABS__VERIFICATION_SECRET": "test_ctf_secret_must_be_32_chars!",
         "DEBUG": "true",
         "USE_AZURE_POSTGRES": "false",
     }

--- a/api/tests/test_migration_chain.py
+++ b/api/tests/test_migration_chain.py
@@ -36,8 +36,11 @@ __all__ = [
 
 def _sync_url() -> str:
     raw = os.environ.get(
-        "DATABASE_URL",
-        "postgresql+asyncpg://postgres:postgres@db:5432/learntocloud",
+        "DATABASE__URL",
+        os.environ.get(
+            "DATABASE_URL",
+            "postgresql+asyncpg://postgres:postgres@db:5432/learntocloud",
+        ),
     )
     return raw.replace("+asyncpg", "+psycopg2")
 

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -13,7 +13,7 @@ from uuid import UUID
 
 import azure.durable_functions as df
 import azure.functions as func
-from learn_to_cloud_shared.core.config import WorkerSettings, configure_settings
+from learn_to_cloud_shared.core.config import get_worker_settings
 from learn_to_cloud_shared.core.database import create_engine, create_session_maker
 from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE, configure_logging
 from learn_to_cloud_shared.core.observability import configure_observability
@@ -50,11 +50,6 @@ from opentelemetry import trace as otel_trace
 from opentelemetry.propagate import extract
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from verification_agents import grade_evidence
-
-# Worker-only profile: no OAuth/session/CORS concerns. Must run before the
-# first ``get_*_settings()`` call (none happen at import time in shared
-# modules), so any module-level placement after the imports is safe.
-configure_settings(WorkerSettings)
 
 
 def _telemetry_destination_configured() -> bool:
@@ -122,7 +117,7 @@ _session_maker: async_sessionmaker[AsyncSession] | None = None
 def _get_session_maker() -> async_sessionmaker[AsyncSession]:
     global _engine, _session_maker
     if _session_maker is None:
-        _engine = create_engine()
+        _engine = create_engine(get_worker_settings().database)
         _session_maker = create_session_maker(_engine)
     return _session_maker
 

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -113,17 +113,17 @@ resource "azurerm_container_app" "api" {
       memory = "0.5Gi"
 
       env {
-        name  = "POSTGRES_HOST"
+        name  = "DATABASE__HOST"
         value = azurerm_postgresql_flexible_server.main.fqdn
       }
 
       env {
-        name  = "POSTGRES_USER"
+        name  = "DATABASE__USER"
         value = local.api_postgres_role
       }
 
       env {
-        name  = "POSTGRES_DATABASE"
+        name  = "DATABASE__NAME"
         value = azurerm_postgresql_flexible_server_database.main.name
       }
 
@@ -133,27 +133,27 @@ resource "azurerm_container_app" "api" {
       }
 
       env {
-        name  = "GITHUB_CLIENT_ID"
+        name  = "OAUTH__CLIENT_ID"
         value = var.github_client_id
       }
 
       env {
-        name        = "GITHUB_CLIENT_SECRET"
+        name        = "OAUTH__CLIENT_SECRET"
         secret_name = "github-client-secret"
       }
 
       env {
-        name        = "GITHUB_TOKEN"
+        name        = "GITHUB__TOKEN"
         secret_name = "github-token"
       }
 
       env {
-        name        = "SESSION_SECRET_KEY"
+        name        = "SESSION__SECRET_KEY"
         secret_name = "session-secret-key"
       }
 
       env {
-        name        = "LABS_VERIFICATION_SECRET"
+        name        = "LABS__VERIFICATION_SECRET"
         secret_name = "ctf-master-secret"
       }
 
@@ -163,7 +163,7 @@ resource "azurerm_container_app" "api" {
       }
 
       env {
-        name  = "FRONTEND_APPLICATIONINSIGHTS_CONNECTION_STRING"
+        name  = "FRONTEND_TELEMETRY__APPLICATIONINSIGHTS_CONNECTION_STRING"
         value = azurerm_application_insights.frontend.connection_string
       }
 
@@ -173,17 +173,17 @@ resource "azurerm_container_app" "api" {
       }
 
       env {
-        name  = "VERIFICATION_FUNCTIONS_BASE_URL"
+        name  = "VERIFICATION_FUNCTIONS__BASE_URL"
         value = "https://${azurerm_function_app_flex_consumption.verification.default_hostname}"
       }
 
       env {
-        name        = "VERIFICATION_FUNCTIONS_KEY"
+        name        = "VERIFICATION_FUNCTIONS__KEY"
         secret_name = "verification-functions-key"
       }
 
       env {
-        name  = "FRONTEND_URL"
+        name  = "CORS__FRONTEND_URL"
         value = "https://learntocloud.guide"
       }
 

--- a/infra/functions.tf
+++ b/infra/functions.tf
@@ -114,20 +114,20 @@ resource "azurerm_function_app_flex_consumption" "verification" {
 
   app_settings = {
     AZURE_CLIENT_ID                          = azurerm_user_assigned_identity.verification_functions.client_id
-    DATABASE_URL                             = ""
+    DATABASE__URL                            = ""
     ENABLE_INSTRUMENTATION                   = "true"
     DURABLE_TASK_SCHEDULER_CONNECTION_STRING = "Endpoint=${azapi_resource.verification_scheduler.output.properties.endpoint};Authentication=ManagedIdentity;ClientID=${azurerm_user_assigned_identity.verification_functions.client_id}"
-    GITHUB_CLIENT_ID                         = var.github_client_id
-    GITHUB_CLIENT_SECRET                     = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-client-secret)"
-    GITHUB_TOKEN                             = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-token)"
+    OAUTH__CLIENT_ID                         = var.github_client_id
+    OAUTH__CLIENT_SECRET                     = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-client-secret)"
+    GITHUB__TOKEN                            = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-token)"
     FOUNDRY_MODEL_DEPLOYMENT_NAME            = azapi_resource.foundry_model_deployment.name
     FOUNDRY_PROJECT_ENDPOINT                 = local.foundry_project_endpoint
-    LABS_VERIFICATION_SECRET                 = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=labs-verification-secret)"
+    LABS__VERIFICATION_SECRET                = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=labs-verification-secret)"
     OTEL_SERVICE_NAME                        = "learn-to-cloud-verification-functions"
-    POSTGRES_DATABASE                        = azurerm_postgresql_flexible_server_database.main.name
-    POSTGRES_HOST                            = azurerm_postgresql_flexible_server.main.fqdn
-    POSTGRES_USER                            = local.verification_functions_postgres_role
-    SESSION_SECRET_KEY                       = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=session-secret-key)"
+    DATABASE__NAME                           = azurerm_postgresql_flexible_server_database.main.name
+    DATABASE__HOST                           = azurerm_postgresql_flexible_server.main.fqdn
+    DATABASE__USER                           = local.verification_functions_postgres_role
+    SESSION__SECRET_KEY                      = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=session-secret-key)"
     TASKHUB_NAME                             = local.verification_functions_task_hub_name
   }
 

--- a/infra/migrations.tf
+++ b/infra/migrations.tf
@@ -32,17 +32,17 @@ resource "azurerm_container_app_job" "migrations" {
       memory  = "1Gi"
 
       env {
-        name  = "POSTGRES_HOST"
+        name  = "DATABASE__HOST"
         value = azurerm_postgresql_flexible_server.main.fqdn
       }
 
       env {
-        name  = "POSTGRES_USER"
+        name  = "DATABASE__USER"
         value = local.migration_postgres_role
       }
 
       env {
-        name  = "POSTGRES_DATABASE"
+        name  = "DATABASE__NAME"
         value = azurerm_postgresql_flexible_server_database.main.name
       }
 
@@ -57,7 +57,7 @@ resource "azurerm_container_app_job" "migrations" {
       }
 
       env {
-        name  = "CONTENT_DIR"
+        name  = "CONTENT__DIR"
         value = "/app/content/phases"
       }
     }

--- a/packages/learn-to-cloud-shared/scripts/validate_content.py
+++ b/packages/learn-to-cloud-shared/scripts/validate_content.py
@@ -14,20 +14,7 @@ from __future__ import annotations
 
 import sys
 
-# Register the minimal settings profile (WorkerSettings) before importing
-# anything that touches the shared settings tree. The shared package
-# defaults to WebSettings, which demands GitHub OAuth secrets in
-# production -- irrelevant for a content validator. WorkerSettings is
-# enough; it has content_dir_path. This MUST run before the YAML loader
-# is imported, so the import below is intentionally out of order.
-from learn_to_cloud_shared.core.config import (
-    WorkerSettings,
-    configure_settings,
-)
-
-configure_settings(WorkerSettings)
-
-from learn_to_cloud_shared.content_yaml_loader import (  # noqa: E402
+from learn_to_cloud_shared.content_yaml_loader import (
     clear_cache,
     validate_content,
 )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/cli/sync_curriculum.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/cli/sync_curriculum.py
@@ -1,10 +1,6 @@
 """Run the curriculum YAML -> DB sync (issue #463 / Phase B).
 
-Importable CLI entry point for the deploy-time curriculum sync. Must
-run in a separate Python process from the Alembic migration runner so
-the settings singleton starts fresh as WorkerSettings (Alembic uses
-DatabaseSettings; sharing the same process can lock the singleton to
-the wrong profile).
+Importable CLI entry point for the deploy-time curriculum sync.
 
 Usage (anywhere the ``learn-to-cloud-shared`` wheel is installed and
 ``CONTENT_DIR`` points at ``content/phases``)::
@@ -32,21 +28,12 @@ import os
 import sys
 from dataclasses import asdict
 
-# Register the minimal settings profile before importing anything that
-# touches the shared settings tree. WebSettings (the package default)
-# would demand GitHub OAuth secrets in production; not needed here.
-from learn_to_cloud_shared.core.config import (
-    WorkerSettings,
-    configure_settings,
-)
-
-configure_settings(WorkerSettings)
-
-from learn_to_cloud_shared.content_sync import (  # noqa: E402
+from learn_to_cloud_shared.content_sync import (
     ContentSyncError,
     sync_curriculum_to_db,
 )
-from learn_to_cloud_shared.core.database import (  # noqa: E402
+from learn_to_cloud_shared.core.config import get_worker_settings
+from learn_to_cloud_shared.core.database import (
     create_engine,
     create_session_maker,
     dispose_engine,
@@ -56,7 +43,8 @@ logger = logging.getLogger(__name__)
 
 
 async def _run() -> int:
-    engine = create_engine()
+    settings = get_worker_settings()
+    engine = create_engine(settings.database)
     session_maker = create_session_maker(engine)
     try:
         async with session_maker() as session:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
@@ -69,7 +69,7 @@ def _get_content_dir() -> Path:
 
     Lazily accessed to avoid module-level settings initialization.
     """
-    return get_worker_settings().content_dir_path
+    return get_worker_settings().content.dir_path
 
 
 def _load_topic(phase_dir: Path, topic_slug: str, *, order: int) -> Topic | None:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
@@ -1,51 +1,19 @@
-"""Application configuration split by runtime profile.
-
-The codebase has three deployable processes with very different needs:
-
-* ``DatabaseSettings`` — minimal set for processes that only need DB
-  access (the Alembic migration job, ad-hoc scripts).
-* ``WorkerSettings`` — adds GitHub token, external API timeouts, and the
-  labs verification secret. Used by the Verification Functions worker.
-* ``WebSettings`` — adds GitHub OAuth, session secret, CORS, docs, and
-  rate-limit config. Used by the FastAPI webapp.
-
-Each entry-point should call :func:`configure_settings` with the most
-specific class it needs before the first ``get_*_settings()`` call::
-
-    # api/alembic/env.py
-    configure_settings(DatabaseSettings)
-
-    # apps/verification-functions/function_app.py
-    configure_settings(WorkerSettings)
-
-    # api/src/learn_to_cloud/main.py — implicit (WebSettings is the default)
-
-Validation is enforced at construction time based on the
-``Environment`` enum. In ``production`` the webapp requires GitHub OAuth
-credentials and a non-default session secret; in ``development`` (used
-by local dev, the dog-food agent, and tests) both checks relax so the
-app starts without contributor-specific OAuth registrations.
-"""
+"""Application configuration split by runtime profile."""
 
 from __future__ import annotations
 
 from enum import StrEnum
-from functools import cached_property
+from functools import lru_cache
 from importlib.resources import files
 from pathlib import Path
-from typing import Self
+from typing import Any, Self
 
-from pydantic import Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Environment(StrEnum):
-    """Runtime environment for the webapp.
-
-    ``development`` relaxes web-specific validation so local dev and the
-    dog-food agent can run without contributor-specific OAuth credentials
-    or a custom session secret. ``production`` enforces both strictly.
-    """
+    """Runtime environment for the webapp."""
 
     DEVELOPMENT = "development"
     PRODUCTION = "production"
@@ -53,69 +21,92 @@ class Environment(StrEnum):
 
 _DEV_SESSION_SECRET = "dev-secret-key-change-in-production"
 
+_SETTINGS_CONFIG = SettingsConfigDict(
+    env_file=".env",
+    env_file_encoding="utf-8",
+    env_nested_delimiter="__",
+    nested_model_default_partial_update=True,
+    extra="ignore",
+    frozen=True,
+)
 
-class DatabaseSettings(BaseSettings):
-    """Minimal settings for DB-only processes (alembic, migration job)."""
 
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        env_file_encoding="utf-8",
-        extra="ignore",
-        frozen=True,
-    )
+def _load_from_environment[SettingsT: BaseSettings](
+    settings_type: type[SettingsT],
+) -> SettingsT:
+    values: dict[str, Any] = {}
+    return settings_type(**values)
 
-    database_url: str = ""
 
-    # Azure PostgreSQL with Managed Identity — takes precedence over database_url
-    postgres_host: str = ""
-    postgres_port: int = 5432
-    postgres_database: str = "learntocloud"
-    postgres_user: str = ""
+class FrozenConfig(BaseModel):
+    """Immutable nested config base."""
 
-    # Connection pool + timeouts.
-    # Total connections per worker = pool_size + max_overflow.
-    db_timeout: int = 30
-    db_pool_size: int = 5
-    db_pool_max_overflow: int = 5
-    db_pool_timeout: int = 30
-    db_pool_recycle: int = 1800
-    db_statement_timeout_ms: int = 10000
-    db_echo: bool = False
+    model_config = {"frozen": True}
+
+
+class DatabaseConfig(FrozenConfig):
+    """Database connection, pool, and timeout config."""
+
+    url: str = ""
+
+    # Azure PostgreSQL with Managed Identity takes precedence over url.
+    host: str = ""
+    port: int = 5432
+    name: str = "learntocloud"
+    user: str = ""
+
+    timeout: int = 30
+    pool_size: int = 5
+    pool_max_overflow: int = 5
+    pool_timeout: int = 30
+    pool_recycle: int = 1800
+    statement_timeout_ms: int = 10000
+    echo: bool = False
 
     @model_validator(mode="after")
     def _validate_database(self) -> Self:
-        if not self.database_url and not self.use_azure_postgres:
+        if not self.url and not self.use_azure_postgres:
             raise ValueError(
                 "Database configuration required. "
-                "Set DATABASE_URL for direct connection, "
-                "or POSTGRES_HOST + POSTGRES_USER for Azure Managed Identity."
+                "Set DATABASE__URL for direct connection, "
+                "or DATABASE__HOST + DATABASE__USER for Azure Managed Identity."
             )
         return self
 
     @property
     def use_azure_postgres(self) -> bool:
-        """When True, connection is built from postgres_* fields."""
-        return bool(self.postgres_host and self.postgres_user)
+        """When True, connection is built from Azure PostgreSQL fields."""
+        return bool(self.host and self.user)
 
 
-class WorkerSettings(DatabaseSettings):
-    """Settings for background workers (Verification Functions).
+class GitHubConfig(FrozenConfig):
+    """Server-to-server GitHub API access."""
 
-    Adds GitHub server-to-server token, external API timeouts, the labs
-    verification secret, and content path resolution. No web/OAuth/session
-    concerns — workers never serve user requests.
-    """
+    token: str = ""
 
-    github_token: str = ""
-    labs_verification_secret: str = ""
+
+class LabsConfig(FrozenConfig):
+    """Lab verification config."""
+
+    verification_secret: str = ""
+
+
+class HttpConfig(FrozenConfig):
+    """Shared outbound HTTP config."""
+
     external_api_timeout: float = 15.0
-    content_dir: str = ""
 
-    @cached_property
-    def content_dir_path(self) -> Path:
+
+class ContentConfig(FrozenConfig):
+    """Authored curriculum content config."""
+
+    dir: str = ""
+
+    @property
+    def dir_path(self) -> Path:
         """Resolve authored curriculum YAML for sync and validation jobs."""
-        if self.content_dir:
-            return Path(self.content_dir)
+        if self.dir:
+            return Path(self.dir)
 
         source_content = Path(
             str(files("learn_to_cloud_shared").joinpath("content", "phases"))
@@ -124,75 +115,36 @@ class WorkerSettings(DatabaseSettings):
             return source_content
 
         raise RuntimeError(
-            "CONTENT_DIR is required because curriculum YAML is not packaged "
-            "with learn-to-cloud-shared. Set CONTENT_DIR to the copied "
+            "CONTENT__DIR is required because curriculum YAML is not packaged "
+            "with learn-to-cloud-shared. Set CONTENT__DIR to the copied "
             "content/phases directory in jobs that sync or validate YAML."
         )
 
 
-class WebSettings(WorkerSettings):
-    """Full settings for the FastAPI webapp.
+class OAuthConfig(FrozenConfig):
+    """User-facing GitHub OAuth config."""
 
-    Adds OAuth, session, CORS, docs, rate-limit, and frontend telemetry
-    config. Validation enforces production hardening: GitHub OAuth must
-    be configured and the session secret must not be the dev default
-    whenever ``environment == production``.
-    """
+    client_id: str = ""
+    client_secret: str = ""
 
-    environment: Environment = Environment.PRODUCTION
 
-    github_client_id: str = ""
-    github_client_secret: str = ""
+class SessionConfig(FrozenConfig):
+    """Session cookie config."""
 
-    session_secret_key: str = _DEV_SESSION_SECRET
+    secret_key: str = _DEV_SESSION_SECRET
 
-    cors_allowed_origins: str = ""
+
+class CorsConfig(FrozenConfig):
+    """Frontend URL and CORS config."""
+
+    allowed_origins: str = ""
     frontend_url: str = "http://localhost:4280"
-    frontend_applicationinsights_connection_string: str = ""
-    frontend_telemetry_sampling_percentage: float = Field(
-        default=100.0, ge=0.0, le=100.0
-    )
 
-    startup_timeout: int = 60
-    verification_wait_timeout: int = 180
-
-    verification_functions_base_url: str = ""
-    verification_functions_key: str = ""
-
-    # memory:// only works for single-instance deployments
-    ratelimit_storage_uri: str = "memory://"
-
-    require_https: bool = True
-    enable_docs: bool = False
-
-    @model_validator(mode="after")
-    def _validate_web(self) -> Self:
-        if self.environment is Environment.PRODUCTION:
-            if not self.github_client_id or not self.github_client_secret:
-                raise ValueError(
-                    "GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET must be set "
-                    "when ENVIRONMENT=production."
-                )
-            if (
-                not self.session_secret_key
-                or self.session_secret_key == _DEV_SESSION_SECRET
-            ):
-                raise ValueError(
-                    "SESSION_SECRET_KEY must be set to a secure random value "
-                    "when ENVIRONMENT=production."
-                )
-        return self
-
-    @property
-    def is_development(self) -> bool:
-        return self.environment is Environment.DEVELOPMENT
-
-    @cached_property
-    def allowed_origins(self) -> list[str]:
-        """Combines localhost (dev only), frontend_url, and cors_allowed_origins."""
+    def origin_list(self, *, is_development: bool) -> list[str]:
+        """Combine localhost, frontend_url, and CSV configured origins."""
         origins: list[str] = []
 
-        if self.is_development:
+        if is_development:
             origins.extend(
                 [
                     "http://localhost:3000",
@@ -203,8 +155,8 @@ class WebSettings(WorkerSettings):
         if self.frontend_url and self.frontend_url not in origins:
             origins.append(self.frontend_url)
 
-        if self.cors_allowed_origins:
-            for origin in self.cors_allowed_origins.split(","):
+        if self.allowed_origins:
+            for origin in self.allowed_origins.split(","):
                 origin = origin.strip()
                 if origin and origin not in origins:
                     origins.append(origin)
@@ -212,88 +164,230 @@ class WebSettings(WorkerSettings):
         return origins
 
 
-# ---------------------------------------------------------------------------
-# Registry — entry-points pick the most specific class their process needs;
-# shared modules pull via the typed accessors below.
-# ---------------------------------------------------------------------------
+class FrontendTelemetryConfig(FrozenConfig):
+    """Frontend telemetry config exposed to templates."""
+
+    applicationinsights_connection_string: str = ""
+    sampling_percentage: float = Field(default=100.0, ge=0.0, le=100.0)
 
 
-_registered_class: type[DatabaseSettings] = WebSettings
-_instance: DatabaseSettings | None = None
+class VerificationFunctionsConfig(FrozenConfig):
+    """Durable verification Functions starter config."""
+
+    base_url: str = ""
+    key: str = ""
 
 
-def configure_settings(cls: type[DatabaseSettings]) -> None:
-    """Bind the Settings subclass for this process.
+class RateLimitConfig(FrozenConfig):
+    """Rate-limit storage config."""
 
-    Must be called at process startup, before the first ``get_*_settings``
-    call. Idempotent when the existing instance already satisfies ``cls``
-    (e.g. a WebSettings instance satisfies a DatabaseSettings request via
-    inheritance). Raises only when the requested class is MORE specific
-    than the constructed instance, which would require validation the
-    instance never ran.
-    """
-    global _registered_class, _instance
-    if _instance is not None and not isinstance(_instance, cls):
-        raise RuntimeError(
-            f"configure_settings({cls.__name__}) called after "
-            f"{type(_instance).__name__} was already constructed. "
-            "Call clear_settings_cache() first if reconfiguration is intentional."
-        )
-    _registered_class = cls
+    # memory:// only works for single-instance deployments.
+    storage_uri: str = "memory://"
 
 
-def get_database_settings() -> DatabaseSettings:
-    """Return the active settings, typed as the minimal ``DatabaseSettings``.
+class WebSecurityConfig(FrozenConfig):
+    """Web security and documentation toggles."""
 
-    Safe to call from any process: every supported settings class derives
-    from ``DatabaseSettings``.
-    """
-    global _instance
-    if _instance is None:
-        _instance = _registered_class()
-    return _instance
+    require_https: bool = True
+    enable_docs: bool = False
 
 
+def _nested_missing(data: dict[str, Any], section: str, field: str) -> bool:
+    value = data.get(section)
+    return not isinstance(value, dict) or value.get(field) in (None, "")
+
+
+def _copy_flat(data: dict[str, Any], *, flat: str, section: str, field: str) -> None:
+    value = data.get(flat)
+    if value in (None, "") or not _nested_missing(data, section, field):
+        return
+    nested = data.setdefault(section, {})
+    if isinstance(nested, dict):
+        nested[field] = value
+
+
+def _apply_flat_compat(data: dict[str, Any]) -> dict[str, Any]:
+    for flat, section, field in (
+        ("database_url", "database", "url"),
+        ("postgres_host", "database", "host"),
+        ("postgres_port", "database", "port"),
+        ("postgres_database", "database", "name"),
+        ("postgres_user", "database", "user"),
+        ("db_timeout", "database", "timeout"),
+        ("db_pool_size", "database", "pool_size"),
+        ("db_pool_max_overflow", "database", "pool_max_overflow"),
+        ("db_pool_timeout", "database", "pool_timeout"),
+        ("db_pool_recycle", "database", "pool_recycle"),
+        ("db_statement_timeout_ms", "database", "statement_timeout_ms"),
+        ("db_echo", "database", "echo"),
+        ("github_token", "github", "token"),
+        ("labs_verification_secret", "labs", "verification_secret"),
+        ("external_api_timeout", "http", "external_api_timeout"),
+        ("content_dir", "content", "dir"),
+        ("github_client_id", "oauth", "client_id"),
+        ("github_client_secret", "oauth", "client_secret"),
+        ("session_secret_key", "session", "secret_key"),
+        ("cors_allowed_origins", "cors", "allowed_origins"),
+        ("frontend_url", "cors", "frontend_url"),
+        (
+            "frontend_applicationinsights_connection_string",
+            "frontend_telemetry",
+            "applicationinsights_connection_string",
+        ),
+        (
+            "frontend_telemetry_sampling_percentage",
+            "frontend_telemetry",
+            "sampling_percentage",
+        ),
+        (
+            "verification_functions_base_url",
+            "verification_functions",
+            "base_url",
+        ),
+        ("verification_functions_key", "verification_functions", "key"),
+        ("ratelimit_storage_uri", "rate_limit", "storage_uri"),
+        ("require_https", "web_security", "require_https"),
+        ("enable_docs", "web_security", "enable_docs"),
+    ):
+        _copy_flat(data, flat=flat, section=section, field=field)
+    return data
+
+
+class _FlatCompatMixin:
+    """Temporary flat env var support during the nested settings rollout."""
+
+    database_url: str = Field(default="", exclude=True)
+    postgres_host: str = Field(default="", exclude=True)
+    postgres_port: int | None = Field(default=None, exclude=True)
+    postgres_database: str = Field(default="", exclude=True)
+    postgres_user: str = Field(default="", exclude=True)
+    db_timeout: int | None = Field(default=None, exclude=True)
+    db_pool_size: int | None = Field(default=None, exclude=True)
+    db_pool_max_overflow: int | None = Field(default=None, exclude=True)
+    db_pool_timeout: int | None = Field(default=None, exclude=True)
+    db_pool_recycle: int | None = Field(default=None, exclude=True)
+    db_statement_timeout_ms: int | None = Field(default=None, exclude=True)
+    db_echo: bool | None = Field(default=None, exclude=True)
+
+    github_token: str = Field(default="", exclude=True)
+    labs_verification_secret: str = Field(default="", exclude=True)
+    external_api_timeout: float | None = Field(default=None, exclude=True)
+    content_dir: str = Field(default="", exclude=True)
+
+    github_client_id: str = Field(default="", exclude=True)
+    github_client_secret: str = Field(default="", exclude=True)
+    session_secret_key: str = Field(default="", exclude=True)
+    cors_allowed_origins: str = Field(default="", exclude=True)
+    frontend_url: str = Field(default="", exclude=True)
+    frontend_applicationinsights_connection_string: str = Field(
+        default="", exclude=True
+    )
+    frontend_telemetry_sampling_percentage: float | None = Field(
+        default=None, exclude=True
+    )
+    verification_functions_base_url: str = Field(default="", exclude=True)
+    verification_functions_key: str = Field(default="", exclude=True)
+    ratelimit_storage_uri: str = Field(default="", exclude=True)
+    require_https: bool | None = Field(default=None, exclude=True)
+    enable_docs: bool | None = Field(default=None, exclude=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_flat_env(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            return _apply_flat_compat(data)
+        return data
+
+
+class MigrationSettings(_FlatCompatMixin, BaseSettings):
+    """Settings loaded by Alembic and migration jobs."""
+
+    model_config = _SETTINGS_CONFIG
+
+    database: DatabaseConfig
+    content: ContentConfig = ContentConfig()
+
+
+class WorkerSettings(_FlatCompatMixin, BaseSettings):
+    """Settings for background workers and shared verification code."""
+
+    model_config = _SETTINGS_CONFIG
+
+    database: DatabaseConfig
+    github: GitHubConfig = GitHubConfig()
+    labs: LabsConfig = LabsConfig()
+    http: HttpConfig = HttpConfig()
+    content: ContentConfig = ContentConfig()
+
+
+class WebSettings(_FlatCompatMixin, BaseSettings):
+    """Settings for the FastAPI webapp."""
+
+    model_config = _SETTINGS_CONFIG
+
+    environment: Environment = Environment.PRODUCTION
+    database: DatabaseConfig
+    github: GitHubConfig = GitHubConfig()
+    labs: LabsConfig = LabsConfig()
+    http: HttpConfig = HttpConfig()
+    content: ContentConfig = ContentConfig()
+    oauth: OAuthConfig = OAuthConfig()
+    session: SessionConfig = SessionConfig()
+    cors: CorsConfig = CorsConfig()
+    frontend_telemetry: FrontendTelemetryConfig = FrontendTelemetryConfig()
+    verification_functions: VerificationFunctionsConfig = VerificationFunctionsConfig()
+    rate_limit: RateLimitConfig = RateLimitConfig()
+    web_security: WebSecurityConfig = WebSecurityConfig()
+    startup_timeout: int = 60
+    verification_wait_timeout: int = 180
+
+    @model_validator(mode="after")
+    def _validate_web(self) -> Self:
+        if self.environment is Environment.PRODUCTION:
+            if not self.oauth.client_id or not self.oauth.client_secret:
+                raise ValueError(
+                    "OAUTH__CLIENT_ID and OAUTH__CLIENT_SECRET must be set "
+                    "when ENVIRONMENT=production."
+                )
+            if (
+                not self.session.secret_key
+                or self.session.secret_key == _DEV_SESSION_SECRET
+            ):
+                raise ValueError(
+                    "SESSION__SECRET_KEY must be set to a secure random value "
+                    "when ENVIRONMENT=production."
+                )
+        return self
+
+    @property
+    def is_development(self) -> bool:
+        return self.environment is Environment.DEVELOPMENT
+
+    @property
+    def allowed_origins(self) -> list[str]:
+        return self.cors.origin_list(is_development=self.is_development)
+
+
+@lru_cache
+def get_migration_settings() -> MigrationSettings:
+    """Return cached migration settings."""
+    return _load_from_environment(MigrationSettings)
+
+
+@lru_cache
 def get_worker_settings() -> WorkerSettings:
-    """Return the active settings, typed as ``WorkerSettings``.
-
-    Raises if the process configured only ``DatabaseSettings`` — the
-    caller is asking for fields a DB-only profile doesn't have.
-    """
-    settings = get_database_settings()
-    if not isinstance(settings, WorkerSettings):
-        raise RuntimeError(
-            "WorkerSettings requested but process is configured with "
-            f"{type(settings).__name__}. Call configure_settings(WorkerSettings) "
-            "before the first get_*_settings() call."
-        )
-    return settings
+    """Return cached worker settings."""
+    return _load_from_environment(WorkerSettings)
 
 
+@lru_cache
 def get_web_settings() -> WebSettings:
-    """Return the active settings, typed as ``WebSettings``.
-
-    Raises if the process is not configured with ``WebSettings``. Webapp
-    code calls this directly so the static type ``WebSettings`` flows
-    through every access — fields the worker or DB profiles lack become
-    type errors at the call site instead of runtime ``AttributeError``.
-    """
-    settings = get_database_settings()
-    if not isinstance(settings, WebSettings):
-        raise RuntimeError(
-            "WebSettings requested but process is configured with "
-            f"{type(settings).__name__}. Call configure_settings(WebSettings) "
-            "before the first get_*_settings() call."
-        )
-    return settings
+    """Return cached web settings for FastAPI dependency injection."""
+    return _load_from_environment(WebSettings)
 
 
 def clear_settings_cache() -> None:
-    """Reset the cached settings instance.
-
-    Tests use this to swap settings between cases. After clearing, the
-    next ``get_*_settings()`` call constructs a fresh instance of the
-    currently-registered class.
-    """
-    global _instance
-    _instance = None
+    """Clear cached settings instances in tests."""
+    get_migration_settings.cache_clear()
+    get_worker_settings.cache_clear()
+    get_web_settings.cache_clear()

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/database.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/database.py
@@ -24,7 +24,7 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.orm import DeclarativeBase
 
 from learn_to_cloud_shared.core.azure_auth import get_token as _get_azure_token
-from learn_to_cloud_shared.core.config import get_database_settings
+from learn_to_cloud_shared.core.config import DatabaseConfig
 from learn_to_cloud_shared.core.observability import instrument_database
 
 logger = logging.getLogger(__name__)
@@ -34,53 +34,52 @@ class Base(DeclarativeBase):
     pass
 
 
-def _build_azure_database_url() -> str:
-    settings = get_database_settings()
+def _build_azure_database_url(settings: DatabaseConfig) -> str:
     return (
-        f"postgresql+asyncpg://{settings.postgres_user}"
-        f"@{settings.postgres_host}:{settings.postgres_port}/{settings.postgres_database}"
+        f"postgresql+asyncpg://{settings.user}"
+        f"@{settings.host}:{settings.port}/{settings.name}"
         f"?ssl=require"
     )
 
 
-async def _azure_asyncpg_creator():
+async def _azure_asyncpg_creator(settings: DatabaseConfig):
     """Create an asyncpg connection using a fresh Entra ID token.
 
     Tokens expire (~1 hour), so each new connection fetches a fresh one
     via managed identity.
     """
-    settings = get_database_settings()
     token = await _get_azure_token()
 
     try:
         return await asyncpg.connect(
-            user=settings.postgres_user,
+            user=settings.user,
             password=token,
-            host=settings.postgres_host,
-            port=settings.postgres_port,
-            database=settings.postgres_database,
+            host=settings.host,
+            port=settings.port,
+            database=settings.name,
             ssl="require",
-            timeout=settings.db_timeout,
+            timeout=settings.timeout,
             server_settings={
-                "statement_timeout": str(settings.db_statement_timeout_ms),
+                "statement_timeout": str(settings.statement_timeout_ms),
             },
         )
     except asyncpg.PostgresConnectionError:
         logger.exception(
             "db.connection.failed",
-            extra={"host": settings.postgres_host, "port": settings.postgres_port},
+            extra={"host": settings.host, "port": settings.port},
         )
         raise
 
 
-def create_engine() -> AsyncEngine:
-    settings = get_database_settings()
-
+def create_engine(settings: DatabaseConfig) -> AsyncEngine:
     if settings.use_azure_postgres:
-        database_url = _build_azure_database_url()
-        async_creator = _azure_asyncpg_creator
+        database_url = _build_azure_database_url(settings)
+
+        async def async_creator() -> asyncpg.Connection:
+            return await _azure_asyncpg_creator(settings)
+
     else:
-        database_url = settings.database_url
+        database_url = settings.url
         async_creator = None
 
     # Note: pool_pre_ping is intentionally NOT enabled. It interacts badly
@@ -89,18 +88,16 @@ def create_engine() -> AsyncEngine:
     # within Azure's idle timeout window; the (rare) silently-dropped
     # connection surfaces as a single failed request that the user retries.
     engine_kwargs: dict = {
-        "echo": settings.db_echo,
-        "pool_size": settings.db_pool_size,
-        "max_overflow": settings.db_pool_max_overflow,
-        "pool_timeout": settings.db_pool_timeout,
-        "pool_recycle": settings.db_pool_recycle,
+        "echo": settings.echo,
+        "pool_size": settings.pool_size,
+        "max_overflow": settings.pool_max_overflow,
+        "pool_timeout": settings.pool_timeout,
+        "pool_recycle": settings.pool_recycle,
     }
 
     if async_creator is None:
         engine_kwargs["connect_args"] = {
-            "server_settings": {
-                "statement_timeout": str(settings.db_statement_timeout_ms)
-            }
+            "server_settings": {"statement_timeout": str(settings.statement_timeout_ms)}
         }
     else:
         engine_kwargs["async_creator"] = async_creator
@@ -165,11 +162,11 @@ DbSession = Annotated[AsyncSession, Depends(get_db)]
 DbSessionReadOnly = Annotated[AsyncSession, Depends(get_db_readonly)]
 
 
-async def init_db(engine: AsyncEngine) -> None:
+async def init_db(engine: AsyncEngine, settings: DatabaseConfig) -> None:
     """Verify database is reachable. Schema managed via migrations."""
     logger.info("db.connectivity.verifying")
 
-    async with asyncio.timeout(get_database_settings().db_timeout):
+    async with asyncio.timeout(settings.timeout):
         async with engine.connect() as conn:
             await conn.execute(text("SELECT 1"))
             await conn.rollback()
@@ -181,9 +178,9 @@ async def dispose_engine(engine: AsyncEngine) -> None:
     logger.info("db.engine.disposed")
 
 
-async def check_db_connection(engine: AsyncEngine) -> None:
+async def check_db_connection(engine: AsyncEngine, settings: DatabaseConfig) -> None:
     """Verify database is reachable."""
-    async with asyncio.timeout(get_database_settings().db_timeout):
+    async with asyncio.timeout(settings.timeout):
         async with engine.connect() as conn:
             await conn.execute(text("SELECT 1"))
             await conn.rollback()

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/github_client.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/github_client.py
@@ -15,7 +15,7 @@ from learn_to_cloud_shared.core.http_client import PooledClient
 def _build_github_client() -> httpx.AsyncClient:
     settings = get_worker_settings()
     return httpx.AsyncClient(
-        timeout=settings.external_api_timeout,
+        timeout=settings.http.external_api_timeout,
         follow_redirects=True,
         limits=httpx.Limits(max_connections=20, max_keepalive_connections=10),
     )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
@@ -52,7 +52,7 @@ from learn_to_cloud_shared.verification.errors import (
 def _build_deployed_api_client() -> httpx.AsyncClient:
     return httpx.AsyncClient(
         timeout=httpx.Timeout(
-            get_worker_settings().external_api_timeout,
+            get_worker_settings().http.external_api_timeout,
             connect=5.0,
         ),
         follow_redirects=False,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
@@ -65,8 +65,8 @@ def get_github_headers() -> dict[str, str]:
     """Get headers for GitHub API requests, including auth token if available."""
     headers = {"Accept": "application/vnd.github.v3+json"}
     settings = get_worker_settings()
-    if settings.github_token:
-        headers["Authorization"] = f"Bearer {settings.github_token}"
+    if settings.github.token:
+        headers["Authorization"] = f"Bearer {settings.github.token}"
     return headers
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/token_base.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/token_base.py
@@ -22,7 +22,7 @@ from learn_to_cloud_shared.schemas import ValidationResult
 
 def _derive_secret(instance_id: str) -> str:
     """Derive an instance-specific secret via SHA-256."""
-    master_secret = get_worker_settings().labs_verification_secret
+    master_secret = get_worker_settings().labs.verification_secret
     if not master_secret:
         raise RuntimeError("Labs verification secret is not configured")
     data = f"{master_secret}:{instance_id}"

--- a/packages/learn-to-cloud-shared/tests/conftest.py
+++ b/packages/learn-to-cloud-shared/tests/conftest.py
@@ -4,11 +4,11 @@ import os
 from collections.abc import AsyncGenerator
 
 os.environ.setdefault(
-    "DATABASE_URL",
+    "DATABASE__URL",
     "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud",
 )
-os.environ.setdefault("GITHUB_TOKEN", "test_github_token")
-os.environ.setdefault("LABS_VERIFICATION_SECRET", "test_ctf_secret_must_be_32_chars!")
+os.environ.setdefault("GITHUB__TOKEN", "test_github_token")
+os.environ.setdefault("LABS__VERIFICATION_SECRET", "test_ctf_secret_must_be_32_chars!")
 os.environ.setdefault("ENVIRONMENT", "development")
 
 import pytest
@@ -37,12 +37,15 @@ from learn_to_cloud_shared.core.database import Base
 
 
 def _build_test_database_url() -> tuple[str, str, int]:
-    """Derive the isolated test database URL from DATABASE_URL."""
+    """Derive the isolated test database URL from configured environment."""
     from sqlalchemy.engine import make_url
 
     raw = os.environ.get(
-        "DATABASE_URL",
-        "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud",
+        "DATABASE__URL",
+        os.environ.get(
+            "DATABASE_URL",
+            "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud",
+        ),
     )
     url = make_url(raw)
     host = url.host or "localhost"

--- a/packages/learn-to-cloud-shared/tests/conftest.py
+++ b/packages/learn-to-cloud-shared/tests/conftest.py
@@ -22,7 +22,17 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.pool import NullPool
 
-from learn_to_cloud_shared.core.config import Environment, WebSettings
+from learn_to_cloud_shared.core.config import (
+    CorsConfig,
+    DatabaseConfig,
+    Environment,
+    GitHubConfig,
+    LabsConfig,
+    OAuthConfig,
+    SessionConfig,
+    WebSecurityConfig,
+    WebSettings,
+)
 from learn_to_cloud_shared.core.database import Base
 
 
@@ -49,15 +59,17 @@ _DB_AVAILABLE: bool | None = None
 def test_settings() -> WebSettings:
     """Create test settings pointing to the test database."""
     return WebSettings(
-        database_url=TEST_DATABASE_URL,
+        database=DatabaseConfig(url=TEST_DATABASE_URL),
         environment=Environment.DEVELOPMENT,
-        require_https=False,
-        github_client_id="test_github_client_id",
-        github_client_secret="test_github_client_secret",
-        session_secret_key="test_session_secret_key_for_testing",
-        github_token="test_github_token",
-        labs_verification_secret="test_ctf_secret_must_be_32_chars!",
-        cors_allowed_origins="",
+        web_security=WebSecurityConfig(require_https=False),
+        oauth=OAuthConfig(
+            client_id="test_github_client_id",
+            client_secret="test_github_client_secret",
+        ),
+        session=SessionConfig(secret_key="test_session_secret_key_for_testing"),
+        github=GitHubConfig(token="test_github_token"),
+        labs=LabsConfig(verification_secret="test_ctf_secret_must_be_32_chars!"),
+        cors=CorsConfig(allowed_origins=""),
     )
 
 

--- a/packages/learn-to-cloud-shared/tests/core/test_config.py
+++ b/packages/learn-to-cloud-shared/tests/core/test_config.py
@@ -1,108 +1,75 @@
-"""Unit tests for the split Settings classes.
-
-Tests cover:
-- DatabaseSettings / WorkerSettings / WebSettings validation per profile
-- Environment enum behavior (development vs production)
-- use_azure_postgres property (on the DB base class)
-- content_dir_path computed property (on the worker class)
-- allowed_origins computed property (on the web class) with deduplication
-- configure_settings / get_*_settings registry + clear_settings_cache
-"""
+"""Unit tests for composed Settings classes."""
 
 import pytest
 from pydantic import ValidationError
 
 from learn_to_cloud_shared.core.config import (
-    DatabaseSettings,
+    ContentConfig,
+    CorsConfig,
+    DatabaseConfig,
     Environment,
+    FrontendTelemetryConfig,
+    GitHubConfig,
+    LabsConfig,
+    MigrationSettings,
+    OAuthConfig,
+    SessionConfig,
+    WebSecurityConfig,
     WebSettings,
     WorkerSettings,
     clear_settings_cache,
-    configure_settings,
-    get_database_settings,
     get_web_settings,
-    get_worker_settings,
 )
 
 
 @pytest.fixture(autouse=True)
-def _reset_registry():
-    """Reset the module-level registry between tests."""
+def _reset_settings_cache():
     clear_settings_cache()
-    configure_settings(WebSettings)  # restore default after every test
     yield
     clear_settings_cache()
-    configure_settings(WebSettings)
-
-
-# ---------------------------------------------------------------------------
-# DatabaseSettings — the minimal class
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestDatabaseSettings:
+class TestDatabaseConfig:
     def test_accepts_database_url(self):
-        s = DatabaseSettings(database_url="postgresql+asyncpg://localhost/test")
-        assert s.database_url == "postgresql+asyncpg://localhost/test"
+        s = DatabaseConfig(url="postgresql+asyncpg://localhost/test")
+        assert s.url == "postgresql+asyncpg://localhost/test"
 
-    def test_requires_database_config(self, monkeypatch: pytest.MonkeyPatch):
-        # The test conftest sets DATABASE_URL — bypass it to exercise the validator.
-        monkeypatch.delenv("DATABASE_URL", raising=False)
-        monkeypatch.delenv("POSTGRES_HOST", raising=False)
-        monkeypatch.delenv("POSTGRES_USER", raising=False)
+    def test_requires_database_config(self):
         with pytest.raises(ValidationError, match="Database configuration"):
-            DatabaseSettings(_env_file=None)  # type: ignore[call-arg]
+            DatabaseConfig()
 
     def test_azure_postgres_satisfies_database_requirement(self):
-        s = DatabaseSettings(
-            database_url="",
-            postgres_host="myhost.postgres.database.azure.com",
-            postgres_user="myuser",
+        s = DatabaseConfig(
+            url="",
+            host="myhost.postgres.database.azure.com",
+            user="myuser",
         )
         assert s.use_azure_postgres is True
 
 
-# ---------------------------------------------------------------------------
-# WorkerSettings
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
 class TestWorkerSettings:
-    def test_inherits_database_validation(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.delenv("DATABASE_URL", raising=False)
-        monkeypatch.delenv("POSTGRES_HOST", raising=False)
-        monkeypatch.delenv("POSTGRES_USER", raising=False)
-        with pytest.raises(ValidationError, match="Database configuration"):
-            WorkerSettings(_env_file=None)  # type: ignore[call-arg]
-
-    def test_accepts_worker_fields(self):
+    def test_accepts_worker_sections(self):
         s = WorkerSettings(
-            database_url="postgresql+asyncpg://localhost/test",
-            github_token="ghp_xxx",
-            labs_verification_secret="secret",
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/test"),
+            github=GitHubConfig(token="ghp_xxx"),
+            labs=LabsConfig(verification_secret="secret"),
         )
-        assert s.github_token == "ghp_xxx"
-        assert s.labs_verification_secret == "secret"
+        assert s.github.token == "ghp_xxx"
+        assert s.labs.verification_secret == "secret"
 
     def test_no_oauth_validation(self):
-        # Worker MUST be allowed to start without web-only OAuth creds.
-        # The validator on WebSettings doesn't exist on WorkerSettings,
-        # so this simply needs to construct successfully.
-        WorkerSettings(database_url="postgresql+asyncpg://localhost/test")
-
-
-# ---------------------------------------------------------------------------
-# WebSettings — environment-driven validation
-# ---------------------------------------------------------------------------
+        WorkerSettings(
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/test")
+        )
 
 
 @pytest.mark.unit
 class TestWebSettingsValidation:
     def test_development_allows_defaults(self):
         s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/test",
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/test"),
             environment="development",
         )
         assert s.environment is Environment.DEVELOPMENT
@@ -110,109 +77,72 @@ class TestWebSettingsValidation:
 
     def test_development_does_not_require_oauth(self):
         s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/test",
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/test"),
             environment="development",
         )
-        assert s.github_client_id == ""
+        assert s.oauth.client_id == ""
 
     def test_production_requires_github_credentials(self):
-        with pytest.raises(ValidationError, match="GITHUB_CLIENT_ID"):
+        with pytest.raises(ValidationError, match="OAUTH__CLIENT_ID"):
             WebSettings(
-                database_url="postgresql+asyncpg://localhost/test",
+                database=DatabaseConfig(url="postgresql+asyncpg://localhost/test"),
                 environment="production",
-                github_client_id="",
-                github_client_secret="",
+                oauth=OAuthConfig(client_id="", client_secret=""),
             )
 
     def test_production_requires_session_secret(self):
-        with pytest.raises(ValidationError, match="SESSION_SECRET_KEY"):
+        with pytest.raises(ValidationError, match="SESSION__SECRET_KEY"):
             WebSettings(
-                database_url="postgresql+asyncpg://localhost/test",
+                database=DatabaseConfig(url="postgresql+asyncpg://localhost/test"),
                 environment="production",
-                github_client_id="id",
-                github_client_secret="secret",
-                # Default session secret should be rejected in production
+                oauth=OAuthConfig(client_id="id", client_secret="secret"),
             )
 
     def test_production_accepts_valid_config(self):
         s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/test",
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/test"),
             environment="production",
-            github_client_id="id",
-            github_client_secret="secret",
-            session_secret_key="a-real-secret-not-the-default",
+            oauth=OAuthConfig(client_id="id", client_secret="secret"),
+            session=SessionConfig(secret_key="a-real-secret-not-the-default"),
         )
         assert s.environment is Environment.PRODUCTION
         assert s.is_development is False
 
 
-# ---------------------------------------------------------------------------
-# content_dir_path (lives on WorkerSettings, available on WebSettings via MRO)
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
 class TestContentDirPath:
     def test_custom_path_from_setting(self):
-        s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/db",
-            environment="development",
-            content_dir="/custom/path",
-        )
-        assert s.content_dir_path.as_posix() == "/custom/path"
+        s = ContentConfig(dir="/custom/path")
+        assert s.dir_path.as_posix() == "/custom/path"
 
     def test_default_fallback(self):
-        s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/db",
-            environment="development",
-        )
-        assert s.content_dir_path.name == "phases"
-        assert "content" in s.content_dir_path.parts
-
-
-# ---------------------------------------------------------------------------
-# Frontend telemetry
-# ---------------------------------------------------------------------------
+        s = ContentConfig()
+        assert s.dir_path.name == "phases"
+        assert "content" in s.dir_path.parts
 
 
 @pytest.mark.unit
 class TestFrontendTelemetryConfig:
     def test_defaults_to_disabled(self):
-        s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/db",
-            environment="development",
-        )
-        assert s.frontend_applicationinsights_connection_string == ""
-        assert s.frontend_telemetry_sampling_percentage == 100.0
+        s = FrontendTelemetryConfig()
+        assert s.applicationinsights_connection_string == ""
+        assert s.sampling_percentage == 100.0
 
     def test_accepts_frontend_connection_string(self):
         conn_str = "InstrumentationKey=abc;IngestionEndpoint=https://example.invalid/"
-        s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/db",
-            environment="development",
-            frontend_applicationinsights_connection_string=conn_str,
-        )
-        assert s.frontend_applicationinsights_connection_string == conn_str
+        s = FrontendTelemetryConfig(applicationinsights_connection_string=conn_str)
+        assert s.applicationinsights_connection_string == conn_str
 
     def test_rejects_invalid_frontend_telemetry_sampling_percentage(self):
         with pytest.raises(ValidationError):
-            WebSettings(
-                database_url="postgresql+asyncpg://localhost/db",
-                environment="development",
-                frontend_telemetry_sampling_percentage=101,
-            )
-
-
-# ---------------------------------------------------------------------------
-# allowed_origins
-# ---------------------------------------------------------------------------
+            FrontendTelemetryConfig(sampling_percentage=101)
 
 
 @pytest.mark.unit
 class TestAllowedOrigins:
     def test_development_includes_localhost(self):
         s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/db",
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/db"),
             environment="development",
         )
         assert "http://localhost:3000" in s.allowed_origins
@@ -220,81 +150,90 @@ class TestAllowedOrigins:
 
     def test_production_excludes_localhost(self):
         s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/db",
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/db"),
             environment="production",
-            github_client_id="id",
-            github_client_secret="secret",
-            session_secret_key="prod-secret",
+            oauth=OAuthConfig(client_id="id", client_secret="secret"),
+            session=SessionConfig(secret_key="prod-secret"),
         )
         assert "http://localhost:3000" not in s.allowed_origins
 
     def test_frontend_url_included(self):
         s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/db",
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/db"),
             environment="development",
-            frontend_url="https://app.example.com",
+            cors=CorsConfig(frontend_url="https://app.example.com"),
         )
         assert any(o == "https://app.example.com" for o in s.allowed_origins)
 
     def test_cors_allowed_origins_csv_parsed(self):
         s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/db",
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/db"),
             environment="development",
-            cors_allowed_origins="https://a.com, https://b.com",
+            cors=CorsConfig(allowed_origins="https://a.com, https://b.com"),
         )
         assert any(o == "https://a.com" for o in s.allowed_origins)
         assert any(o == "https://b.com" for o in s.allowed_origins)
 
     def test_deduplication(self):
         s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/db",
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/db"),
             environment="development",
-            frontend_url="http://localhost:4280",
+            cors=CorsConfig(frontend_url="http://localhost:4280"),
         )
         assert s.allowed_origins.count("http://localhost:4280") == 1
 
 
-# ---------------------------------------------------------------------------
-# Registry — configure_settings + get_*_settings + clear_settings_cache
-# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestFlatEnvCompatibility:
+    def test_old_database_url_populates_nested_database(self):
+        s = MigrationSettings(database_url="postgresql+asyncpg://localhost/db")
+        assert s.database.url == "postgresql+asyncpg://localhost/db"
+
+    def test_new_nested_database_wins_over_old_flat_database_url(self):
+        s = MigrationSettings(
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/new"),
+            database_url="postgresql+asyncpg://localhost/old",
+        )
+        assert s.database.url == "postgresql+asyncpg://localhost/new"
+
+    def test_old_web_flat_fields_populate_nested_sections(self):
+        s = WebSettings(
+            database_url="postgresql+asyncpg://localhost/db",
+            environment="production",
+            github_client_id="id",
+            github_client_secret="secret",
+            session_secret_key="prod-secret",
+            require_https=False,
+        )
+        assert s.database.url == "postgresql+asyncpg://localhost/db"
+        assert s.oauth.client_id == "id"
+        assert s.session.secret_key == "prod-secret"
+        assert s.web_security.require_https is False
 
 
 @pytest.mark.unit
-class TestSettingsRegistry:
-    def test_get_database_settings_works_with_web_default(self):
-        # The autouse fixture configures WebSettings; WebSettings ISA DatabaseSettings
-        s = get_database_settings()
-        assert isinstance(s, DatabaseSettings)
-
-    def test_get_worker_settings_requires_worker_or_web_profile(self):
-        configure_settings(DatabaseSettings)
-        with pytest.raises(RuntimeError, match="WorkerSettings"):
-            get_worker_settings()
-
-    def test_get_web_settings_requires_web_profile(self):
-        configure_settings(WorkerSettings)
-        with pytest.raises(RuntimeError, match="WebSettings"):
-            get_web_settings()
-
-    def test_clear_cache_allows_reconfiguration(self):
-        configure_settings(WebSettings)
-        get_database_settings()  # constructs WebSettings
+class TestSettingsFactories:
+    def test_get_web_settings_is_cached(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://localhost/db")
+        monkeypatch.setenv("ENVIRONMENT", "development")
         clear_settings_cache()
-        configure_settings(DatabaseSettings)
-        s = get_database_settings()
-        assert type(s) is DatabaseSettings
+        assert get_web_settings() is get_web_settings()
 
-    def test_configure_more_specific_after_construction_raises(self):
-        # Worker instance exists; configuring WebSettings (more specific —
-        # would need OAuth validation Worker never ran) must raise.
-        configure_settings(WorkerSettings)
-        get_database_settings()  # constructs WorkerSettings
-        with pytest.raises(RuntimeError, match="configure_settings"):
-            configure_settings(WebSettings)
+    def test_clear_settings_cache_reloads_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://localhost/one")
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        clear_settings_cache()
+        assert get_web_settings().database.url.endswith("/one")
 
-    def test_configure_less_specific_after_construction_is_noop(self):
-        # Web instance exists; configuring DatabaseSettings (less specific)
-        # is fine because WebSettings already satisfies the DB-only request.
-        configure_settings(WebSettings)
-        get_database_settings()  # constructs WebSettings
-        configure_settings(DatabaseSettings)  # should NOT raise
+        monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://localhost/two")
+        clear_settings_cache()
+        assert get_web_settings().database.url.endswith("/two")
+
+
+@pytest.mark.unit
+class TestWebSecurityConfig:
+    def test_require_https_can_be_disabled(self):
+        s = WebSecurityConfig(require_https=False)
+        assert s.require_https is False

--- a/packages/learn-to-cloud-shared/tests/core/test_config.py
+++ b/packages/learn-to-cloud-shared/tests/core/test_config.py
@@ -185,7 +185,10 @@ class TestAllowedOrigins:
 
 @pytest.mark.unit
 class TestFlatEnvCompatibility:
-    def test_old_database_url_populates_nested_database(self):
+    def test_old_database_url_populates_nested_database(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.delenv("DATABASE__URL", raising=False)
         s = MigrationSettings(database_url="postgresql+asyncpg://localhost/db")
         assert s.database.url == "postgresql+asyncpg://localhost/db"
 
@@ -196,7 +199,10 @@ class TestFlatEnvCompatibility:
         )
         assert s.database.url == "postgresql+asyncpg://localhost/new"
 
-    def test_old_web_flat_fields_populate_nested_sections(self):
+    def test_old_web_flat_fields_populate_nested_sections(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.delenv("DATABASE__URL", raising=False)
         s = WebSettings(
             database_url="postgresql+asyncpg://localhost/db",
             environment="production",
@@ -222,6 +228,7 @@ class TestSettingsFactories:
     def test_clear_settings_cache_reloads_environment(
         self, monkeypatch: pytest.MonkeyPatch
     ):
+        monkeypatch.delenv("DATABASE__URL", raising=False)
         monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://localhost/one")
         monkeypatch.setenv("ENVIRONMENT", "development")
         clear_settings_cache()

--- a/packages/learn-to-cloud-shared/tests/core/test_github_client.py
+++ b/packages/learn-to-cloud-shared/tests/core/test_github_client.py
@@ -33,7 +33,7 @@ class TestGetGitHubClient:
     @pytest.mark.asyncio
     async def test_creates_client_on_first_call(self):
         mock_settings = MagicMock()
-        mock_settings.external_api_timeout = 10.0
+        mock_settings.http.external_api_timeout = 10.0
         with patch(
             "learn_to_cloud_shared.core.github_client.get_worker_settings",
             autospec=True,
@@ -46,7 +46,7 @@ class TestGetGitHubClient:
     @pytest.mark.asyncio
     async def test_returns_same_instance(self):
         mock_settings = MagicMock()
-        mock_settings.external_api_timeout = 10.0
+        mock_settings.http.external_api_timeout = 10.0
         with patch(
             "learn_to_cloud_shared.core.github_client.get_worker_settings",
             autospec=True,
@@ -59,7 +59,7 @@ class TestGetGitHubClient:
     @pytest.mark.asyncio
     async def test_recreates_after_close(self):
         mock_settings = MagicMock()
-        mock_settings.external_api_timeout = 10.0
+        mock_settings.http.external_api_timeout = 10.0
         with patch(
             "learn_to_cloud_shared.core.github_client.get_worker_settings",
             autospec=True,

--- a/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
@@ -55,7 +55,7 @@ class TestParseRetryAfter:
 class TestGetGitHubHeaders:
     def test_includes_auth_when_token_present(self):
         mock_settings = MagicMock()
-        mock_settings.github_token = "ghp_test123"
+        mock_settings.github.token = "ghp_test123"
         with patch(
             "learn_to_cloud_shared.verification.github_profile.get_worker_settings",
             autospec=True,
@@ -67,7 +67,7 @@ class TestGetGitHubHeaders:
 
     def test_no_auth_when_token_missing(self):
         mock_settings = MagicMock()
-        mock_settings.github_token = ""
+        mock_settings.github.token = ""
         with patch(
             "learn_to_cloud_shared.verification.github_profile.get_worker_settings",
             autospec=True,

--- a/packages/learn-to-cloud-shared/tests/test_database.py
+++ b/packages/learn-to-cloud-shared/tests/test_database.py
@@ -14,6 +14,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from learn_to_cloud_shared.core.config import DatabaseConfig
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -136,6 +138,8 @@ class TestCloseCredential:
 class TestCheckDbConnection:
     """Verify check_db_connection has a timeout guard."""
 
+    _settings = DatabaseConfig(url="postgresql+asyncpg://localhost/test")
+
     async def test_timeout_on_hanging_connection(self):
         """check_db_connection should raise TimeoutError if DB hangs."""
         from learn_to_cloud_shared.core.database import check_db_connection
@@ -167,7 +171,7 @@ class TestCheckDbConnection:
             ),
             pytest.raises(TimeoutError),
         ):
-            await check_db_connection(mock_engine)
+            await check_db_connection(mock_engine, self._settings)
 
     async def test_success_path(self):
         """check_db_connection should succeed when DB responds."""
@@ -182,7 +186,7 @@ class TestCheckDbConnection:
         # connect() is a sync call returning an async CM
         mock_engine.connect = MagicMock(return_value=mock_cm)
 
-        await check_db_connection(mock_engine)
+        await check_db_connection(mock_engine, self._settings)
 
         mock_conn.execute.assert_awaited_once()
         mock_conn.rollback.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Refactors shared settings from inherited runtime classes into composed nested config models.
- Updates API, migration, shared worker, and Function app wiring to use nested settings sections.
- Updates local, Terraform, and deploy workflow environment variables to the new double-underscore names while keeping a temporary flat-name compatibility shim.
- Rewrites settings tests around composition and adds compatibility coverage.

Closes #450.

## Validation
- cd api && uv run ruff check . ../packages/learn-to-cloud-shared
- cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared
- cd api && uv run ty check --exclude scripts --exclude tests .
- cd packages/learn-to-cloud-shared && uv run ty check --exclude tests .
- cd api && uv run pytest tests/
- cd packages/learn-to-cloud-shared && uv run pytest tests/
- cd apps/verification-functions && uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run python -c "import function_app"