### PR TITLE
Add GitHubMetadata and WorkflowRuns testing seams

### DIFF
--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ci_status.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ci_status.py
@@ -18,7 +18,7 @@ Workflow::
         → check conclusion
         → ValidationResult
 
-For GitHub API helpers, see ``github_profile.py``.
+For the workflow-runs seam, see ``workflow_runs.py``.
 """
 
 from __future__ import annotations
@@ -27,10 +27,13 @@ import httpx
 from opentelemetry import trace
 
 from learn_to_cloud_shared.schemas import ValidationResult
-from learn_to_cloud_shared.verification.github_profile import (
+from learn_to_cloud_shared.verification.github_http import (
     RETRIABLE_EXCEPTIONS,
-    github_api_get,
     github_error_to_validation_result,
+)
+from learn_to_cloud_shared.verification.workflow_runs import (
+    WorkflowRuns,
+    default_workflow_runs,
 )
 
 tracer = trace.get_tracer(__name__)
@@ -42,6 +45,7 @@ _CI_WORKFLOW_FILE = "ci.yml"
 async def verify_ci_status(
     owner: str,
     repo: str,
+    runs: WorkflowRuns | None = None,
 ) -> ValidationResult:
     """Verify that CI tests pass on the learner's fork's main branch.
 
@@ -51,11 +55,13 @@ async def verify_ci_status(
     Args:
         owner: Repository owner (GitHub username).
         repo: Repository name.
+        runs: Workflow-runs port (defaults to the production adapter).
 
     Returns:
         ``ValidationResult`` — valid when the most recent CI run on
         ``main`` has ``conclusion == "success"``.
     """
+    runs = runs or default_workflow_runs()
     with tracer.start_as_current_span(
         "ci_status_verification",
         attributes={
@@ -63,15 +69,9 @@ async def verify_ci_status(
             "github.repo": repo,
         },
     ) as span:
-        # ── Fetch latest CI workflow runs on main ─────────────────────────
-        url = (
-            f"https://api.github.com/repos/{owner}/{repo}"
-            f"/actions/workflows/{_CI_WORKFLOW_FILE}/runs"
-        )
-        params = {"branch": "main", "per_page": 1}
-
+        # ── Fetch latest CI workflow run on main ──────────────────────────
         try:
-            response = await github_api_get(url, params=params)
+            latest_run = await runs.latest_run(owner, repo, _CI_WORKFLOW_FILE)
         except (
             httpx.HTTPStatusError,
             *RETRIABLE_EXCEPTIONS,
@@ -95,10 +95,7 @@ async def verify_ci_status(
                 context={"owner": owner, "repo": repo},
             )
 
-        data = response.json()
-        runs: list[dict] = data.get("workflow_runs", [])
-
-        if not runs:
+        if latest_run is None:
             span.set_attribute("verification.passed", False)
             span.set_attribute("verification.reason", "no_runs")
             return ValidationResult(
@@ -110,7 +107,6 @@ async def verify_ci_status(
                 ),
             )
 
-        latest_run = runs[0]
         conclusion = latest_run.get("conclusion")
         status = latest_run.get("status")
         run_url = latest_run.get("html_url", "")

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/devops_analysis.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/devops_analysis.py
@@ -9,16 +9,14 @@ import asyncio
 import httpx
 from opentelemetry import trace
 
-from learn_to_cloud_shared.core.github_client import get_github_client
 from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
 from learn_to_cloud_shared.verification.evidence import truncate_to_bytes
 from learn_to_cloud_shared.verification.github_profile import (
     RETRIABLE_EXCEPTIONS,
-    get_github_headers,
-    github_api_get,
     github_error_to_validation_result,
 )
 from learn_to_cloud_shared.verification.graders import grade_indicator_task
+from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
 from learn_to_cloud_shared.verification.tasks.base import VerificationTask
 from learn_to_cloud_shared.verification.tasks.phase5 import (
     MAX_FILE_SIZE_BYTES,
@@ -100,25 +98,8 @@ def _check_task_indicators(
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Repository tree and file fetching
+# Repository file fetching
 # ─────────────────────────────────────────────────────────────────────────────
-
-
-async def fetch_repo_tree(owner: str, repo: str, branch: str = "main") -> list[str]:
-    """Fetch the file tree of a GitHub repository.
-
-    Uses the Git Trees API with ``recursive=1`` to get all files in one call.
-
-    Returns:
-        List of file paths in the repository.
-    """
-    url = f"https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}"
-    response = await github_api_get(url, params={"recursive": 1})
-
-    tree_data = response.json()
-    return [
-        item["path"] for item in tree_data.get("tree", []) if item.get("type") == "blob"
-    ]
 
 
 def _filter_devops_files(all_files: list[str]) -> dict[str, list[str]]:
@@ -162,18 +143,15 @@ def _filter_devops_files(all_files: list[str]) -> dict[str, list[str]]:
 
 
 async def _fetch_file_content(
-    owner: str, repo: str, path: str, branch: str = "main"
-) -> str:
-    """Fetch a single file's raw content from GitHub."""
-    client = await get_github_client()
+    repo_files: RepoFiles, owner: str, repo: str, path: str, branch: str = "main"
+) -> str | None:
+    """Fetch a single file's raw content, truncating and flagging suspicious text.
 
-    url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}"
-    headers = get_github_headers()
-
-    response = await client.get(url, headers=headers)
-    response.raise_for_status()
-
-    content = response.text
+    Returns ``None`` when the file cannot be read.
+    """
+    content = await repo_files.file(owner, repo, path, branch)
+    if content is None:
+        return None
 
     if len(content.encode("utf-8")) > MAX_FILE_SIZE_BYTES:
         content = truncate_to_bytes(content, MAX_FILE_SIZE_BYTES)
