### PR TITLE
Refactor async verification: resolve repo identity once (#427)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,3 +8,11 @@ FROM mcr.microsoft.com/devcontainers/base:debian
 # owned by root, the vscode user cannot write to it, and "copilot plugin ..."
 # fails silently during onCreate (which aborts the whole devcontainer setup).
 RUN mkdir -p /home/vscode/.copilot && chown vscode:vscode /home/vscode/.copilot
+
+# Install the PostgreSQL command-line client (psql). The query-prod-db skill
+# uses psql to connect to the production database with Entra ID tokens. The base
+# image does not include it, so without this line the skill fails with
+# "psql: command not found".
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -25,11 +25,6 @@
       "resolved": "ghcr.io/devcontainers/features/terraform@sha256:503d0888b3a43a32335e08cd4477f8c4629404ad83f6a36f0e0fee7f567c06c7",
       "integrity": "sha256:503d0888b3a43a32335e08cd4477f8c4629404ad83f6a36f0e0fee7f567c06c7"
     },
-    "ghcr.io/microsoft/aspire-devcontainer-feature/aspire:2": {
-      "version": "2.0.0",
-      "resolved": "ghcr.io/microsoft/aspire-devcontainer-feature/aspire@sha256:85cef97f2de880d21a742f799120af2e53f69f4c9334d525381629f81c0409af",
-      "integrity": "sha256:85cef97f2de880d21a742f799120af2e53f69f4c9334d525381629f81c0409af"
-    },
     "ghcr.io/va-h/devcontainers-features/uv:1": {
       "version": "1.1.4",
       "resolved": "ghcr.io/va-h/devcontainers-features/uv@sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "API: FastAPI (uvicorn)",
       "type": "debugpy",
       "request": "launch",
-      "python": "${workspaceFolder}/api/.venv/bin/python",
+      "python": "${workspaceFolder}/.venv/bin/python",
       "module": "uvicorn",
       "args": ["learn_to_cloud.main:app", "--reload", "--reload-include", "*.py", "--reload-include", "*.html", "--reload-exclude", ".venv", "--host", "0.0.0.0", "--port", "8000"],
       "cwd": "${workspaceFolder}/api",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,4 @@
-{}
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "python.terminal.activateEnvironment": true
+}

--- a/api/.env.example
+++ b/api/.env.example
@@ -25,8 +25,10 @@ WEB_SECURITY__REQUIRE_HTTPS=false
 # LABS__VERIFICATION_SECRET=your_secret_here
 
 # Durable verification Functions starter (required for verification submissions)
+# Local development talks to the anonymous `func start` host, so only the base
+# URL is needed. The managed-identity token scope is set automatically in Azure
+# (see infra/container-apps.tf) and is not used locally.
 # VERIFICATION_FUNCTIONS__BASE_URL=http://localhost:7071
-# VERIFICATION_FUNCTIONS__KEY=your_function_key
 
 # Database debug logging (very verbose, logs every SQL query)
 # DATABASE__ECHO=false

