### PR TITLE
Remove flat settings compatibility layer

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -34,11 +34,14 @@ if [ ! -f api/.env ] && [ -f api/.env.example ]; then
     cp api/.env.example api/.env
 fi
 
-# Ensure DATABASE_URL uses the devcontainer Docker network hostname (db:5432).
+# Ensure DATABASE__URL uses the devcontainer Docker network hostname (db:5432).
 # This fixes stale .env files that point to localhost instead of the db service.
-if [ -f api/.env ] && ! grep -q "^DATABASE_URL=.*@db:5432/" api/.env; then
-    echo "📝 Updating DATABASE_URL to devcontainer DB host (db:5432)..."
-    sed -i 's|^DATABASE_URL=.*|DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud|' api/.env
+if [ -f api/.env ] && grep -q "^DATABASE_URL=" api/.env; then
+    echo "📝 Migrating DATABASE_URL to DATABASE__URL for devcontainer DB host (db:5432)..."
+    sed -i 's|^DATABASE_URL=.*|DATABASE__URL=postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud|' api/.env
+elif [ -f api/.env ] && ! grep -q "^DATABASE__URL=.*@db:5432/" api/.env; then
+    echo "📝 Updating DATABASE__URL to devcontainer DB host (db:5432)..."
+    sed -i 's|^DATABASE__URL=.*|DATABASE__URL=postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud|' api/.env
 fi
 
 # Ensure DEBUG=true is in .env for local development

--- a/.github/skills/validate/SKILL.md
+++ b/.github/skills/validate/SKILL.md
@@ -146,9 +146,9 @@ cd <workspace>/apps/verification-functions && uv run python -c "import function_
 
 **Mandatory when this change adds or modifies a `.github/workflows/deploy.yml` step that runs a Python script or command.**
 
-CI runs scripts with a minimal env (just `DATABASE_URL` is set in the `ci` job). Local dev shells almost always have more env vars set (devcontainer, `.env` files, shell history). Scripts that work locally can blow up in CI because they touch settings/config that demand env vars CI doesn't have.
+CI runs scripts with a minimal env (just `DATABASE__URL` is set in the `ci` job). Local dev shells almost always have more env vars set (devcontainer, `.env` files, shell history). Scripts that work locally can blow up in CI because they touch settings/config that demand env vars CI doesn't have.
 