@@ -192,6 +170,7 @@ async def _fetch_file_content(
 
 
 async def _fetch_all_devops_files(
+    repo_files: RepoFiles,
     owner: str,
     repo: str,
     devops_files: dict[str, list[str]],
@@ -211,11 +190,8 @@ async def _fetch_all_devops_files(
         return {task.id: [] for task in PHASE5_TASKS}
 
     async def _fetch_one(task_id: str, path: str) -> tuple[str, str | None]:
-        try:
-            content = await _fetch_file_content(owner, repo, path, branch)
-            return (task_id, content)
-        except httpx.HTTPStatusError:
-            return (task_id, None)
+        content = await _fetch_file_content(repo_files, owner, repo, path, branch)
+        return (task_id, content)
 
     results = await asyncio.gather(
         *[_fetch_one(tid, p) for tid, p in fetch_tasks],
@@ -247,8 +223,11 @@ async def _fetch_all_devops_files(
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-async def run_devops_workflow(owner: str, repo: str) -> ValidationResult:
+async def run_devops_workflow(
+    owner: str, repo: str, repo_files: RepoFiles | None = None
+) -> ValidationResult:
     """Run the full Phase 5 DevOps verification."""
+    repo_files = repo_files or default_repo_files()
     with tracer.start_as_current_span(
         "devops_verification",
         attributes={
@@ -258,7 +237,7 @@ async def run_devops_workflow(owner: str, repo: str) -> ValidationResult:
     ) as span:
         # ── Step 1: Fetch repo tree ──────────────────────────────
         try:
-            all_files = await fetch_repo_tree(owner, repo)
+            all_files = await repo_files.tree(owner, repo)
         except (
             httpx.HTTPStatusError,
             *RETRIABLE_EXCEPTIONS,
@@ -305,7 +284,9 @@ async def run_devops_workflow(owner: str, repo: str) -> ValidationResult:
 
         # ── Step 3: Fetch file contents ──────────────────────────
         devops_files = _filter_devops_files(all_files)
-        file_contents = await _fetch_all_devops_files(owner, repo, devops_files)
+        file_contents = await _fetch_all_devops_files(
+            repo_files, owner, repo, devops_files
+        )
 
         span.set_attribute(
             "repo.fetched_files",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/devops_analysis.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/devops_analysis.py
@@ -11,7 +11,7 @@ from opentelemetry import trace
 
 from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
 from learn_to_cloud_shared.verification.evidence import truncate_to_bytes
-from learn_to_cloud_shared.verification.github_profile import (
+from learn_to_cloud_shared.verification.github_http import (
     RETRIABLE_EXCEPTIONS,
     github_error_to_validation_result,
 )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/errors.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/errors.py
@@ -7,11 +7,24 @@ a single source of truth.
 
 from __future__ import annotations
 
+import logging
+
 import httpx
-from opentelemetry import trace
+from opentelemetry import metrics, trace
 from opentelemetry.util.types import AttributeValue
 
 from learn_to_cloud_shared.schemas import ValidationResult
+
+logger = logging.getLogger(__name__)
+
+_meter = metrics.get_meter("learn_to_cloud")
+# Low-cardinality counter for alerting on upstream/auth failures. Owner/repo
+# stay out of the metric (high cardinality); they live on the log and span.
+_GITHUB_API_ERROR_COUNTER = _meter.create_counter(
+    name="github.api_error",
+    description="GitHub API calls that failed with an auth, client, or server error",
+    unit="{error}",
+)
 
 # ---------------------------------------------------------------------------
 # Base retriable exceptions (httpx network / timeout errors)
@@ -63,28 +76,41 @@ def github_error_to_result(
 ) -> ValidationResult:
     """Map GitHub API exceptions to a user-facing ValidationResult.
 
+    A 404 is a normal outcome (the learner pointed us at something that
+    isn't there), so it stays quiet: span/result only, no warning log or
+    metric. Auth/client errors (401/403), server errors (5xx), and transient
+    network failures are operational problems that operators need to find
+    across all users, so they emit a WARN log (severity, queryable) and bump
+    the ``github.api_error`` counter (alertable) in addition to the span
+    event.
+
     Args:
         e: The caught exception.
         event: Structured log event name (e.g. ``"pr_verification.api_error"``).
         context: Extra fields for structured logging (owner, repo, pr, etc.).
     """
     if isinstance(e, httpx.HTTPStatusError):
-        if e.response.status_code == 404:
+        status = e.response.status_code
+        if status == 404:
             return ValidationResult(
                 is_valid=False,
                 message="Resource not found on GitHub. Check the URL and try again.",
             )
         span = trace.get_current_span()
-        span.add_event(event, {**context, "status": e.response.status_code})
+        span.add_event(event, {**context, "status": status})
+        logger.warning(event, extra={**context, "status": status})
+        _GITHUB_API_ERROR_COUNTER.add(1, {"status": status})
         return ValidationResult(
             is_valid=False,
-            message=f"GitHub API error ({e.response.status_code}). Try again later.",
+            message=f"GitHub API error ({status}). Try again later.",
             verification_completed=False,
         )
 
     # RETRIABLE_EXCEPTIONS (RequestError, TimeoutException, etc.)
     span = trace.get_current_span()
     span.add_event(event, {**context, "error": str(e)})
+    logger.warning(event, extra={**context, "error": str(e)})
+    _GITHUB_API_ERROR_COUNTER.add(1, {"status": "transient"})
     return ValidationResult(
         is_valid=False,
         message="Could not reach GitHub. Please try again later.",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/evidence.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/evidence.py
@@ -4,13 +4,7 @@ from __future__ import annotations
 
 from hashlib import sha256
 
-import httpx
-from opentelemetry import trace
-
-from learn_to_cloud_shared.core.github_client import (
-    get_github_client as _get_github_client,
-)
-from learn_to_cloud_shared.verification.github_profile import get_github_headers
+from learn_to_cloud_shared.verification.repo_files import RepoFiles
 from learn_to_cloud_shared.verification.tasks.base import (
     EvidenceBundle,
     EvidenceItem,
@@ -18,32 +12,8 @@ from learn_to_cloud_shared.verification.tasks.base import (
 )
 
 
-async def fetch_repo_file_content(
-    owner: str,
-    repo: str,
-    path: str,
-    branch: str = "main",
-) -> str | None:
-    """Fetch raw repository file content from GitHub."""
-    client = await _get_github_client()
-    headers = get_github_headers()
-
-    url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}"
-    try:
-        response = await client.get(url, headers=headers)
-        response.raise_for_status()
-    except httpx.HTTPStatusError:
-        span = trace.get_current_span()
-        span.add_event(
-            "repo_file_fetch_failed",
-            {"owner": owner, "repo": repo, "path": path},
-        )
-        return None
-
-    return response.text
-
-
 async def collect_repo_file_evidence(
+    repo_files: RepoFiles,
     owner: str,
     repo: str,
     paths: list[str],
@@ -55,7 +25,7 @@ async def collect_repo_file_evidence(
     total_bytes = 0
 
     for path in list(dict.fromkeys(paths))[: task.evidence.max_files]:
-        content = await fetch_repo_file_content(owner, repo, path, branch)
+        content = await repo_files.file(owner, repo, path, branch)
         if content is None:
             continue
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
@@ -53,6 +53,38 @@ def persisted_validation_message(message: str | None) -> str | None:
     return f"{message[: MAX_VALIDATION_MESSAGE_LENGTH - 3]}..."
 
 
+def _log_submission_completed(
+    *,
+    user_id: int,
+    requirement: HandsOnRequirement,
+    validation_result: ValidationResult,
+    execution_path: str | None = None,
+) -> None:
+    """Log the canonical one-line submission outcome.
+
+    Normal outcomes, including learner-fault failures, log at INFO. When the
+    check could not complete because of an our-side or upstream fault
+    (``verification_completed=False``), log at WARNING so operators can find
+    and alert on it by severity instead of digging through traces.
+    """
+    extra: dict[str, object] = {
+        "user_id": user_id,
+        "requirement_slug": requirement.slug,
+        "submission_type": requirement.submission_type,
+        "is_valid": validation_result.is_valid,
+        "verification_completed": validation_result.verification_completed,
+        "validation_message": (
+            validation_result.message if not validation_result.is_valid else None
+        ),
+    }
+    if execution_path is not None:
+        extra["execution_path"] = execution_path
+    level = (
+        logging.INFO if validation_result.verification_completed else logging.WARNING
+    )
+    logger.log(level, "submission.completed", extra=extra)
+
+
 def to_submission_data(submission: Submission) -> SubmissionData:
     """Project a ``Submission`` row into the ``SubmissionData`` response model.
 
@@ -187,20 +219,10 @@ async def execute_submission_validation(
             validation_result.verification_completed,
         )
 
-        logger.info(
-            "submission.completed",
-            extra={
-                "user_id": user_id,
-                "requirement_slug": requirement.slug,
-                "submission_type": requirement.submission_type,
-                "is_valid": validation_result.is_valid,
-                "verification_completed": validation_result.verification_completed,
-                "validation_message": (
-                    validation_result.message
-                    if not validation_result.is_valid
-                    else None
-                ),
-            },
+        _log_submission_completed(
+            user_id=user_id,
+            requirement=requirement,
+            validation_result=validation_result,
         )
 
         return build_submission_result(db_submission, validation_result)
@@ -284,21 +306,11 @@ async def execute_sync_submission_validation(
             validation_result.verification_completed,
         )
 
-        logger.info(
-            "submission.completed",
-            extra={
-                "user_id": user_id,
-                "requirement_slug": requirement.slug,
-                "submission_type": requirement.submission_type,
-                "is_valid": validation_result.is_valid,
-                "verification_completed": validation_result.verification_completed,
-                "validation_message": (
-                    validation_result.message
-                    if not validation_result.is_valid
-                    else None
-                ),
-                "execution_path": "sync",
-            },
+        _log_submission_completed(
+            user_id=user_id,
+            requirement=requirement,
+            validation_result=validation_result,
+            execution_path="sync",
         )
 
         return build_submission_result(db_submission, validation_result)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_http.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_http.py
@@ -1,0 +1,122 @@
+"""Low-level GitHub HTTP plumbing shared by verification services.
+
+This is the single home for talking to the GitHub API: the shared
+``httpx.AsyncClient``, auth headers, retry policy, and the mapping of
+5xx/429 responses to the retriable :class:`GitHubServerError`. Higher-level
+seams (``GitHubMetadata``, ``WorkflowRuns``, ``RepoFiles``) and the profile
+validators build on top of these primitives instead of each re-implementing
+retry and error handling.
+
+SCALABILITY:
+- Retry with exponential backoff + jitter for transient failures (3 attempts).
+- Connection pooling via the shared ``httpx.AsyncClient``.
+"""
+
+from __future__ import annotations
+
+import httpx
+from tenacity import (
+    RetryCallState,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+from learn_to_cloud_shared.core.config import get_worker_settings
+from learn_to_cloud_shared.core.github_client import (
+    get_github_client as _get_github_client,
+)
+from learn_to_cloud_shared.verification.errors import (
+    GitHubServerError,
+    github_error_to_result,
+    make_retriable,
+)
+
+# Exceptions that should trigger retry.
+RETRIABLE_EXCEPTIONS: tuple[type[Exception], ...] = make_retriable(GitHubServerError)
+
+# Re-export under the historical name used across verification modules.
+github_error_to_validation_result = github_error_to_result
+
+
+def _parse_retry_after(header_value: str | None) -> float | None:
+    """Parse a ``Retry-After`` header into seconds."""
+    if not header_value:
+        return None
+    try:
+        return float(header_value)
+    except ValueError:
+        return None
+
+
+def _wait_with_retry_after(retry_state: RetryCallState) -> float:
+    """Wait respecting ``Retry-After`` when present, else exponential backoff."""
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    if isinstance(exc, GitHubServerError) and exc.retry_after:
+        return min(exc.retry_after, 60.0)
+    return wait_exponential_jitter(initial=0.5, max=10)(retry_state)
+
+
+def get_github_headers() -> dict[str, str]:
+    """Get headers for GitHub API requests, including the auth token if set."""
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    settings = get_worker_settings()
+    if settings.github.token:
+        headers["Authorization"] = f"Bearer {settings.github.token}"
+    return headers
+
+
+def raise_for_server_error(response: httpx.Response) -> None:
+    """Map a 5xx or 429 response to the retriable :class:`GitHubServerError`."""
+    if response.status_code >= 500:
+        raise GitHubServerError(f"GitHub returned {response.status_code}")
+    if response.status_code == 429:
+        retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+        raise GitHubServerError("GitHub rate limited (429)", retry_after=retry_after)
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=_wait_with_retry_after,
+    retry=retry_if_exception_type(RETRIABLE_EXCEPTIONS),
+    reraise=True,
+)
+async def github_api_get(
+    url: str,
+    *,
+    extra_headers: dict[str, str] | None = None,
+    params: dict[str, str | int] | None = None,
+) -> httpx.Response:
+    """Resilient GitHub API GET with retry and 5xx/429 mapping.
+
+    Raises:
+        GitHubServerError: On 5xx or 429 (triggers retry).
+        httpx.HTTPStatusError: On non-retriable HTTP errors (4xx).
+    """
+    client = await _get_github_client()
+    headers = get_github_headers()
+    if extra_headers:
+        headers.update(extra_headers)
+    response = await client.get(url, headers=headers, params=params)
+    raise_for_server_error(response)
+    response.raise_for_status()
+    return response
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=_wait_with_retry_after,
+    retry=retry_if_exception_type(RETRIABLE_EXCEPTIONS),
+    reraise=True,
+)
+async def github_head_status(url: str) -> int:
+    """Resilient GitHub HEAD returning the status code, with 5xx/429 retry.
+
+    Raises:
+        GitHubServerError: On 5xx or 429 (triggers retry).
+    """
+    client = await _get_github_client()
+    response = await client.head(url)
+    raise_for_server_error(response)
+    return response.status_code

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_metadata.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_metadata.py
@@ -1,0 +1,101 @@
+"""The GitHubMetadata seam: existence and repository-metadata lookups.
+
+Phase 0/1/2 hands-on grading asks two questions of GitHub that are not
+about reading a repository's files: "does this URL exist?" (a HEAD request)
+and "what does this repository's metadata say?" (the repo JSON, used to
+confirm a fork). This small interface captures exactly those two questions.
+
+Two adapters justify the seam: :class:`GitHubApiMetadata` talks to live
+GitHub in production, :class:`InMemoryGitHubMetadata` answers from an
+in-memory mapping in tests. Validators accept an optional ``GitHubMetadata``
+and fall back to :func:`default_github_metadata` when none is supplied.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+import httpx
+
+from learn_to_cloud_shared.verification.github_http import (
+    github_api_get,
+    github_head_status,
+)
+
+
+@runtime_checkable
+class GitHubMetadata(Protocol):
+    """Existence and metadata lookups against GitHub.
+
+    ``url_exists`` returns ``True`` for a 200 and ``False`` otherwise (for
+    example a 404). ``repo_metadata`` returns the repository JSON, or
+    ``None`` when the repository does not exist (404). Both raise the
+    retriable :class:`GitHubServerError` on 5xx/429 and propagate
+    ``httpx`` network errors; callers map those to an incomplete result.
+    """
+
+    async def url_exists(self, url: str) -> bool: ...
+
+    async def repo_metadata(self, owner: str, repo: str) -> dict[str, Any] | None: ...
+
+
+class GitHubApiMetadata:
+    """Production adapter backed by the GitHub HTTP API."""
+
+    async def url_exists(self, url: str) -> bool:
+        """Return ``True`` when a HEAD request to ``url`` returns 200."""
+        status = await github_head_status(url)
+        return status == 200
+
+    async def repo_metadata(self, owner: str, repo: str) -> dict[str, Any] | None:
+        """Return the repository JSON, or ``None`` when it does not exist."""
+        url = f"https://api.github.com/repos/{owner}/{repo}"
+        try:
+            response = await github_api_get(url)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return None
+            raise
+        return response.json()
+
+
+class InMemoryGitHubMetadata:
+    """Test adapter answering from in-memory data.
+
+    ``existing_urls`` is the set of URLs that should report as existing.
+    ``repos`` maps ``"owner/repo"`` to its metadata JSON; a missing key
+    reports as a 404 (``None``). Set ``url_error`` or ``repo_error`` to make
+    the matching call raise (for example a ``GitHubServerError`` or an
+    ``httpx`` network error) to model infrastructure failures.
+    """
+
+    def __init__(
+        self,
+        *,
+        existing_urls: set[str] | None = None,
+        repos: dict[str, dict[str, Any]] | None = None,
+        url_error: Exception | None = None,
+        repo_error: Exception | None = None,
+    ) -> None:
+        self._existing_urls = set(existing_urls or set())
+        self._repos = dict(repos or {})
+        self._url_error = url_error
+        self._repo_error = repo_error
+
+    async def url_exists(self, url: str) -> bool:
+        if self._url_error is not None:
+            raise self._url_error
+        return url in self._existing_urls
+
+    async def repo_metadata(self, owner: str, repo: str) -> dict[str, Any] | None:
+        if self._repo_error is not None:
+            raise self._repo_error
+        return self._repos.get(f"{owner}/{repo}")
+
+
+_DEFAULT_GITHUB_METADATA = GitHubApiMetadata()
+
+
+def default_github_metadata() -> GitHubMetadata:
+    """Return the shared production adapter used when no port is injected."""
+    return _DEFAULT_GITHUB_METADATA

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
@@ -12,6 +12,7 @@ on, see ``github_metadata.py``.
 For the main hands-on verification orchestration, see hands_on_verification.py
 """
 
+import httpx
 from opentelemetry import trace
 
 from learn_to_cloud_shared.schemas import ValidationResult
@@ -127,6 +128,14 @@ async def check_repo_is_fork_of(
             is_valid=False,
             message=f"Request error: {e!s}",
             verification_completed=False,
+        )
+    except httpx.HTTPStatusError as e:
+        span = trace.get_current_span()
+        span.record_exception(e)
+        return github_error_to_validation_result(
+            e,
+            event="fork_check.api_error",
+            context={"username": username, "repo": repo_name},
         )
     except Exception as e:
         span = trace.get_current_span()

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
@@ -6,129 +6,42 @@ This module handles all GitHub-specific validations including:
 - Repository fork verification (Phase 1)
 
 For URL parsing, see ``repo_utils.parse_github_url``.
+For the GitHub HTTP plumbing (retry, headers, error mapping), see
+``github_http.py``. For the existence/metadata seam these validators build
+on, see ``github_metadata.py``.
 For the main hands-on verification orchestration, see hands_on_verification.py
-
-SCALABILITY:
-- Retry with exponential backoff + jitter for transient failures (3 attempts)
-- Connection pooling via shared httpx.AsyncClient
 """
 
-import httpx
 from opentelemetry import trace
-from tenacity import (
-    RetryCallState,
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential_jitter,
-)
 
-from learn_to_cloud_shared.core.config import get_worker_settings
-from learn_to_cloud_shared.core.github_client import (
-    get_github_client as _get_github_client,
-)
 from learn_to_cloud_shared.schemas import ValidationResult
-from learn_to_cloud_shared.verification.errors import (
-    GitHubServerError,
-    github_error_to_result,
-    make_retriable,
+from learn_to_cloud_shared.verification.github_http import (
+    RETRIABLE_EXCEPTIONS,
+    github_error_to_validation_result,
+)
+from learn_to_cloud_shared.verification.github_metadata import (
+    GitHubMetadata,
+    default_github_metadata,
 )
 from learn_to_cloud_shared.verification.repo_utils import parse_github_url
 
-
-def _parse_retry_after(header_value: str | None) -> float | None:
-    """Parse Retry-After header into seconds."""
-    if not header_value:
-        return None
-    try:
-        return float(header_value)
-    except ValueError:
-        return None
-
-
-def _wait_with_retry_after(retry_state: RetryCallState) -> float:
-    """Wait respecting Retry-After header, else exponential backoff."""
-    exc = retry_state.outcome.exception() if retry_state.outcome else None
-    if isinstance(exc, GitHubServerError) and exc.retry_after:
-        return min(exc.retry_after, 60.0)
-    return wait_exponential_jitter(initial=0.5, max=10)(retry_state)
+__all__ = [
+    "GitHubMetadata",
+    "RETRIABLE_EXCEPTIONS",
+    "check_github_url_exists",
+    "check_repo_is_fork_of",
+    "default_github_metadata",
+    "github_error_to_validation_result",
+    "parse_github_url",
+    "validate_github_profile",
+    "validate_profile_readme",
+    "validate_repo_fork",
+]
 
 
-# Exceptions that should trigger retry
-RETRIABLE_EXCEPTIONS: tuple[type[Exception], ...] = make_retriable(GitHubServerError)
-
-# Re-export for backward compatibility
-github_error_to_validation_result = github_error_to_result
-
-
-def get_github_headers() -> dict[str, str]:
-    """Get headers for GitHub API requests, including auth token if available."""
-    headers = {"Accept": "application/vnd.github.v3+json"}
-    settings = get_worker_settings()
-    if settings.github.token:
-        headers["Authorization"] = f"Bearer {settings.github.token}"
-    return headers
-
-
-@retry(
-    stop=stop_after_attempt(3),
-    wait=_wait_with_retry_after,
-    retry=retry_if_exception_type(RETRIABLE_EXCEPTIONS),
-    reraise=True,
-)
-async def github_api_get(
-    url: str,
-    *,
-    extra_headers: dict[str, str] | None = None,
-    params: dict[str, str | int] | None = None,
-) -> httpx.Response:
-    """Resilient GitHub API GET with retry and 5xx/429 mapping.
-
-    Raises:
-        GitHubServerError: On 5xx or 429 (triggers retry).
-        httpx.HTTPStatusError: On non-retriable HTTP errors (4xx).
-    """
-    client = await _get_github_client()
-    headers = get_github_headers()
-    if extra_headers:
-        headers.update(extra_headers)
-    response = await client.get(url, headers=headers, params=params)
-    if response.status_code >= 500:
-        raise GitHubServerError(f"GitHub API returned {response.status_code}")
-    if response.status_code == 429:
-        retry_after = _parse_retry_after(response.headers.get("Retry-After"))
-        raise GitHubServerError("GitHub rate limited (429)", retry_after=retry_after)
-    response.raise_for_status()
-    return response
-
-
-@retry(
-    stop=stop_after_attempt(3),
-    wait=_wait_with_retry_after,
-    retry=retry_if_exception_type(RETRIABLE_EXCEPTIONS),
-    reraise=True,
-)
-async def _check_github_url_exists_with_retry(url: str) -> tuple[bool, str]:
-    """Internal: Check URL with retry. Use check_github_url_exists() instead."""
-    client = await _get_github_client()
-    response = await client.head(url)
-
-    if response.status_code >= 500:
-        raise GitHubServerError(f"GitHub returned {response.status_code}")
-
-    if response.status_code == 429:
-        retry_after = _parse_retry_after(response.headers.get("Retry-After"))
-        raise GitHubServerError("GitHub rate limited (429)", retry_after=retry_after)
-
-    if response.status_code == 200:
-        return True, "URL exists"
-    elif response.status_code == 404:
-        return False, "URL not found (404)"
-    else:
-        return False, f"Unexpected status code: {response.status_code}"
-
-
-async def check_github_url_exists(url: str) -> ValidationResult:
+async def check_github_url_exists(
+    url: str, metadata: GitHubMetadata | None = None
+) -> ValidationResult:
     """Check if a GitHub URL exists by making a HEAD request.
 
     Returns:
@@ -139,9 +52,13 @@ async def check_github_url_exists(url: str) -> ValidationResult:
 
     RETRY: 3 attempts with exponential backoff + jitter for transient failures.
     """
+    metadata = metadata or default_github_metadata()
     try:
-        exists, msg = await _check_github_url_exists_with_retry(url)
-        return ValidationResult(is_valid=exists, message=msg)
+        exists = await metadata.url_exists(url)
+        return ValidationResult(
+            is_valid=exists,
+            message="URL exists" if exists else "URL not found (404)",
+        )
     except RETRIABLE_EXCEPTIONS as e:
         span = trace.get_current_span()
         span.record_exception(e)
@@ -162,53 +79,11 @@ async def check_github_url_exists(url: str) -> ValidationResult:
         )
 
 
-@retry(
-    stop=stop_after_attempt(3),
-    wait=_wait_with_retry_after,
-    retry=retry_if_exception_type(RETRIABLE_EXCEPTIONS),
-    reraise=True,
-)
-async def _check_repo_is_fork_of_with_retry(
-    username: str, repo_name: str, original_repo: str
-) -> tuple[bool, str]:
-    """Internal: Check fork with retry. Use check_repo_is_fork_of() instead."""
-    api_url = f"https://api.github.com/repos/{username}/{repo_name}"
-
-    client = await _get_github_client()
-    response = await client.get(api_url, headers=get_github_headers())
-
-    if response.status_code >= 500:
-        raise GitHubServerError(f"GitHub API returned {response.status_code}")
-
-    if response.status_code == 429:
-        retry_after = _parse_retry_after(response.headers.get("Retry-After"))
-        raise GitHubServerError("GitHub rate limited (429)", retry_after=retry_after)
-
-    if response.status_code == 404:
-        return False, f"Repository {username}/{repo_name} not found"
-
-    if response.status_code != 200:
-        return False, f"GitHub API error: {response.status_code}"
-
-    repo_data = response.json()
-
-    if not repo_data.get("fork", False):
-        return False, "Repository is not a fork"
-
-    parent = repo_data.get("parent", {})
-    parent_full_name = parent.get("full_name", "")
-
-    if parent_full_name.lower() == original_repo.lower():
-        return True, f"Verified fork of {original_repo}"
-    else:
-        return (
-            False,
-            f"Forked from {parent_full_name}, not {original_repo}",
-        )
-
-
 async def check_repo_is_fork_of(
-    username: str, repo_name: str, original_repo: str
+    username: str,
+    repo_name: str,
+    original_repo: str,
+    metadata: GitHubMetadata | None = None,
 ) -> ValidationResult:
     """Check if a repository is a fork of the specified original repository.
 
@@ -216,6 +91,7 @@ async def check_repo_is_fork_of(
         username: The GitHub username
         repo_name: The repository name
         original_repo: The original repo in format "owner/repo"
+        metadata: GitHub metadata port (defaults to the production adapter)
 
     Returns:
         ValidationResult with is_valid=True if repo is a fork of original_repo.
@@ -223,11 +99,26 @@ async def check_repo_is_fork_of(
 
     RETRY: 3 attempts with exponential backoff + jitter for transient failures.
     """
+    metadata = metadata or default_github_metadata()
     try:
-        is_fork, msg = await _check_repo_is_fork_of_with_retry(
-            username, repo_name, original_repo
+        repo_data = await metadata.repo_metadata(username, repo_name)
+        if repo_data is None:
+            return ValidationResult(
+                is_valid=False,
+                message=f"Repository {username}/{repo_name} not found",
+            )
+        if not repo_data.get("fork", False):
+            return ValidationResult(is_valid=False, message="Repository is not a fork")
+        parent = repo_data.get("parent", {})
+        parent_full_name = parent.get("full_name", "")
+        if parent_full_name.lower() == original_repo.lower():
+            return ValidationResult(
+                is_valid=True, message=f"Verified fork of {original_repo}"
+            )
+        return ValidationResult(
+            is_valid=False,
+            message=f"Forked from {parent_full_name}, not {original_repo}",
         )
-        return ValidationResult(is_valid=is_fork, message=msg)
     except RETRIABLE_EXCEPTIONS as e:
         span = trace.get_current_span()
         span.record_exception(e)
@@ -252,7 +143,9 @@ async def check_repo_is_fork_of(
 
 
 async def validate_github_profile(
-    github_url: str, expected_username: str
+    github_url: str,
+    expected_username: str,
+    metadata: GitHubMetadata | None = None,
 ) -> ValidationResult:
     """Validate a GitHub profile URL submission.
 
@@ -284,7 +177,7 @@ async def validate_github_profile(
         )
 
     profile_url = f"https://github.com/{username}"
-    result = await check_github_url_exists(profile_url)
+    result = await check_github_url_exists(profile_url, metadata)
 
     if not result.is_valid:
         return result.model_copy(
@@ -304,7 +197,9 @@ async def validate_github_profile(
 
 
 async def validate_profile_readme(
-    github_url: str, expected_username: str
+    github_url: str,
+    expected_username: str,
+    metadata: GitHubMetadata | None = None,
 ) -> ValidationResult:
     """Validate a GitHub profile README submission.
 
@@ -345,7 +240,7 @@ async def validate_profile_readme(
             repo_exists=False,
         )
 
-    result = await check_github_url_exists(github_url)
+    result = await check_github_url_exists(github_url, metadata)
 
     if not result.is_valid:
         return result.model_copy(
@@ -365,7 +260,10 @@ async def validate_profile_readme(
 
 
 async def validate_repo_fork(
-    github_url: str, expected_username: str, required_repo: str
+    github_url: str,
+    expected_username: str,
+    required_repo: str,
+    metadata: GitHubMetadata | None = None,
 ) -> ValidationResult:
     """Validate a repository fork submission.
 
@@ -404,7 +302,7 @@ async def validate_repo_fork(
         )
 
     fork_result = await check_repo_is_fork_of(
-        parsed.username, parsed.repo_name, required_repo
+        parsed.username, parsed.repo_name, required_repo, metadata
     )
 
     if not fork_result.is_valid:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/journal_api.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/journal_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from learn_to_cloud_shared.verification.evidence import collect_repo_file_evidence
+from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
 from learn_to_cloud_shared.verification.tasks.base import (
     EvidenceBundle,
     VerificationTask,
@@ -21,10 +22,12 @@ async def collect_journal_api_implementation_evidence(
     repo: str,
     file_paths: list[str],
     task: VerificationTask = JOURNAL_API_FINAL_RUBRIC_TASK,
+    repo_files: RepoFiles | None = None,
 ) -> EvidenceBundle:
     """Collect bounded Phase 3 Journal API evidence for rubric grading."""
+    repo_files = repo_files or default_repo_files()
     paths = _select_journal_api_evidence_paths(file_paths, task)
-    return await collect_repo_file_evidence(owner, repo, paths, task)
+    return await collect_repo_file_evidence(repo_files, owner, repo, paths, task)
 
 
 def _select_journal_api_evidence_paths(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -9,10 +9,10 @@ from learn_to_cloud_shared.schemas import (
     HandsOnRequirement,
     ValidationResult,
 )
-from learn_to_cloud_shared.verification.devops_analysis import fetch_repo_tree
 from learn_to_cloud_shared.verification.journal_api import (
     collect_journal_api_implementation_evidence,
 )
+from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
 from learn_to_cloud_shared.verification.repo_utils import validate_repo_url
 from learn_to_cloud_shared.verification.security_scanning import (
     collect_security_scanning_evidence,
@@ -50,6 +50,7 @@ class LLMGradingDecisionPayload(FrozenModel):
 
 async def collect_llm_grading_requests(
     run_result: VerificationRunResult,
+    repo_files: RepoFiles | None = None,
 ) -> list[LLMGradingRequest]:
     """Collect evidence and prompts for tasks that require LLM grading."""
     if not run_result.validation_result.verification_completed:
@@ -59,11 +60,13 @@ async def collect_llm_grading_requests(
     if not tasks:
         return []
 
+    repo_files = repo_files or default_repo_files()
+
     if run_result.job.requirement.slug == "security-scanning":
-        return await _collect_phase6_requests(run_result, tasks)
+        return await _collect_phase6_requests(run_result, tasks, repo_files)
 
     if run_result.job.requirement.slug == "journal-api-implementation":
-        return await _collect_phase3_requests(run_result, tasks)
+        return await _collect_phase3_requests(run_result, tasks, repo_files)
 
     return []
 
@@ -123,6 +126,7 @@ def llm_grading_unavailable_result(
 async def _collect_phase6_requests(
     run_result: VerificationRunResult,
     tasks: list[VerificationTask],
+    repo_files: RepoFiles,
 ) -> list[LLMGradingRequest]:
     github_username = run_result.job.github_username
     if github_username is None:
@@ -138,7 +142,7 @@ async def _collect_phase6_requests(
         return []
 
     owner, repo = repo_result
-    file_paths = await fetch_repo_tree(owner, repo)
+    file_paths = await repo_files.tree(owner, repo)
     requests: list[LLMGradingRequest] = []
     for task in tasks:
         evidence = await collect_security_scanning_evidence(
@@ -146,6 +150,7 @@ async def _collect_phase6_requests(
             repo,
             file_paths,
             task,
+            repo_files=repo_files,
         )
         requests.append(
             LLMGradingRequest(
@@ -166,6 +171,7 @@ async def _collect_phase6_requests(
 async def _collect_phase3_requests(
     run_result: VerificationRunResult,
     tasks: list[VerificationTask],
+    repo_files: RepoFiles,
 ) -> list[LLMGradingRequest]:
     if not run_result.validation_result.is_valid:
         return []
@@ -184,7 +190,7 @@ async def _collect_phase3_requests(
         return []
 
     owner, repo = repo_result
-    file_paths = await fetch_repo_tree(owner, repo)
+    file_paths = await repo_files.tree(owner, repo)
     requests: list[LLMGradingRequest] = []
     for task in tasks:
         evidence = await collect_journal_api_implementation_evidence(
@@ -192,6 +198,7 @@ async def _collect_phase3_requests(
             repo,
             file_paths,
             task,
+            repo_files=repo_files,
         )
         requests.append(
             LLMGradingRequest(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_files.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_files.py
@@ -18,7 +18,7 @@ import httpx
 from opentelemetry import trace
 
 from learn_to_cloud_shared.core.github_client import get_github_client
-from learn_to_cloud_shared.verification.github_profile import (
+from learn_to_cloud_shared.verification.github_http import (
     get_github_headers,
     github_api_get,
 )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_files.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_files.py
@@ -1,0 +1,114 @@
+"""The RepoFiles seam: read access to a learner's GitHub repository.
+
+Grading rules depend on this small interface (read the file tree, read a
+single file's text) instead of reaching the network directly. Production
+injects :class:`GitHubRepoFiles`; tests inject :class:`InMemoryRepoFiles`.
+
+Two adapters justify the seam: live GitHub in production, an in-memory
+mapping in tests. Graders accept an optional ``RepoFiles`` and fall back to
+:func:`default_repo_files` when none is supplied, so callers that do not
+care about the seam keep working while tests can swap in a fake.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import httpx
+from opentelemetry import trace
+
+from learn_to_cloud_shared.core.github_client import get_github_client
+from learn_to_cloud_shared.verification.github_profile import (
+    get_github_headers,
+    github_api_get,
+)
+
+
+@runtime_checkable
+class RepoFiles(Protocol):
+    """Read access to a GitHub repository's files.
+
+    ``tree`` raises ``httpx.HTTPStatusError`` (for example a 404 when the
+    repository is missing or private) and the retriable GitHub server
+    errors raised by the production adapter; callers already handle these.
+    ``file`` returns ``None`` when a file cannot be read.
+    """
+
+    async def tree(self, owner: str, repo: str, branch: str = "main") -> list[str]: ...
+
+    async def file(
+        self, owner: str, repo: str, path: str, branch: str = "main"
+    ) -> str | None: ...
+
+
+class GitHubRepoFiles:
+    """Production adapter backed by the GitHub HTTP API."""
+
+    async def tree(self, owner: str, repo: str, branch: str = "main") -> list[str]:
+        """Return every blob path in the repository via the Git Trees API."""
+        url = f"https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}"
+        response = await github_api_get(url, params={"recursive": 1})
+        tree_data = response.json()
+        return [
+            item["path"]
+            for item in tree_data.get("tree", [])
+            if item.get("type") == "blob"
+        ]
+
+    async def file(
+        self, owner: str, repo: str, path: str, branch: str = "main"
+    ) -> str | None:
+        """Return a file's raw text, or ``None`` if it cannot be read."""
+        client = await get_github_client()
+        headers = get_github_headers()
+        url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}"
+        try:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+        except httpx.HTTPStatusError:
+            span = trace.get_current_span()
+            span.add_event(
+                "repo_file_fetch_failed",
+                {"owner": owner, "repo": repo, "path": path},
+            )
+            return None
+        return response.text
+
+
+class InMemoryRepoFiles:
+    """Test adapter backed by an in-memory mapping of path to content.
+
+    ``files`` maps a repository path to its text. ``tree`` defaults to the
+    keys of ``files`` but can be set explicitly to model files that exist in
+    the tree yet cannot be fetched. Set ``tree_error`` to make ``tree`` raise
+    (for example an ``httpx.HTTPStatusError`` for a missing repository).
+    """
+
+    def __init__(
+        self,
+        files: dict[str, str] | None = None,
+        *,
+        tree: list[str] | None = None,
+        tree_error: Exception | None = None,
+    ) -> None:
+        self._files = dict(files or {})
+        self._tree = list(tree) if tree is not None else list(self._files)
+        self._tree_error = tree_error
+
+    async def tree(self, owner: str, repo: str, branch: str = "main") -> list[str]:
+        if self._tree_error is not None:
+            raise self._tree_error
+        return list(self._tree)
+
+    async def file(
+        self, owner: str, repo: str, path: str, branch: str = "main"
+    ) -> str | None:
+        return self._files.get(path)
+
+
+_DEFAULT_REPO_FILES = GitHubRepoFiles()
+
+
+def default_repo_files() -> RepoFiles:
+    """Return the shared production adapter used when no port is injected."""
+    return _DEFAULT_REPO_FILES

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/security_scanning.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/security_scanning.py
@@ -29,14 +29,13 @@ from tenacity import (
 )
 
 from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
-from learn_to_cloud_shared.verification.devops_analysis import fetch_repo_tree
 from learn_to_cloud_shared.verification.evidence import (
     collect_repo_file_evidence,
-    fetch_repo_file_content,
 )
 from learn_to_cloud_shared.verification.github_profile import (
     RETRIABLE_EXCEPTIONS,
 )
+from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
 from learn_to_cloud_shared.verification.repo_utils import VerificationError
 from learn_to_cloud_shared.verification.tasks.base import (
     EvidenceBundle,
@@ -55,7 +54,9 @@ class SecurityVerificationError(VerificationError):
     """Raised when Phase 6 security scanning verification fails."""
 
 
-async def _check_dependabot(owner: str, repo: str, file_paths: list[str]) -> TaskResult:
+async def _check_dependabot(
+    repo_files: RepoFiles, owner: str, repo: str, file_paths: list[str]
+) -> TaskResult:
     """Check for a valid Dependabot configuration file in the repo tree.
 
     Verifies both file existence and content: the file must contain
@@ -73,7 +74,7 @@ async def _check_dependabot(owner: str, repo: str, file_paths: list[str]) -> Tas
             ),
         )
 
-    content = await _fetch_workflow_content(owner, repo, found[0])
+    content = await _fetch_workflow_content(repo_files, owner, repo, found[0])
     if not content:
         return TaskResult(
             task_name=DEPENDABOT_TASK.name,
@@ -143,12 +144,16 @@ def _find_codeql_workflow_candidates(file_paths: list[str]) -> list[str]:
     return codeql_by_name + other_workflows
 
 
-async def _fetch_workflow_content(owner: str, repo: str, path: str) -> str | None:
+async def _fetch_workflow_content(
+    repo_files: RepoFiles, owner: str, repo: str, path: str
+) -> str | None:
     """Fetch a single workflow file's raw content from GitHub."""
-    return await fetch_repo_file_content(owner, repo, path)
+    return await repo_files.file(owner, repo, path)
 
 
-async def _check_codeql(owner: str, repo: str, file_paths: list[str]) -> TaskResult:
+async def _check_codeql(
+    repo_files: RepoFiles, owner: str, repo: str, file_paths: list[str]
+) -> TaskResult:
     """Check for CodeQL workflow in the repository.
 
     First checks filenames for 'codeql', then fetches workflow content
@@ -170,7 +175,9 @@ async def _check_codeql(owner: str, repo: str, file_paths: list[str]) -> TaskRes
     codeql_named = [c for c in candidates if "codeql" in c.rsplit("/", 1)[-1].lower()]
     if codeql_named:
         # Fetch to confirm it actually uses the CodeQL action
-        content = await _fetch_workflow_content(owner, repo, codeql_named[0])
+        content = await _fetch_workflow_content(
+            repo_files, owner, repo, codeql_named[0]
+        )
         if content and CODEQL_ACTION_PATTERN in content:
             return TaskResult(
                 task_name=CODEQL_TASK.name,
@@ -183,7 +190,9 @@ async def _check_codeql(owner: str, repo: str, file_paths: list[str]) -> TaskRes
         : CODEQL_TASK.evidence.max_files
     ]
 
-    fetch_tasks = [_fetch_workflow_content(owner, repo, path) for path in to_check]
+    fetch_tasks = [
+        _fetch_workflow_content(repo_files, owner, repo, path) for path in to_check
+    ]
     results = await asyncio.gather(*fetch_tasks, return_exceptions=True)
 
     for path, result in zip(to_check, results, strict=True):
@@ -211,8 +220,10 @@ async def collect_security_scanning_evidence(
     repo: str,
     file_paths: list[str],
     task: VerificationTask = SECURITY_SCANNING_RUBRIC_TASK,
+    repo_files: RepoFiles | None = None,
 ) -> EvidenceBundle:
     """Collect bounded Phase 6 repository evidence for rubric grading."""
+    repo_files = repo_files or default_repo_files()
     codeql_candidates = set(_find_codeql_workflow_candidates(file_paths))
     candidate_paths = [
         path
@@ -220,7 +231,7 @@ async def collect_security_scanning_evidence(
         if path in DEPENDABOT_CONFIG_PATHS or path in codeql_candidates
     ]
     unique_paths = list(dict.fromkeys(candidate_paths))[: task.evidence.max_files]
-    return await collect_repo_file_evidence(owner, repo, unique_paths, task)
+    return await collect_repo_file_evidence(repo_files, owner, repo, unique_paths, task)
 
 
 @retry(
@@ -230,11 +241,11 @@ async def collect_security_scanning_evidence(
     reraise=True,
 )
 async def _verify_security_scanning(
-    owner: str, repo: str, file_paths: list[str]
+    repo_files: RepoFiles, owner: str, repo: str, file_paths: list[str]
 ) -> ValidationResult:
     """Internal: run security scanning checks with retry."""
-    dependabot_result = await _check_dependabot(owner, repo, file_paths)
-    codeql_result = await _check_codeql(owner, repo, file_paths)
+    dependabot_result = await _check_dependabot(repo_files, owner, repo, file_paths)
+    codeql_result = await _check_codeql(repo_files, owner, repo, file_paths)
 
     task_results = [dependabot_result, codeql_result]
     any_passed = dependabot_result.passed or codeql_result.passed
@@ -279,6 +290,7 @@ async def _verify_security_scanning(
 async def validate_security_scanning(
     owner: str,
     repo: str,
+    repo_files: RepoFiles | None = None,
 ) -> ValidationResult:
     """Verify a learner's GitHub repo has security scanning enabled.
 
@@ -293,13 +305,15 @@ async def validate_security_scanning(
     Args:
         owner: Repository owner (GitHub username).
         repo: Repository name.
+        repo_files: Read access to the repository; defaults to live GitHub.
 
     Returns:
         ValidationResult with is_valid=True if at least one security feature
         is found, and detailed task_results for feedback.
     """
+    repo_files = repo_files or default_repo_files()
     try:
-        all_files = await fetch_repo_tree(owner, repo)
+        all_files = await repo_files.tree(owner, repo)
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:
             return ValidationResult(
@@ -312,4 +326,4 @@ async def validate_security_scanning(
             )
         raise
 
-    return await _verify_security_scanning(owner, repo, all_files)
+    return await _verify_security_scanning(repo_files, owner, repo, all_files)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/security_scanning.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/security_scanning.py
@@ -32,7 +32,7 @@ from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
 from learn_to_cloud_shared.verification.evidence import (
     collect_repo_file_evidence,
 )
-from learn_to_cloud_shared.verification.github_profile import (
+from learn_to_cloud_shared.verification.github_http import (
     RETRIABLE_EXCEPTIONS,
 )
 from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/workflow_runs.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/workflow_runs.py
@@ -1,0 +1,84 @@
+"""The WorkflowRuns seam: read access to a repository's CI workflow runs.
+
+Phase 3 grading trusts the test suite that ships with the upstream starter
+repository: a green GitHub Actions run on ``main`` is the acceptance gate.
+The only question asked of GitHub is "what is the most recent run of this
+workflow on this branch?" This small interface captures exactly that.
+
+Two adapters justify the seam: :class:`GitHubApiWorkflowRuns` talks to live
+GitHub in production, :class:`InMemoryWorkflowRuns` answers from in-memory
+data in tests. ``verify_ci_status`` accepts an optional ``WorkflowRuns`` and
+falls back to :func:`default_workflow_runs` when none is supplied.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from learn_to_cloud_shared.verification.github_http import github_api_get
+
+
+@runtime_checkable
+class WorkflowRuns(Protocol):
+    """Read access to a repository's GitHub Actions workflow runs.
+
+    ``latest_run`` returns the most recent run for ``workflow`` on
+    ``branch`` as the GitHub run JSON, or ``None`` when no runs exist. It
+    raises ``httpx.HTTPStatusError`` (for example a 404 when the workflow
+    file is absent) and the retriable :class:`GitHubServerError`; callers
+    already handle these.
+    """
+
+    async def latest_run(
+        self, owner: str, repo: str, workflow: str, branch: str = "main"
+    ) -> dict[str, Any] | None: ...
+
+
+class GitHubApiWorkflowRuns:
+    """Production adapter backed by the GitHub HTTP API."""
+
+    async def latest_run(
+        self, owner: str, repo: str, workflow: str, branch: str = "main"
+    ) -> dict[str, Any] | None:
+        """Return the most recent workflow run, or ``None`` when there are none."""
+        url = (
+            f"https://api.github.com/repos/{owner}/{repo}"
+            f"/actions/workflows/{workflow}/runs"
+        )
+        params: dict[str, str | int] = {"branch": branch, "per_page": 1}
+        response = await github_api_get(url, params=params)
+        runs: list[dict[str, Any]] = response.json().get("workflow_runs", [])
+        return runs[0] if runs else None
+
+
+class InMemoryWorkflowRuns:
+    """Test adapter answering from in-memory data.
+
+    ``run`` is the run JSON returned by ``latest_run`` (``None`` models a
+    repository with no runs). Set ``error`` to make ``latest_run`` raise (for
+    example an ``httpx.HTTPStatusError`` for a missing workflow file).
+    """
+
+    def __init__(
+        self,
+        run: dict[str, Any] | None = None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self._run = run
+        self._error = error
+
+    async def latest_run(
+        self, owner: str, repo: str, workflow: str, branch: str = "main"
+    ) -> dict[str, Any] | None:
+        if self._error is not None:
+            raise self._error
+        return self._run
+
+
+_DEFAULT_WORKFLOW_RUNS = GitHubApiWorkflowRuns()
+
+
+def default_workflow_runs() -> WorkflowRuns:
+    """Return the shared production adapter used when no port is injected."""
+    return _DEFAULT_WORKFLOW_RUNS

--- a/packages/learn-to-cloud-shared/tests/services/test_ci_status_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_ci_status_verification_service.py
@@ -9,25 +9,21 @@ Tests cover:
 - GitHub API errors
 
 URL validation and ownership checks are tested in the dispatcher tests.
-"""
 
-from unittest.mock import MagicMock, patch
+These tests inject an :class:`InMemoryWorkflowRuns` adapter instead of
+patching internals, so they exercise the real ``verify_ci_status`` logic
+through the ``WorkflowRuns`` seam.
+"""
 
 import httpx
 import pytest
 
 from learn_to_cloud_shared.verification.ci_status import verify_ci_status
+from learn_to_cloud_shared.verification.errors import GitHubServerError
+from learn_to_cloud_shared.verification.workflow_runs import InMemoryWorkflowRuns
 
 _TEST_OWNER = "testuser"
 _TEST_REPO = "journal-starter"
-
-
-def _make_response(json_data: dict, status_code: int = 200) -> httpx.Response:
-    """Create an httpx.Response with JSON body."""
-    response = MagicMock(spec=httpx.Response)
-    response.status_code = status_code
-    response.json.return_value = json_data
-    return response
 
 
 # =============================================================================
@@ -39,115 +35,90 @@ def _make_response(json_data: dict, status_code: int = 200) -> httpx.Response:
 class TestCiStatusCheck:
     """Tests for the GitHub Actions workflow status check."""
 
-    @patch("learn_to_cloud_shared.verification.ci_status.github_api_get", autospec=True)
-    async def test_workflow_not_found_returns_helpful_message(self, mock_get):
+    async def test_workflow_not_found_returns_helpful_message(self):
         response = httpx.Response(404, request=httpx.Request("GET", "https://test"))
-        mock_get.side_effect = httpx.HTTPStatusError(
-            "Not Found", request=response.request, response=response
+        runs = InMemoryWorkflowRuns(
+            error=httpx.HTTPStatusError(
+                "Not Found", request=response.request, response=response
+            )
         )
-        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO)
+        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO, runs)
         assert not result.is_valid
         assert "CI workflow not found" in result.message
         assert "ci.yml" in result.message
 
-    @patch("learn_to_cloud_shared.verification.ci_status.github_api_get", autospec=True)
-    async def test_no_runs_on_main(self, mock_get):
-        mock_get.return_value = _make_response({"workflow_runs": []})
-        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO)
+    async def test_no_runs_on_main(self):
+        runs = InMemoryWorkflowRuns(run=None)
+        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO, runs)
         assert not result.is_valid
         assert "No CI runs found" in result.message
 
-    @patch("learn_to_cloud_shared.verification.ci_status.github_api_get", autospec=True)
-    async def test_run_in_progress(self, mock_get):
-        mock_get.return_value = _make_response(
+    async def test_run_in_progress(self):
+        runs = InMemoryWorkflowRuns(
             {
-                "workflow_runs": [
-                    {
-                        "status": "in_progress",
-                        "conclusion": None,
-                        "run_number": 5,
-                        "html_url": "https://github.com/testuser/journal-starter/actions/runs/123",
-                    }
-                ]
+                "status": "in_progress",
+                "conclusion": None,
+                "run_number": 5,
+                "html_url": "https://github.com/testuser/journal-starter/actions/runs/123",
             }
         )
-        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO)
+        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO, runs)
         assert not result.is_valid
         assert "still" in result.message
         assert "#5" in result.message
 
-    @patch("learn_to_cloud_shared.verification.ci_status.github_api_get", autospec=True)
-    async def test_run_queued(self, mock_get):
-        mock_get.return_value = _make_response(
+    async def test_run_queued(self):
+        runs = InMemoryWorkflowRuns(
             {
-                "workflow_runs": [
-                    {
-                        "status": "queued",
-                        "conclusion": None,
-                        "run_number": 3,
-                        "html_url": "https://github.com/testuser/journal-starter/actions/runs/456",
-                    }
-                ]
+                "status": "queued",
+                "conclusion": None,
+                "run_number": 3,
+                "html_url": "https://github.com/testuser/journal-starter/actions/runs/456",
             }
         )
-        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO)
+        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO, runs)
         assert not result.is_valid
         assert "#3" in result.message
 
-    @patch("learn_to_cloud_shared.verification.ci_status.github_api_get", autospec=True)
-    async def test_run_succeeded(self, mock_get):
-        mock_get.return_value = _make_response(
+    async def test_run_succeeded(self):
+        runs = InMemoryWorkflowRuns(
             {
-                "workflow_runs": [
-                    {
-                        "status": "completed",
-                        "conclusion": "success",
-                        "run_number": 10,
-                        "html_url": "https://github.com/testuser/journal-starter/actions/runs/789",
-                    }
-                ]
+                "status": "completed",
+                "conclusion": "success",
+                "run_number": 10,
+                "html_url": "https://github.com/testuser/journal-starter/actions/runs/789",
             }
         )
-        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO)
+        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO, runs)
         assert result.is_valid
         assert "#10" in result.message
         assert "passing" in result.message.lower()
 
-    @patch("learn_to_cloud_shared.verification.ci_status.github_api_get", autospec=True)
-    async def test_run_failed(self, mock_get):
+    async def test_run_failed(self):
         run_url = "https://github.com/testuser/journal-starter/actions/runs/999"
-        mock_get.return_value = _make_response(
+        runs = InMemoryWorkflowRuns(
             {
-                "workflow_runs": [
-                    {
-                        "status": "completed",
-                        "conclusion": "failure",
-                        "run_number": 7,
-                        "html_url": run_url,
-                    }
-                ]
+                "status": "completed",
+                "conclusion": "failure",
+                "run_number": 7,
+                "html_url": run_url,
             }
         )
-        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO)
+        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO, runs)
         assert not result.is_valid
         assert "failure" in result.message
         assert run_url in result.message
 
-    @patch("learn_to_cloud_shared.verification.ci_status.github_api_get", autospec=True)
-    async def test_run_cancelled(self, mock_get):
-        mock_get.return_value = _make_response(
+    async def test_run_cancelled(self):
+        runs = InMemoryWorkflowRuns(
             {
-                "workflow_runs": [
-                    {
-                        "status": "completed",
-                        "conclusion": "cancelled",
-                        "run_number": 4,
-                        "html_url": "https://github.com/testuser/journal-starter/actions/runs/111",
-                    }
-                ]
+                "status": "completed",
+                "conclusion": "cancelled",
+                "run_number": 4,
+                "html_url": "https://github.com/testuser/journal-starter/actions/runs/111",
             }
         )
-        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO)
+        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO, runs)
         assert not result.is_valid
         assert "cancelled" in result.message
 
@@ -161,26 +132,20 @@ class TestCiStatusCheck:
 class TestCiStatusErrorHandling:
     """Tests for GitHub API error handling."""
 
-    @patch("learn_to_cloud_shared.verification.ci_status.github_api_get", autospec=True)
-    async def test_github_server_error(self, mock_get):
-        response = httpx.Response(500, request=httpx.Request("GET", "https://test"))
-        mock_get.side_effect = httpx.HTTPStatusError(
-            "Server Error", request=response.request, response=response
-        )
-        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO)
+    async def test_github_server_error(self):
+        runs = InMemoryWorkflowRuns(error=GitHubServerError("GitHub returned 500"))
+        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO, runs)
         assert not result.is_valid
         assert result.verification_completed is False
 
-    @patch("learn_to_cloud_shared.verification.ci_status.github_api_get", autospec=True)
-    async def test_transient_failure(self, mock_get):
-        mock_get.side_effect = httpx.ConnectError("connection refused")
-        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO)
+    async def test_transient_failure(self):
+        runs = InMemoryWorkflowRuns(error=httpx.ConnectError("connection refused"))
+        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO, runs)
         assert not result.is_valid
         assert result.verification_completed is False
 
-    @patch("learn_to_cloud_shared.verification.ci_status.github_api_get", autospec=True)
-    async def test_request_timeout(self, mock_get):
-        mock_get.side_effect = httpx.TimeoutException("timed out")
-        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO)
+    async def test_request_timeout(self):
+        runs = InMemoryWorkflowRuns(error=httpx.TimeoutException("timed out"))
+        result = await verify_ci_status(_TEST_OWNER, _TEST_REPO, runs)
         assert not result.is_valid
         assert result.verification_completed is False

--- a/packages/learn-to-cloud-shared/tests/services/test_devops_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_devops_verification_service.py
@@ -7,8 +7,6 @@ Tests cover:
 - End-to-end run_devops_workflow flow
 """
 
-from unittest.mock import MagicMock, patch
-
 import httpx
 import pytest
 
@@ -18,6 +16,7 @@ from learn_to_cloud_shared.verification.devops_analysis import (
     _filter_devops_files,
     run_devops_workflow,
 )
+from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
 from learn_to_cloud_shared.verification.tasks.base import (
     EvidencePolicy,
     IndicatorGraderConfig,
@@ -285,17 +284,18 @@ class TestRunDevopsWorkflow:
     @pytest.mark.asyncio
     async def test_repo_not_found(self):
         """Should return clear error when repository doesn't exist."""
-        mock_response = MagicMock()
-        mock_response.status_code = 404
+        response = httpx.Response(
+            status_code=404, request=httpx.Request("GET", "https://api.github.com")
+        )
+        repo_files = InMemoryRepoFiles(
+            tree_error=httpx.HTTPStatusError(
+                "Not Found", request=response.request, response=response
+            )
+        )
 
-        with patch(
-            "learn_to_cloud_shared.verification.devops_analysis.fetch_repo_tree",
-            autospec=True,
-            side_effect=httpx.HTTPStatusError(
-                "Not Found", request=MagicMock(), response=mock_response
-            ),
-        ):
-            result = await run_devops_workflow("testuser", "journal-starter")
+        result = await run_devops_workflow(
+            "testuser", "journal-starter", repo_files=repo_files
+        )
 
         assert result.is_valid is False
         assert "not found" in result.message.lower()
@@ -303,12 +303,11 @@ class TestRunDevopsWorkflow:
     @pytest.mark.asyncio
     async def test_all_missing_returns_fast(self):
         """When no tasks pass existence check, return immediately."""
-        with patch(
-            "learn_to_cloud_shared.verification.devops_analysis.fetch_repo_tree",
-            autospec=True,
-            return_value=["README.md"],
-        ):
-            result = await run_devops_workflow("testuser", "journal-starter")
+        repo_files = InMemoryRepoFiles(tree=["README.md"])
+
+        result = await run_devops_workflow(
+            "testuser", "journal-starter", repo_files=repo_files
+        )
 
         assert result.is_valid is False
         assert result.task_results is not None
@@ -325,13 +324,11 @@ class TestRunDevopsWorkflow:
             "k8s/deployment.yaml",
             # k8s/service.yaml intentionally absent
         ]
+        repo_files = InMemoryRepoFiles(tree=mock_files)
 
-        with patch(
-            "learn_to_cloud_shared.verification.devops_analysis.fetch_repo_tree",
-            autospec=True,
-            return_value=mock_files,
-        ):
-            result = await run_devops_workflow("testuser", "journal-starter")
+        result = await run_devops_workflow(
+            "testuser", "journal-starter", repo_files=repo_files
+        )
 
         assert result.is_valid is False
         assert result.task_results is not None
@@ -343,16 +340,6 @@ class TestRunDevopsWorkflow:
     @pytest.mark.asyncio
     async def test_all_tasks_pass_with_good_content(self):
         """Happy path: all required files exist with proper content."""
-        mock_files = [
-            "Dockerfile",
-            ".dockerignore",
-            ".github/workflows/ci.yml",
-            "infra/main.tf",
-            "infra/variables.tf",
-            "k8s/deployment.yaml",
-            "k8s/service.yaml",
-        ]
-
         dockerfile_content = (
             "FROM python:3.12-slim\nWORKDIR /app\n"
             "COPY requirements.txt .\nRUN pip install -r requirements.txt\n"
@@ -399,22 +386,11 @@ class TestRunDevopsWorkflow:
                 "    - port: 80\n      targetPort: 8000\n"
             ),
         }
+        repo_files = InMemoryRepoFiles(file_map)
 
-        async def mock_fetch(owner, repo, path, branch="main"):
-            return file_map.get(path, "")
-
-        with (
-            patch(
-                "learn_to_cloud_shared.verification.devops_analysis.fetch_repo_tree",
-                autospec=True,
-                return_value=mock_files,
-            ),
-            patch(
-                "learn_to_cloud_shared.verification.devops_analysis._fetch_file_content",
-                side_effect=mock_fetch,
-            ),
-        ):
-            result = await run_devops_workflow("testuser", "journal-starter")
+        result = await run_devops_workflow(
+            "testuser", "journal-starter", repo_files=repo_files
+        )
 
         assert result.is_valid is True
         assert result.task_results is not None

--- a/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
@@ -7,16 +7,23 @@ Tests cover:
 - validate_github_profile ownership and existence checks
 - validate_profile_readme URL, ownership, and repo name checks
 - validate_repo_fork URL, ownership, and fork verification
+
+The validation tests inject an :class:`InMemoryGitHubMetadata` adapter
+instead of patching internals, so they exercise the real validator logic
+through the ``GitHubMetadata`` seam.
 """
 
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from learn_to_cloud_shared.schemas import ValidationResult
-from learn_to_cloud_shared.verification.github_profile import (
+from learn_to_cloud_shared.verification.errors import GitHubServerError
+from learn_to_cloud_shared.verification.github_http import (
     _parse_retry_after,
     get_github_headers,
+)
+from learn_to_cloud_shared.verification.github_metadata import InMemoryGitHubMetadata
+from learn_to_cloud_shared.verification.github_profile import (
     parse_github_url,
     validate_github_profile,
     validate_profile_readme,
@@ -57,7 +64,7 @@ class TestGetGitHubHeaders:
         mock_settings = MagicMock()
         mock_settings.github.token = "ghp_test123"
         with patch(
-            "learn_to_cloud_shared.verification.github_profile.get_worker_settings",
+            "learn_to_cloud_shared.verification.github_http.get_worker_settings",
             autospec=True,
             return_value=mock_settings,
         ):
@@ -69,7 +76,7 @@ class TestGetGitHubHeaders:
         mock_settings = MagicMock()
         mock_settings.github.token = ""
         with patch(
-            "learn_to_cloud_shared.verification.github_profile.get_worker_settings",
+            "learn_to_cloud_shared.verification.github_http.get_worker_settings",
             autospec=True,
             return_value=mock_settings,
         ):
@@ -199,46 +206,30 @@ class TestValidateGitHubProfile:
 
     @pytest.mark.asyncio
     async def test_profile_exists_succeeds(self):
-        with patch(
-            "learn_to_cloud_shared.verification.github_profile.check_github_url_exists",
-            autospec=True,
-            return_value=ValidationResult(is_valid=True, message="URL exists"),
-        ):
-            result = await validate_github_profile(
-                "https://github.com/testuser", "testuser"
-            )
+        metadata = InMemoryGitHubMetadata(existing_urls={"https://github.com/testuser"})
+        result = await validate_github_profile(
+            "https://github.com/testuser", "testuser", metadata
+        )
         assert result.is_valid is True
         assert result.username_match is True
 
     @pytest.mark.asyncio
     async def test_profile_not_found_fails(self):
-        with patch(
-            "learn_to_cloud_shared.verification.github_profile.check_github_url_exists",
-            autospec=True,
-            return_value=ValidationResult(
-                is_valid=False, message="URL not found (404)"
-            ),
-        ):
-            result = await validate_github_profile(
-                "https://github.com/testuser", "testuser"
-            )
+        metadata = InMemoryGitHubMetadata(existing_urls=set())
+        result = await validate_github_profile(
+            "https://github.com/testuser", "testuser", metadata
+        )
         assert result.is_valid is False
         assert result.username_match is True
 
     @pytest.mark.asyncio
     async def test_server_error_propagated(self):
-        with patch(
-            "learn_to_cloud_shared.verification.github_profile.check_github_url_exists",
-            autospec=True,
-            return_value=ValidationResult(
-                is_valid=False,
-                message="GitHub service temporarily unavailable",
-                verification_completed=False,
-            ),
-        ):
-            result = await validate_github_profile(
-                "https://github.com/testuser", "testuser"
-            )
+        metadata = InMemoryGitHubMetadata(
+            url_error=GitHubServerError("GitHub service temporarily unavailable")
+        )
+        result = await validate_github_profile(
+            "https://github.com/testuser", "testuser", metadata
+        )
         assert result.is_valid is False
         assert result.verification_completed is False
 
@@ -278,30 +269,16 @@ class TestValidateProfileReadme:
 
     @pytest.mark.asyncio
     async def test_readme_exists_succeeds(self):
-        with patch(
-            "learn_to_cloud_shared.verification.github_profile.check_github_url_exists",
-            autospec=True,
-            return_value=ValidationResult(is_valid=True, message="URL exists"),
-        ):
-            result = await validate_profile_readme(
-                "https://github.com/testuser/testuser/blob/main/README.md",
-                "testuser",
-            )
+        url = "https://github.com/testuser/testuser/blob/main/README.md"
+        metadata = InMemoryGitHubMetadata(existing_urls={url})
+        result = await validate_profile_readme(url, "testuser", metadata)
         assert result.is_valid is True
 
     @pytest.mark.asyncio
     async def test_readme_not_found_fails(self):
-        with patch(
-            "learn_to_cloud_shared.verification.github_profile.check_github_url_exists",
-            autospec=True,
-            return_value=ValidationResult(
-                is_valid=False, message="URL not found (404)"
-            ),
-        ):
-            result = await validate_profile_readme(
-                "https://github.com/testuser/testuser/blob/main/README.md",
-                "testuser",
-            )
+        url = "https://github.com/testuser/testuser/blob/main/README.md"
+        metadata = InMemoryGitHubMetadata(existing_urls=set())
+        result = await validate_profile_readme(url, "testuser", metadata)
         assert result.is_valid is False
 
 
@@ -339,51 +316,74 @@ class TestValidateRepoFork:
 
     @pytest.mark.asyncio
     async def test_valid_fork_succeeds(self):
-        with patch(
-            "learn_to_cloud_shared.verification.github_profile.check_repo_is_fork_of",
-            autospec=True,
-            return_value=ValidationResult(
-                is_valid=True, message="Verified fork of learntocloud/repo"
-            ),
-        ):
-            result = await validate_repo_fork(
-                "https://github.com/testuser/repo",
-                "testuser",
-                "learntocloud/repo",
-            )
+        metadata = InMemoryGitHubMetadata(
+            repos={
+                "testuser/repo": {
+                    "fork": True,
+                    "parent": {"full_name": "learntocloud/repo"},
+                }
+            }
+        )
+        result = await validate_repo_fork(
+            "https://github.com/testuser/repo",
+            "testuser",
+            "learntocloud/repo",
+            metadata,
+        )
         assert result.is_valid is True
 
     @pytest.mark.asyncio
     async def test_not_a_fork_fails(self):
-        with patch(
-            "learn_to_cloud_shared.verification.github_profile.check_repo_is_fork_of",
-            autospec=True,
-            return_value=ValidationResult(
-                is_valid=False, message="Repository is not a fork"
-            ),
-        ):
-            result = await validate_repo_fork(
-                "https://github.com/testuser/repo",
-                "testuser",
-                "learntocloud/repo",
-            )
+        metadata = InMemoryGitHubMetadata(repos={"testuser/repo": {"fork": False}})
+        result = await validate_repo_fork(
+            "https://github.com/testuser/repo",
+            "testuser",
+            "learntocloud/repo",
+            metadata,
+        )
         assert result.is_valid is False
 
     @pytest.mark.asyncio
+    async def test_wrong_parent_fails(self):
+        metadata = InMemoryGitHubMetadata(
+            repos={
+                "testuser/repo": {
+                    "fork": True,
+                    "parent": {"full_name": "someone-else/repo"},
+                }
+            }
+        )
+        result = await validate_repo_fork(
+            "https://github.com/testuser/repo",
+            "testuser",
+            "learntocloud/repo",
+            metadata,
+        )
+        assert result.is_valid is False
+        assert "not learntocloud/repo" in result.message
+
+    @pytest.mark.asyncio
+    async def test_repo_not_found_fails(self):
+        metadata = InMemoryGitHubMetadata(repos={})
+        result = await validate_repo_fork(
+            "https://github.com/testuser/repo",
+            "testuser",
+            "learntocloud/repo",
+            metadata,
+        )
+        assert result.is_valid is False
+        assert "not found" in result.message
+
+    @pytest.mark.asyncio
     async def test_server_error_propagated(self):
-        with patch(
-            "learn_to_cloud_shared.verification.github_profile.check_repo_is_fork_of",
-            autospec=True,
-            return_value=ValidationResult(
-                is_valid=False,
-                message="GitHub unavailable",
-                verification_completed=False,
-            ),
-        ):
-            result = await validate_repo_fork(
-                "https://github.com/testuser/repo",
-                "testuser",
-                "learntocloud/repo",
-            )
+        metadata = InMemoryGitHubMetadata(
+            repo_error=GitHubServerError("GitHub unavailable")
+        )
+        result = await validate_repo_fork(
+            "https://github.com/testuser/repo",
+            "testuser",
+            "learntocloud/repo",
+            metadata,
+        )
         assert result.is_valid is False
         assert result.verification_completed is False

--- a/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
@@ -15,6 +15,7 @@ through the ``GitHubMetadata`` seam.
 
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from learn_to_cloud_shared.verification.errors import GitHubServerError
@@ -373,6 +374,24 @@ class TestValidateRepoFork:
         )
         assert result.is_valid is False
         assert "not found" in result.message
+
+    @pytest.mark.asyncio
+    async def test_auth_error_does_not_penalise(self):
+        response = httpx.Response(401, request=httpx.Request("GET", "https://test"))
+        metadata = InMemoryGitHubMetadata(
+            repo_error=httpx.HTTPStatusError(
+                "Unauthorized", request=response.request, response=response
+            )
+        )
+        result = await validate_repo_fork(
+            "https://github.com/testuser/repo",
+            "testuser",
+            "learntocloud/repo",
+            metadata,
+        )
+        assert result.is_valid is False
+        assert result.verification_completed is False
+        assert "Unexpected error" not in result.message
 
     @pytest.mark.asyncio
     async def test_server_error_propagated(self):

--- a/packages/learn-to-cloud-shared/tests/services/test_security_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_security_verification_service.py
@@ -4,20 +4,28 @@ Covers:
 - 404 / not-public repo handling
 - Dependabot and CodeQL detection
 
+Evidence is supplied through the ``RepoFiles`` seam with an in-memory
+adapter, so these tests exercise the grading rules without the network.
+
 URL validation and ownership checks are tested in the dispatcher tests.
 """
-
-from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 
+from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
 from learn_to_cloud_shared.verification.security_scanning import (
     validate_security_scanning,
 )
 
 _TEST_OWNER = "testuser"
 _TEST_REPO = "my-repo"
+
+_VALID_DEPENDABOT = "version: 2\nupdates:\n  - package-ecosystem: pip\n"
+_CODEQL_WORKFLOW = (
+    "name: CodeQL\non: [push]\njobs:\n  analyze:\n    steps:\n"
+    "      - uses: github/codeql-action/analyze@v3\n"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -34,14 +42,52 @@ class TestValidateSecurityScanning404:
         mock_response = httpx.Response(
             status_code=404, request=httpx.Request("GET", "https://api.github.com")
         )
-        with patch(
-            "learn_to_cloud_shared.verification.security_scanning.fetch_repo_tree",
-            new_callable=AsyncMock,
-            side_effect=httpx.HTTPStatusError(
+        repo_files = InMemoryRepoFiles(
+            tree_error=httpx.HTTPStatusError(
                 "Not Found", request=mock_response.request, response=mock_response
-            ),
-        ):
-            result = await validate_security_scanning(_TEST_OWNER, _TEST_REPO)
-            assert result.is_valid is False
-            assert "not found" in result.message.lower()
-            assert result.username_match is True
+            )
+        )
+        result = await validate_security_scanning(
+            _TEST_OWNER, _TEST_REPO, repo_files=repo_files
+        )
+        assert result.is_valid is False
+        assert "not found" in result.message.lower()
+        assert result.username_match is True
+
+
+# ---------------------------------------------------------------------------
+# Dependabot and CodeQL detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestValidateSecurityScanningDetection:
+    """Detection of security scanning configuration."""
+
+    @pytest.mark.asyncio
+    async def test_dependabot_only_passes(self):
+        repo_files = InMemoryRepoFiles({".github/dependabot.yml": _VALID_DEPENDABOT})
+        result = await validate_security_scanning(
+            _TEST_OWNER, _TEST_REPO, repo_files=repo_files
+        )
+        assert result.is_valid is True
+
+    @pytest.mark.asyncio
+    async def test_codeql_only_passes(self):
+        repo_files = InMemoryRepoFiles(
+            {".github/workflows/codeql.yml": _CODEQL_WORKFLOW}
+        )
+        result = await validate_security_scanning(
+            _TEST_OWNER, _TEST_REPO, repo_files=repo_files
+        )
+        assert result.is_valid is True
+
+    @pytest.mark.asyncio
+    async def test_no_scanning_fails(self):
+        repo_files = InMemoryRepoFiles({"README.md": "# project\n"})
+        result = await validate_security_scanning(
+            _TEST_OWNER, _TEST_REPO, repo_files=repo_files
+        )
+        assert result.is_valid is False
+        assert result.task_results is not None
+        assert all(not t.passed for t in result.task_results)


### PR DESCRIPTION
## Summary

This makes the GitHub checks behind hands-on verification testable without
reaching the real GitHub network, in the same style as the RepoFiles change
from the first commit on this branch.

What changed and why it matters:

- Moved the shared GitHub HTTP code (the resilient GET, auth headers, retry
  rules, and 5xx/429 handling) out of `github_profile.py` into a new
  `github_http.py`. That file used to be a catch-all other modules reached
  into. Now `github_profile.py` is only about validating profiles and forks.
  The modules that used those helpers import them from the new home. This
  split was needed to avoid an import loop.

- Added `GitHubMetadata` (`github_metadata.py`): a small interface that
  answers "does this URL exist?" and "what does this repo's metadata say?"
  (used to confirm a fork). The phase 0/1/2 profile and fork checks now take
  this interface. Production talks to GitHub; tests pass an in-memory
  stand-in.

- Added `WorkflowRuns` (`workflow_runs.py`): a one-question interface,
  "what is the latest CI run for this workflow on this branch?" The phase 3
  CI check now takes it.

- Rewrote the profile and CI status tests to hand in the in-memory stand-ins
  instead of patching private internals, so they exercise the real logic
  through the new interfaces.

One small, deliberate note: for rare, untested HTTP responses (codes that are
not 200/404/5xx/429) the result wording is slightly simpler than before.
Every tested path keeps its exact behavior and message.

All quality gates pass: ruff, ty, and pytest for the shared package (497
passed), the api (206 passed), and the verification functions.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.
