### PR TITLE
Add post-deploy smoke test for the verification submit path (#438)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -371,6 +371,7 @@ jobs:
         env:
           TF_VAR_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
           TF_VAR_github_client_id: ${{ secrets.TF_VAR_github_client_id }}
+          TF_VAR_smoke_test_token: ${{ secrets.SMOKE_TEST_TOKEN }}
           TF_VAR_postgres_entra_admin_object_id: ${{ vars.POSTGRES_ENTRA_ADMIN_OBJECT_ID }}
           TF_VAR_postgres_entra_admin_principal_name: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME }}
           TF_VAR_postgres_entra_admin_principal_type: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE || 'Group' }}
@@ -658,4 +659,54 @@ jobs:
           az containerapp logs show \
             --name "$APP_NAME" --resource-group "$RG" --revision "$REVISION" \
             --tail 100 --format text 2>&1 || true
+          exit 1
+
+      - name: Smoke test verification submit path
+        env:
+          SMOKE_TEST_TOKEN: ${{ secrets.SMOKE_TEST_TOKEN }}
+          SMOKE_URL: ${{ needs.terraform.outputs.api_url }}/internal/smoke/verification
+        run: |
+          set -euo pipefail
+
+          # The gate only runs once the shared secret exists in both places
+          # (the GitHub secret here and, via Terraform, the running app). Until
+          # then, warn loudly instead of blocking every deploy.
+          if [[ -z "${SMOKE_TEST_TOKEN:-}" ]]; then
+            echo "::warning::SMOKE_TEST_TOKEN is not set — skipping the post-deploy verification smoke test."
+            echo "Set the SMOKE_TEST_TOKEN repository secret to activate this deploy gate."
+            exit 0
+          fi
+
+          echo "POSTing verification smoke check to $SMOKE_URL"
+
+          # Retry briefly: traffic can take a few seconds to fully shift to the
+          # freshly deployed revision after readiness reports healthy.
+          code=000
+          for i in {1..6}; do
+            code=$(curl -s -o /tmp/smoke_body.txt -w "%{http_code}" \
+              -X POST "$SMOKE_URL" \
+              -H "X-Smoke-Test-Token: $SMOKE_TEST_TOKEN" || echo 000)
+            echo "Attempt $i: HTTP $code"
+
+            if [[ "$code" == "200" ]]; then
+              echo "Verification smoke test passed."
+              cat /tmp/smoke_body.txt || true
+              exit 0
+            fi
+
+            # A 5xx means the verification submit code path is broken against the
+            # live database schema (the incident #432 class of failure). Fail now.
+            if [[ "$code" =~ ^5 ]]; then
+              echo "ERROR: smoke endpoint returned $code — verification submit path is broken."
+              cat /tmp/smoke_body.txt || true
+              exit 1
+            fi
+
+            sleep 5
+          done
+
+          echo "ERROR: verification smoke test did not pass (last HTTP $code)."
+          echo "401 means the app's SMOKE_TEST__TOKEN does not match this secret;"
+          echo "404 means the app has no token configured yet."
+          cat /tmp/smoke_body.txt || true
           exit 1

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -38,6 +38,7 @@ from learn_to_cloud.routes import (
     auth_router,
     health_router,
     htmx_router,
+    internal_router,
     pages_router,
     users_router,
 )
@@ -237,6 +238,7 @@ async def apple_touch_icon() -> FileResponse:
 
 
 app.include_router(health_router)
+app.include_router(internal_router)
 app.include_router(auth_router)
 app.include_router(users_router)
 app.include_router(htmx_router)

--- a/api/src/learn_to_cloud/routes/__init__.py
+++ b/api/src/learn_to_cloud/routes/__init__.py
@@ -3,6 +3,7 @@
 from learn_to_cloud.routes.auth_routes import router as auth_router
 from learn_to_cloud.routes.health_routes import router as health_router
 from learn_to_cloud.routes.htmx_routes import router as htmx_router
+from learn_to_cloud.routes.internal_routes import router as internal_router
 from learn_to_cloud.routes.pages_routes import router as pages_router
 from learn_to_cloud.routes.users_routes import router as users_router
 
@@ -10,6 +11,7 @@ __all__ = [
     "auth_router",
     "health_router",
     "htmx_router",
+    "internal_router",
     "pages_router",
     "users_router",
 ]

