### PR TITLE
chore: replace Aspire devcontainer feature with standalone CLI install

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,8 +21,7 @@
       "tflint": "none",
       "terragrunt": "none"
     },
-    "ghcr.io/va-h/devcontainers-features/uv:1": {},
-    "ghcr.io/microsoft/aspire-devcontainer-feature/aspire:2": {}
+    "ghcr.io/va-h/devcontainers-features/uv:1": {}
   },
   "customizations": {
     "vscode": {
@@ -46,8 +45,7 @@
         "dbaeumer.vscode-eslint",
         "bradlc.vscode-tailwindcss",
         "GitHub.copilot",
-        "ms-azuretools.vscode-azure-mcp-server",
-        "microsoft-aspire.aspire-vscode"
+        "ms-azuretools.vscode-azure-mcp-server"
       ]
     }
   },

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -56,6 +56,14 @@ else
     playwright install --with-deps chrome
 fi
 
+# Install Aspire CLI for the MCP server (aspire agent mcp).
+# Installed via the standalone script so we don't need .NET SDK or the VS Code
+# extension (which pulls in C# DevKit and .NET Installer as dependencies).
+if ! command -v aspire &> /dev/null; then
+    echo "🌐 Installing Aspire CLI..."
+    curl -sSL https://aspire.dev/install.sh | bash
+fi
+
 # Install Azure Functions Core Tools for local Durable Functions development.
 if ! command -v func &> /dev/null; then
     echo "⚡ Installing Azure Functions Core Tools..."


### PR DESCRIPTION
## What changed

Removed the Aspire devcontainer feature (`ghcr.io/microsoft/aspire-devcontainer-feature/aspire:2`) and its VS Code extension (`microsoft-aspire.aspire-vscode`) from devcontainer.json.

Added a standalone Aspire CLI install via `curl -sSL https://aspire.dev/install.sh | bash` in on-create.sh instead.

## Why

We only need the Aspire CLI for the MCP server (`aspire agent mcp`). The devcontainer feature bundles the Aspire VS Code extension, which pulls in C# DevKit and .NET Installer as transitive dependencies. Those extensions are unnecessary for this Python project and add clutter to the editor.

## Result

The Aspire CLI is still available for the MCP server, but without the extra C#/.NET extensions being installed.