### PR TITLE
Use GitHub numeric ID as the only login identity (#458, #426)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ tfplan
 research.md
 plan.md
 issue-resolution-report.md
+
+# Firecrawl research artifacts (local only)
+.firecrawl/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,16 @@ repos:
         files: ^(api|apps/verification-functions|packages/learn-to-cloud-shared)/.*\.py$
         pass_filenames: false
 
+  # squawk - migration SQL safety lint (mirrors the CI check exactly)
+  - repo: local
+    hooks:
+      - id: squawk-migrations
+        name: squawk migration SQL lint
+        entry: bash -c 'cd api && uv run python scripts/lint_migration_sql.py'
+        language: system
+        files: ^api/alembic/versions/.*\.py$
+        pass_filenames: false
+
   # General file hygiene + check-yaml
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/api/alembic/versions/0040_github_username_not_null.py
+++ b/api/alembic/versions/0040_github_username_not_null.py
@@ -25,7 +25,10 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.drop_constraint("uq_users_github_username", "users", type_="unique")
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    op.execute("ALTER TABLE users DROP CONSTRAINT IF EXISTS uq_users_github_username")
 
     # Backfill any rows whose username was previously cleared by the old
     # username-stealing behaviour. The placeholder self-heals on next login.
@@ -33,13 +36,27 @@ def upgrade() -> None:
         "UPDATE users SET github_username = 'gh-' || id WHERE github_username IS NULL"
     )
 
-    op.alter_column("users", "github_username", nullable=False)
-    op.create_index("ix_users_github_username", "users", ["github_username"])
+    op.execute("ALTER TABLE users ALTER COLUMN github_username SET NOT NULL")
+
+    # CREATE INDEX CONCURRENTLY must run outside a transaction. autocommit_block
+    # commits the current tx, builds the index without blocking writes, then
+    # opens a fresh tx. IF NOT EXISTS keeps the statement safe to retry.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_users_github_username ON users (github_username)"
+        )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_users_github_username", table_name="users")
-    op.alter_column("users", "github_username", nullable=True)
-    op.create_unique_constraint(
-        "uq_users_github_username", "users", ["github_username"]
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_users_github_username")
+
+    op.execute("ALTER TABLE users ALTER COLUMN github_username DROP NOT NULL")
+    op.execute(
+        "ALTER TABLE users "
+        "ADD CONSTRAINT uq_users_github_username UNIQUE (github_username)"
     )

--- a/api/alembic/versions/0040_github_username_not_null.py
+++ b/api/alembic/versions/0040_github_username_not_null.py
@@ -6,8 +6,8 @@ username from the previous owner" behaviour, and NOT NULL enforces that every
 authenticated user always carries their current GitHub handle.
 
 Order matters: drop the unique constraint first, backfill any NULL usernames
-with a deterministic placeholder, then set NOT NULL, then add a plain
-(non-unique) index for lookups.
+with a deterministic placeholder, make the column NOT NULL via the safe
+CHECK-then-flip pattern, then add a plain (non-unique) index concurrently.
 
 Revision ID: 0040_github_username_not_null
 Revises: 0039_reapply_fn_requirement_kind_lookup_grant
@@ -36,7 +36,47 @@ def upgrade() -> None:
         "UPDATE users SET github_username = 'gh-' || id WHERE github_username IS NULL"
     )
 
+    # NOT NULL via the CHECK-then-flip pattern (see api/.squawk.toml and 0028).
+    # A plain SET NOT NULL scans the whole table under an ACCESS EXCLUSIVE lock.
+    # Adding a CHECK ... NOT VALID then VALIDATE-ing it in a separate
+    # transaction does the scan under a weaker lock that still allows reads and
+    # writes; the later SET NOT NULL then skips the scan because the validated
+    # CHECK already proves no NULLs exist. Each step is guarded so a retry works.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'ck_users_github_username_nn'
+          ) THEN
+            ALTER TABLE users
+              ADD CONSTRAINT ck_users_github_username_nn
+              CHECK (github_username IS NOT NULL) NOT VALID;
+          END IF;
+        END$$;
+        """
+    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            DO $$
+            BEGIN
+              IF EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'ck_users_github_username_nn'
+                  AND NOT convalidated
+              ) THEN
+                ALTER TABLE users
+                  VALIDATE CONSTRAINT ck_users_github_username_nn;
+              END IF;
+            END$$;
+            """
+        )
     op.execute("ALTER TABLE users ALTER COLUMN github_username SET NOT NULL")