--- a/api/src/learn_to_cloud/routes/internal_routes.py
+++ b/api/src/learn_to_cloud/routes/internal_routes.py
@@ -23,7 +23,7 @@ _SMOKE_TOKEN_HEADER = "X-Smoke-Test-Token"
 @router.post("/internal/smoke/verification")
 async def smoke_verification(
     request: Request,
-    x_smoke_test_token: str | None = Header(default=None),
+    x_smoke_test_token: str | None = Header(default=None, alias=_SMOKE_TOKEN_HEADER),
 ) -> dict[str, str]:
     """Post-deploy smoke check for the verification submit code path.
 

--- a/api/src/learn_to_cloud/routes/internal_routes.py
+++ b/api/src/learn_to_cloud/routes/internal_routes.py
@@ -1,0 +1,65 @@
+"""Internal operational endpoints.
+
+These routes are not part of the user-facing product. They support
+deployment and monitoring tooling and are gated by a shared secret so
+they are only reachable where that secret is configured.
+"""
+
+import hmac
+import logging
+
+from fastapi import APIRouter, Header, HTTPException, Request
+from starlette import status
+
+from learn_to_cloud.services.submissions_service import run_submit_smoke_check
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["internal"], include_in_schema=False)
+
+_SMOKE_TOKEN_HEADER = "X-Smoke-Test-Token"
+
+
+@router.post("/internal/smoke/verification")
+async def smoke_verification(
+    request: Request,
+    x_smoke_test_token: str | None = Header(default=None),
+) -> dict[str, str]:
+    """Post-deploy smoke check for the verification submit code path.
+
+    Exercises the same database reads and value parsing as a real
+    verification submission, without writing anything, so a deploy whose
+    code does not match the migrated database schema fails here instead of
+    silently returning 500s to real users (see incident #432).
+
+    Returns 200 when the read path runs cleanly. Returns 503 when it does
+    not, which fails the post-deploy smoke step in CI. The endpoint is
+    disabled (404) unless ``SMOKE_TEST__TOKEN`` is configured, and rejects
+    requests (401) whose ``X-Smoke-Test-Token`` header does not match it.
+    """
+    configured_token = request.app.state.settings.smoke_test.token
+
+    if not configured_token:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    provided = x_smoke_test_token or ""
+    if not hmac.compare_digest(provided, configured_token):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid smoke-test token.",
+        )
+
+    try:
+        result = await run_submit_smoke_check(request.app.state.session_maker)
+    except Exception as exc:
+        logger.exception("internal.smoke.verification.failed")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Verification smoke check failed: {type(exc).__name__}: {exc}",
+        ) from exc
+
+    logger.info(
+        "internal.smoke.verification.ok",
+        extra={"requirement_slug": result["requirement_slug"]},
+    )
+    return {"status": "ok", **result}

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -323,6 +323,9 @@ async def run_submit_smoke_check(
     try:
         SubmittedValue.from_raw(ctx.requirement, "smoke-test")
     except ValueError:
+        # A value-format validation error means the parsing code ran fine,
+        # so it is not a schema/code-health signal and is safe to ignore
+        # here. Any other error type propagates and fails the smoke check.
         pass
 
     return {"requirement_slug": requirement.slug}

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -34,6 +34,7 @@ from learn_to_cloud_shared.verification.execution import (
     to_submission_data,
 )
 from learn_to_cloud_shared.verification.requirements import (
+    RequirementIndex,
     get_prerequisite_phase,
     load_requirement_index,
 )
@@ -275,3 +276,66 @@ async def create_verification_job(
         requirement=ctx.requirement,
         github_username=github_username,
     )
+
+
+# Synthetic user id for the read-only smoke check. It is never a real
+# account (GitHub user ids are positive), so every read returns nothing
+# and the check writes no rows.
+_SMOKE_USER_ID = 0
+
+
+async def run_submit_smoke_check(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> dict[str, str]:
+    """Exercise the verification submit read path without writing anything.
+
+    Runs the same requirement loading, submissions read, phase gating, and
+    typed-value parsing that :func:`create_verification_job` performs for a
+    real submission, but against a synthetic user and an early phase, and
+    stops before persisting anything.
+
+    The goal is to catch a schema-versus-code mismatch (the class of bug
+    behind incident #432) right after deploy: if the running code expects a
+    column or value shape the migrated database does not have, the reads
+    here raise and the post-deploy smoke test fails instead of letting real
+    user submissions return 500s for days.
+
+    Returns the slug it exercised so callers can log what was checked.
+    """
+    async with session_maker() as read_session:
+        index = await load_requirement_index(read_session)
+
+    requirement = _pick_smoke_requirement(index)
+
+    # The synthetic user has no submissions, so preconditions read the
+    # requirement index and the submissions table, then return cleanly.
+    # An early-phase requirement has no prerequisite phase, so the
+    # sequential gating check does not raise for the synthetic user.
+    ctx = await _check_submission_preconditions(
+        session_maker,
+        user_id=_SMOKE_USER_ID,
+        requirement_slug=requirement.slug,
+    )
+
+    # Exercise the submission-type-to-value mapping. A value-validation
+    # error here means the code ran fine, so it is not a health signal;
+    # any other error (e.g. an unmapped submission type) propagates.
+    try:
+        SubmittedValue.from_raw(ctx.requirement, "smoke-test")
+    except ValueError:
+        pass
+
+    return {"requirement_slug": requirement.slug}
+
+
+def _pick_smoke_requirement(index: RequirementIndex) -> HandsOnRequirement:
+    """Pick the first requirement in the earliest phase that has one.
+
+    The earliest phase has no prerequisite, so the precondition check runs
+    to completion for the synthetic user instead of tripping phase gating.
+    """
+    for phase_order in sorted(index.by_phase_order):
+        requirements = index.by_phase_order[phase_order]
+        if requirements:
+            return requirements[0]
+    raise RuntimeError("Smoke check found no hands-on requirements to exercise.")

--- a/api/tests/routes/test_internal_routes.py
+++ b/api/tests/routes/test_internal_routes.py
@@ -1,0 +1,79 @@
+"""Unit tests for internal operational routes."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from learn_to_cloud.routes.internal_routes import smoke_verification
+
+
+def _request_with_token(configured: str) -> MagicMock:
+    """Build a mock request whose app carries the given configured token."""
+    request = MagicMock()
+    request.app.state.settings.smoke_test.token = configured
+    request.app.state.session_maker = MagicMock()
+    return request
+
+
+@pytest.mark.unit
+class TestSmokeVerificationEndpoint:
+    """Tests for POST /internal/smoke/verification."""
+
+    async def test_returns_404_when_token_not_configured(self):
+        """The endpoint is disabled (404) when no token is configured."""
+        request = _request_with_token("")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await smoke_verification(request, x_smoke_test_token="anything")
+
+        assert exc_info.value.status_code == 404
+
+    async def test_returns_401_when_header_missing(self):
+        """A missing token header is rejected with 401."""
+        request = _request_with_token("expected-secret")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await smoke_verification(request, x_smoke_test_token=None)
+
+        assert exc_info.value.status_code == 401
+
+    async def test_returns_401_when_header_mismatch(self):
+        """A wrong token header is rejected with 401."""
+        request = _request_with_token("expected-secret")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await smoke_verification(request, x_smoke_test_token="wrong-secret")
+
+        assert exc_info.value.status_code == 401
+
+    async def test_returns_200_when_token_matches_and_check_passes(self):
+        """A matching token runs the read-only check and returns ok."""
+        request = _request_with_token("expected-secret")
+
+        with patch(
+            "learn_to_cloud.routes.internal_routes.run_submit_smoke_check",
+            new_callable=AsyncMock,
+            return_value={"requirement_slug": "phase0-req"},
+        ) as mock_check:
+            result = await smoke_verification(
+                request, x_smoke_test_token="expected-secret"
+            )
+
+        assert result == {"status": "ok", "requirement_slug": "phase0-req"}
+        mock_check.assert_awaited_once_with(request.app.state.session_maker)
+
+    async def test_returns_503_when_check_raises(self):
+        """A failing read path surfaces as 503 so CI fails the deploy."""
+        request = _request_with_token("expected-secret")
+
+        with patch(
+            "learn_to_cloud.routes.internal_routes.run_submit_smoke_check",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("schema mismatch"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await smoke_verification(request, x_smoke_test_token="expected-secret")
+
+        assert exc_info.value.status_code == 503
+        assert "RuntimeError" in exc_info.value.detail

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -16,6 +16,9 @@ from learn_to_cloud_shared.schemas import HandsOnRequirement, Phase
 from learn_to_cloud_shared.verification.requirements import RequirementIndex
 
 from learn_to_cloud.services.submissions_service import (
+    _SMOKE_USER_ID as SMOKE_USER_ID,
+)
+from learn_to_cloud.services.submissions_service import (
     AlreadyValidatedError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
@@ -23,6 +26,10 @@ from learn_to_cloud.services.submissions_service import (
     VerificationJobSubmission,
     create_verification_job,
     get_phase_submission_context,
+    run_submit_smoke_check,
+)
+from learn_to_cloud.services.submissions_service import (
+    _pick_smoke_requirement as pick_smoke_requirement,
 )
 
 
@@ -599,3 +606,95 @@ class TestGetPhaseSubmissionContext:
                 "next_steps": "review the rubric",
             }
         ]
+
+
+@pytest.mark.unit
+class TestRunSubmitSmokeCheck:
+    """Tests for the read-only post-deploy verification smoke check."""
+
+    def test_pick_smoke_requirement_returns_earliest_phase(self):
+        """The canary picks the first requirement of the earliest phase."""
+        from learn_to_cloud_shared.testing.requirement_factories import (
+            journal_api_verifier_requirement,
+        )
+
+        early = journal_api_verifier_requirement(
+            slug="early", name="early", description="early"
+        )
+        late = journal_api_verifier_requirement(
+            slug="late", name="late", description="late"
+        )
+        index = RequirementIndex(
+            by_phase_order={5: [late], 0: [early]},
+            by_slug={"early": early, "late": late},
+            phase_order_by_req_slug={"early": 0, "late": 5},
+        )
+
+        assert pick_smoke_requirement(index).slug == "early"
+
+    def test_pick_smoke_requirement_raises_when_no_requirements(self):
+        """An empty index is itself a failure worth surfacing."""
+        with pytest.raises(RuntimeError):
+            pick_smoke_requirement(RequirementIndex())
+
+    @pytest.mark.asyncio
+    async def test_smoke_check_exercises_read_path_without_writes(self):
+        """The canary reads for the synthetic user and writes nothing."""
+        mock_session_maker = _mock_session_maker()
+        mock_requirement = _make_mock_requirement()
+
+        with (
+            patch(
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(mock_requirement),
+            ),
+            patch(
+                "learn_to_cloud.services.submissions_service.SubmissionRepository",
+                autospec=True,
+            ) as mock_repo_class,
+            patch(
+                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
+                autospec=True,
+            ) as mock_job_repo_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
+            mock_repo.are_all_requirements_validated = AsyncMock(return_value=True)
+            mock_repo_class.return_value = mock_repo
+
+            result = await run_submit_smoke_check(mock_session_maker)
+
+        assert result["requirement_slug"] == mock_requirement.slug
+        # Reads use the synthetic, non-existent user id.
+        mock_repo.get_by_user_and_requirement.assert_awaited_once_with(
+            SMOKE_USER_ID, mock_requirement.uuid
+        )
+        # The canary never creates a verification job (no writes).
+        mock_job_repo_class.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_smoke_check_propagates_read_errors(self):
+        """A schema/code mismatch surfaces as a raised error, not a clean pass."""
+        mock_session_maker = _mock_session_maker()
+        mock_requirement = _make_mock_requirement()
+
+        with (
+            patch(
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                new_callable=AsyncMock,
+                return_value=_build_index(mock_requirement),
+            ),
+            patch(
+                "learn_to_cloud.services.submissions_service.SubmissionRepository",
+                autospec=True,
+            ) as mock_repo_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_and_requirement = AsyncMock(
+                side_effect=RuntimeError("column submissions.foo does not exist")
+            )
+            mock_repo_class.return_value = mock_repo
+
+            with pytest.raises(RuntimeError):
+                await run_submit_smoke_check(mock_session_maker)

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -82,6 +82,18 @@ resource "azurerm_container_app" "api" {
     key_vault_secret_id = "${azurerm_key_vault.main.vault_uri}secrets/labs-verification-secret"
   }
 
+  # The smoke-test token is the single source of truth for the post-deploy
+  # verification smoke endpoint and is supplied directly from a GitHub Actions
+  # secret (not Key Vault), so it is set inline here. Only created when a
+  # token is provided so applies without the secret stay valid.
+  dynamic "secret" {
+    for_each = var.smoke_test_token != "" ? [1] : []
+    content {
+      name  = "smoke-test-token"
+      value = var.smoke_test_token
+    }
+  }
+
   ingress {
     external_enabled = true
     target_port      = 8000
@@ -150,6 +162,14 @@ resource "azurerm_container_app" "api" {
       env {
         name        = "LABS__VERIFICATION_SECRET"
         secret_name = "ctf-master-secret"
+      }
+
+      dynamic "env" {
+        for_each = var.smoke_test_token != "" ? [1] : []
+        content {
+          name        = "SMOKE_TEST__TOKEN"
+          secret_name = "smoke-test-token"
+        }
       }
 
       env {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -165,6 +165,19 @@ variable "github_client_id" {
   type        = string
 }
 
+variable "smoke_test_token" {
+  description = <<-EOT
+    Shared secret for the post-deploy verification smoke endpoint
+    (POST /internal/smoke/verification). When set, it is delivered to the API
+    Container App as the SMOKE_TEST__TOKEN secret so the app can validate smoke
+    requests. When empty, the endpoint stays disabled (returns 404). Sourced
+    from the SMOKE_TEST_TOKEN GitHub Actions secret via TF_VAR_smoke_test_token.
+  EOT
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "verification_functions_auth_client_id" {
   description = "Client ID of the pre-created Entra app registration."
   type        = string

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
@@ -134,6 +134,17 @@ class SessionConfig(FrozenConfig):
     secret_key: str = _DEV_SESSION_SECRET
 
 
+class SmokeTestConfig(FrozenConfig):
+    """Post-deploy smoke-test config.
+
+    ``token`` gates the internal verification smoke endpoint. When empty
+    (the default), the endpoint is disabled and returns 404, so the
+    diagnostic surface only exists where the secret is configured.
+    """
+
+    token: str = ""
+
+
 class CorsConfig(FrozenConfig):
     """Frontend URL and CORS config."""
 
@@ -226,6 +237,7 @@ class WebSettings(BaseSettings):
     content: ContentConfig = ContentConfig()
     oauth: OAuthConfig = OAuthConfig()
     session: SessionConfig = SessionConfig()
+    smoke_test: SmokeTestConfig = SmokeTestConfig()
     cors: CorsConfig = CorsConfig()
     frontend_telemetry: FrontendTelemetryConfig = FrontendTelemetryConfig()
     verification_functions: VerificationFunctionsConfig = VerificationFunctionsConfig()


### PR DESCRIPTION
## What this does

Adds an automatic check that runs right after each deploy to confirm the verification **submit** feature actually works against the live database.

It exists to catch the kind of problem from incident **#432**, where the running code expected a database change that had not been applied yet, so every verification submission quietly returned a 500 error for **eight days** before anyone noticed. Our existing `/ready` check only confirms the database is reachable, not that the code and schema agree.

Closes #438.

## How it works (plain language)

1. **New internal-only endpoint** `POST /internal/smoke/verification` runs the same database reads and value parsing that a real submission does, but for a fake (non-existent) user and **without saving anything**. If the code and the database schema do not match, this read path fails loudly. This is the exact class of bug behind #432.
2. **Secret-gated.** The endpoint is completely disabled (returns `404`) unless `SMOKE_TEST__TOKEN` is configured, and it rejects any request whose `X-Smoke-Test-Token` header does not match the configured value (`401`, constant-time compare).
3. **New deploy step.** After the workflow confirms the freshly deployed revision is healthy and serving traffic, a new step calls the endpoint. A `200` means the submit path is healthy. A `5xx` fails the workflow, so a broken deploy is caught in well under a minute instead of days.

## Token handling — one source of truth, can't drift

- The token comes from a single GitHub Actions secret: **`SMOKE_TEST_TOKEN`**.
- Terraform reads it as a sensitive variable (`smoke_test_token`) and sets it on the API Container App as an app secret, so the running app validates against the same value.
- The smoke step sends that same GitHub secret in the request header, so the two sides can never get out of sync.
- The token only guards a read-only, do-nothing diagnostic endpoint, so its worst-case blast radius is tiny.

## Safe, gradual rollout

Until the `SMOKE_TEST_TOKEN` secret is created, the smoke step prints a loud warning and **skips** (exit 0) instead of blocking deploys. Once the secret exists, the gate becomes active automatically.

> [!IMPORTANT]
> To activate the gate, add a repository secret named `SMOKE_TEST_TOKEN` (any strong random string, e.g. `python -c "import secrets; print(secrets.token_hex(32))"`). No Key Vault change or new Azure permissions are required.

## Why read-only and reusing real code

The check writes nothing to production. It reuses the **real** submission pre-validation code (`_check_submission_preconditions` + typed-value parsing) so it stays in step with the actual submit logic rather than drifting into a separate copy.

## Verification

- New unit tests: route auth (404 when unconfigured, 401 on bad/missing token, 200 on success, 503 when the read path fails) and the service canary (picks earliest-phase requirement, uses the synthetic user id, writes nothing, propagates read errors).
- Ran the full quality gates: `ruff check`, `ruff format --check`, `ty check` (api + shared + verification-functions), `pytest` (api 212 passed, shared 496 passed).
- `terraform fmt -check` and `terraform validate` pass.
- **End-to-end locally** against a real database: valid token returned `200` having exercised the `github-profile` phase-0 read path; wrong/missing token returned `401`; `/ready` unaffected.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>