### PR TITLE
Remove the three dead submission types (#560)

### DIFF
--- a/api/alembic/versions/0041_remove_dead_submission_types.py
+++ b/api/alembic/versions/0041_remove_dead_submission_types.py
@@ -1,0 +1,151 @@
+"""remove dead submission types
+
+Drops the three retired submission types (``journal_api_response``,
+``code_analysis``, ``pr_review``) from the only remaining per-type CHECK
+constraint, ``ck_requirements_submission_value_kind_matches_type`` on the
+``requirements`` table. The ``submissions`` and ``verification_jobs`` tables no
+longer have a ``submission_type`` column (dropped in 0029 / 0030), so they need
+no change here.
+
+Production was confirmed to have zero ``requirements`` rows (active or
+soft-deleted) using these types before this migration was written. The guard
+below re-checks that at apply time and refuses to proceed if any offending row
+exists, because there is no safe automatic value to migrate a dead curriculum
+type to, and we must never silently delete curriculum or learner data.
+
+The tightened constraint is added ``NOT VALID`` here and validated in the
+follow-up migration 0042, so the validation scan does not run in the same
+transaction as the swap (matches the 0036 / 0037 pattern and keeps squawk
+happy).
+
+Revision ID: 0041_remove_dead_submission_types
+Revises: 0040_github_username_not_null
+Create Date: 2026-06-21
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0041_remove_dead_submission_types"
+down_revision: str | None = "0040_github_username_not_null"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CONSTRAINT = "ck_requirements_submission_value_kind_matches_type"
+
+# New definition: ``pr_review`` removed from the github_url group and the whole
+# text group (``journal_api_response`` + ``code_analysis``) dropped, since no
+# remaining type uses the ``text`` value kind.
+_NEW_CHECK = """
+(
+    submission_type IN (
+        'github_profile',
+        'profile_readme',
+        'repo_fork',
+        'journal_api_verifier',
+        'devops_analysis',
+        'security_scanning',
+        'ci_status'
+    )
+    AND submission_value_kind = 'github_url'
+)
+OR (
+    submission_type IN (
+        'ctf_token',
+        'networking_token',
+        'iac_token'
+    )
+    AND submission_value_kind = 'token'
+)
+OR (
+    submission_type = 'deployed_api'
+    AND submission_value_kind = 'deployed_url'
+)
+"""
+
+# Prior definition, restored on downgrade.
+_OLD_CHECK = """
+(
+    submission_type IN (
+        'github_profile',
+        'profile_readme',
+        'repo_fork',
+        'pr_review',
+        'journal_api_verifier',
+        'devops_analysis',
+        'security_scanning',
+        'ci_status'
+    )
+    AND submission_value_kind = 'github_url'
+)
+OR (
+    submission_type IN (
+        'ctf_token',
+        'networking_token',
+        'iac_token'
+    )
+    AND submission_value_kind = 'token'
+)
+OR (
+    submission_type = 'deployed_api'
+    AND submission_value_kind = 'deployed_url'
+)
+OR (
+    submission_type IN (
+        'journal_api_response',
+        'code_analysis'
+    )
+    AND submission_value_kind = 'text'
+)
+"""
+
+_DEAD_TYPES = "('journal_api_response', 'code_analysis', 'pr_review')"
+
+# Refuse to tighten the constraint if any requirements row still uses a dead
+# type. Counts active and soft-deleted rows; raises with a clear message so an
+# operator investigates instead of losing data silently.
+_GUARD = f"""
+DO $$
+DECLARE
+    offending integer;
+BEGIN
+    SELECT count(*) INTO offending
+    FROM requirements
+    WHERE submission_type IN {_DEAD_TYPES};
+
+    IF offending > 0 THEN
+        RAISE EXCEPTION
+            'Found % requirements row(s) using a retired submission type %. '
+            'Resolve these rows manually before removing the types.',
+            offending, {_DEAD_TYPES!r};
+    END IF;
+END $$;
+"""
+
+
+def _replace_constraint(condition: str) -> None:
+    op.execute(f"ALTER TABLE requirements DROP CONSTRAINT IF EXISTS {_CONSTRAINT}")
+    op.execute(
+        f"""
+        ALTER TABLE requirements
+        ADD CONSTRAINT {_CONSTRAINT}
+        CHECK ({condition})
+        NOT VALID
+        """
+    )
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    op.execute(_GUARD)
+    _replace_constraint(_NEW_CHECK)
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    _replace_constraint(_OLD_CHECK)

--- a/api/alembic/versions/0042_validate_remove_dead_submission_types.py
+++ b/api/alembic/versions/0042_validate_remove_dead_submission_types.py
@@ -1,0 +1,32 @@
+"""validate the tightened requirements submission-type constraint
+
+Validates the ``NOT VALID`` constraint added in 0041 in its own transaction, so
+the validation scan does not block reads alongside the swap (matches the
+0036 / 0037 split).
+
+Revision ID: 0042_validate_remove_dead_submission_types
+Revises: 0041_remove_dead_submission_types
+Create Date: 2026-06-21
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0042_validate_remove_dead_submission_types"
+down_revision: str | None = "0041_remove_dead_submission_types"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CONSTRAINT = "ck_requirements_submission_value_kind_matches_type"
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+
+    op.execute(f"ALTER TABLE requirements VALIDATE CONSTRAINT {_CONSTRAINT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/learn_to_cloud/templates/partials/verification_feedback.html
+++ b/api/src/learn_to_cloud/templates/partials/verification_feedback.html
@@ -1,6 +1,6 @@
 <!-- Reusable AI verification feedback panel.
      Used by all submission types that return task-level feedback
-     (PR_REVIEW, DEVOPS_ANALYSIS, etc.)
+     (DEVOPS_ANALYSIS, SECURITY_SCANNING, etc.)
 
      Required context:
        feedback_tasks   – list of dicts with keys: name, passed, message

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -89,9 +89,6 @@ _DEFAULT_ORCHESTRATOR_NAME = "verification_orchestrator"
 # declared per type in verification/dispatcher.py (_VALIDATOR_REGISTRY);
 # this map only picks the orchestrator name for the background types.
 _ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE = {
-    SubmissionType.JOURNAL_API_RESPONSE: "verify_phase3_journal_api_orchestrator",
-    SubmissionType.CODE_ANALYSIS: "verify_phase3_journal_api_orchestrator",
-    SubmissionType.PR_REVIEW: "verify_phase3_pr_review_orchestrator",
     SubmissionType.JOURNAL_API_VERIFIER: (
         "verify_phase3_journal_api_verifier_orchestrator"
     ),
@@ -481,18 +478,6 @@ def verify_networking_token_orchestrator(context: df.DurableOrchestrationContext
 
     See :func:`verify_github_profile_orchestrator` for rationale.
     """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase3_journal_api_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 3 journal API verification."""
-    return ((yield from _run_verification_orchestration(context)),)
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase3_pr_review_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 3 pull request verification."""
     return (yield from _run_verification_orchestration(context))
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -104,12 +104,6 @@ class SubmissionType(StrEnum):
     NETWORKING_TOKEN = "networking_token"
 
     # Phase 3: Journal API implementation
-    # JOURNAL_API_RESPONSE kept for backward compatibility with existing DB records
-    JOURNAL_API_RESPONSE = "journal_api_response"
-    # CODE_ANALYSIS kept so SQLAlchemy can deserialize old rows during
-    # rolling deploys before the 0015 migration converts them to ci_status.
-    CODE_ANALYSIS = "code_analysis"
-    PR_REVIEW = "pr_review"
     JOURNAL_API_VERIFIER = "journal_api_verifier"
 
     # Phase 4: Cloud deployment validation
@@ -634,7 +628,6 @@ class CurriculumRequirement(TimestampMixin, Base):
                     'github_profile',
                     'profile_readme',
                     'repo_fork',
-                    'pr_review',
                     'journal_api_verifier',
                     'devops_analysis',
                     'security_scanning',
@@ -653,13 +646,6 @@ class CurriculumRequirement(TimestampMixin, Base):
             OR (
                 submission_type = 'deployed_api'
                 AND submission_value_kind = 'deployed_url'
-            )
-            OR (
-                submission_type IN (
-                    'journal_api_response',
-                    'code_analysis'
-                )
-                AND submission_value_kind = 'text'
             )
             """,
             name="ck_requirements_submission_value_kind_matches_type",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -724,8 +724,8 @@ class SubmissionResult(FrozenModel):
 class TaskResult(FrozenModel):
     """Result of verifying a single task in a multi-task verification.
 
-    Used by PR_REVIEW, DEVOPS_ANALYSIS, and SECURITY_SCANNING validations
-    to provide detailed per-task feedback.
+    Used by DEVOPS_ANALYSIS and SECURITY_SCANNING validations to provide
+    detailed per-task feedback.
     """
 
     task_name: str

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
@@ -14,7 +14,6 @@ _GITHUB_URL_TYPES = {
     SubmissionType.GITHUB_PROFILE.value,
     SubmissionType.PROFILE_README.value,
     SubmissionType.REPO_FORK.value,
-    SubmissionType.PR_REVIEW.value,
     SubmissionType.JOURNAL_API_VERIFIER.value,
     SubmissionType.DEVOPS_ANALYSIS.value,
     SubmissionType.SECURITY_SCANNING.value,
@@ -26,10 +25,6 @@ _TOKEN_TYPES = {
     "iac_token",
 }
 _DEPLOYED_URL_TYPES = {SubmissionType.DEPLOYED_API.value}
-_TEXT_TYPES = {
-    SubmissionType.JOURNAL_API_RESPONSE.value,
-    SubmissionType.CODE_ANALYSIS.value,
-}
 
 
 class SubmittedValueColumns(Protocol):
@@ -175,8 +170,6 @@ def value_kind_for_submission_type(
         return SubmissionValueKind.TOKEN
     if raw_type in _DEPLOYED_URL_TYPES:
         return SubmissionValueKind.DEPLOYED_URL
-    if raw_type in _TEXT_TYPES:
-        return SubmissionValueKind.TEXT
     raise ValueError(f"Unknown submission_type for submitted value: {raw_type!r}")
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
@@ -222,9 +222,8 @@ async def _adapt_security_scanning(
 
 
 # Single source of truth: each active submission type maps to one descriptor.
-# Legacy/retired types (journal_api_response, code_analysis, pr_review) are
-# intentionally absent; lookups use ``.get(...)`` so they surface as the
-# explicit "Unknown submission type" result instead of raising.
+# Lookups use ``.get(...)`` so an unregistered type surfaces as the explicit
+# "Unknown submission type" result instead of raising.
 _VALIDATOR_REGISTRY: dict[SubmissionType, ValidatorDescriptor] = {
     SubmissionType.GITHUB_PROFILE: ValidatorDescriptor(
         adapter=_adapt_github_profile,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/url_derivation.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/url_derivation.py
@@ -40,7 +40,6 @@ _PASS_THROUGH_TYPES: frozenset[SubmissionType] = frozenset(
         SubmissionType.CTF_TOKEN,
         SubmissionType.NETWORKING_TOKEN,
         SubmissionType.DEPLOYED_API,
-        SubmissionType.JOURNAL_API_RESPONSE,
     }
 )
 

--- a/packages/learn-to-cloud-shared/tests/test_submission_values.py
+++ b/packages/learn-to-cloud-shared/tests/test_submission_values.py
@@ -22,7 +22,6 @@ from learn_to_cloud_shared.testing.requirement_factories import (
         (SubmissionType.JOURNAL_API_VERIFIER, SubmissionValueKind.GITHUB_URL),
         (SubmissionType.CTF_TOKEN, SubmissionValueKind.TOKEN),
         (SubmissionType.DEPLOYED_API, SubmissionValueKind.DEPLOYED_URL),
-        (SubmissionType.JOURNAL_API_RESPONSE, SubmissionValueKind.TEXT),
         ("ci_status", SubmissionValueKind.GITHUB_URL),
         ("iac_token", SubmissionValueKind.TOKEN),
     ],

--- a/packages/learn-to-cloud-shared/tests/verification/test_dispatcher.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_dispatcher.py
@@ -43,18 +43,8 @@ _EXPECTED_REPO_BACKED = {
 # The only type that does not require a GitHub username.
 _EXPECTED_NO_USERNAME = {SubmissionType.DEPLOYED_API}
 
-# Retired types kept only so old DB rows deserialize; they have no validator.
-_LEGACY_TYPES = {
-    SubmissionType.JOURNAL_API_RESPONSE,
-    SubmissionType.CODE_ANALYSIS,
-    SubmissionType.PR_REVIEW,
-}
-
-# Types backed by an active HandsOnRequirement subclass (the discriminated
-# union). Derived from the schema so it stays in lockstep with it.
-_ACTIVE_TYPES = {
-    member.value for member in SubmissionType if member not in _LEGACY_TYPES
-}
+# Every submission type now has an active validator descriptor.
+_ACTIVE_TYPES = {member.value for member in SubmissionType}
 
 
 def test_inline_set_is_exactly_the_phase_0_to_2_types():
@@ -84,16 +74,6 @@ def test_is_inline_false_for_background_types(submission_type):
 
 
 @pytest.mark.parametrize(
-    "submission_type", sorted(_LEGACY_TYPES, key=lambda t: t.value)
-)
-def test_legacy_types_have_no_descriptor_and_are_not_inline(submission_type):
-    assert descriptor_for(submission_type) is None
-    assert execution_mode_for(submission_type) is None
-    assert is_inline(submission_type) is False
-    assert is_repo_backed(submission_type) is False
-
-
-@pytest.mark.parametrize(
     "submission_type", sorted(_EXPECTED_REPO_BACKED, key=lambda t: t.value)
 )
 def test_repo_backed_true_for_repo_url_types(submission_type):
@@ -111,7 +91,7 @@ def test_repo_backed_false_for_non_repo_types(submission_type):
 @pytest.mark.parametrize(
     "submission_type",
     sorted(
-        set(SubmissionType) - _EXPECTED_NO_USERNAME - _LEGACY_TYPES,
+        set(SubmissionType) - _EXPECTED_NO_USERNAME,
         key=lambda t: t.value,
     ),
 )
@@ -130,9 +110,8 @@ def test_deployed_api_does_not_require_username():
 def test_registry_covers_every_active_submission_type_exactly_once():
     """Completeness: each active type has exactly one descriptor, no extras.
 
-    ``_ACTIVE_TYPES`` is derived from the SubmissionType enum minus the
-    retired legacy values, so adding a real type without registering it (or
-    registering a legacy type) fails here.
+    ``_ACTIVE_TYPES`` is derived from the full SubmissionType enum, so adding a
+    real type without registering it fails here.
     """
     registry_values = {t.value for t in _VALIDATOR_REGISTRY}
     assert registry_values == _ACTIVE_TYPES

--- a/scripts/seed_progress.py
+++ b/scripts/seed_progress.py
@@ -107,8 +107,6 @@ async def main(github_username: str) -> None:
                         submitted_value = (
                             f"https://github.com/{github_username}/journal-starter"
                         )
-                    elif sub_type == "pr_review":
-                        submitted_value = f"https://seed-data.example.com/{req.slug}"
                     elif sub_type == "deployed_api":
                         submitted_value = "https://journal-api.example.com"
                     else:


### PR DESCRIPTION
Closes #560.

## What this does

Three submission types had no validator and were kept only so old database rows could still be read: `journal_api_response`, `code_analysis`, and `pr_review`. After the registry refactor in #428 the dispatcher just returned "Unknown submission type" for them, so they were dead weight that added noise and small footguns (a stale background worker, permissive database rules, and value mappings).

This change removes them properly:

- Removes the three values from the `SubmissionType` list.
- Adds two database migrations (`0041`, `0042`). The first checks production has no rows using these types, then tightens the `requirements` table rule to forbid them (added `NOT VALID`); the second validates that rule in its own transaction (the repo's established two-step pattern). The `submissions` and `verification_jobs` tables no longer have a `submission_type` column (dropped in `0029`/`0030`), so they need no change.
- Deletes the two now-unused background workers in the Functions app (`verify_phase3_pr_review_orchestrator` and `verify_phase3_journal_api_orchestrator`) and their lookup-map entries.
- Cleans up every remaining reference: the value-kind map in `submission_values.py`, the URL pass-through list in `url_derivation.py`, a dispatcher comment, the `seed_progress.py` branch, and two stale code comments.
- Updates the tests that pinned these types as "legacy".

## Safety

- **Production checked first.** Queried prod before writing the migration: zero rows use these three types in `requirements` (active and soft-deleted), `submissions`, or `verification_jobs`.
- **No silent data loss.** The migration guards at apply time and raises a clear error if an unexpected offending row is ever found, rather than deleting data.
- **No in-flight workers stranded.** A background worker is only chosen by a verification job's requirement type, and there are zero such jobs, so removing the two workers is safe.

## Out of scope

`SubmissionValueKind.TEXT` and the `text_value` column are now unused but left in place per the issue. A follow-up can retire the text storage path if desired.

## Checks

`uv run poe check` passes locally (ruff lint/format, ty type check, squawk migration lint, all tests, and the Functions import smoke test).