+    op.execute(
+        "ALTER TABLE users DROP CONSTRAINT IF EXISTS ck_users_github_username_nn"
+    )
 
     # CREATE INDEX CONCURRENTLY must run outside a transaction. autocommit_block
     # commits the current tx, builds the index without blocking writes, then

--- a/api/alembic/versions/0040_github_username_not_null.py
+++ b/api/alembic/versions/0040_github_username_not_null.py
@@ -1,0 +1,45 @@
+"""make users.github_username non-null, drop unique constraint
+
+Identity is the immutable GitHub numeric ID (users.id), so github_username is
+display-only. Dropping the unique constraint removes the data-loss "steal the
+username from the previous owner" behaviour, and NOT NULL enforces that every
+authenticated user always carries their current GitHub handle.
+
+Order matters: drop the unique constraint first, backfill any NULL usernames
+with a deterministic placeholder, then set NOT NULL, then add a plain
+(non-unique) index for lookups.
+
+Revision ID: 0040_github_username_not_null
+Revises: 0039_reapply_fn_requirement_kind_lookup_grant
+Create Date: 2026-05-27
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0040_github_username_not_null"
+down_revision: str | None = "0039_reapply_fn_requirement_kind_lookup_grant"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("uq_users_github_username", "users", type_="unique")
+
+    # Backfill any rows whose username was previously cleared by the old
+    # username-stealing behaviour. The placeholder self-heals on next login.
+    op.execute(
+        "UPDATE users SET github_username = 'gh-' || id WHERE github_username IS NULL"
+    )
+
+    op.alter_column("users", "github_username", nullable=False)
+    op.create_index("ix_users_github_username", "users", ["github_username"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_github_username", table_name="users")
+    op.alter_column("users", "github_username", nullable=True)
+    op.create_unique_constraint(
+        "uq_users_github_username", "users", ["github_username"]
+    )

--- a/api/src/learn_to_cloud/core/auth.py
+++ b/api/src/learn_to_cloud/core/auth.py
@@ -31,7 +31,7 @@ class AuthenticatedUser:
     """Authenticated identity stored in the session cookie."""
 
     user_id: int
-    github_username: str | None
+    github_username: str
 
 
 def init_oauth(settings: OAuthConfig) -> None:
@@ -101,13 +101,22 @@ def ensure_session_id(request: Request) -> str:
 
 
 def get_authenticated_user_from_session(request: Request) -> AuthenticatedUser | None:
-    """Read authenticated identity from the session cookie."""
+    """Read authenticated identity from the session cookie.
+
+    Returns None when either the user ID or the GitHub username is missing.
+    The username is always written to the session at login, so a missing
+    username means a stale cookie (for example, a user whose row predates the
+    NOT NULL backfill); returning None forces a clean re-login.
+    """
     user_id = get_user_id_from_session(request)
     if user_id is None:
         return None
+    github_username = get_github_username_from_session(request)
+    if github_username is None:
+        return None
     return AuthenticatedUser(
         user_id=user_id,
-        github_username=get_github_username_from_session(request),
+        github_username=github_username,
     )
 
 

--- a/api/src/learn_to_cloud/routes/auth_routes.py
+++ b/api/src/learn_to_cloud/routes/auth_routes.py
@@ -96,6 +96,13 @@ async def callback(request: Request) -> RedirectResponse:
         return RedirectResponse(url="/", status_code=302)
 
     github_username = github_user.get("login", "")
+    if not github_username:
+        logger.error(
+            "auth.callback.missing_github_login",
+            extra={"status_code": getattr(resp, "status_code", None)},
+        )
+        return RedirectResponse(url="/", status_code=302)
+
     avatar_url = github_user.get("avatar_url")
     first_name, last_name = parse_display_name(github_user.get("name", ""))
 

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -64,7 +64,6 @@ from learn_to_cloud.services.steps_service import (
 )
 from learn_to_cloud.services.submissions_service import (
     AlreadyValidatedError,
-    GitHubUsernameRequiredError,
     InvalidSubmittedValueError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
@@ -89,7 +88,6 @@ logger = logging.getLogger(__name__)
 # Submission errors whose message is safe to show directly to the user.
 _USER_FACING_ERRORS = (
     AlreadyValidatedError,
-    GitHubUsernameRequiredError,
     InvalidSubmittedValueError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
@@ -339,16 +337,11 @@ async def htmx_submit_verification(
                     return _render_card(
                         error_banner="Please enter a value before submitting."
                     )
-            if github_username is None and not is_derivable(
-                requirement.submission_type
-            ):
-                derived_value = user_input or ""
-            else:
-                derived_value = derive_submission_value(
-                    requirement=requirement,
-                    github_username=github_username or "",
-                    user_input=user_input,
-                )
+            derived_value = derive_submission_value(
+                requirement=requirement,
+                github_username=github_username,
+                user_input=user_input,
+            )
         except ValueError as ve:
             return _render_card(error_banner=str(ve))
     else:

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from uuid import UUID
 
-from learn_to_cloud_shared.models import SubmissionType, VerificationJob
+from learn_to_cloud_shared.models import VerificationJob
 from learn_to_cloud_shared.repositories.submission_repository import (
     SubmissionRepository,
 )
@@ -109,10 +109,6 @@ class RequirementNotFoundError(Exception):
     pass
 
 
-class GitHubUsernameRequiredError(Exception):
-    pass
-
-
 class InvalidSubmittedValueError(Exception):
     pass
 
@@ -178,13 +174,11 @@ async def _check_submission_preconditions(
     session_maker: async_sessionmaker[AsyncSession],
     user_id: int,
     requirement_slug: str,
-    github_username: str | None,
     submitted_value: str | None = None,
 ) -> _PreValidationContext:
     """Shared pre-validation checks for submission paths.
 
