### PR TITLE
Fix verification database permissions

### DIFF
--- a/api/alembic/versions/0038_grant_fn_requirement_kind_lookup.py
+++ b/api/alembic/versions/0038_grant_fn_requirement_kind_lookup.py
@@ -1,0 +1,69 @@
+"""grant Functions role requirement kind lookup
+
+Revision ID: 0038_grant_fn_requirement_kind_lookup
+Revises: 0037_validate_typed_submitted_value_constraints
+Create Date: 2026-05-26
+"""
+
+import os
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0038_grant_fn_requirement_kind_lookup"
+down_revision: str | None = "0037_validate_typed_submitted_value_constraints"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_REQUIRED_COLUMNS = "uuid, submission_value_kind"
+
+
+def upgrade() -> None:
+    role = _verification_functions_role()
+    if not role:
+        return
+
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                GRANT SELECT ({_REQUIRED_COLUMNS})
+                ON requirements
+                TO "{role}";
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    role = _verification_functions_role()
+    if not role:
+        return
+
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                REVOKE SELECT ({_REQUIRED_COLUMNS})
+                ON requirements
+                FROM "{role}";
+            END IF;
+        END $$;
+        """
+    )
+
+
+def _verification_functions_role() -> str | None:
+    role = os.environ.get("POSTGRES_VERIFICATION_FUNCTIONS_ROLE")
+    if not role:
+        return None
+    if not (role[0].isalpha() or role[0] == "_") or not all(
+        c.isalnum() or c == "_" for c in role
+    ):
+        raise RuntimeError(
+            f"POSTGRES_VERIFICATION_FUNCTIONS_ROLE is not a valid identifier: {role!r}"
+        )
+    return role


### PR DESCRIPTION
## Summary

This adds a new Alembic migration that grants the verification Functions database role only the two requirements columns needed by the typed submitted value trigger.

The alert came from Postgres rejecting the trigger lookup during submission persistence. The function role did not need broad curriculum access, but it still needs to read requirements.uuid and requirements.submission_value_kind while inserting or updating submissions.

## Validation

- cd api && uv run ruff check . ../packages/learn-to-cloud-shared
- cd apps/verification-functions && uv run ruff check .
- cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared
- cd apps/verification-functions && uv run ruff format --check .
- cd api && uv run ty check --exclude scripts --exclude tests .
- cd packages/learn-to-cloud-shared && uv run ty check --exclude tests .
- cd apps/verification-functions && uv run ty check .
- API startup and smoke tests for /health, /ready, and /openapi.json
- cd api && uv run pytest tests/
- cd packages/learn-to-cloud-shared && uv run pytest tests/
- cd apps/verification-functions && uv run python -c "import function_app"