### PR TITLE
Route verification execution mode through a validator registry (#428)

### DIFF
--- a/.github/agents/dog-food.agent.md
+++ b/.github/agents/dog-food.agent.md
@@ -208,11 +208,11 @@ the form is in a clean state:
 
 ```bash
 cd /workspaces/learn-to-cloud-app/api && uv run python scripts/reset_local_submissions.py \
-  --requirement-id <requirement-id> \
+  --requirement-slug <requirement-slug> \
   --user-id 6733686
 ```
 
-Replace `<requirement-id>` with the value from the Submission Types Reference
+Replace `<requirement-slug>` with the value from the Submission Types Reference
 table (e.g. `journal-api-implementation` for phase 3). The `--user-id` is the
 GitHub user ID for `madebygps` (`6733686`). Run with `--dry-run` first if you
 want to preview what will be deleted.
@@ -224,7 +224,7 @@ http://localhost:8000/phase/{N}
 ```
 
 Confirm the page loads (no 500, `<nav>` and `<main>` present). Find the
-requirement card for the target requirement ID (see the Submission Types
+requirement card for the target requirement slug (see the Submission Types
 Reference table above).
 
 ### 5c — Submit the requirement
@@ -257,7 +257,7 @@ for the next run:
 
 ```bash
 cd /workspaces/learn-to-cloud-app/api && uv run python scripts/reset_local_submissions.py \
-  --requirement-id <requirement-id> \
+  --requirement-slug <requirement-slug> \
   --user-id 6733686
 ```
 
@@ -305,7 +305,7 @@ Basic / Phase X submission
 | Field | Value |
 |-------|-------|
 | Phase | X |
-| Requirement | requirement-id |
+| Requirement | requirement-slug |
 | Submitted value | ... |
 | Verification result | ✅ Passed / ❌ Failed / ⏳ Timed out |
 | Message | (text from the requirement card) |

--- a/.github/agents/dog-food.agent.md
+++ b/.github/agents/dog-food.agent.md
@@ -57,6 +57,9 @@ This runs in a **Linux devcontainer** with:
 - Playwright MCP server (`@playwright/mcp`) is installed globally via npm in
   `.devcontainer/on-create.sh` and registered in `.mcp.json` / `.vscode/mcp.json`.
   Chromium and its OS libraries are installed via `playwright install --with-deps`.
+  Both MCP configs pin `--browser chromium`, because the Playwright MCP default
+  is the `chrome` channel, which is not installable on Linux arm64. If browser
+  launch fails, confirm that flag is present rather than symlinking binaries.
 
 All terminal commands use **bash** via `run_in_terminal`. Never use PowerShell.
 
@@ -96,11 +99,20 @@ test -f local.settings.json || cp local.settings.example.json local.settings.jso
 nohup uv run func start --port 7071 > /tmp/functions.log 2>&1 &
 ```
 
-Wait 10 seconds, then verify:
+Wait 10 seconds, then verify the host is ready. The Functions app does **not**
+expose a health route, so confirm readiness by checking the startup log for the
+worker initializing and the HTTP triggers being registered:
 
 ```bash
-sleep 10 && curl -s --max-time 5 http://localhost:7071/api/health || echo "Functions not ready yet — check /tmp/functions.log"
+sleep 10 && grep -Eq "Worker process started and initialized|Host started|Functions:" /tmp/functions.log \
+  && echo "Functions host ready" \
+  || echo "Functions not ready yet — check /tmp/functions.log"
 ```
+
+The two HTTP routes the host should register are
+`verification/jobs/{job_id}/start` (POST) and
+`verification/jobs/{instance_id}/status` (GET). There is no `/api/health`
+endpoint, so do not curl one.
 
 If the Functions runtime fails to start, report the error but continue — the
 submission attempt will fail at the polling stage and you can diagnose from logs.

--- a/.github/skills/reset-local-submissions/SKILL.md
+++ b/.github/skills/reset-local-submissions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reset-local-submissions
-description: Undo local submissions for DevOps and Verify Journal API Implementation so you can re-test verification flows. Also supports custom requirement IDs and user scoping. Use when user says "reset local submissions", "undo local verification", "reset phase X locally", or "let me re-test verification".
+description: Undo local submissions for DevOps and Verify Journal API Implementation so you can re-test verification flows. Also supports custom requirement slugs and user scoping. Use when user says "reset local submissions", "undo local verification", "reset phase X locally", or "let me re-test verification".
 ---
 
 # Reset Local Submissions
@@ -40,21 +40,27 @@ Run `--dry-run` first (without `--user-id`) to discover the IDs in your local da
 cd <workspace>/api && uv run python scripts/reset_local_submissions.py --user-id <github_user_id>
 ```
 
-## Custom Requirement IDs
+## Custom Requirement Slugs
+
+A requirement slug is the human-friendly identifier such as
+`devops-implementation` or `journal-api-implementation`.
 
 ```bash
 cd <workspace>/api && uv run python scripts/reset_local_submissions.py \
-  --requirement-id <requirement_id_1> \
-  --requirement-id <requirement_id_2>
+  --requirement-slug <requirement_slug_1> \
+  --requirement-slug <requirement_slug_2>
 ```
+
+The older `--requirement-id` flag still works as a deprecated alias, but it
+prints a warning. Prefer `--requirement-slug`.
 
 ## Combined Example
 
 ```bash
 cd <workspace>/api && uv run python scripts/reset_local_submissions.py \
   --user-id <user_id> \
-  --requirement-id devops-implementation \
-  --requirement-id journal-api-implementation
+  --requirement-slug devops-implementation \
+  --requirement-slug journal-api-implementation
 ```
 
 ## Expected Output

--- a/.github/skills/reset-local-submissions/SKILL.md
+++ b/.github/skills/reset-local-submissions/SKILL.md
@@ -51,9 +51,6 @@ cd <workspace>/api && uv run python scripts/reset_local_submissions.py \
   --requirement-slug <requirement_slug_2>
 ```
 
-The older `--requirement-id` flag still works as a deprecated alias, but it
-prints a warning. Prefer `--requirement-slug`.
-
 ## Combined Example
 
 ```bash

--- a/.mcp.json
+++ b/.mcp.json
@@ -27,7 +27,7 @@
     "playwright": {
       "type": "local",
       "command": "playwright-mcp",
-      "args": ["--headless", "--isolated", "--no-sandbox"],
+      "args": ["--headless", "--isolated", "--no-sandbox", "--browser", "chromium"],
       "tools": ["*"]
     }
   }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -14,7 +14,9 @@
       "args": [
         "--headless",
         "--isolated",
-        "--no-sandbox"
+        "--no-sandbox",
+        "--browser",
+        "chromium"
       ]
     }
   }

--- a/api/scripts/reset_local_submissions.py
+++ b/api/scripts/reset_local_submissions.py
@@ -1,7 +1,11 @@
 """Reset local submission records for testing.
 
-Deletes submission rows by requirement ID. Progress is automatically
+Deletes submission rows by requirement slug. Progress is automatically
 correct on next page load because it's computed from the submissions table.
+
+Submissions reference a requirement by ``requirement_uuid`` (FK to
+``requirements.uuid``); the human-friendly slug lives on the requirements
+table, so we join through it to match the slugs passed on the command line.
 
 Examples:
     uv run python scripts/reset_local_submissions.py
@@ -30,7 +34,7 @@ DEFAULT_REQUIREMENT_IDS = [
 
 
 async def reset_submissions(
-    requirement_ids: list[str],
+    requirement_slugs: list[str],
     user_ids: list[int] | None,
     dry_run: bool,
 ) -> int:
@@ -41,21 +45,19 @@ async def reset_submissions(
     engine = create_engine(get_web_settings().database)
     try:
         async with engine.begin() as conn:
-            where_clauses = ["requirement_id = ANY(:requirement_ids)"]
-            params: dict[str, object] = {"requirement_ids": requirement_ids}
-
+            params: dict[str, object] = {"requirement_slugs": requirement_slugs}
+            user_filter = ""
             if user_ids:
-                where_clauses.append("user_id = ANY(:user_ids)")
+                user_filter = " AND s.user_id = ANY(:user_ids)"
                 params["user_ids"] = user_ids
-
-            where_sql = " AND ".join(where_clauses)
 
             preview_query = text(
                 f"""
-                SELECT user_id, requirement_id, phase_id, attempt_number, is_validated
-                FROM submissions
-                WHERE {where_sql}
-                ORDER BY user_id, requirement_id, attempt_number
+                SELECT s.user_id, r.slug AS requirement_slug, s.is_validated
+                FROM submissions s
+                JOIN requirements r ON r.uuid = s.requirement_uuid
+                WHERE r.slug = ANY(:requirement_slugs){user_filter}
+                ORDER BY s.user_id, r.slug
                 """
             )
             preview_result = await conn.execute(preview_query, params)
@@ -78,9 +80,11 @@ async def reset_submissions(
 
             delete_query = text(
                 f"""
-                DELETE FROM submissions
-                WHERE {where_sql}
-                RETURNING user_id, requirement_id, phase_id
+                DELETE FROM submissions s
+                USING requirements r
+                WHERE r.uuid = s.requirement_uuid
+                  AND r.slug = ANY(:requirement_slugs){user_filter}
+                RETURNING s.user_id, r.slug AS requirement_slug
                 """
             )
             delete_result = await conn.execute(delete_query, params)
@@ -94,14 +98,14 @@ async def reset_submissions(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Reset local submissions for selected requirement IDs.",
+        description="Reset local submissions for selected requirement slugs.",
     )
     parser.add_argument(
         "--requirement-id",
         action="append",
-        dest="requirement_ids",
+        dest="requirement_slugs",
         help=(
-            "Requirement ID to delete (repeatable). "
+            "Requirement slug to delete (repeatable). "
             "Defaults to devops-implementation and journal-api-implementation."
         ),
     )
@@ -122,10 +126,10 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    requirement_ids = args.requirement_ids or DEFAULT_REQUIREMENT_IDS
+    requirement_slugs = args.requirement_slugs or DEFAULT_REQUIREMENT_IDS
     deleted_count = asyncio.run(
         reset_submissions(
-            requirement_ids=requirement_ids,
+            requirement_slugs=requirement_slugs,
             user_ids=args.user_ids,
             dry_run=args.dry_run,
         )

--- a/api/scripts/reset_local_submissions.py
+++ b/api/scripts/reset_local_submissions.py
@@ -12,7 +12,7 @@ Examples:
     uv run python scripts/reset_local_submissions.py --dry-run
     uv run python scripts/reset_local_submissions.py --user-id 12345
     uv run python scripts/reset_local_submissions.py \
-        --requirement-id devops-implementation
+        --requirement-slug devops-implementation
 """
 
 from __future__ import annotations
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import sys
 
 from learn_to_cloud_shared.core.config import get_web_settings
 from learn_to_cloud_shared.core.database import create_engine
@@ -27,7 +28,7 @@ from sqlalchemy import text
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_REQUIREMENT_IDS = [
+DEFAULT_REQUIREMENT_SLUGS = [
     "devops-implementation",
     "journal-api-implementation",
 ]
@@ -96,18 +97,37 @@ async def reset_submissions(
         await engine.dispose()
 
 
+class _DeprecatedRequirementId(argparse.Action):
+    """Accept the old --requirement-id flag and warn it is deprecated."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        print(
+            "Warning: --requirement-id is deprecated; use --requirement-slug instead.",
+            file=sys.stderr,
+        )
+        current = getattr(namespace, self.dest) or []
+        current.append(values)
+        setattr(namespace, self.dest, current)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Reset local submissions for selected requirement slugs.",
     )
     parser.add_argument(
-        "--requirement-id",
+        "--requirement-slug",
         action="append",
         dest="requirement_slugs",
         help=(
             "Requirement slug to delete (repeatable). "
             "Defaults to devops-implementation and journal-api-implementation."
         ),
+    )
+    parser.add_argument(
+        "--requirement-id",
+        action=_DeprecatedRequirementId,
+        dest="requirement_slugs",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--user-id",
@@ -126,7 +146,7 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    requirement_slugs = args.requirement_slugs or DEFAULT_REQUIREMENT_IDS
+    requirement_slugs = args.requirement_slugs or DEFAULT_REQUIREMENT_SLUGS
     deleted_count = asyncio.run(
         reset_submissions(
             requirement_slugs=requirement_slugs,

--- a/api/scripts/reset_local_submissions.py
+++ b/api/scripts/reset_local_submissions.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-import sys
 
 from learn_to_cloud_shared.core.config import get_web_settings
 from learn_to_cloud_shared.core.database import create_engine
@@ -97,19 +96,6 @@ async def reset_submissions(
         await engine.dispose()
 
 
-class _DeprecatedRequirementId(argparse.Action):
-    """Accept the old --requirement-id flag and warn it is deprecated."""
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        print(
-            "Warning: --requirement-id is deprecated; use --requirement-slug instead.",
-            file=sys.stderr,
-        )
-        current = getattr(namespace, self.dest) or []
-        current.append(values)
-        setattr(namespace, self.dest, current)
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Reset local submissions for selected requirement slugs.",
@@ -122,12 +108,6 @@ def parse_args() -> argparse.Namespace:
             "Requirement slug to delete (repeatable). "
             "Defaults to devops-implementation and journal-api-implementation."
         ),
-    )
-    parser.add_argument(
-        "--requirement-id",
-        action=_DeprecatedRequirementId,
-        dest="requirement_slugs",
-        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--user-id",

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -28,7 +28,7 @@ from learn_to_cloud_shared.schemas import (
     SubmissionResult,
 )
 from learn_to_cloud_shared.submission_values import SubmittedValue
-from learn_to_cloud_shared.verification.dispatcher import is_sync_verifiable
+from learn_to_cloud_shared.verification.dispatcher import is_inline
 from learn_to_cloud_shared.verification.execution import (
     execute_sync_submission_validation,
     to_submission_data,
@@ -251,7 +251,7 @@ async def create_verification_job(
     except ValueError as exc:
         raise InvalidSubmittedValueError(str(exc)) from exc
 
-    if is_sync_verifiable(ctx.requirement.submission_type):
+    if is_inline(ctx.requirement.submission_type):
         submission_result = await execute_sync_submission_validation(
             session_maker=session_maker,
             user_id=user_id,

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -81,11 +81,13 @@ configure_observability()
 app = df.DFApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
 _DEFAULT_ORCHESTRATOR_NAME = "verification_orchestrator"
-# Async-only submission types: phase 3+ verifications that involve LLM
-# grading, multi-task fan-out, or external probes with retries and stay on
-# the Durable Functions path. Phase 0-2 sync types (github_profile,
+# BACKGROUND submission types: phase 3+ verifications that involve LLM
+# grading, multi-task fan-out, or external probes with retries and run on
+# the Durable Functions path. The INLINE phase 0-2 types (github_profile,
 # profile_readme, repo_fork, ctf_token, networking_token) run inside the
-# FastAPI request instead and are intentionally absent.
+# FastAPI request instead and are intentionally absent. Execution mode is
+# declared per type in verification/dispatcher.py (_VALIDATOR_REGISTRY);
+# this map only picks the orchestrator name for the background types.
 _ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE = {
     SubmissionType.JOURNAL_API_RESPONSE: "verify_phase3_journal_api_orchestrator",
     SubmissionType.CODE_ANALYSIS: "verify_phase3_journal_api_orchestrator",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -85,7 +85,10 @@ class SubmissionType(StrEnum):
     2. Add a validator function in the appropriate module:
        - GitHub-based: api/services/github_hands_on_verification_service.py
        - Or create a new module for complex verification types
-    3. Add the routing case in validate_submission() in hands_on_verification.py
+    3. Register a descriptor for it in
+       ``verification/dispatcher.py`` (``_VALIDATOR_REGISTRY``): the
+       descriptor declares the adapter callable, its execution mode, and
+       whether it needs a GitHub username or is repo-backed.
     4. Add optional fields to HandsOnRequirement schema if needed
     """
 
@@ -117,6 +120,26 @@ class SubmissionType(StrEnum):
 
     # Phase 6: Security posture
     SECURITY_SCANNING = "security_scanning"
+
+
+class ExecutionMode(StrEnum):
+    """Where a verification runs and when the learner gets the answer.
+
+    Every validator is an ``async def`` coroutine; this enum is about
+    *where* the work runs, not about asyncio. It replaces the older
+    "sync vs async" wording, which was misleading in a codebase where
+    every validator already awaits.
+    """
+
+    # Runs inside the FastAPI request and answers immediately. Used for
+    # checks that finish in well under a second (one GitHub API call or a
+    # constant-time token compare).
+    INLINE = "inline"
+
+    # Handed off to Durable Functions and answered later via polling.
+    # Used for checks that involve LLM grading, fan-out, or external
+    # probes with retries.
+    BACKGROUND = "background"
 
 
 class SubmissionValueKind(StrEnum):

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
@@ -14,7 +14,9 @@ To add a new verification type:
 2. Add optional fields to HandsOnRequirement in schemas.py if needed
 3. Create a validator function (here or in a new module):
    - async def validate_<type>(url: str, ...) -> ValidationResult
-4. Add routing case in validate_submission() below
+4. Register a ValidatorDescriptor for it in _VALIDATOR_REGISTRY below:
+   declare its adapter callable, execution mode (INLINE vs BACKGROUND),
+   whether it needs a GitHub username, and whether it is repo-backed.
 
 For GitHub-specific validations, see github_profile.py
 For CTF token validation, see ctf.py
@@ -24,10 +26,11 @@ For phase requirements, see requirements.py
 
 import time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 
 from opentelemetry import metrics, trace
 
-from learn_to_cloud_shared.models import SubmissionType
+from learn_to_cloud_shared.models import ExecutionMode, SubmissionType
 from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
 from learn_to_cloud_shared.verification.ci_status import verify_ci_status
 from learn_to_cloud_shared.verification.deployed_api import validate_deployed_api
@@ -124,48 +127,186 @@ async def validate_submission(
         _VERIFICATION_DURATION.record(elapsed, attrs)
 
 
-_USERNAME_NOT_REQUIRED: frozenset[SubmissionType] = frozenset(
-    {SubmissionType.DEPLOYED_API}
-)
+# Uniform call shape for every validator, regardless of how the underlying
+# function is written. Adapters below absorb the per-validator differences
+# (sync token functions, the repo_fork config path, deployed_api taking only
+# a value, and repo-backed owner/repo resolution).
+ValidatorAdapter = Callable[
+    [HandsOnRequirement, str, str],
+    Awaitable[ValidationResult],
+]
 
 
-# Submission types that finish in well under a second (one GitHub API call
-# or a constant-time token compare) and can run inside the FastAPI request
-# instead of going through Durable Functions.  Phase 3+ types involve LLM
-# grading, fan-out, or external probes with retries and stay on the async
-# Durable path.
-SYNC_VERIFIABLE_SUBMISSION_TYPES: frozenset[SubmissionType] = frozenset(
-    {
-        SubmissionType.GITHUB_PROFILE,
-        SubmissionType.PROFILE_README,
-        SubmissionType.REPO_FORK,
-        SubmissionType.CTF_TOKEN,
-        SubmissionType.NETWORKING_TOKEN,
-    }
-)
+@dataclass(frozen=True)
+class ValidatorDescriptor:
+    """Everything the dispatcher needs to know about one submission type.
+
+    Collapses what used to be four separate type-keyed structures (the
+    if/elif routing chain plus three frozensets) into a single home, so a
+    new verification type is declared in exactly one place.
+    """
+
+    adapter: ValidatorAdapter
+    # Where the check runs: INLINE finishes in the request, BACKGROUND goes
+    # through Durable Functions. This is a property of the work itself, so it
+    # lives with the validator rather than in requirement content.
+    execution_mode: ExecutionMode
+    # Whether a GitHub username is required before the validator runs.
+    requires_username: bool
+    # Whether the submitted value is a server-derived GitHub repo URL whose
+    # owner/repo identity can be parsed straight from it.
+    repo_backed: bool
 
 
-def is_sync_verifiable(submission_type: SubmissionType) -> bool:
-    """Return True if the submission type runs synchronously in FastAPI."""
-    return submission_type in SYNC_VERIFIABLE_SUBMISSION_TYPES
+async def _adapt_github_profile(
+    requirement: HandsOnRequirement, submitted_value: str, username: str
+) -> ValidationResult:
+    return await validate_github_profile(submitted_value, username)
 
 
-# Submission types whose persisted value is a server-derived GitHub repo URL
-# (``https://github.com/<user>/<fork>``). Their owner/repo identity can be
-# parsed straight from the validated submission value -- see
-# ``repo_utils.resolve_repository``.
-_REPO_BACKED_SUBMISSION_TYPES: frozenset[SubmissionType] = frozenset(
-    {
-        SubmissionType.JOURNAL_API_VERIFIER,
-        SubmissionType.DEVOPS_ANALYSIS,
-        SubmissionType.SECURITY_SCANNING,
-    }
-)
+async def _adapt_profile_readme(
+    requirement: HandsOnRequirement, submitted_value: str, username: str
+) -> ValidationResult:
+    return await validate_profile_readme(submitted_value, username)
+
+
+async def _adapt_repo_fork(
+    requirement: HandsOnRequirement, submitted_value: str, username: str
+) -> ValidationResult:
+    if not requirement.required_repo:
+        return ValidationResult(
+            is_valid=False,
+            message="Requirement configuration error: missing required_repo",
+            username_match=False,
+            repo_exists=False,
+        )
+    return await validate_repo_fork(
+        submitted_value, username, requirement.required_repo
+    )
+
+
+async def _adapt_ctf_token(
+    requirement: HandsOnRequirement, submitted_value: str, username: str
+) -> ValidationResult:
+    return verify_ctf_token(submitted_value, username)
+
+
+async def _adapt_networking_token(
+    requirement: HandsOnRequirement, submitted_value: str, username: str
+) -> ValidationResult:
+    return verify_networking_token(submitted_value, username)
+
+
+async def _adapt_deployed_api(
+    requirement: HandsOnRequirement, submitted_value: str, username: str
+) -> ValidationResult:
+    return await validate_deployed_api(submitted_value)
+
+
+async def _adapt_journal_api_verifier(
+    requirement: HandsOnRequirement, submitted_value: str, username: str
+) -> ValidationResult:
+    return await _verify_repo_backed(submitted_value, verify_ci_status)
+
+
+async def _adapt_devops_analysis(
+    requirement: HandsOnRequirement, submitted_value: str, username: str
+) -> ValidationResult:
+    return await _verify_repo_backed(submitted_value, run_devops_workflow)
+
+
+async def _adapt_security_scanning(
+    requirement: HandsOnRequirement, submitted_value: str, username: str
+) -> ValidationResult:
+    return await _verify_repo_backed(submitted_value, validate_security_scanning)
+
+
+# Single source of truth: each active submission type maps to one descriptor.
+# Legacy/retired types (journal_api_response, code_analysis, pr_review) are
+# intentionally absent; lookups use ``.get(...)`` so they surface as the
+# explicit "Unknown submission type" result instead of raising.
+_VALIDATOR_REGISTRY: dict[SubmissionType, ValidatorDescriptor] = {
+    SubmissionType.GITHUB_PROFILE: ValidatorDescriptor(
+        adapter=_adapt_github_profile,
+        execution_mode=ExecutionMode.INLINE,
+        requires_username=True,
+        repo_backed=False,
+    ),
+    SubmissionType.PROFILE_README: ValidatorDescriptor(
+        adapter=_adapt_profile_readme,
+        execution_mode=ExecutionMode.INLINE,
+        requires_username=True,
+        repo_backed=False,
+    ),
+    SubmissionType.REPO_FORK: ValidatorDescriptor(
+        adapter=_adapt_repo_fork,
+        execution_mode=ExecutionMode.INLINE,
+        requires_username=True,
+        repo_backed=False,
+    ),
+    SubmissionType.CTF_TOKEN: ValidatorDescriptor(
+        adapter=_adapt_ctf_token,
+        execution_mode=ExecutionMode.INLINE,
+        requires_username=True,
+        repo_backed=False,
+    ),
+    SubmissionType.NETWORKING_TOKEN: ValidatorDescriptor(
+        adapter=_adapt_networking_token,
+        execution_mode=ExecutionMode.INLINE,
+        requires_username=True,
+        repo_backed=False,
+    ),
+    SubmissionType.JOURNAL_API_VERIFIER: ValidatorDescriptor(
+        adapter=_adapt_journal_api_verifier,
+        execution_mode=ExecutionMode.BACKGROUND,
+        requires_username=True,
+        repo_backed=True,
+    ),
+    SubmissionType.DEVOPS_ANALYSIS: ValidatorDescriptor(
+        adapter=_adapt_devops_analysis,
+        execution_mode=ExecutionMode.BACKGROUND,
+        requires_username=True,
+        repo_backed=True,
+    ),
+    SubmissionType.DEPLOYED_API: ValidatorDescriptor(
+        adapter=_adapt_deployed_api,
+        execution_mode=ExecutionMode.BACKGROUND,
+        requires_username=False,
+        repo_backed=False,
+    ),
+    SubmissionType.SECURITY_SCANNING: ValidatorDescriptor(
+        adapter=_adapt_security_scanning,
+        execution_mode=ExecutionMode.BACKGROUND,
+        requires_username=True,
+        repo_backed=True,
+    ),
+}
+
+
+def descriptor_for(
+    submission_type: SubmissionType,
+) -> ValidatorDescriptor | None:
+    """Return the descriptor for a submission type, or None if unsupported."""
+    return _VALIDATOR_REGISTRY.get(submission_type)
+
+
+def execution_mode_for(
+    submission_type: SubmissionType,
+) -> ExecutionMode | None:
+    """Return the execution mode for a submission type, or None if unsupported."""
+    descriptor = _VALIDATOR_REGISTRY.get(submission_type)
+    return descriptor.execution_mode if descriptor is not None else None
+
+
+def is_inline(submission_type: SubmissionType) -> bool:
+    """Return True if the submission type runs inline in the FastAPI request."""
+    return execution_mode_for(submission_type) is ExecutionMode.INLINE
 
 
 def is_repo_backed(submission_type: SubmissionType) -> bool:
     """Return True if the submission value is a server-derived GitHub repo URL."""
-    return submission_type in _REPO_BACKED_SUBMISSION_TYPES
+    descriptor = _VALIDATOR_REGISTRY.get(submission_type)
+    return descriptor.repo_backed if descriptor is not None else False
 
 
 async def _dispatch_validation(
@@ -174,11 +315,17 @@ async def _dispatch_validation(
     expected_username: str | None = None,
 ) -> ValidationResult:
     """Route to the appropriate validator based on submission type."""
+    descriptor = _VALIDATOR_REGISTRY.get(requirement.submission_type)
+    if descriptor is None:
+        return ValidationResult(
+            is_valid=False,
+            message=f"Unknown submission type: {requirement.submission_type}",
+            username_match=False,
+            repo_exists=False,
+        )
+
     # Most submission types require a GitHub username — check once up front.
-    if (
-        requirement.submission_type not in _USERNAME_NOT_REQUIRED
-        and not expected_username
-    ):
+    if descriptor.requires_username and not expected_username:
         return ValidationResult(
             is_valid=False,
             message="GitHub username is required for this verification",
@@ -186,52 +333,9 @@ async def _dispatch_validation(
         )
 
     # Narrow type: after the guard above, username is str for all branches
-    # that require it. DEPLOYED_API never reads it.
+    # that require it. Validators that don't need it ignore the value.
     username: str = expected_username or ""
-
-    if requirement.submission_type == SubmissionType.GITHUB_PROFILE:
-        return await validate_github_profile(submitted_value, username)
-
-    elif requirement.submission_type == SubmissionType.PROFILE_README:
-        return await validate_profile_readme(submitted_value, username)
-
-    elif requirement.submission_type == SubmissionType.REPO_FORK:
-        if not requirement.required_repo:
-            return ValidationResult(
-                is_valid=False,
-                message="Requirement configuration error: missing required_repo",
-                username_match=False,
-                repo_exists=False,
-            )
-        return await validate_repo_fork(
-            submitted_value, username, requirement.required_repo
-        )
-
-    elif requirement.submission_type == SubmissionType.CTF_TOKEN:
-        return verify_ctf_token(submitted_value, username)
-
-    elif requirement.submission_type == SubmissionType.NETWORKING_TOKEN:
-        return verify_networking_token(submitted_value, username)
-
-    elif requirement.submission_type == SubmissionType.JOURNAL_API_VERIFIER:
-        return await _verify_repo_backed(submitted_value, verify_ci_status)
-
-    elif requirement.submission_type == SubmissionType.DEVOPS_ANALYSIS:
-        return await _verify_repo_backed(submitted_value, run_devops_workflow)
-
-    elif requirement.submission_type == SubmissionType.DEPLOYED_API:
-        return await validate_deployed_api(submitted_value)
-
-    elif requirement.submission_type == SubmissionType.SECURITY_SCANNING:
-        return await _verify_repo_backed(submitted_value, validate_security_scanning)
-
-    else:
-        return ValidationResult(
-            is_valid=False,
-            message=f"Unknown submission type: {requirement.submission_type}",
-            username_match=False,
-            repo_exists=False,
-        )
+    return await descriptor.adapter(requirement, submitted_value, username)
 
 
 async def _verify_repo_backed(

--- a/packages/learn-to-cloud-shared/tests/verification/test_dispatcher.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_dispatcher.py
@@ -1,14 +1,23 @@
-"""Tests for the sync/async dispatch helper in the verification dispatcher."""
+"""Tests for the registry-driven dispatch in the verification dispatcher.
+
+Each submission type's behavior (execution mode, username requirement, and
+whether it is repo-backed) is declared once in ``_VALIDATOR_REGISTRY``. These
+tests pin that registry so a new or changed type can't silently alter routing.
+"""
 
 import pytest
 
-from learn_to_cloud_shared.models import SubmissionType
+from learn_to_cloud_shared.models import ExecutionMode, SubmissionType
 from learn_to_cloud_shared.verification.dispatcher import (
-    SYNC_VERIFIABLE_SUBMISSION_TYPES,
-    is_sync_verifiable,
+    _VALIDATOR_REGISTRY,
+    descriptor_for,
+    execution_mode_for,
+    is_inline,
+    is_repo_backed,
 )
 
-_EXPECTED_SYNC = {
+# The submission types that run inside the FastAPI request (phases 0-2).
+_EXPECTED_INLINE = {
     SubmissionType.GITHUB_PROFILE,
     SubmissionType.PROFILE_README,
     SubmissionType.REPO_FORK,
@@ -16,26 +25,114 @@ _EXPECTED_SYNC = {
     SubmissionType.NETWORKING_TOKEN,
 }
 
+# The submission types that go through Durable Functions (phases 3-6).
+_EXPECTED_BACKGROUND = {
+    SubmissionType.JOURNAL_API_VERIFIER,
+    SubmissionType.DEVOPS_ANALYSIS,
+    SubmissionType.DEPLOYED_API,
+    SubmissionType.SECURITY_SCANNING,
+}
 
-def test_sync_verifiable_set_is_exactly_the_phase_0_to_2_types():
-    """Guard rail: any new sync type must be added intentionally.
+# Server-derived GitHub repo URL types (owner/repo parsed from the value).
+_EXPECTED_REPO_BACKED = {
+    SubmissionType.JOURNAL_API_VERIFIER,
+    SubmissionType.DEVOPS_ANALYSIS,
+    SubmissionType.SECURITY_SCANNING,
+}
 
-    Keeping this assertion concrete protects against silently routing a
-    new phase 3+ verification through the in-request path.
+# The only type that does not require a GitHub username.
+_EXPECTED_NO_USERNAME = {SubmissionType.DEPLOYED_API}
+
+# Retired types kept only so old DB rows deserialize; they have no validator.
+_LEGACY_TYPES = {
+    SubmissionType.JOURNAL_API_RESPONSE,
+    SubmissionType.CODE_ANALYSIS,
+    SubmissionType.PR_REVIEW,
+}
+
+# Types backed by an active HandsOnRequirement subclass (the discriminated
+# union). Derived from the schema so it stays in lockstep with it.
+_ACTIVE_TYPES = {
+    member.value for member in SubmissionType if member not in _LEGACY_TYPES
+}
+
+
+def test_inline_set_is_exactly_the_phase_0_to_2_types():
+    """Guard rail: any new inline type must be added intentionally.
+
+    Keeping this concrete protects against silently routing a new phase 3+
+    verification through the in-request path.
     """
-    assert SYNC_VERIFIABLE_SUBMISSION_TYPES == _EXPECTED_SYNC
+    inline = {t for t in _VALIDATOR_REGISTRY if is_inline(t)}
+    assert inline == _EXPECTED_INLINE
 
 
 @pytest.mark.parametrize(
-    "submission_type", sorted(_EXPECTED_SYNC, key=lambda t: t.value)
+    "submission_type", sorted(_EXPECTED_INLINE, key=lambda t: t.value)
 )
-def test_is_sync_verifiable_true_for_phase_0_to_2_types(submission_type):
-    assert is_sync_verifiable(submission_type) is True
+def test_is_inline_true_for_inline_types(submission_type):
+    assert is_inline(submission_type) is True
+    assert execution_mode_for(submission_type) is ExecutionMode.INLINE
+
+
+@pytest.mark.parametrize(
+    "submission_type", sorted(_EXPECTED_BACKGROUND, key=lambda t: t.value)
+)
+def test_is_inline_false_for_background_types(submission_type):
+    assert is_inline(submission_type) is False
+    assert execution_mode_for(submission_type) is ExecutionMode.BACKGROUND
+
+
+@pytest.mark.parametrize(
+    "submission_type", sorted(_LEGACY_TYPES, key=lambda t: t.value)
+)
+def test_legacy_types_have_no_descriptor_and_are_not_inline(submission_type):
+    assert descriptor_for(submission_type) is None
+    assert execution_mode_for(submission_type) is None
+    assert is_inline(submission_type) is False
+    assert is_repo_backed(submission_type) is False
+
+
+@pytest.mark.parametrize(
+    "submission_type", sorted(_EXPECTED_REPO_BACKED, key=lambda t: t.value)
+)
+def test_repo_backed_true_for_repo_url_types(submission_type):
+    assert is_repo_backed(submission_type) is True
 
 
 @pytest.mark.parametrize(
     "submission_type",
-    sorted(set(SubmissionType) - _EXPECTED_SYNC, key=lambda t: t.value),
+    sorted(_EXPECTED_INLINE | _EXPECTED_NO_USERNAME, key=lambda t: t.value),
 )
-def test_is_sync_verifiable_false_for_async_types(submission_type):
-    assert is_sync_verifiable(submission_type) is False
+def test_repo_backed_false_for_non_repo_types(submission_type):
+    assert is_repo_backed(submission_type) is False
+
+
+@pytest.mark.parametrize(
+    "submission_type",
+    sorted(
+        set(SubmissionType) - _EXPECTED_NO_USERNAME - _LEGACY_TYPES,
+        key=lambda t: t.value,
+    ),
+)
+def test_requires_username_true_except_deployed_api(submission_type):
+    descriptor = descriptor_for(submission_type)
+    assert descriptor is not None
+    assert descriptor.requires_username is True
+
+
+def test_deployed_api_does_not_require_username():
+    descriptor = descriptor_for(SubmissionType.DEPLOYED_API)
+    assert descriptor is not None
+    assert descriptor.requires_username is False
+
+
+def test_registry_covers_every_active_submission_type_exactly_once():
+    """Completeness: each active type has exactly one descriptor, no extras.
+
+    ``_ACTIVE_TYPES`` is derived from the SubmissionType enum minus the
+    retired legacy values, so adding a real type without registering it (or
+    registering a legacy type) fails here.
+    """
+    registry_values = {t.value for t in _VALIDATOR_REGISTRY}
+    assert registry_values == _ACTIVE_TYPES


### PR DESCRIPTION
## What this changes

When a learner submits work to be checked, the system decides whether to run that check **right away inside the web request** (fast checks) or **hand it off to the background system** (slow checks like AI grading). Until now that decision was hardcoded as a fixed list of submission types, and the same list-by-type pattern was repeated in four different places. Changing how a check runs meant editing code in several spots and hoping you didn't miss one.

This replaces all of that with a **single registry**. Each submission type now declares, in one place, everything the router needs to know about it:

- which validator runs it
- where it runs (the new `ExecutionMode`: **`INLINE`** = in the request, **`BACKGROUND`** = Durable Functions)
- whether it needs a GitHub username
- whether its value is a GitHub repo URL

Adding or changing a verification type is now a one-place edit.

## Why `INLINE` / `BACKGROUND` instead of "sync" / "async"

Every validator in this codebase is already an `async def`, so calling one path "sync" was misleading. The real difference is *where* the work runs and *when* the learner gets an answer, which these names describe directly.

## Closes #428

Resolves #428. One note: the issue says "configurable per requirement"; this lands it per submission **type** (the property belongs to the validator, not to content). We discussed this and decided it's the better design, since the execution mode is a fact about the work, not a content choice. Recommend tweaking the issue wording to "per validator / submission type."

## Safety

- **No database change.** Routing behavior is preserved exactly and pinned by tests.
- Retired legacy types (`journal_api_response`, `code_analysis`, `pr_review`) keep returning today's "Unknown submission type" result.
- Cleaning up those dead types is tracked separately in #560 (needs a production-data check and a migration).

## Verification

`uv run poe check` passes: 516 tests passed, 1 skipped, 86.6% coverage.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>