-    Validates requirement existence, already-validated status, phase gating,
-    and GitHub username requirement.
+    Validates requirement existence, already-validated status, and phase gating.
 
     Opens a short-lived DB session for reads, then releases it before returning.
     """
@@ -225,25 +219,6 @@ async def _check_submission_preconditions(
 
     # read_session is now closed — connection returned to pool
 
-    if (
-        requirement.submission_type
-        in (
-            SubmissionType.GITHUB_PROFILE,
-            SubmissionType.PROFILE_README,
-            SubmissionType.REPO_FORK,
-            SubmissionType.CTF_TOKEN,
-            SubmissionType.NETWORKING_TOKEN,
-            SubmissionType.JOURNAL_API_VERIFIER,
-            SubmissionType.DEVOPS_ANALYSIS,
-            SubmissionType.SECURITY_SCANNING,
-        )
-        and not github_username
-    ):
-        raise GitHubUsernameRequiredError(
-            "You need to link your GitHub account to submit. "
-            "Please sign out and sign in with GitHub."
-        )
-
     return _PreValidationContext(
         requirement=requirement,
         phase_order=phase_order,
@@ -268,7 +243,6 @@ async def create_verification_job(
         session_maker,
         user_id,
         requirement_slug,
-        github_username,
         submitted_value,
     )
     try:

--- a/api/src/learn_to_cloud/services/users_service.py
+++ b/api/src/learn_to_cloud/services/users_service.py
@@ -46,21 +46,14 @@ async def get_or_create_user_from_github(
 ) -> User:
     """Create or update a user from GitHub OAuth profile data.
 