-This step caught a real production failure (issue #469: `validate_content.py` instantiated `WebSettings` which required `GITHUB_CLIENT_ID`/`GITHUB_CLIENT_SECRET`, both unset in CI).
+This step caught a real production failure (issue #469: `validate_content.py` instantiated `WebSettings` which required `OAUTH__CLIENT_ID`/`OAUTH__CLIENT_SECRET`, both unset in CI).
 
 ### How to reproduce CI's env
 
@@ -156,11 +156,11 @@ Strip your shell to bare essentials, then re-run the new CI step's command exact
 
 ```bash
 env -i HOME=$HOME PATH=$PATH \
-    DATABASE_URL="postgresql+asyncpg://postgres:postgres@db:5432/learntocloud" \
+    DATABASE__URL="postgresql+asyncpg://postgres:postgres@db:5432/learntocloud" \
     uv run python <path/to/new_script.py>
 ```
 
-`env -i` clears all env vars. `HOME` and `PATH` are kept so `uv` and Python work. `DATABASE_URL` matches the value in `deploy.yml`'s `ci` job env block.
+`env -i` clears all env vars. `HOME` and `PATH` are kept so `uv` and Python work. `DATABASE__URL` matches the value in `deploy.yml`'s `ci` job env block.
 
 If the new CI step uses additional env vars in the workflow, add them here too — only the ones the workflow sets.
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,8 +12,8 @@
       "envFile": "${workspaceFolder}/api/.env",
       "env": {
         "DYLD_FALLBACK_LIBRARY_PATH": "/opt/homebrew/lib",
-        "VERIFICATION_FUNCTIONS_BASE_URL": "http://localhost:7071",
-        "VERIFICATION_FUNCTIONS_KEY": "local-dev",
+        "VERIFICATION_FUNCTIONS__BASE_URL": "http://localhost:7071",
+        "VERIFICATION_FUNCTIONS__KEY": "local-dev",
         "OTEL_EXPORTER_OTLP_ENDPOINT": "http://aspire-dashboard:18889",
         "OTEL_SERVICE_NAME": "learn-to-cloud-api"
       },

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ See the [Contributing Guide](docs/contributing.md) for linting, testing, the dog
 
 Push to `main` triggers automated deployment via GitHub Actions → Terraform → Azure.
 Production verification uses the GitHub Actions secret `TF_VAR_github_token`
-to populate the `GITHUB_TOKEN` environment variable used by verification jobs.
+to populate the `GITHUB__TOKEN` environment variable used by verification jobs.
 
 ## License
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -56,16 +56,13 @@ def _build_test_database_url() -> tuple[str, str, int]:
     """Derive test DB URL from the configured database env var.
 
     Returns (test_url, host, port). The test database is always
-    'test_learn_to_cloud' regardless of what DATABASE_URL specifies.
+    'test_learn_to_cloud' regardless of what DATABASE__URL specifies.
     """
     from sqlalchemy.engine import make_url
 
     raw = os.environ.get(
         "DATABASE__URL",
-        os.environ.get(
-            "DATABASE_URL",
-            "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud",
-        ),
+        "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud",
     )
     url = make_url(raw)
     host = url.host or "localhost"

--- a/api/tests/core/test_templates.py
+++ b/api/tests/core/test_templates.py
@@ -17,7 +17,10 @@ def _clear_settings():
 
 @pytest.mark.unit
 def test_frontend_telemetry_context_disabled_by_default(monkeypatch):
-    monkeypatch.delenv("FRONTEND_APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+    monkeypatch.delenv(
+        "FRONTEND_TELEMETRY__APPLICATIONINSIGHTS_CONNECTION_STRING",
+        raising=False,
+    )
 
     context = _frontend_telemetry_context(MagicMock())
 
@@ -27,7 +30,10 @@ def test_frontend_telemetry_context_disabled_by_default(monkeypatch):
 @pytest.mark.unit
 def test_frontend_telemetry_context_includes_connection_string(monkeypatch):
     conn_str = "InstrumentationKey=abc;IngestionEndpoint=https://example.invalid/"
-    monkeypatch.setenv("FRONTEND_APPLICATIONINSIGHTS_CONNECTION_STRING", conn_str)
+    monkeypatch.setenv(
+        "FRONTEND_TELEMETRY__APPLICATIONINSIGHTS_CONNECTION_STRING",
+        conn_str,
+    )
 
     context = _frontend_telemetry_context(MagicMock())
 
@@ -42,8 +48,11 @@ def test_frontend_telemetry_context_includes_connection_string(monkeypatch):
 @pytest.mark.unit
 def test_frontend_telemetry_context_includes_sampling_percentage(monkeypatch):
     conn_str = "InstrumentationKey=abc;IngestionEndpoint=https://example.invalid/"
-    monkeypatch.setenv("FRONTEND_APPLICATIONINSIGHTS_CONNECTION_STRING", conn_str)
-    monkeypatch.setenv("FRONTEND_TELEMETRY_SAMPLING_PERCENTAGE", "10")
+    monkeypatch.setenv(
+        "FRONTEND_TELEMETRY__APPLICATIONINSIGHTS_CONNECTION_STRING",
+        conn_str,
+    )
+    monkeypatch.setenv("FRONTEND_TELEMETRY__SAMPLING_PERCENTAGE", "10")
 
     context = _frontend_telemetry_context(MagicMock())
 

--- a/api/tests/test_migration_chain.py
+++ b/api/tests/test_migration_chain.py
@@ -37,10 +37,7 @@ __all__ = [
 def _sync_url() -> str:
     raw = os.environ.get(
         "DATABASE__URL",
-        os.environ.get(
-            "DATABASE_URL",
-            "postgresql+asyncpg://postgres:postgres@db:5432/learntocloud",
-        ),
+        "postgresql+asyncpg://postgres:postgres@db:5432/learntocloud",
     )
     return raw.replace("+asyncpg", "+psycopg2")
 

--- a/apps/verification-functions/local.settings.example.json
+++ b/apps/verification-functions/local.settings.example.json
@@ -5,15 +5,15 @@
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://dts:8080;TaskHub=default;Authentication=None",
     "TASKHUB_NAME": "default",
-    "DATABASE_URL": "postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud",
+    "DATABASE__URL": "postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud",
     "DEBUG": "true",
-    "GITHUB_TOKEN": "",
+    "GITHUB__TOKEN": "",
     "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "http://aspire-dashboard:18889",
     "OTEL_SERVICE_NAME": "learn-to-cloud-verification-functions",
     "FOUNDRY_PROJECT_ENDPOINT": "",
     "FOUNDRY_MODEL_DEPLOYMENT_NAME": "",
     "AzureWebJobsSecretStorageType": "Files",
-    "LABS_VERIFICATION_SECRET": "local_dev_secret_at_least_32_chars"
+    "LABS__VERIFICATION_SECRET": "local_dev_secret_at_least_32_chars"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,8 @@ services:
     ports:
       - "127.0.0.1:8000:8000"
     environment:
-      - DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud
-      - GITHUB_TOKEN=test_token
+      - DATABASE__URL=postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud
+      - GITHUB__TOKEN=test_token
       - APPLICATIONINSIGHTS_CONNECTION_STRING=
     depends_on:
       db:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
@@ -192,114 +192,7 @@ class WebSecurityConfig(FrozenConfig):
     enable_docs: bool = False
 
 
-def _nested_missing(data: dict[str, Any], section: str, field: str) -> bool:
-    value = data.get(section)
-    return not isinstance(value, dict) or value.get(field) in (None, "")
-
-
-def _copy_flat(data: dict[str, Any], *, flat: str, section: str, field: str) -> None:
-    value = data.get(flat)
-    if value in (None, "") or not _nested_missing(data, section, field):
-        return
-    nested = data.setdefault(section, {})
-    if isinstance(nested, dict):
-        nested[field] = value
-
-
-def _apply_flat_compat(data: dict[str, Any]) -> dict[str, Any]:
-    for flat, section, field in (
-        ("database_url", "database", "url"),
-        ("postgres_host", "database", "host"),
-        ("postgres_port", "database", "port"),
-        ("postgres_database", "database", "name"),
-        ("postgres_user", "database", "user"),
-        ("db_timeout", "database", "timeout"),
-        ("db_pool_size", "database", "pool_size"),
-        ("db_pool_max_overflow", "database", "pool_max_overflow"),
-        ("db_pool_timeout", "database", "pool_timeout"),
-        ("db_pool_recycle", "database", "pool_recycle"),
-        ("db_statement_timeout_ms", "database", "statement_timeout_ms"),
-        ("db_echo", "database", "echo"),
-        ("github_token", "github", "token"),
-        ("labs_verification_secret", "labs", "verification_secret"),
-        ("external_api_timeout", "http", "external_api_timeout"),
-        ("content_dir", "content", "dir"),
-        ("github_client_id", "oauth", "client_id"),
-        ("github_client_secret", "oauth", "client_secret"),
-        ("session_secret_key", "session", "secret_key"),
-        ("cors_allowed_origins", "cors", "allowed_origins"),
-        ("frontend_url", "cors", "frontend_url"),
-        (
-            "frontend_applicationinsights_connection_string",
-            "frontend_telemetry",
-            "applicationinsights_connection_string",
-        ),
-        (
-            "frontend_telemetry_sampling_percentage",
-            "frontend_telemetry",
-            "sampling_percentage",
-        ),
-        (
-            "verification_functions_base_url",
-            "verification_functions",
-            "base_url",
-        ),
-        ("verification_functions_key", "verification_functions", "key"),
-        ("ratelimit_storage_uri", "rate_limit", "storage_uri"),
-        ("require_https", "web_security", "require_https"),
-        ("enable_docs", "web_security", "enable_docs"),
-    ):
-        _copy_flat(data, flat=flat, section=section, field=field)
-    return data
-
-
-class _FlatCompatMixin:
-    """Temporary flat env var support during the nested settings rollout."""
-
-    database_url: str = Field(default="", exclude=True)
-    postgres_host: str = Field(default="", exclude=True)
-    postgres_port: int | None = Field(default=None, exclude=True)
-    postgres_database: str = Field(default="", exclude=True)
-    postgres_user: str = Field(default="", exclude=True)
-    db_timeout: int | None = Field(default=None, exclude=True)
-    db_pool_size: int | None = Field(default=None, exclude=True)
-    db_pool_max_overflow: int | None = Field(default=None, exclude=True)
-    db_pool_timeout: int | None = Field(default=None, exclude=True)
-    db_pool_recycle: int | None = Field(default=None, exclude=True)
-    db_statement_timeout_ms: int | None = Field(default=None, exclude=True)
-    db_echo: bool | None = Field(default=None, exclude=True)
-
-    github_token: str = Field(default="", exclude=True)
-    labs_verification_secret: str = Field(default="", exclude=True)
-    external_api_timeout: float | None = Field(default=None, exclude=True)
-    content_dir: str = Field(default="", exclude=True)
-
-    github_client_id: str = Field(default="", exclude=True)
-    github_client_secret: str = Field(default="", exclude=True)
-    session_secret_key: str = Field(default="", exclude=True)
-    cors_allowed_origins: str = Field(default="", exclude=True)
-    frontend_url: str = Field(default="", exclude=True)
-    frontend_applicationinsights_connection_string: str = Field(
-        default="", exclude=True
-    )
-    frontend_telemetry_sampling_percentage: float | None = Field(
-        default=None, exclude=True
-    )
-    verification_functions_base_url: str = Field(default="", exclude=True)
-    verification_functions_key: str = Field(default="", exclude=True)
-    ratelimit_storage_uri: str = Field(default="", exclude=True)
-    require_https: bool | None = Field(default=None, exclude=True)
-    enable_docs: bool | None = Field(default=None, exclude=True)
-
-    @model_validator(mode="before")
-    @classmethod
-    def _migrate_flat_env(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            return _apply_flat_compat(data)
-        return data
-
-
-class MigrationSettings(_FlatCompatMixin, BaseSettings):
+class MigrationSettings(BaseSettings):
     """Settings loaded by Alembic and migration jobs."""
 
     model_config = _SETTINGS_CONFIG
@@ -308,7 +201,7 @@ class MigrationSettings(_FlatCompatMixin, BaseSettings):
     content: ContentConfig = ContentConfig()
 
 
-class WorkerSettings(_FlatCompatMixin, BaseSettings):
+class WorkerSettings(BaseSettings):
     """Settings for background workers and shared verification code."""
 
     model_config = _SETTINGS_CONFIG
@@ -320,7 +213,7 @@ class WorkerSettings(_FlatCompatMixin, BaseSettings):
     content: ContentConfig = ContentConfig()
 
 
-class WebSettings(_FlatCompatMixin, BaseSettings):
+class WebSettings(BaseSettings):
     """Settings for the FastAPI webapp."""
 
     model_config = _SETTINGS_CONFIG

--- a/packages/learn-to-cloud-shared/tests/conftest.py
+++ b/packages/learn-to-cloud-shared/tests/conftest.py
@@ -42,10 +42,7 @@ def _build_test_database_url() -> tuple[str, str, int]:
 
     raw = os.environ.get(
         "DATABASE__URL",
-        os.environ.get(
-            "DATABASE_URL",
-            "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud",
-        ),
+        "postgresql+asyncpg://postgres:postgres@db:5432/test_learn_to_cloud",
     )
     url = make_url(raw)
     host = url.host or "localhost"

--- a/packages/learn-to-cloud-shared/tests/core/test_config.py
+++ b/packages/learn-to-cloud-shared/tests/core/test_config.py
@@ -11,7 +11,6 @@ from learn_to_cloud_shared.core.config import (
     FrontendTelemetryConfig,
     GitHubConfig,
     LabsConfig,
-    MigrationSettings,
     OAuthConfig,
     SessionConfig,
     WebSecurityConfig,
@@ -184,43 +183,9 @@ class TestAllowedOrigins:
 
 
 @pytest.mark.unit
-class TestFlatEnvCompatibility:
-    def test_old_database_url_populates_nested_database(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        monkeypatch.delenv("DATABASE__URL", raising=False)
-        s = MigrationSettings(database_url="postgresql+asyncpg://localhost/db")
-        assert s.database.url == "postgresql+asyncpg://localhost/db"
-
-    def test_new_nested_database_wins_over_old_flat_database_url(self):
-        s = MigrationSettings(
-            database=DatabaseConfig(url="postgresql+asyncpg://localhost/new"),
-            database_url="postgresql+asyncpg://localhost/old",
-        )
-        assert s.database.url == "postgresql+asyncpg://localhost/new"
-
-    def test_old_web_flat_fields_populate_nested_sections(
-        self, monkeypatch: pytest.MonkeyPatch
-    ):
-        monkeypatch.delenv("DATABASE__URL", raising=False)
-        s = WebSettings(
-            database_url="postgresql+asyncpg://localhost/db",
-            environment="production",
-            github_client_id="id",
-            github_client_secret="secret",
-            session_secret_key="prod-secret",
-            require_https=False,
-        )
-        assert s.database.url == "postgresql+asyncpg://localhost/db"
-        assert s.oauth.client_id == "id"
-        assert s.session.secret_key == "prod-secret"
-        assert s.web_security.require_https is False
-
-
-@pytest.mark.unit
 class TestSettingsFactories:
     def test_get_web_settings_is_cached(self, monkeypatch: pytest.MonkeyPatch):
-        monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://localhost/db")
+        monkeypatch.setenv("DATABASE__URL", "postgresql+asyncpg://localhost/db")
         monkeypatch.setenv("ENVIRONMENT", "development")
         clear_settings_cache()
         assert get_web_settings() is get_web_settings()
@@ -228,13 +193,12 @@ class TestSettingsFactories:
     def test_clear_settings_cache_reloads_environment(
         self, monkeypatch: pytest.MonkeyPatch
     ):
-        monkeypatch.delenv("DATABASE__URL", raising=False)
-        monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://localhost/one")
+        monkeypatch.setenv("DATABASE__URL", "postgresql+asyncpg://localhost/one")
         monkeypatch.setenv("ENVIRONMENT", "development")
         clear_settings_cache()
         assert get_web_settings().database.url.endswith("/one")
 
-        monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://localhost/two")
+        monkeypatch.setenv("DATABASE__URL", "postgresql+asyncpg://localhost/two")
         clear_settings_cache()
         assert get_web_settings().database.url.endswith("/two")
 

--- a/scripts/dogfood_session.py
+++ b/scripts/dogfood_session.py
@@ -5,7 +5,7 @@ browser automation or test scripts can inject the session without
 going through the GitHub OAuth flow.
 
 Usage:
-    cd api && uv run python ../scripts/dogfood_session.py          # auto-detect first user
+    cd api && uv run python ../scripts/dogfood_session.py
     cd api && uv run python ../scripts/dogfood_session.py 6733686  # specific user ID
 
 Security:
@@ -21,18 +21,19 @@ import sys
 from base64 import b64encode
 
 import itsdangerous
+import sqlalchemy
 
 SECRET_KEY = "dev-secret-key-change-in-production"
 
 
 def _load_secret_key() -> str:
-    """Load the session secret key from the API's .env file, falling back to the default."""
+    """Load the session secret key from the API's .env file."""
     env_path = os.path.join(os.path.dirname(__file__), "..", "api", ".env")
     if os.path.exists(env_path):
         with open(env_path) as f:
             for line in f:
                 line = line.strip()
-                if line.startswith("SESSION_SECRET_KEY"):
+                if line.startswith("SESSION__SECRET_KEY"):
                     _, _, value = line.partition("=")
                     value = value.strip().strip("'\"")
                     if value:
@@ -41,19 +42,17 @@ def _load_secret_key() -> str:
 
 
 def _get_user_from_db(user_id: int | None = None) -> dict[str, object] | None:
-    """Query the local DB for a user. Returns {"id": ..., "github_username": ...} or None."""
+    """Query the local DB for a user."""
     try:
-        import sqlalchemy
-
         # Build a sync URL from the async one in .env
-        raw_url = os.environ.get("DATABASE_URL", "")
+        raw_url = os.environ.get("DATABASE__URL", "")
         if not raw_url:
             # Try loading from .env file in api/ directory
             env_path = os.path.join(os.path.dirname(__file__), "..", "api", ".env")
             if os.path.exists(env_path):
                 with open(env_path) as f:
                     for line in f:
-                        if line.startswith("DATABASE_URL="):
+                        if line.startswith("DATABASE__URL="):
                             raw_url = line.split("=", 1)[1].strip()
                             break
 
@@ -67,13 +66,16 @@ def _get_user_from_db(user_id: int | None = None) -> dict[str, object] | None:
         with engine.connect() as conn:
             if user_id is not None:
                 row = conn.execute(
-                    sqlalchemy.text("SELECT id, github_username FROM users WHERE id = :id"),
+                    sqlalchemy.text(
+                        "SELECT id, github_username FROM users WHERE id = :id"
+                    ),
                     {"id": user_id},
                 ).fetchone()
             else:
                 row = conn.execute(
                     sqlalchemy.text(
-                        "SELECT id, github_username FROM users WHERE github_username = 'madebygps' LIMIT 1"
+                        "SELECT id, github_username FROM users "
+                        "WHERE github_username = 'madebygps' LIMIT 1"
                     )
                 ).fetchone()
 

--- a/scripts/seed_progress.py
+++ b/scripts/seed_progress.py
@@ -11,18 +11,17 @@ import os
 import sys
 from datetime import UTC, datetime
 
+from learn_to_cloud_shared.content_service import get_all_phases
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from learn_to_cloud_shared.content_service import get_all_phases
-
-DATABASE_URL = os.environ.get(
-    "DATABASE_URL", "postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud"
+database_url = os.environ.get(
+    "DATABASE__URL", "postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud"
 )
 
 
 async def main(github_username: str) -> None:
-    engine = create_async_engine(DATABASE_URL)
+    engine = create_async_engine(database_url)
     session_maker = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with session_maker() as session:


### PR DESCRIPTION
## Summary
- Remove the temporary flat environment variable compatibility shim from shared settings
- Update remaining local/dev settings surfaces to use nested double-underscore environment names
- Remove fallback tests for old flat variables and update env-loading tests to nested names

## Validation
- cd api && uv run ruff check . ../packages/learn-to-cloud-shared ../scripts/dogfood_session.py ../scripts/seed_progress.py
- cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared ../scripts/dogfood_session.py ../scripts/seed_progress.py
- cd api && uv run ty check --exclude scripts --exclude tests .
- cd api && uv run pytest tests/
- cd packages/learn-to-cloud-shared && uv run ty check --exclude tests .
- cd packages/learn-to-cloud-shared && uv run pytest tests/
- cd apps/verification-functions && uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run python -c "import function_app"