### PR TITLE
Fix migration image content directory setting

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -71,7 +71,7 @@ COPY --chown=appuser:appuser api/alembic/ ./alembic/
 COPY --chown=appuser:appuser api/scripts/run_migrations.py ./scripts/run_migrations.py
 COPY --chown=appuser:appuser packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases /app/content/phases
 
-ENV CONTENT_DIR="/app/content/phases"
+ENV CONTENT__DIR="/app/content/phases"
 
 CMD ["python", "scripts/run_migrations.py"]
 

--- a/api/scripts/run_migrations.py
+++ b/api/scripts/run_migrations.py
@@ -23,7 +23,7 @@ second and third calls — only one IMDS roundtrip happens per job.
 The sync CLI lives inside the installed package
 (``learn_to_cloud_shared.cli.sync_curriculum``) rather than a filesystem
 script. The migration image copies curriculum YAML separately and points
-``CONTENT_DIR`` at that path, so the API image does not need to ship YAML.
+``CONTENT__DIR`` at that path, so the API image does not need to ship YAML.
 ``python -m`` finds the module via the wheel's import path, which is
 portable across local devcontainer, CI, and production.
 """

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/cli/sync_curriculum.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/cli/sync_curriculum.py
@@ -3,7 +3,7 @@
 Importable CLI entry point for the deploy-time curriculum sync.
 
 Usage (anywhere the ``learn-to-cloud-shared`` wheel is installed and
-``CONTENT_DIR`` points at ``content/phases``)::
+``CONTENT__DIR`` points at ``content/phases``)::
 
     python -m learn_to_cloud_shared.cli.sync_curriculum
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_sync.py
@@ -1,6 +1,6 @@
 """Deploy-time sync from YAML curriculum to DB tables (issue #463).
 
-Reads the authored curriculum YAML from ``CONTENT_DIR`` in production,
+Reads the authored curriculum YAML from ``CONTENT__DIR`` in production,
 runs the strict cross-file validators, and upserts every curriculum entity
 into its corresponding DB table. Entities no longer present in YAML are
 soft-deleted; entities that reappear (same UUID) have their ``deleted_at``

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
@@ -5,7 +5,7 @@ Phase C (issue #461), runtime reads in the API go through the DB loader in
 ``content_db_loader.py`` via the public ``content_service`` module. The YAML
 loader is still authoritative for deploy-time YAML to DB sync
 (``content_sync.py``) and for the strict cross-file validators run in CI.
-Production migration jobs provide the YAML path through ``CONTENT_DIR``.
+Production migration jobs provide the YAML path through ``CONTENT__DIR``.
 
 Do not import from this module in request-serving code paths. Use
 ``learn_to_cloud_shared.content_service`` (async, DB-backed) instead.


### PR DESCRIPTION
## Summary
- Set the migration image default curriculum path with the nested `CONTENT__DIR` environment variable.
- Update deploy-time curriculum sync documentation references from `CONTENT_DIR` to `CONTENT__DIR`.

## Why
The production deploy failed during the migration image self-check because the image still exported the old flat `CONTENT_DIR` name after the flat settings compatibility layer was removed.

## Validation
- `cd api && uv run ruff check . ../packages/learn-to-cloud-shared`
- `cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared`
- `cd api && uv run ty check --exclude scripts --exclude tests .`
- `cd packages/learn-to-cloud-shared && uv run ty check --exclude tests .`
- `cd api && uv run pytest tests/`
- `cd packages/learn-to-cloud-shared && uv run pytest tests/`
- `cd apps/verification-functions && uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run python -c "import function_app"`
- Local CONTENT__DIR YAML-loading smoke test passed.

Note: Docker is not installed in the current environment, so I could not run the exact container smoke test locally.