-    Called during the OAuth callback. Uses upsert to handle both new
-    and returning users in a single query.
-
-    If another user already has this GitHub username, it is cleared from
-    them first (GitHub usernames are unique across our user base).
+    Called during the OAuth callback. Identity is the immutable GitHub
+    numeric ID (``github_id``), so the upsert keys on it. ``github_username``
+    is display-only and refreshed from GitHub on every login.
     """
     user_repo = UserRepository(db)
     normalized_username = normalize_github_username(github_username)
-
-    # Clear username from any other user before upsert (business rule:
-    # GitHub usernames must be unique, latest OAuth login wins).
-    if normalized_username:
-        existing_owner = await user_repo.get_by_github_username(normalized_username)
-        if existing_owner and existing_owner.id != github_id:
-            await user_repo.clear_github_username(existing_owner.id)
+    if not normalized_username:
+        raise ValueError("github_username is required and cannot be empty")
 
     user = await user_repo.upsert(
         github_id,

--- a/api/tests/core/test_auth.py
+++ b/api/tests/core/test_auth.py
@@ -109,10 +109,12 @@ class TestGetAuthenticatedUserFromSession:
         result = get_authenticated_user_from_session(request)
         assert result == AuthenticatedUser(user_id=42, github_username="testuser")
 
-    def test_returns_identity_without_username(self):
+    def test_returns_none_without_username(self):
+        # Username is always written to the session at login. A missing
+        # username means a stale cookie, so we force a clean re-login.
         request = _make_request(session={"user_id": 42})
         result = get_authenticated_user_from_session(request)
-        assert result == AuthenticatedUser(user_id=42, github_username=None)
+        assert result is None
 
     def test_returns_none_when_user_id_missing(self):
         request = _make_request(session={"github_username": "testuser"})
@@ -125,7 +127,7 @@ class TestRequireAuth:
     """Test require_auth dependency."""
 
     def test_returns_user_id_and_sets_state(self):
-        request = _make_request(session={"user_id": 42})
+        request = _make_request(session={"user_id": 42, "github_username": "user"})
         result = require_auth(request)
         assert result == 42
         assert request.state.user_id == 42
@@ -169,7 +171,7 @@ class TestOptionalAuth:
     """Test optional_auth dependency."""
 
     def test_returns_user_id_and_sets_state(self):
-        request = _make_request(session={"user_id": 99})
+        request = _make_request(session={"user_id": 99, "github_username": "user"})
         result = optional_auth(request)
         assert result == 99
         assert request.state.user_id == 99

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -17,7 +17,6 @@ from learn_to_cloud_shared.verification.requirements import RequirementIndex
 
 from learn_to_cloud.services.submissions_service import (
     AlreadyValidatedError,
-    GitHubUsernameRequiredError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
     SyncVerificationResult,
@@ -153,37 +152,6 @@ class TestSubmissionValidationErrors:
                 submitted_value="https://github.com/user/repo",
                 github_username="user",
             )
-
-    @pytest.mark.asyncio
-    async def test_github_username_required_for_journal_api_verifier(self):
-        mock_session_maker = _mock_session_maker()
-        mock_requirement = _make_mock_requirement(
-            submission_type=SubmissionType.JOURNAL_API_VERIFIER
-        )
-
-        with (
-            patch(
-                "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
-                return_value=_build_index(mock_requirement),
-            ),
-            patch(
-                "learn_to_cloud.services.submissions_service.SubmissionRepository",
-                autospec=True,
-            ) as mock_repo_class,
-        ):
-            mock_repo = MagicMock()
-            mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
-            mock_repo_class.return_value = mock_repo
-
-            with pytest.raises(GitHubUsernameRequiredError):
-                await create_verification_job(
-                    session_maker=mock_session_maker,
-                    user_id=123,
-                    requirement_slug="test-requirement",
-                    submitted_value="https://github.com/user/repo",
-                    github_username=None,
-                )
 
 
 @pytest.mark.unit
@@ -493,43 +461,6 @@ class TestSyncDispatchBranch:
                     requirement_slug="test-requirement",
                     submitted_value="some-token",
                     github_username="user",
-                )
-
-        mock_sync_execute.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_sync_path_requires_github_username_for_ctf_token(self):
-        mock_session_maker = _mock_session_maker()
-        mock_requirement = _make_mock_requirement(
-            submission_type=SubmissionType.CTF_TOKEN,
-        )
-
-        with (
-            patch(
-                "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
-                return_value=_build_index(mock_requirement),
-            ),
-            patch(
-                "learn_to_cloud.services.submissions_service.SubmissionRepository",
-                autospec=True,
-            ) as mock_repo_class,
-            patch(
-                "learn_to_cloud.services.submissions_service.execute_sync_submission_validation",
-                new_callable=AsyncMock,
-            ) as mock_sync_execute,
-        ):
-            mock_repo = MagicMock()
-            mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
-            mock_repo_class.return_value = mock_repo
-
-            with pytest.raises(GitHubUsernameRequiredError):
-                await create_verification_job(
-                    session_maker=mock_session_maker,
-                    user_id=123,
-                    requirement_slug="test-requirement",
-                    submitted_value="some-token",
-                    github_username=None,
                 )
 
         mock_sync_execute.assert_not_awaited()

--- a/api/tests/services/test_users_service.py
+++ b/api/tests/services/test_users_service.py
@@ -177,7 +177,6 @@ class TestGetOrCreateUserFromGithub:
             "learn_to_cloud.services.users_service.UserRepository", autospec=True
         ) as MockRepo:
             repo = MockRepo.return_value
-            repo.get_by_github_username = AsyncMock(return_value=None)
             repo.upsert = AsyncMock(return_value=mock_user)
             result = await get_or_create_user_from_github(
                 AsyncMock(),
@@ -189,25 +188,3 @@ class TestGetOrCreateUserFromGithub:
             )
         assert result is mock_user
         repo.upsert.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_username_conflict_clears_old_owner(self):
-        old_owner = MagicMock()
-        old_owner.id = 456
-        new_user = MagicMock()
-        with patch(
-            "learn_to_cloud.services.users_service.UserRepository", autospec=True
-        ) as MockRepo:
-            repo = MockRepo.return_value
-            repo.get_by_github_username = AsyncMock(return_value=old_owner)
-            repo.clear_github_username = AsyncMock()
-            repo.upsert = AsyncMock(return_value=new_user)
-            await get_or_create_user_from_github(
-                AsyncMock(),
-                github_id=123,
-                first_name="New",
-                last_name="User",
-                avatar_url=None,
-                github_username="sharedname",
-            )
-        repo.clear_github_username.assert_awaited_once_with(456)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -49,17 +49,15 @@ class User(TimestampMixin, Base):
     """User model - authenticated via GitHub OAuth."""
 
     __tablename__ = "users"
-    __table_args__ = (
-        UniqueConstraint("github_username", name="uq_users_github_username"),
-    )
+    __table_args__ = (Index("ix_users_github_username", "github_username"),)
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=False)
     first_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     last_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
-    github_username: Mapped[str | None] = mapped_column(
+    github_username: Mapped[str] = mapped_column(
         String(255),
-        nullable=True,
+        nullable=False,
     )
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/user_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/user_repository.py
@@ -28,25 +28,14 @@ class UserRepository:
         result = await self.db.execute(select(User).where(User.id == user_id))
         return result.scalar_one_or_none()
 
-    async def get_by_github_username(self, username: str) -> User | None:
-        """Get a user by their GitHub username.
-
-        Expects username to be pre-normalized (lowercase) by service layer.
-        Uses indexed lookup on github_username (unique constraint ensures one).
-        """
-        result = await self.db.execute(
-            select(User).where(User.github_username == username)
-        )
-        return result.scalar_one_or_none()
-
     async def get_or_create(
         self,
         user_id: int,
         *,
+        github_username: str,
         first_name: str | None = None,
         last_name: str | None = None,
         avatar_url: str | None = None,
-        github_username: str | None = None,
     ) -> User:
         """Get user from DB or create from GitHub OAuth data.
 
