### PR TITLE
Pass verification role to migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,6 +152,7 @@ jobs:
           --health-retries 5
     env:
       DATABASE__URL: postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud
+      POSTGRES_VERIFICATION_FUNCTIONS_ROLE: ltc_verification_functions_dev
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -340,6 +341,7 @@ jobs:
       migration_identity_client_id: ${{ steps.tf-outputs.outputs.migration_identity_client_id }}
       migration_identity_id: ${{ steps.tf-outputs.outputs.migration_identity_id }}
       migration_postgres_role: ${{ steps.tf-outputs.outputs.migration_postgres_role }}
+      verification_functions_postgres_role: ${{ steps.tf-outputs.outputs.verification_functions_postgres_role }}
       api_url: ${{ steps.tf-outputs.outputs.api_url }}
       verification_functions_name: ${{ steps.tf-outputs.outputs.verification_functions_name }}
     steps:
@@ -423,6 +425,7 @@ jobs:
           echo "migration_identity_client_id=$(terraform output -raw migration_identity_client_id)" >> "$GITHUB_OUTPUT"
           echo "migration_identity_id=$(terraform output -raw migration_identity_id)" >> "$GITHUB_OUTPUT"
           echo "migration_postgres_role=$(terraform output -raw migration_postgres_role)" >> "$GITHUB_OUTPUT"
+          echo "verification_functions_postgres_role=$(terraform output -raw verification_functions_postgres_role)" >> "$GITHUB_OUTPUT"
           echo "api_url=$(terraform output -raw api_url)" >> "$GITHUB_OUTPUT"
           echo "verification_functions_name=$(terraform output -raw verification_functions_name)" >> "$GITHUB_OUTPUT"
 
@@ -550,6 +553,7 @@ jobs:
           DATABASE_NAME: ${{ needs.terraform.outputs.database_name }}
           DATABASE_HOST: ${{ needs.terraform.outputs.database_host }}
           DATABASE_USER: ${{ needs.terraform.outputs.migration_postgres_role }}
+          POSTGRES_VERIFICATION_FUNCTIONS_ROLE: ${{ needs.terraform.outputs.verification_functions_postgres_role }}
           RESOURCE_GROUP: ${{ needs.terraform.outputs.resource_group_name }}
           IMAGE: ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:${{ github.sha }}
         run: |
@@ -568,6 +572,7 @@ jobs:
                 DATABASE__USER="$DATABASE_USER" \
                 DATABASE__NAME="$DATABASE_NAME" \
                 AZURE_CLIENT_ID="$MIGRATION_CLIENT_ID" \
+                POSTGRES_VERIFICATION_FUNCTIONS_ROLE="$POSTGRES_VERIFICATION_FUNCTIONS_ROLE" \
                 CONTENT__DIR="/app/content/phases" \
               --registry-identity "$MIGRATION_IDENTITY_ID" \
               --query name \

--- a/api/alembic/versions/0039_reapply_fn_requirement_kind_lookup_grant.py
+++ b/api/alembic/versions/0039_reapply_fn_requirement_kind_lookup_grant.py
@@ -1,0 +1,70 @@
+"""reapply Functions role requirement kind lookup grant
+
+Revision ID: 0039_reapply_fn_requirement_kind_lookup_grant
+Revises: 0038_grant_fn_requirement_kind_lookup
+Create Date: 2026-05-26
+"""
+
+import os
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0039_reapply_fn_requirement_kind_lookup_grant"
+down_revision: str | None = "0038_grant_fn_requirement_kind_lookup"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_REQUIRED_COLUMNS = "uuid, submission_value_kind"
+_ENV_VAR = "POSTGRES_VERIFICATION_FUNCTIONS_ROLE"
+
+
+def upgrade() -> None:
+    role = _verification_functions_role()
+    _grant_requirement_lookup(role)
+
+
+def downgrade() -> None:
+    role = _verification_functions_role()
+    _revoke_requirement_lookup(role)
+
+
+def _grant_requirement_lookup(role: str) -> None:
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                GRANT SELECT ({_REQUIRED_COLUMNS})
+                ON requirements
+                TO "{role}";
+            END IF;
+        END $$;
+        """
+    )
+
+
+def _revoke_requirement_lookup(role: str) -> None:
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                REVOKE SELECT ({_REQUIRED_COLUMNS})
+                ON requirements
+                FROM "{role}";
+            END IF;
+        END $$;
+        """
+    )
+
+
+def _verification_functions_role() -> str:
+    role = os.environ.get(_ENV_VAR)
+    if not role:
+        raise RuntimeError(f"{_ENV_VAR} must be set before running this migration")
+    if not (role[0].isalpha() or role[0] == "_") or not all(
+        c.isalnum() or c == "_" for c in role
+    ):
+        raise RuntimeError(f"{_ENV_VAR} is not a valid identifier: {role!r}")
+    return role

--- a/api/tests/test_migration_chain.py
+++ b/api/tests/test_migration_chain.py
@@ -24,6 +24,10 @@ from pytest_alembic.tests import (
 from sqlalchemy import create_engine, text
 
 MIGRATION_DB = "test_alembic_migrations"
+os.environ.setdefault(
+    "POSTGRES_VERIFICATION_FUNCTIONS_ROLE",
+    "ltc_verification_functions_dev",
+)
 
 # Re-export built-in tests so pytest discovers them.
 __all__ = [


### PR DESCRIPTION
## Summary
- add migration 0039 to reapply the narrow requirements column grant for the verification Functions database role
- pass verification_functions_postgres_role from Terraform outputs into the migration job environment
- set POSTGRES_VERIFICATION_FUNCTIONS_ROLE in CI migration checks so missing env is caught before deploy

## Why
Migration 0038 was already stamped as applied, but the deploy job did not pass POSTGRES_VERIFICATION_FUNCTIONS_ROLE when starting the Container Apps job. That made 0038 a safe no-op, so dev kept failing with permission denied on requirements.

## Validation
- cd api && uv run ruff check . ../packages/learn-to-cloud-shared
- cd api && uv run ruff format --check . ../packages/learn-to-cloud-shared
- cd api && uv run ty check --exclude scripts --exclude tests .
- cd packages/learn-to-cloud-shared && uv run ty check --exclude tests .
- cd apps/verification-functions && uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run python -c "import function_app"
- cd api && uv run pytest tests/ -x
- cd packages/learn-to-cloud-shared && uv run pytest tests/ -x
- env -i HOME=$HOME PATH=$PATH DATABASE__URL=postgresql+asyncpg://postgres:postgres@db:5432/learntocloud POSTGRES_VERIFICATION_FUNCTIONS_ROLE=ltc_verification_functions_dev uv run alembic upgrade head
- API smoke checks for /health, /ready, and /openapi.json