### PR TITLE
fix: devcontainer setup failures (Copilot home permissions + migration 0039)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,10 @@
 FROM mcr.microsoft.com/devcontainers/base:debian
+
+# Pre-create the Copilot home directory owned by the vscode user.
+# docker-compose.yml mounts a named volume (copilot_home) at this path so the
+# Copilot CLI login and plugins survive container rebuilds. When Docker first
+# creates that volume it copies the ownership of this directory. Without this
+# line the directory does not exist in the image, so Docker creates the volume
+# owned by root, the vscode user cannot write to it, and "copilot plugin ..."
+# fails silently during onCreate (which aborts the whole devcontainer setup).
+RUN mkdir -p /home/vscode/.copilot && chown vscode:vscode /home/vscode/.copilot

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -19,11 +19,16 @@ npm install -g \
     mcp-remote@latest
 
 echo "🧠 Configuring Copilot Azure skills..."
-if ! copilot plugin marketplace list | grep -q "azure-skills"; then
-    copilot plugin marketplace add microsoft/azure-skills
+# Best-effort: configuring Copilot plugins must never abort the whole
+# devcontainer setup. If a step fails (for example, the Copilot CLI is not
+# logged in yet), warn and continue so the rest of on-create still runs.
+if ! copilot plugin marketplace list 2>/dev/null | grep -q "azure-skills"; then
+    copilot plugin marketplace add microsoft/azure-skills \
+        || echo "⚠️  Could not add the azure-skills marketplace; skipping. Run 'copilot plugin marketplace add microsoft/azure-skills' manually later."
 fi
-if ! copilot plugin list | grep -q "azure@azure-skills"; then
-    copilot plugin install azure@azure-skills
+if ! copilot plugin list 2>/dev/null | grep -q "azure@azure-skills"; then
+    copilot plugin install azure@azure-skills \
+        || echo "⚠️  Could not install the azure-skills plugin; skipping. Run 'copilot plugin install azure@azure-skills' manually later."
 fi
 
 # Setup Python environments. Each uv project owns its local .venv.

--- a/api/alembic/versions/0039_reapply_fn_requirement_kind_lookup_grant.py
+++ b/api/alembic/versions/0039_reapply_fn_requirement_kind_lookup_grant.py
@@ -21,11 +21,15 @@ _ENV_VAR = "POSTGRES_VERIFICATION_FUNCTIONS_ROLE"
 
 def upgrade() -> None:
     role = _verification_functions_role()
+    if not role:
+        return
     _grant_requirement_lookup(role)
 
 
 def downgrade() -> None:
     role = _verification_functions_role()
+    if not role:
+        return
     _revoke_requirement_lookup(role)
 
 
@@ -59,10 +63,10 @@ def _revoke_requirement_lookup(role: str) -> None:
     )
 
 
-def _verification_functions_role() -> str:
+def _verification_functions_role() -> str | None:
     role = os.environ.get(_ENV_VAR)
     if not role:
-        raise RuntimeError(f"{_ENV_VAR} must be set before running this migration")
+        return None
     if not (role[0].isalpha() or role[0] == "_") or not all(
         c.isalnum() or c == "_" for c in role
     ):


### PR DESCRIPTION
## Problem

Two issues were breaking fresh devcontainer builds:

1. **Copilot home directory permissions**: The Docker volume `copilot_home` mounted at `/home/vscode/.copilot` was created owned by root because the directory did not exist in the image. The vscode user could not write to it, so `copilot plugin` commands failed, and because `on-create.sh` uses `set -e`, the entire setup aborted.

2. **Migration 0039 crash**: Migration 0039 requires `POSTGRES_VERIFICATION_FUNCTIONS_ROLE` to be set, but this env var only exists in production (Azure). Migration 0038 handles this gracefully by returning `None` and skipping the grant, but 0039 was written to crash with a `RuntimeError`. This broke `alembic upgrade head` during `postCreateCommand`.

## Fix

**Copilot home (Dockerfile + on-create.sh):**
- Dockerfile now pre-creates `/home/vscode/.copilot` owned by vscode, so Docker copies that ownership when creating the named volume.
- `on-create.sh` plugin install steps now warn and continue instead of aborting the entire setup.

**Migration 0039:**
- Changed to match 0038's pattern: return `None` and skip the grant when the env var is not set. Production already ran this migration (it is stamped as applied and will never execute again). Only fresh dev databases are affected.

## How to verify

Rebuild the devcontainer from scratch. All migrations should run to completion and the setup should finish without errors.

**Note:** If you have an existing `copilot_home` volume owned by root, you need to delete it once so a correctly owned one is recreated.