### PR TITLE
Fix reset-local-submissions foreign-key violation (#564)

### DIFF
--- a/api/scripts/reset_local_submissions.py
+++ b/api/scripts/reset_local_submissions.py
@@ -3,6 +3,11 @@
 Deletes submission rows by requirement slug. Progress is automatically
 correct on next page load because it's computed from the submissions table.
 
+Dependent ``verification_jobs`` rows are deleted first (a completed async
+verification job links back to the submission it produced via
+``result_submission_id``), otherwise the submission delete would raise a
+foreign-key violation.
+
 Submissions reference a requirement by ``requirement_uuid`` (FK to
 ``requirements.uuid``); the human-friendly slug lives on the requirements
 table, so we join through it to match the slugs passed on the command line.
@@ -77,6 +82,22 @@ async def reset_submissions(
             if dry_run:
                 print("Dry run enabled: no changes applied.")
                 return 0
+
+            job_user_filter = " AND vj.user_id = ANY(:user_ids)" if user_ids else ""
+            delete_jobs_query = text(
+                f"""
+                DELETE FROM verification_jobs vj
+                USING requirements r
+                WHERE r.uuid = vj.requirement_uuid
+                  AND r.slug = ANY(:requirement_slugs){job_user_filter}
+                """
+            )
+            jobs_result = await conn.execute(delete_jobs_query, params)
+            if jobs_result.rowcount:
+                print(
+                    f"Deleted {jobs_result.rowcount} dependent "
+                    "verification_jobs row(s)."
+                )
 
             delete_query = text(
                 f"""


### PR DESCRIPTION
Closes #564.

## What this fixes

The local helper `api/scripts/reset_local_submissions.py` (used by the `reset-local-submissions` skill) deleted rows from `submissions` directly. When an async verification had already finished, the resulting `verification_jobs` row pointed back at that submission through `result_submission_id` (FK `fk_verification_jobs_result_submission_id`). Deleting the submission then failed with:

```
asyncpg.exceptions.ForeignKeyViolationError: update or delete on table "submissions"
violates foreign key constraint "fk_verification_jobs_result_submission_id" on table "verification_jobs"
```

This hit any async-verified requirement (for example the Phase 3 journal API flow), and the reset had to be unstuck by clearing the `verification_jobs` rows by hand.

## The change

Before deleting the matching submissions, the script now deletes the dependent `verification_jobs` rows in foreign-key-safe order, scoped to the same requirement slugs and the same `--user-id` filter when one is set. This clears both completed jobs (which link back to a submission) and any in-flight jobs, so the next verification run starts clean.

The dry-run path is unchanged: it still previews and applies no changes.

## Scope

- Local developer tooling only. No production data paths are affected.
- No migration, no schema change.

## Checks

`uv run poe static` passes (ruff lint/format, ty type check). There are no existing tests for this dev script.