### PR TITLE
fix: update existing verification auth settings

### DIFF
--- a/infra/functions.tf
+++ b/infra/functions.tf
@@ -144,7 +144,7 @@ resource "azurerm_function_app_flex_consumption" "verification" {
   ]
 }
 
-resource "azapi_resource" "verification_auth_settings" {
+resource "azapi_update_resource" "verification_auth_settings" {
   type      = "Microsoft.Web/sites/config@2022-09-01"
   name      = "authsettingsV2"
   parent_id = azurerm_function_app_flex_consumption.verification.id
@@ -189,8 +189,6 @@ resource "azapi_resource" "verification_auth_settings" {
       }
     }
   }
-
-  schema_validation_enabled = false
 
   depends_on = [
     azurerm_function_app_flex_consumption.verification,


### PR DESCRIPTION
## What changed

This fixes the latest deploy failure by switching the verification Function auth settings from azapi_resource to azapi_update_resource.

## Why this matters

Azure already has the authsettingsV2 config object for the Function App, but Terraform state did not know about it. azapi_resource tried to create that existing object and failed. azapi_update_resource updates the existing config object instead, which is the right behavior for this App Service child config.

## Validation

- prek run --all-files
- terraform -chdir=infra fmt -check
- Docker Terraform validate with backend disabled
- Azure-backed Terraform plan: 1 add, 1 change, 0 destroy