--- a/api/src/learn_to_cloud/rendering/context.py
+++ b/api/src/learn_to_cloud/rendering/context.py
@@ -232,6 +232,7 @@ def build_requirement_card_context(
     feedback_passed: int = 0,
     server_error: bool = False,
     server_error_message: str | None = None,
+    server_error_retryable: bool = True,
     error_banner: str | None = None,
     processing: bool = False,
     verification_status_token: str | None = None,
@@ -257,6 +258,9 @@ def build_requirement_card_context(
         feedback_passed: Count of passing tasks (for the summary line).
         server_error: Whether to render the server-error banner.
         server_error_message: Optional server-error text.
+        server_error_retryable: Whether to invite the user to retry. False for
+            server-side problems (e.g. misconfiguration) where retrying cannot
+            succeed, so the banner omits the "try again immediately" guidance.
         error_banner: Optional inline error banner text.
         processing: Whether the card is in the "analysing..." state.
         verification_status_token: Signed token used by the HTMX polling card.
@@ -283,6 +287,7 @@ def build_requirement_card_context(
         "feedback_passed": feedback_passed,
         "server_error": server_error,
         "server_error_message": server_error_message,
+        "server_error_retryable": server_error_retryable,
         "error_banner": error_banner,
         "processing": processing,
         "verification_status_token": verification_status_token,

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -95,12 +95,17 @@ _USER_FACING_ERRORS = (
 )
 
 _DURABLE_START_ERROR_MESSAGE = (
-    "Verification could not be started. This attempt was not counted — "
-    "please try again."
+    "Verification could not be started. This attempt was not counted, please try again."
+)
+_DURABLE_UNAVAILABLE_ERROR_MESSAGE = (
+    "Verification is temporarily unavailable because of a problem on our side, "
+    "not something you did. Retrying won't fix it. Please report it by opening "
+    "an issue at https://github.com/learntocloud/learn-to-cloud-app/issues."
 )
 _DURABLE_TERMINAL_ERROR_MESSAGE = (
     "Verification failed because the verification service hit an internal error. "
-    "This attempt was not counted. Please try again."
+    "Please try again in a few minutes. If it keeps failing, open an issue at "
+    "https://github.com/learntocloud/learn-to-cloud-app/issues."
 )
 
 _ACTIVE_DURABLE_STATUSES = {"pending", "running", "continuedasnew"}
@@ -302,6 +307,7 @@ async def htmx_submit_verification(
         feedback_passed: int = 0,
         server_error: bool = False,
         server_error_message: str | None = None,
+        server_error_retryable: bool = True,
         error_banner: str | None = None,
         processing: bool = False,
         verification_status_token: str | None = None,
@@ -319,6 +325,7 @@ async def htmx_submit_verification(
                 feedback_passed=feedback_passed,
                 server_error=server_error,
                 server_error_message=server_error_message,
+                server_error_retryable=server_error_retryable,
                 error_banner=error_banner,
                 processing=processing,
                 verification_status_token=verification_status_token,
@@ -372,7 +379,7 @@ async def htmx_submit_verification(
             server_error=True,
             server_error_message=(
                 "An unexpected error occurred during verification. "
-                "This attempt was not counted — please try again."
+                "This attempt was not counted, please try again."
             ),
         )
 
@@ -500,6 +507,15 @@ async def _start_async_job_and_render(
                 job_submission.job.id,
             )
             await write_session.commit()
+        # A config error means the verification service is misconfigured on our
+        # side, so retrying will never help. A start error is usually a
+        # transient hiccup in the Functions app, so retrying is worth it.
+        if isinstance(exc, DurableVerificationConfigError):
+            return render_card(
+                server_error=True,
+                server_error_message=_DURABLE_UNAVAILABLE_ERROR_MESSAGE,
+                server_error_retryable=False,
+            )
         return render_card(
             server_error=True,
             server_error_message=_DURABLE_START_ERROR_MESSAGE,
@@ -584,6 +600,7 @@ async def htmx_verification_job_status(
                 github_username=current_user.github_username,
                 server_error=True,
                 server_error_message=_DURABLE_TERMINAL_ERROR_MESSAGE,
+                server_error_retryable=False,
             ),
         )
 

--- a/api/src/learn_to_cloud/services/durable_verification_client.py
+++ b/api/src/learn_to_cloud/services/durable_verification_client.py
@@ -56,10 +56,9 @@ async def start_verification_orchestration(
     settings = get_web_settings()
     base_url, token_scope = _verification_endpoint_config(settings)
 
-    token = await _get_verification_token(token_scope)
+    headers = await _verification_auth_headers(token_scope)
 
     url = f"{base_url}/api/verification/jobs/{prepared.id}/start"
-    headers = {"Authorization": f"Bearer {token}"}
     body: dict[str, Any] = prepared.to_payload()
 
     timeout = settings.http.external_api_timeout
@@ -97,10 +96,9 @@ async def get_verification_orchestration_status(
     settings = get_web_settings()
     base_url, token_scope = _verification_endpoint_config(settings)
 
-    token = await _get_verification_token(token_scope)
+    headers = await _verification_auth_headers(token_scope)
 
     url = f"{base_url}/api/verification/jobs/{instance_id}/status"
-    headers = {"Authorization": f"Bearer {token}"}
 
     timeout = settings.http.external_api_timeout
     try:
@@ -134,16 +132,34 @@ async def get_verification_orchestration_status(
     )
 
 
-def _verification_endpoint_config(settings: Any) -> tuple[str, str]:
+def _verification_endpoint_config(settings: Any) -> tuple[str, str | None]:
     base_url = settings.verification_functions.base_url.rstrip("/")
-    token_scope = settings.verification_functions.token_scope
 
-    if not base_url or not token_scope:
+    if not base_url:
+        raise DurableVerificationConfigError(
+            "Verification Functions endpoint is not configured."
+        )
+
+    # The local Functions host runs with AuthLevel.ANONYMOUS, so no bearer token
+    # is needed (or obtainable) in development. Everywhere else the API
+    # authenticates with a managed-identity token for the configured scope.
+    if settings.is_development:
+        return base_url, None
+
+    token_scope = settings.verification_functions.token_scope
+    if not token_scope:
         raise DurableVerificationConfigError(
             "Verification Functions endpoint is not configured."
         )
 
     return base_url, token_scope
+
+
+async def _verification_auth_headers(token_scope: str | None) -> dict[str, str]:
+    if token_scope is None:
+        return {}
+    token = await _get_verification_token(token_scope)
+    return {"Authorization": f"Bearer {token}"}
 
 
 async def _get_verification_token(token_scope: str) -> str:

--- a/api/src/learn_to_cloud/templates/macros/callouts.html
+++ b/api/src/learn_to_cloud/templates/macros/callouts.html
@@ -32,8 +32,20 @@ Macros:
     "warning": "bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-200",
 } %}
 
-{% macro banner(message, variant="error") %}
+{% macro banner(message, variant="error", report=false, report_title="", report_context="") %}
 <div class="mt-3 rounded-md p-3 {{ _BANNER_CLASSES[variant] }}">
     <p class="text-sm">{{ message }}</p>
+    {% if report %}
+    <a
+        href="https://github.com/learntocloud/learn-to-cloud-app/issues/new"
+        data-report-issue
+        data-issue-title="{{ report_title or 'Issue: Verification error' }}"
+        data-issue-labels="bug"
+        {% if report_context %}data-issue-context="{{ report_context }}"{% endif %}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="mt-2 inline-flex items-center gap-1 text-sm font-medium underline hover:no-underline"
+    >Report this issue</a>
+    {% endif %}
 </div>
 {% endmacro %}

--- a/api/src/learn_to_cloud/templates/pages/phase.html
+++ b/api/src/learn_to_cloud/templates/pages/phase.html
@@ -89,7 +89,7 @@
         {% elif not ns.found_active %}
         {# First incomplete — show full card #}
         {% set ns.found_active = true %}
-        {% with requirement=req, submission=submission, feedback_tasks=feedback_tasks, feedback_passed=feedback_passed, phase_id=phase.order, error_banner=persisted_error, server_error=False, server_error_message=None, processing=active_job is not none, verification_status_token=verification_status_token, verification_status_delay_seconds=2, derived_url=derived_urls_by_req.get(req.slug) %}
+        {% with requirement=req, submission=submission, feedback_tasks=feedback_tasks, feedback_passed=feedback_passed, phase_id=phase.order, error_banner=persisted_error, server_error=False, server_error_message=None, server_error_retryable=True, processing=active_job is not none, verification_status_token=verification_status_token, verification_status_delay_seconds=2, derived_url=derived_urls_by_req.get(req.slug) %}
         {% include "partials/requirement_card.html" %}
         {% endwith %}
         {% else %}

--- a/api/src/learn_to_cloud/templates/partials/requirement_card.html
+++ b/api/src/learn_to_cloud/templates/partials/requirement_card.html
@@ -111,16 +111,28 @@
     </form>
     {% endif %}
 
+    {% set _failure_reportable = submission is not none and not submission.is_validated and not submission.verification_completed %}
     {% if server_error %}
     {{ banner(
         (server_error_message or 'The verification service encountered an error.')
-        + ' This attempt was not counted against your rate limit — you can try again immediately.',
-        'warning'
+        + (' This attempt was not counted against your rate limit, so you can try again immediately.'
+           if server_error_retryable
+           else ' This attempt was not counted against your rate limit.'),
+        'warning',
+        report=true,
+        report_title='Verification error: ' ~ requirement.name,
+        report_context='requirement=' ~ requirement.slug
     ) }}
     {% endif %}
 
     {% if error_banner %}
-    {{ banner(error_banner, 'error') }}
+    {{ banner(
+        error_banner,
+        'error',
+        report=_failure_reportable,
+        report_title='Verification error: ' ~ requirement.name,
+        report_context='requirement=' ~ requirement.slug
+    ) }}
     {% endif %}
 
     {% if feedback_tasks %}

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -32,6 +32,7 @@ from learn_to_cloud.routes.htmx_routes import (
 )
 from learn_to_cloud.services.durable_verification_client import (
     DurableStatusResult,
+    DurableVerificationConfigError,
     DurableVerificationStartError,
 )
 from learn_to_cloud.services.steps_service import StepValidationError
@@ -364,6 +365,129 @@ class TestHtmxSubmitVerification:
         assert isinstance(result, HTMLResponse)
         repo.delete_active.assert_awaited_once_with(job.id)
         write_session.commit.assert_awaited_once()
+
+    async def test_durable_config_error_does_not_invite_immediate_retry(
+        self, _patch_templates
+    ):
+        """A config error is a server-side misconfiguration, so retrying never
+        helps. The banner must not tell the user to try again immediately."""
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        job = _mock_job()
+        async_result = VerificationJobSubmission(
+            job=cast(VerificationJob, job),
+            created=True,
+            requirement=_async_requirement(),
+            github_username="user",
+        )
+        write_session = AsyncMock()
+        request.app.state.session_maker.return_value.__aenter__.return_value = (
+            write_session
+        )
+        repo = MagicMock()
+        repo.delete_active = AsyncMock(return_value=True)
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.derive_submission_value",
+                autospec=True,
+                return_value="https://github.com/user/repo",
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                new_callable=AsyncMock,
+                return_value=async_result,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                new_callable=AsyncMock,
+                side_effect=DurableVerificationConfigError("not configured"),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                return_value=repo,
+            ),
+        ):
+            result = await htmx_submit_verification(
+                request,
+                AsyncMock(),
+                current_user,
+                requirement_slug="req-1",
+                submitted_value="https://github.com/user/repo",
+            )
+
+        assert isinstance(result, HTMLResponse)
+        # The in-flight slot is still freed so a later (post-fix) retry works.
+        repo.delete_active.assert_awaited_once_with(job.id)
+        _, _, context = _patch_templates.TemplateResponse.call_args.args
+        assert context["server_error"] is True
+        assert context["server_error_retryable"] is False
+        assert "open" in context["server_error_message"].lower()
+        assert (
+            "github.com/learntocloud/learn-to-cloud-app/issues"
+            in context["server_error_message"]
+        )
+        assert "immediately" not in context["server_error_message"]
+        assert "team has been notified" not in context["server_error_message"]
+
+    async def test_durable_start_error_invites_retry(self, _patch_templates):
+        """A transient start error should still mark the banner retryable."""
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        job = _mock_job()
+        async_result = VerificationJobSubmission(
+            job=cast(VerificationJob, job),
+            created=True,
+            requirement=_async_requirement(),
+            github_username="user",
+        )
+        write_session = AsyncMock()
+        request.app.state.session_maker.return_value.__aenter__.return_value = (
+            write_session
+        )
+        repo = MagicMock()
+        repo.delete_active = AsyncMock(return_value=True)
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.derive_submission_value",
+                autospec=True,
+                return_value="https://github.com/user/repo",
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                new_callable=AsyncMock,
+                return_value=async_result,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                new_callable=AsyncMock,
+                side_effect=DurableVerificationStartError("boom"),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                return_value=repo,
+            ),
+        ):
+            await htmx_submit_verification(
+                request,
+                AsyncMock(),
+                current_user,
+                requirement_slug="req-1",
+                submitted_value="https://github.com/user/repo",
+            )
+
+        _, _, context = _patch_templates.TemplateResponse.call_args.args
+        assert context["server_error"] is True
+        assert context["server_error_retryable"] is True
 
     async def test_sync_submit_returns_reload_trigger(self):
         """Sync submission types finish in-request and return a page-reload
@@ -710,10 +834,12 @@ class TestHtmxVerificationJobStatus:
         mock_session.commit.assert_awaited_once()
         _, _, context = _patch_templates.TemplateResponse.call_args.args
         assert context["server_error"] is True
+        assert context["server_error_retryable"] is False
         assert (
             context["server_error_message"]
             == "Verification failed because the verification service hit an internal "
-            "error. This attempt was not counted. Please try again."
+            "error. Please try again in a few minutes. If it keeps failing, open an "
+            "issue at https://github.com/learntocloud/learn-to-cloud-app/issues."
         )
 
     async def test_canceled_status_also_deletes_active_job(self):

--- a/api/tests/services/test_durable_verification_client.py
+++ b/api/tests/services/test_durable_verification_client.py
@@ -28,6 +28,7 @@ def _settings(
     *,
     base_url: str = "http://localhost:7071/",
     token_scope: str = "api://verification-functions/.default",
+    is_development: bool = False,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         verification_functions=SimpleNamespace(
@@ -35,6 +36,7 @@ def _settings(
             token_scope=token_scope,
         ),
         http=SimpleNamespace(external_api_timeout=3.0),
+        is_development=is_development,
     )
 
 
@@ -90,6 +92,50 @@ async def test_starts_orchestration_with_bearer_token_header_and_payload():
         headers={"Authorization": "Bearer access-token"},
         json=prepared.to_payload(),
     )
+
+
+async def test_development_skips_token_and_sends_no_auth_header():
+    prepared = _prepared()
+    client, context_manager = _async_client(httpx.Response(202, json={"id": "abc"}))
+
+    with (
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_web_settings",
+            return_value=_settings(token_scope="", is_development=True),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_azure_token",
+            new=AsyncMock(side_effect=AssertionError("token must not be requested")),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.httpx.AsyncClient",
+            return_value=context_manager,
+        ),
+    ):
+        result = await start_verification_orchestration(prepared)
+
+    assert result.instance_id == "abc"
+    client.post.assert_awaited_once_with(
+        f"http://localhost:7071/api/verification/jobs/{prepared.id}/start",
+        headers={},
+        json=prepared.to_payload(),
+    )
+
+
+async def test_development_missing_base_url_fails_before_http_call():
+    with (
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_web_settings",
+            return_value=_settings(base_url="", token_scope="", is_development=True),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.httpx.AsyncClient"
+        ) as async_client,
+        pytest.raises(DurableVerificationConfigError),
+    ):
+        await start_verification_orchestration(_prepared())
+
+    async_client.assert_not_called()
 
 
 async def test_missing_config_fails_before_http_call():

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -49,7 +49,7 @@ from opentelemetry import context as otel_context
 from opentelemetry import trace as otel_trace
 from opentelemetry.propagate import extract
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
-from verification_agents import grade_evidence
+from verification_agents import grade_evidence, missing_grading_config
 
 
 def _telemetry_destination_configured() -> bool:
@@ -376,25 +376,41 @@ def _run_verification_orchestration(context: df.DurableOrchestrationContext):
         context.set_custom_status(
             _job_custom_status("llm_grading", job_id, prepared_verification_job)
         )
-        try:
-            decisions: list[dict[str, object]] = []
-            for request_payload in llm_requests:
-                decision_payload = yield context.call_activity_with_retry(
-                    "run_llm_grading",
-                    _LLM_RETRY_OPTIONS,
-                    request_payload,
-                )
-                decisions.append(_activity_payload(decision_payload))
-
-            run_result = yield context.call_activity(
-                "apply_llm_grading_results",
-                {"run_result": run_result, "decisions": decisions},
-            )
-        except Exception as exc:
+        config_status = yield context.call_activity("ensure_grading_config", None)
+        if not config_status.get("valid"):
+            missing = config_status.get("missing_vars") or []
             run_result = yield context.call_activity(
                 "llm_grading_failed",
-                {"run_result": run_result, "detail": str(exc)},
+                {
+                    "run_result": run_result,
+                    "detail": f"missing grading config: {', '.join(missing)}",
+                    "error_type": "MissingGradingConfig",
+                },
             )
+        else:
+            try:
+                decisions: list[dict[str, object]] = []
+                for request_payload in llm_requests:
+                    decision_payload = yield context.call_activity_with_retry(
+                        "run_llm_grading",
+                        _LLM_RETRY_OPTIONS,
+                        request_payload,
+                    )
+                    decisions.append(_activity_payload(decision_payload))
+
+                run_result = yield context.call_activity(
+                    "apply_llm_grading_results",
+                    {"run_result": run_result, "decisions": decisions},
+                )
+            except Exception as exc:
+                run_result = yield context.call_activity(
+                    "llm_grading_failed",
+                    {
+                        "run_result": run_result,
+                        "detail": str(exc),
+                        "error_type": type(exc).__name__,
+                    },
+                )
 
     context.set_custom_status(
         _job_custom_status("persisting", job_id, prepared_verification_job)
@@ -580,6 +596,22 @@ async def collect_llm_grading_requests(
         return [request.model_dump(mode="json") for request in requests]
 
 
+@app.activity_trigger(input_name="payload")
+async def ensure_grading_config(
+    payload,
+    context: func.Context,
+) -> dict[str, object]:
+    """Report whether the Foundry grading config is present.
+
+    Missing config is a permanent deployment error, not a transient fault,
+    so the orchestrator runs this once without retries and fails the job
+    fast instead of retrying the grading activity four times.
+    """
+    with _attached_invocation_context(context):
+        missing = missing_grading_config()
+        return {"valid": not missing, "missing_vars": missing}
+
+
 @app.activity_trigger(input_name="request_payload")
 async def run_llm_grading(
     request_payload,
@@ -633,14 +665,24 @@ async def llm_grading_failed(
         detail = data.get("detail")
         if not isinstance(detail, str) or not detail:
             detail = "unknown_error"
+        error_type = data.get("error_type")
+        if not isinstance(error_type, str) or not error_type:
+            error_type = "unknown"
         run_result_payload = VerificationRunResult.from_payload(
             _activity_payload(data["run_result"])
         )
         _set_prepared_job_span_attributes(run_result_payload.job)
-        run_result = llm_grading_unavailable_result(
-            run_result_payload,
-            detail,
+        # Record the real cause in telemetry so operators can diagnose the
+        # failure. The user-facing result stays generic on purpose.
+        span = otel_trace.get_current_span()
+        if span.is_recording():
+            span.set_attribute("verification.llm_grading_error_type", error_type)
+            span.set_attribute("verification.llm_grading_error_detail", detail)
+        logger.error(
+            "verification.llm_grading.failed",
+            extra={"error_type": error_type, "detail": detail},
         )
+        run_result = llm_grading_unavailable_result(run_result_payload)
         result_payload = run_result.to_payload()
         _set_result_span_attributes(result_payload)
         return result_payload

--- a/apps/verification-functions/local.settings.example.json
+++ b/apps/verification-functions/local.settings.example.json
@@ -1,5 +1,6 @@
 {
   "IsEncrypted": false,
+  "_comment_PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "Local dev only. Forces protobuf's pure-Python implementation to avoid an upstream Azure Functions bug where the Python 3.13 worker segfaults (exit code 139) loading protobuf's native extension on arm64 dev containers. Not used in production (this file is never deployed). See Azure/azure-functions-python-worker#1797.",
   "Values": {
     "AzureWebJobsStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;TableEndpoint=http://azurite:10002/devstoreaccount1;",
     "FUNCTIONS_WORKER_RUNTIME": "python",
@@ -9,8 +10,9 @@
     "DEBUG": "true",
     "GITHUB__TOKEN": "",
     "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
-    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://aspire-dashboard:18889",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://aspire-dashboard:18888",
     "OTEL_SERVICE_NAME": "learn-to-cloud-verification-functions",
+    "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python",
     "FOUNDRY_PROJECT_ENDPOINT": "",
     "FOUNDRY_MODEL_DEPLOYMENT_NAME": "",
     "AzureWebJobsSecretStorageType": "Files",

--- a/apps/verification-functions/verification_agents.py
+++ b/apps/verification-functions/verification_agents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
+from dataclasses import dataclass
 from functools import cache
 from typing import Any
 
@@ -16,6 +17,7 @@ from learn_to_cloud_shared.verification.tasks import LLMGradingDecision
 VERIFICATION_GRADER_AGENT_NAME = "VerificationGrader"
 _PROJECT_ENDPOINT_ENV = "FOUNDRY_PROJECT_ENDPOINT"
 _MODEL_DEPLOYMENT_ENV = "FOUNDRY_MODEL_DEPLOYMENT_NAME"
+_REQUIRED_GRADING_ENV = (_PROJECT_ENDPOINT_ENV, _MODEL_DEPLOYMENT_ENV)
 
 _GRADER_INSTRUCTIONS = """
 You are the Learn to Cloud verification grader.
@@ -42,11 +44,36 @@ _GRADER_OPTIONS: OpenAIChatOptions[LLMGradingDecision] = {
 }
 
 
-def _required_env(name: str) -> str:
-    value = os.getenv(name)
-    if value is None or not value.strip():
-        raise RuntimeError(f"{name} is required for LLM verification grading")
-    return value
+def missing_grading_config() -> list[str]:
+    """Return required grading env var names that are unset or blank.
+
+    Reading env vars is not a transient operation, so callers can treat a
+    non-empty result as a permanent configuration error and fail fast
+    instead of retrying.
+    """
+    return [
+        name for name in _REQUIRED_GRADING_ENV if not (os.getenv(name) or "").strip()
+    ]
+
+
+@dataclass(frozen=True)
+class GradingConfig:
+    """Foundry settings the verification grader needs."""
+
+    project_endpoint: str
+    model_deployment_name: str
+
+    @classmethod
+    def from_env(cls) -> GradingConfig:
+        missing = missing_grading_config()
+        if missing:
+            raise RuntimeError(
+                f"{', '.join(missing)} required for LLM verification grading"
+            )
+        return cls(
+            project_endpoint=os.environ[_PROJECT_ENDPOINT_ENV].strip(),
+            model_deployment_name=os.environ[_MODEL_DEPLOYMENT_ENV].strip(),
+        )
 
 
 def _credential() -> DefaultAzureCredential | ManagedIdentityCredential:
@@ -61,11 +88,16 @@ def _credential() -> DefaultAzureCredential | ManagedIdentityCredential:
 
 @cache
 def get_verification_grader() -> Agent[Any]:
-    """Return the lazily-constructed Foundry-backed grading agent."""
+    """Return the lazily-constructed Foundry-backed grading agent.
+
+    Validates required config defensively: the orchestrator pre-checks it,
+    but activities can run on a different worker, so this stays a guard.
+    """
+    config = GradingConfig.from_env()
     return Agent(
         client=FoundryChatClient(
-            project_endpoint=_required_env(_PROJECT_ENDPOINT_ENV),
-            model=_required_env(_MODEL_DEPLOYMENT_ENV),
+            project_endpoint=config.project_endpoint,
+            model=config.model_deployment_name,
             credential=_credential(),
         ),
         instructions=_GRADER_INSTRUCTIONS,

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -253,3 +253,47 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_durable_
     action_groups = [azurerm_monitor_action_group.critical.id]
   }
 }
+
+# The verification submit handler catches DurableVerificationConfigError and
+# returns a 200 page with an error banner, so the 5xx-based alerts above never
+# see it. A config error means verification is misconfigured on our side and is
+# broken for every learner until someone fixes it, so we page on the very first
+# occurrence by matching the structured log event and its error_type dimension.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "api_verification_config_error" {
+  name                = "alert-ltc-api-verification-config-error-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Alert when the verification submit path hits a configuration error (returns 200, so no 5xx alert fires)"
+  severity            = 1
+  enabled             = true
+  tags                = local.tags
+
+  scopes                = [azurerm_application_insights.main.id]
+  evaluation_frequency  = "PT5M"
+  window_duration       = "PT5M"
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query                   = <<-QUERY
+      traces
+      | extend ErrorType = tostring(customDimensions.error_type)
+      | where cloud_RoleName in ("learn-to-cloud-api", "ca-ltc-api-${var.environment}")
+          or cloud_RoleName has "learn-to-cloud-api"
+          or cloud_RoleName has "ca-ltc-api"
+      | where message has "htmx.submit.durable_start_failed"
+      | where ErrorType == "DurableVerificationConfigError"
+    QUERY
+    time_aggregation_method = "Count"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.critical.id]
+  }
+}

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
@@ -23,6 +23,7 @@ For phase requirements, see requirements.py
 """
 
 import time
+from collections.abc import Awaitable, Callable
 
 from opentelemetry import metrics, trace
 
@@ -38,7 +39,7 @@ from learn_to_cloud_shared.verification.github_profile import (
 )
 from learn_to_cloud_shared.verification.repo_utils import (
     VerificationError,
-    validate_repo_url,
+    resolve_repository,
 )
 from learn_to_cloud_shared.verification.security_scanning import (
     validate_security_scanning,
@@ -46,9 +47,6 @@ from learn_to_cloud_shared.verification.security_scanning import (
 from learn_to_cloud_shared.verification.token_base import (
     verify_ctf_token,
     verify_networking_token,
-)
-from learn_to_cloud_shared.verification.url_derivation import (
-    fork_name_from_required_repo,
 )
 
 _meter = metrics.get_meter("learn_to_cloud")
@@ -152,6 +150,24 @@ def is_sync_verifiable(submission_type: SubmissionType) -> bool:
     return submission_type in SYNC_VERIFIABLE_SUBMISSION_TYPES
 
 
+# Submission types whose persisted value is a server-derived GitHub repo URL
+# (``https://github.com/<user>/<fork>``). Their owner/repo identity can be
+# parsed straight from the validated submission value -- see
+# ``repo_utils.resolve_repository``.
+_REPO_BACKED_SUBMISSION_TYPES: frozenset[SubmissionType] = frozenset(
+    {
+        SubmissionType.JOURNAL_API_VERIFIER,
+        SubmissionType.DEVOPS_ANALYSIS,
+        SubmissionType.SECURITY_SCANNING,
+    }
+)
+
+
+def is_repo_backed(submission_type: SubmissionType) -> bool:
+    """Return True if the submission value is a server-derived GitHub repo URL."""
+    return submission_type in _REPO_BACKED_SUBMISSION_TYPES
+
+
 async def _dispatch_validation(
     requirement: HandsOnRequirement,
     submitted_value: str,
@@ -198,31 +214,16 @@ async def _dispatch_validation(
         return verify_networking_token(submitted_value, username)
 
     elif requirement.submission_type == SubmissionType.JOURNAL_API_VERIFIER:
-        expected_name = _expected_fork_name(requirement)
-        result = validate_repo_url(submitted_value, username, expected_name)
-        if isinstance(result, ValidationResult):
-            return result
-        owner, repo = result
-        return await verify_ci_status(owner, repo)
+        return await _verify_repo_backed(submitted_value, verify_ci_status)
 
     elif requirement.submission_type == SubmissionType.DEVOPS_ANALYSIS:
-        expected_name = _expected_fork_name(requirement)
-        result = validate_repo_url(submitted_value, username, expected_name)
-        if isinstance(result, ValidationResult):
-            return result
-        owner, repo = result
-        return await run_devops_workflow(owner, repo)
+        return await _verify_repo_backed(submitted_value, run_devops_workflow)
 
     elif requirement.submission_type == SubmissionType.DEPLOYED_API:
         return await validate_deployed_api(submitted_value)
 
     elif requirement.submission_type == SubmissionType.SECURITY_SCANNING:
-        expected_name = _expected_fork_name(requirement)
-        result = validate_repo_url(submitted_value, username, expected_name)
-        if isinstance(result, ValidationResult):
-            return result
-        owner, repo = result
-        return await validate_security_scanning(owner, repo)
+        return await _verify_repo_backed(submitted_value, validate_security_scanning)
 
     else:
         return ValidationResult(
@@ -233,11 +234,17 @@ async def _dispatch_validation(
         )
 
 
-def _expected_fork_name(requirement: HandsOnRequirement) -> str | None:
-    """Return the expected fork repo name from ``required_repo``, if set."""
-    if not requirement.required_repo:
-        return None
-    try:
-        return fork_name_from_required_repo(requirement.required_repo)
-    except ValueError:
-        return None
+async def _verify_repo_backed(
+    submitted_value: str,
+    verifier: Callable[[str, str], Awaitable[ValidationResult]],
+) -> ValidationResult:
+    """Resolve the repo identity from the validated submission value and verify.
+
+    The owner/repo come straight from the server-derived, DB-validated
+    submission URL, so no ownership or fork-name re-check is needed here (see
+    ``resolve_repository``). A malformed URL surfaces as a ``ValidationResult``.
+    """
+    repo = resolve_repository(submitted_value)
+    if isinstance(repo, ValidationResult):
+        return repo
+    return await verifier(repo.owner, repo.repo)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -7,13 +7,11 @@ import json
 from learn_to_cloud_shared.schemas import (
     FrozenModel,
     HandsOnRequirement,
-    ValidationResult,
 )
 from learn_to_cloud_shared.verification.journal_api import (
     collect_journal_api_implementation_evidence,
 )
 from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
-from learn_to_cloud_shared.verification.repo_utils import validate_repo_url
 from learn_to_cloud_shared.verification.security_scanning import (
     collect_security_scanning_evidence,
 )
@@ -24,9 +22,6 @@ from learn_to_cloud_shared.verification.tasks import (
     LLMGradingDecision,
     VerificationTask,
     require_llm_rubric_grader,
-)
-from learn_to_cloud_shared.verification.url_derivation import (
-    fork_name_from_required_repo,
 )
 from learn_to_cloud_shared.verification_job_executor import (
     VerificationRunResult,
@@ -102,6 +97,7 @@ def apply_llm_grading_decisions(
     return VerificationRunResult(
         job=run_result.job,
         validation_result=validation_result,
+        repository=run_result.repository,
     )
 
 
@@ -120,6 +116,7 @@ def llm_grading_unavailable_result(
     return VerificationRunResult(
         job=run_result.job,
         validation_result=validation_result,
+        repository=run_result.repository,
     )
 
 
@@ -128,20 +125,11 @@ async def _collect_phase6_requests(
     tasks: list[VerificationTask],
     repo_files: RepoFiles,
 ) -> list[LLMGradingRequest]:
-    github_username = run_result.job.github_username
-    if github_username is None:
+    repository = run_result.repository
+    if repository is None:
         return []
 
-    expected_name = _expected_fork_name(run_result.job.requirement)
-    repo_result = validate_repo_url(
-        run_result.job.typed_submitted_value.as_text,
-        github_username,
-        expected_name,
-    )
-    if isinstance(repo_result, ValidationResult):
-        return []
-
-    owner, repo = repo_result
+    owner, repo = repository.owner, repository.repo
     file_paths = await repo_files.tree(owner, repo)
     requests: list[LLMGradingRequest] = []
     for task in tasks:
@@ -176,20 +164,11 @@ async def _collect_phase3_requests(
     if not run_result.validation_result.is_valid:
         return []
 
-    github_username = run_result.job.github_username
-    if github_username is None:
+    repository = run_result.repository
+    if repository is None:
         return []
 
-    expected_name = _expected_fork_name(run_result.job.requirement)
-    repo_result = validate_repo_url(
-        run_result.job.typed_submitted_value.as_text,
-        github_username,
-        expected_name,
-    )
-    if isinstance(repo_result, ValidationResult):
-        return []
-
-    owner, repo = repo_result
+    owner, repo = repository.owner, repository.repo
     file_paths = await repo_files.tree(owner, repo)
     requests: list[LLMGradingRequest] = []
     for task in tasks:
@@ -282,12 +261,3 @@ def _llm_tasks_for_requirement(
     if requirement.slug == "journal-api-implementation":
         return PHASE3_LLM_TASKS
     return []
-
-
-def _expected_fork_name(requirement: HandsOnRequirement) -> str | None:
-    if not requirement.required_repo:
-        return None
-    try:
-        return fork_name_from_required_repo(requirement.required_repo)
-    except ValueError:
-        return None

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -103,13 +103,20 @@ def apply_llm_grading_decisions(
 
 def llm_grading_unavailable_result(
     run_result: VerificationRunResult,
-    detail: str,
 ) -> VerificationRunResult:
-    """Return a server-error validation result for LLM grader failures."""
+    """Return a server-error validation result for LLM grader failures.
+
+    The user-facing message stays generic; callers are responsible for
+    recording the real cause in telemetry.
+    """
     validation_result = run_result.validation_result.model_copy(
         update={
             "is_valid": False,
-            "message": "LLM verification grading failed. Please try again later.",
+            "message": (
+                "Automated grading is temporarily unavailable. This is a "
+                "problem on our end, not yours. Please report it so we can "
+                "fix it."
+            ),
             "verification_completed": False,
         }
     )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_utils.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_utils.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Mapping
+from dataclasses import dataclass
 from urllib.parse import urlparse
 
 from learn_to_cloud_shared.schemas import ParsedGitHubUrl, ValidationResult
@@ -97,36 +99,50 @@ def extract_repo_info(repo_url: str) -> tuple[str, str]:
     return parsed.username, parsed.repo_name
 
 
-def validate_repo_url(
-    repo_url: str,
-    github_username: str,
-    expected_repo_name: str | None = None,
-) -> tuple[str, str] | ValidationResult:
-    """Parse a GitHub URL and verify the repo belongs to *github_username*."""
+@dataclass(frozen=True, slots=True)
+class RepositoryRef:
+    """A resolved GitHub repository identity (``owner`` + repo ``name``).
+
+    Carried across the Durable verification pipeline so the repo identity is
+    parsed once from the validated submission value and reused by later steps
+    instead of being re-derived.
+    """
+
+    owner: str
+    repo: str
+
+    def to_payload(self) -> dict[str, str]:
+        """Return a JSON-serializable activity payload."""
+        return {"owner": self.owner, "repo": self.repo}
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, object]) -> RepositoryRef:
+        """Rehydrate a repository reference from a Durable activity payload."""
+        owner = payload.get("owner")
+        repo = payload.get("repo")
+        if not isinstance(owner, str) or not isinstance(repo, str):
+            raise TypeError("RepositoryRef payload requires string 'owner' and 'repo'")
+        return cls(owner=owner, repo=repo)
+
+
+def resolve_repository(submitted_value: str) -> RepositoryRef | ValidationResult:
+    """Parse the owner/repo identity from a validated submission URL.
+
+    The async repo-backed submission types (journal API verifier, DevOps
+    analysis, security scanning) persist a server-built
+    ``https://github.com/<user>/<fork>`` value. That value is derived from the
+    authenticated session's GitHub username plus the requirement's
+    ``required_repo`` at submit time (see ``url_derivation``), and the
+    Functions starter validates it against the ``verification_jobs`` row before
+    execution. Ownership and fork-name are therefore guaranteed by
+    construction, so this only parses the identity -- it deliberately does not
+    re-check that the owner matches a username or that the repo matches an
+    expected fork name. A malformed URL still returns a failing
+    ``ValidationResult`` so a corrupt persisted value surfaces instead of
+    crashing a later step.
+    """
     try:
-        owner, repo = extract_repo_info(repo_url)
+        owner, repo = extract_repo_info(submitted_value)
     except ValueError as e:
         return ValidationResult(is_valid=False, message=str(e))
-
-    if owner.lower() != github_username.lower():
-        return ValidationResult(
-            is_valid=False,
-            message=(
-                f"Repository owner '{owner}' does not match your GitHub username "
-                f"'{github_username}'. Please submit your own repository."
-            ),
-            username_match=False,
-        )
-
-    if expected_repo_name is not None and repo.lower() != expected_repo_name.lower():
-        return ValidationResult(
-            is_valid=False,
-            message=(
-                f"Repository '{repo}' does not match the expected fork name "
-                f"'{expected_repo_name}'. Submit the fork from the phase's "
-                "upstream project."
-            ),
-            username_match=True,
-        )
-
-    return owner, repo
+    return RepositoryRef(owner=owner, repo=repo)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/security_scanning.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/security_scanning.py
@@ -270,7 +270,7 @@ async def _verify_security_scanning(
             else codeql_result.task_name
         )
         message = (
-            f"{passed_name} is configured — security scanning verified! "
+            f"{passed_name} is configured. Security scanning verified! "
             "Consider enabling the other scanner for more comprehensive coverage."
         )
     else:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -48,10 +48,17 @@ from learn_to_cloud_shared.submission_values import (
     SubmittedValue,
     submission_value_from_columns,
 )
-from learn_to_cloud_shared.verification.dispatcher import validate_submission
+from learn_to_cloud_shared.verification.dispatcher import (
+    is_repo_backed,
+    validate_submission,
+)
 from learn_to_cloud_shared.verification.execution import (
     persist_validation_result,
     persisted_validation_message,
+)
+from learn_to_cloud_shared.verification.repo_utils import (
+    RepositoryRef,
+    resolve_repository,
 )
 
 tracer = trace.get_tracer(__name__)
@@ -204,22 +211,33 @@ class VerificationRunResult:
 
     job: PreparedVerificationJob
     validation_result: ValidationResult
+    repository: RepositoryRef | None = None
 
     def to_payload(self) -> dict[str, object]:
         """Return a JSON-serializable activity payload."""
-        return {
+        payload: dict[str, object] = {
             "job": self.job.to_payload(),
             "validation_result": self.validation_result.model_dump(mode="json"),
         }
+        if self.repository is not None:
+            payload["repository"] = self.repository.to_payload()
+        return payload
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, object]) -> VerificationRunResult:
         """Rehydrate a validation result from a Durable activity payload."""
+        repository_payload = payload.get("repository")
+        repository = (
+            RepositoryRef.from_payload(_expect_mapping(repository_payload))
+            if repository_payload is not None
+            else None
+        )
         return cls(
             job=PreparedVerificationJob.from_payload(_expect_mapping(payload["job"])),
             validation_result=ValidationResult.model_validate(
                 payload["validation_result"]
             ),
+            repository=repository,
         )
 
 
@@ -320,23 +338,29 @@ async def prepare_verification_job(
     session_maker: async_sessionmaker[AsyncSession],
     prepared_input: PreparedVerificationJob,
 ) -> VerificationJobPreparation:
-    """Validate a verification job and dispatch to the right execution path.
+    """Preflight a verification job: anti-forgery identity check + replay guard.
 
     The orchestration always carries a full ``PreparedVerificationJob``
-    payload (curriculum-decoupling refactor). This activity:
+    payload (curriculum-decoupling refactor). This activity is the trust
+    boundary and idempotency gate for the run:
 
-    1. Loads the ``verification_jobs`` row and validates the immutable
-       identity fields (``user_id``, ``requirement_uuid``,
-       ``submitted_value``) against the payload, so a forged start
-       request can't make us run validation against an arbitrary user
-       or requirement.
-    2. If the job is already linked to a ``Submission`` (Durable
-       retried prepare after the persist activity already finished),
-       returns the same execution result from the linked Submission.
+    1. **Anti-forgery identity check.** Loads the ``verification_jobs`` row and
+       asserts the payload's immutable identity fields (``user_id``,
+       ``requirement_uuid``, ``submitted_value``) match it. The requirement
+       *definition* and ``github_username`` snapshot are trusted from the
+       payload (the Functions role has no curriculum/users grants), so this
+       row match is what stops a forged or buggy start request from running
+       validation against an arbitrary user or requirement.
+    2. **Replay/idempotency short-circuit.** Durable retries an activity on a
+       transient fault and resumes it after a worker crash, so this can run
+       more than once for the same job. If the job is already linked to a
+       ``Submission`` (the persist activity already finished on a prior
+       attempt), it returns that same execution result instead of re-running,
+       so retries never produce a second outcome.
     3. Otherwise returns the prepared job for the orchestrator to run.
 
-    The Functions role only needs ``SELECT`` on ``verification_jobs``
-    + ``submissions`` here -- no curriculum or users reads.
+    The Functions role only needs ``SELECT`` on ``verification_jobs`` +
+    ``submissions`` here -- no curriculum or users reads.
     """
     normalized_job_id = _coerce_job_id(job_id)
 
