### PR TITLE
Fix verification exception alert noise

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -169,7 +169,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_function
   name                = "alert-ltc-verification-functions-exceptions-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  description         = "Alert when verification Functions record any exceptions in a 5-minute window"
+  description         = "Alert when verification Functions record non-learner API exceptions in a 5-minute window"
   severity            = 1
   enabled             = true
   tags                = local.tags
@@ -181,10 +181,21 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_function
 
   criteria {
     query                   = <<-QUERY
+      let LearnerApiDependencyFailures =
+          dependencies
+          | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
+              or cloud_RoleName has "verification-functions"
+              or cloud_RoleName has "func-ltc-verification"
+          | where type == "HTTP"
+          | where name in ("POST /entries", "GET /entries")
+              or name startswith "DELETE /entries/"
+          | project operation_Id, dependencySpanId = id;
       exceptions
       | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
           or cloud_RoleName has "verification-functions"
           or cloud_RoleName has "func-ltc-verification"
+      | join kind=leftanti LearnerApiDependencyFailures
+          on operation_Id, $left.operation_ParentId == $right.dependencySpanId
     QUERY
     time_aggregation_method = "Count"
     operator                = "GreaterThanOrEqual"


### PR DESCRIPTION
## Summary
- Exclude expected learner API dependency failures from the verification Functions exception alert.
- Keep Function app, Durable, database, and platform exceptions alertable.
- Update the alert description to clarify it covers non-learner API exceptions.

## Why
Learner APIs are intentionally untrusted inputs. If a learner's API times out or returns an error while we validate it, that should become a failed verification result, not a Sev1 platform alert.

## Validation
- Patched KQL against the incident window changed the exception count from 15 to 0.
- Terraform fmt and validate passed in an Azure CLI container with the lock file read-only.
- API ruff, format check, ty, and tests passed.
- Shared package ty and tests passed.
- Verification Functions ruff, format check, ty, and import check passed.