### PR TITLE
Fix API debugger to use the shared workspace virtual environment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "API: FastAPI (uvicorn)",
       "type": "debugpy",
       "request": "launch",
-      "python": "${workspaceFolder}/api/.venv/bin/python",
+      "python": "${workspaceFolder}/.venv/bin/python",
       "module": "uvicorn",
       "args": ["learn_to_cloud.main:app", "--reload", "--reload-include", "*.py", "--reload-include", "*.html", "--reload-exclude", ".venv", "--host", "0.0.0.0", "--port", "8000"],
       "cwd": "${workspaceFolder}/api",


### PR DESCRIPTION
## What this fixes

Starting the **API: FastAPI (uvicorn)** debug configuration on a freshly built dev container fails with:

```
Couldn't spawn debuggee: [Errno 2] No such file or directory: '/workspaces/learn-to-cloud-app/api/.venv/bin/python'
```

## Why it happens

When the three Python projects were combined into one uv workspace (#551), uv stopped creating a per-project virtual environment inside `api/` and now creates a single shared environment at the repository root (`.venv`). The VS Code debug config was never updated, so it still pointed at the old `api/.venv/bin/python` path. On any container built after that change, that path does not exist and the debugger cannot start.

Containers created before the merge still have a leftover `api/.venv`, which is why the problem only shows up on freshly rebuilt environments.

## The change

Point the API debug config at the root `.venv` that uv now creates. One line in `.vscode/launch.json`. Verified the root environment can import both `uvicorn` and the `learn_to_cloud` app.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>