@@ -431,7 +455,25 @@ async def run_verification(
             "verification.completed",
             validation_result.verification_completed,
         )
-        return VerificationRunResult(job=job, validation_result=validation_result)
+        repository = _resolve_repository_ref(job)
+        return VerificationRunResult(
+            job=job,
+            validation_result=validation_result,
+            repository=repository,
+        )
+
+
+def _resolve_repository_ref(job: PreparedVerificationJob) -> RepositoryRef | None:
+    """Parse the repo identity once for repo-backed jobs, to carry forward.
+
+    Later async steps (LLM grading) reuse this instead of re-parsing the
+    submission URL. Non-repo types and unparseable values yield ``None``;
+    the carried value is purely an optimization, so callers still guard on it.
+    """
+    if not is_repo_backed(job.requirement.submission_type):
+        return None
+    resolved = resolve_repository(job.typed_submitted_value.as_text)
+    return resolved if isinstance(resolved, RepositoryRef) else None
 
 
 async def persist_verification_result(

--- a/packages/learn-to-cloud-shared/tests/services/test_repo_utils.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_repo_utils.py
@@ -2,15 +2,16 @@
 
 Tests cover:
 - GitHub URL parsing and validation (extract_repo_info)
-- Repository ownership validation (validate_repo_url)
+- Repository identity resolution (resolve_repository / RepositoryRef)
 """
 
 import pytest
 
 from learn_to_cloud_shared.schemas import ValidationResult
 from learn_to_cloud_shared.verification.repo_utils import (
+    RepositoryRef,
     extract_repo_info,
-    validate_repo_url,
+    resolve_repository,
 )
 
 # ---------------------------------------------------------------------------
@@ -94,63 +95,52 @@ class TestExtractRepoInfo:
 
 
 # ---------------------------------------------------------------------------
-# validate_repo_url
+# resolve_repository / RepositoryRef
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-class TestValidateRepoUrl:
-    """Tests for URL parsing + ownership validation."""
+class TestResolveRepository:
+    """Tests for parsing repo identity from a validated submission URL.
 
-    def test_valid_url_matching_username(self):
-        result = validate_repo_url(
-            "https://github.com/testuser/journal-starter", "testuser"
+    ``resolve_repository`` intentionally does not re-check ownership or fork
+    name: the submission value is server-derived and DB-validated upstream.
+    """
+
+    def test_parses_owner_and_repo(self):
+        result = resolve_repository("https://github.com/testuser/journal-starter")
+        assert result == RepositoryRef(owner="testuser", repo="journal-starter")
+
+    def test_preserves_owner_casing(self):
+        result = resolve_repository("https://github.com/TestUser/journal-starter")
+        assert result == RepositoryRef(owner="TestUser", repo="journal-starter")
+
+    def test_strips_git_suffix_and_subpath(self):
+        result = resolve_repository(
+            "https://github.com/testuser/journal-starter.git/tree/main"
         )
-        assert result == ("testuser", "journal-starter")
+        assert result == RepositoryRef(owner="testuser", repo="journal-starter")
 
-    def test_case_insensitive_match(self):
-        result = validate_repo_url(
-            "https://github.com/TestUser/journal-starter", "testuser"
-        )
-        assert result == ("TestUser", "journal-starter")
-
-    def test_username_mismatch_returns_validation_result(self):
-        result = validate_repo_url(
-            "https://github.com/otheruser/journal-starter", "testuser"
-        )
-        assert isinstance(result, ValidationResult)
-        assert result.is_valid is False
-        assert "does not match" in result.message
-
-    def test_invalid_url_returns_validation_result(self):
-        result = validate_repo_url("not-a-url", "testuser")
+    def test_malformed_url_returns_validation_result(self):
+        result = resolve_repository("not-a-url")
         assert isinstance(result, ValidationResult)
         assert result.is_valid is False
         assert "Invalid GitHub repository URL" in result.message
 
-    def test_expected_repo_name_match(self):
-        result = validate_repo_url(
-            "https://github.com/testuser/journal-starter",
-            "testuser",
-            expected_repo_name="journal-starter",
-        )
-        assert result == ("testuser", "journal-starter")
-
-    def test_expected_repo_name_case_insensitive_match(self):
-        result = validate_repo_url(
-            "https://github.com/testuser/Journal-Starter",
-            "testuser",
-            expected_repo_name="journal-starter",
-        )
-        assert result == ("testuser", "Journal-Starter")
-
-    def test_expected_repo_name_mismatch_returns_validation_result(self):
-        result = validate_repo_url(
-            "https://github.com/testuser/wrong-repo",
-            "testuser",
-            expected_repo_name="journal-starter",
-        )
+    def test_non_github_host_returns_validation_result(self):
+        result = resolve_repository("https://gitlab.com/testuser/repo")
         assert isinstance(result, ValidationResult)
         assert result.is_valid is False
-        assert "does not match the expected fork name" in result.message
-        assert result.username_match is True
+
+
+@pytest.mark.unit
+class TestRepositoryRefPayload:
+    """RepositoryRef survives a Durable payload round trip."""
+
+    def test_round_trip(self):
+        ref = RepositoryRef(owner="testuser", repo="journal-starter")
+        assert RepositoryRef.from_payload(ref.to_payload()) == ref
+
+    def test_from_payload_rejects_non_string_fields(self):
+        with pytest.raises(TypeError):
+            RepositoryRef.from_payload({"owner": "testuser", "repo": 5})

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -23,6 +23,7 @@ from learn_to_cloud_shared.repositories.verification_job_repository import (
 from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
 from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.verification.execution import MAX_VALIDATION_MESSAGE_LENGTH
+from learn_to_cloud_shared.verification.repo_utils import RepositoryRef
 from learn_to_cloud_shared.verification_job_executor import (
     VALIDATION_FAILED_ERROR_CODE,
     VERIFICATION_INCOMPLETE_ERROR_CODE,
@@ -186,6 +187,11 @@ async def test_split_verification_primitives_prepare_run_and_persist(
 
     assert await _count_submissions(session_maker) == 0
     assert run_result.to_payload()["job"] == preparation.job.to_payload()
+    assert run_result.repository == RepositoryRef(owner="executoruser", repo="repo")
+    assert run_result.to_payload()["repository"] == {
+        "owner": "executoruser",
+        "repo": "repo",
+    }
 
     result = await persist_verification_result(
         run_result,

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -195,10 +195,12 @@ def test_apply_llm_grading_decisions_fails_when_score_is_below_threshold():
 
 @pytest.mark.unit
 def test_llm_grading_unavailable_result_marks_server_error():
-    updated = llm_grading_unavailable_result(_run_result(), "structured output missing")
+    updated = llm_grading_unavailable_result(_run_result())
 
     assert updated.validation_result.is_valid is False
     assert updated.validation_result.verification_completed is False
     assert updated.validation_result.message == (
-        "LLM verification grading failed. Please try again later."
+        "Automated grading is temporarily unavailable. This is a "
+        "problem on our end, not yours. Please report it so we can "
+        "fix it."
     )

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -14,6 +14,7 @@ from learn_to_cloud_shared.verification.llm_grading import (
     collect_llm_grading_requests,
     llm_grading_unavailable_result,
 )
+from learn_to_cloud_shared.verification.repo_utils import RepositoryRef
 from learn_to_cloud_shared.verification.tasks import (
     PHASE3_LLM_TASKS,
     PHASE6_LLM_TASKS,
@@ -55,6 +56,7 @@ def _run_result(is_valid: bool = True) -> VerificationRunResult:
                 )
             ],
         ),
+        repository=RepositoryRef(owner="learner", repo="journal"),
     )
 
 
@@ -81,6 +83,7 @@ def _phase3_run_result(is_valid: bool = True) -> VerificationRunResult:
             is_valid=is_valid,
             message="CI tests are passing on main.",
         ),
+        repository=RepositoryRef(owner="learner", repo="journal-starter"),
     )
 
 
@@ -141,6 +144,20 @@ def test_apply_phase3_llm_decision_appends_feedback_when_passed():
 @pytest.mark.unit
 async def test_collect_phase3_llm_requests_skips_when_ci_failed():
     requests = await collect_llm_grading_requests(_phase3_run_result(is_valid=False))
+
+    assert requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_collect_llm_requests_skips_when_repository_missing():
+    run_result = _run_result()
+    without_repo = VerificationRunResult(
+        job=run_result.job,
+        validation_result=run_result.validation_result,
+    )
+
+    requests = await collect_llm_grading_requests(without_repo)
 
     assert requests == []
 


### PR DESCRIPTION
## What this does

Closes #427.

The async verification pipeline was checking the same repository ownership over and over, and several files had their own copies of the same small helper functions. This pull request cleans that up so the work happens once, in one place.

## Plain-language summary

- **Resolve the repository once.** When a verification job starts, we now figure out the repository owner and name a single time and carry that result forward through the pipeline. Before, every step re-parsed the URL and re-checked ownership.
- **One shared helper instead of three copies.** The dispatcher had three nearly identical branches for repository-backed checks. They are now a single shared helper.
- **Removed dead checks.** For the submission types whose URL is built by the server from the logged-in user's session, the old verify-time "does the owner match the username" and "does the fork name match" checks could never fail, because the server (not the learner) decides the URL. They were removed.
- **Clearer docstring.** `prepare_verification_job` now explains its two real jobs: stop forged submissions, and make safe retries idempotent.

## Behavior note

If a learner changes their GitHub username between submitting and async grading, we now grade the repository they actually submitted instead of failing on a username mismatch. This is the more correct behavior.

## Why this is safe (the trust chain)

For the affected submission types, the server discards any URL the form posts and rebuilds it from the authenticated session username before storing it. So "owner equals username" was guaranteed true by construction and the removed checks were dead weight. The repository identity is now sourced from the database-validated submitted value, which is strictly more robust.

## Testing

- `uv run poe check` passes locally (ruff lint + format, ty type check, migration SQL lint, full test suite).
- 497 passed, 1 skipped.
- Pre-commit hooks pass.