@@ -89,10 +78,10 @@ class UserRepository:
         self,
         user_id: int,
         *,
+        github_username: str,
         first_name: str | None = None,
         last_name: str | None = None,
         avatar_url: str | None = None,
-        github_username: str | None = None,
     ) -> User:
         """Insert or update a user in a single query.
 
@@ -121,14 +110,6 @@ class UserRepository:
         )
         result = await self.db.execute(stmt)
         return result.scalar_one()
-
-    async def clear_github_username(self, user_id: int) -> None:
-        """Clear the github_username field for a specific user."""
-        user = await self.get_by_id(user_id)
-        if user is not None:
-            user.github_username = None
-            user.updated_at = utcnow()
-            await self.db.flush()
 
     async def delete(self, user_id: int) -> None:
         """Delete a user by ID. Cascades to related records."""

--- a/packages/learn-to-cloud-shared/tests/repositories/test_user_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_user_repository.py
@@ -75,21 +75,6 @@ class TestGetById:
         assert user is None
 
 
-class TestGetByGithubUsername:
-    async def test_returns_user(self, db_session: AsyncSession):
-        repo = UserRepository(db_session)
-        await repo.upsert(22222, github_username="testuser")
-
-        user = await repo.get_by_github_username("testuser")
-        assert user is not None
-        assert user.id == 22222
-
-    async def test_returns_none_for_missing(self, db_session: AsyncSession):
-        repo = UserRepository(db_session)
-        user = await repo.get_by_github_username("nonexistent")
-        assert user is None
-
-
 class TestDelete:
     async def test_removes_user(self, db_session: AsyncSession):
         repo = UserRepository(db_session)


### PR DESCRIPTION
## What this does

Makes a user's GitHub **numeric ID** the single source of truth for their identity, and stops treating the GitHub **username** as something that must be unique across all accounts.

Closes #458 and #426.

## The problem (in plain language)

When someone signed in, the old code looked up whether any **other** account already had their GitHub username. If one did, it **wiped that other person's username out of the database** so the new login could take it. So a real user could silently lose their username just because someone else renamed their GitHub handle into the one they used to have.

On top of that, the username was allowed to be empty in the database. That triggered a misleading "you need to link your GitHub account, please sign out and sign in" error on the submit page, even for people who were obviously already signed in with GitHub.

The key insight: we already key every account on the GitHub numeric ID (it is the primary key and never changes). The username is only ever used for display and for building submission URLs. So there was never a real reason to fight over usernames.

## What changed

- **Sign-in no longer steals usernames.** It just saves the latest username for the account that is signing in, keyed on the unchanging numeric ID.
- **Dropped the unique rule on username**, made the column **required (NOT NULL)** instead, and added a plain (non-unique) index for lookups.
- **New migration** `0040_github_username_not_null`: drops the old unique constraint, backfills a deterministic placeholder (`gh-<id>`) for any account whose username was previously wiped (self-heals on next login), then sets NOT NULL and adds the index. Order is drop-constraint → backfill → set NOT NULL, per repo convention.
- **Removed the dead "link your GitHub account" error path** (`GitHubUsernameRequiredError`) and all the now-unreachable code, imports, and tests around it.
- **Sign-in callback** now redirects cleanly if GitHub ever returns a response with no username, mirroring how we already handle a missing ID.
- **Stale session cookies** with no username now force a clean re-login (only affects accounts that were victims of the old bug).
- Removed `get_by_github_username` and `clear_github_username` from the user repository (no longer needed).

## Why this is the standard approach

Authenticating on an immutable, provider-issued numeric subject (not a mutable handle) is the documented best practice for OAuth/OIDC identity. Usernames are display data; the numeric ID is the stable key.

## Testing

All quality gates pass locally:
- `ruff check`, `ruff format --check`, `ty check` for api + shared + verification-functions
- `pytest`: 203 passed (api), 496 passed / 1 skipped (shared)
- Migration up/down consistency and model-matches-DDL tests pass with the new migration in the chain.