### PR TITLE
Retire the unused text submitted-value kind (#565)

### DIFF
--- a/api/alembic/versions/0043_retire_text_value_kind.py
+++ b/api/alembic/versions/0043_retire_text_value_kind.py
@@ -1,0 +1,346 @@
+"""retire the text value kind
+
+Removes the now-unreachable ``text`` submitted-value kind. After the dead
+submission types were dropped (#560 / migration 0041), no submission type maps
+to ``text``, so the ``text_value`` column and every constraint / trigger branch
+that mentions it are dead weight.
+
+This migration:
+
+- Guards at apply time that no ``submissions`` / ``verification_jobs`` /
+  ``requirements`` row uses ``submission_value_kind = 'text'`` (or a non-null
+  ``text_value``) and refuses to proceed otherwise, so data is never silently
+  dropped. Production was confirmed clean (zero such rows) before this migration
+  was written.
+- Recreates the ``set_typed_submitted_value`` trigger function and its two
+  triggers without the ``text`` branch / ``text_value`` column, so the column
+  can be dropped without a dangling dependency.
+- Replaces the typed-value shape and format CHECK constraints on
+  ``submissions`` and ``verification_jobs`` with versions that no longer mention
+  the ``text`` kind or ``text_value``. They are added ``NOT VALID`` here and
+  validated in the follow-up migration 0044 (matches the 0036 / 0037 pattern,
+  keeps the validation scan out of this transaction, and keeps squawk happy).
+- Drops the ``text_value`` column from both tables.
+
+The matching application code that referenced ``text_value`` /
+``SubmissionValueKind.TEXT`` is removed in the same change, so the destructive
+column drop follows the repo's documented rolling-deploy tradeoff: briefly,
+draining old pods may error once the column is gone.
+
+Revision ID: 0043_retire_text_value_kind
+Revises: 0042_validate_remove_dead_submission_types
+Create Date: 2026-06-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0043_retire_text_value_kind"
+down_revision: str | None = "0042_validate_remove_dead_submission_types"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Refuse to drop the text path if any row still uses it. Raises with a clear
+# message so an operator investigates instead of losing data silently.
+_GUARD = """
+DO $$
+DECLARE
+    offending bigint;
+BEGIN
+    SELECT
+        (SELECT count(*) FROM submissions
+         WHERE submission_value_kind = 'text' OR text_value IS NOT NULL)
+      + (SELECT count(*) FROM verification_jobs
+         WHERE submission_value_kind = 'text' OR text_value IS NOT NULL)
+      + (SELECT count(*) FROM requirements
+         WHERE submission_value_kind = 'text')
+    INTO offending;
+
+    IF offending > 0 THEN
+        RAISE EXCEPTION
+            'Found % row(s) still using the text value kind. '
+            'Resolve these rows manually before retiring the text path.',
+            offending;
+    END IF;
+END $$;
+"""
+
+# Trigger function without the ``text`` branch. ``text_value`` is no longer
+# referenced so the column can be dropped after this runs.
+_TRIGGER_FUNCTION_NO_TEXT = """
+CREATE OR REPLACE FUNCTION set_typed_submitted_value()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    expected_kind text;
+BEGIN
+    SELECT submission_value_kind
+    INTO expected_kind
+    FROM requirements
+    WHERE uuid = NEW.requirement_uuid;
+
+    IF expected_kind IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    NEW.submission_value_kind = COALESCE(
+        NEW.submission_value_kind,
+        expected_kind
+    );
+
+    IF NEW.submission_value_kind = 'github_url'
+        AND NEW.github_url IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.github_url = NEW.submitted_value;
+    ELSIF NEW.submission_value_kind = 'token'
+        AND NEW.token_value IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.token_value = NEW.submitted_value;
+    ELSIF NEW.submission_value_kind = 'deployed_url'
+        AND NEW.deployed_url IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.deployed_url = NEW.submitted_value;
+    END IF;
+
+    RETURN NEW;
+END
+$$
+"""
+
+# Prior trigger function, restored on downgrade (with the ``text`` branch).
+_TRIGGER_FUNCTION_WITH_TEXT = """
+CREATE OR REPLACE FUNCTION set_typed_submitted_value()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    expected_kind text;
+BEGIN
+    SELECT submission_value_kind
+    INTO expected_kind
+    FROM requirements
+    WHERE uuid = NEW.requirement_uuid;
+
+    IF expected_kind IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    NEW.submission_value_kind = COALESCE(
+        NEW.submission_value_kind,
+        expected_kind
+    );
+
+    IF NEW.submission_value_kind = 'github_url'
+        AND NEW.github_url IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.github_url = NEW.submitted_value;
+    ELSIF NEW.submission_value_kind = 'token'
+        AND NEW.token_value IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.token_value = NEW.submitted_value;
+    ELSIF NEW.submission_value_kind = 'deployed_url'
+        AND NEW.deployed_url IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.deployed_url = NEW.submitted_value;
+    ELSIF NEW.submission_value_kind = 'text'
+        AND NEW.text_value IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.text_value = NEW.submitted_value;
+    END IF;
+
+    RETURN NEW;
+END
+$$
+"""
+
+# Shape check without the ``text`` branch / ``text_value`` column.
+_SHAPE_CHECK_NO_TEXT = """
+(
+    submission_value_kind = 'github_url'
+    AND github_url IS NOT NULL
+    AND token_value IS NULL
+    AND deployed_url IS NULL
+    AND submitted_value = github_url
+)
+OR (
+    submission_value_kind = 'token'
+    AND token_value IS NOT NULL
+    AND github_url IS NULL
+    AND deployed_url IS NULL
+    AND submitted_value = token_value
+)
+OR (
+    submission_value_kind = 'deployed_url'
+    AND deployed_url IS NOT NULL
+    AND github_url IS NULL
+    AND token_value IS NULL
+    AND submitted_value = deployed_url
+)
+"""
+
+# Prior shape check, restored on downgrade (with the ``text`` branch).
+_SHAPE_CHECK_WITH_TEXT = """
+(
+    submission_value_kind = 'github_url'
+    AND github_url IS NOT NULL
+    AND token_value IS NULL
+    AND deployed_url IS NULL
+    AND text_value IS NULL
+    AND submitted_value = github_url
+)
+OR (
+    submission_value_kind = 'token'
+    AND token_value IS NOT NULL
+    AND github_url IS NULL
+    AND deployed_url IS NULL
+    AND text_value IS NULL
+    AND submitted_value = token_value
+)
+OR (
+    submission_value_kind = 'deployed_url'
+    AND deployed_url IS NOT NULL
+    AND github_url IS NULL
+    AND token_value IS NULL
+    AND text_value IS NULL
+    AND submitted_value = deployed_url
+)
+OR (
+    submission_value_kind = 'text'
+    AND text_value IS NOT NULL
+    AND github_url IS NULL
+    AND token_value IS NULL
+    AND deployed_url IS NULL
+    AND submitted_value = text_value
+)
+"""
+
+# Format check without the ``text_value`` clause.
+_FORMAT_CHECK_NO_TEXT = """
+(
+    github_url IS NULL
+    OR length(btrim(github_url)) > 0
+)
+AND (
+    deployed_url IS NULL
+    OR length(btrim(deployed_url)) > 0
+)
+AND (
+    token_value IS NULL
+    OR length(btrim(token_value)) > 0
+)
+"""
+
+# Prior format check, restored on downgrade (with the ``text_value`` clause).
+_FORMAT_CHECK_WITH_TEXT = """
+(
+    github_url IS NULL
+    OR length(btrim(github_url)) > 0
+)
+AND (
+    deployed_url IS NULL
+    OR length(btrim(deployed_url)) > 0
+)
+AND (
+    token_value IS NULL
+    OR length(btrim(token_value)) > 0
+)
+AND (
+    text_value IS NULL
+    OR length(btrim(text_value)) > 0
+)
+"""
+
+_TABLES = (
+    ("submissions", "ck_submissions"),
+    ("verification_jobs", "ck_verification_jobs"),
+)
+
+
+def _replace_check_not_valid(table: str, name: str, condition: str) -> None:
+    op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {name}")
+    op.execute(
+        f"""
+        ALTER TABLE {table}
+        ADD CONSTRAINT {name}
+        CHECK ({condition})
+        NOT VALID
+        """
+    )
+
+
+def _recreate_trigger(table: str, *, include_text_value: bool) -> None:
+    name = f"trg_{table}_set_typed_submitted_value"
+    text_column = ",\n            text_value" if include_text_value else ""
+    op.execute(f"DROP TRIGGER IF EXISTS {name} ON {table}")
+    op.execute(
+        f"""
+        CREATE TRIGGER {name}
+        BEFORE INSERT OR UPDATE OF
+            requirement_uuid,
+            submitted_value,
+            submission_value_kind,
+            github_url,
+            token_value,
+            deployed_url{text_column}
+        ON {table}
+        FOR EACH ROW
+        EXECUTE FUNCTION set_typed_submitted_value()
+        """
+    )
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    op.execute(_GUARD)
+
+    op.execute(_TRIGGER_FUNCTION_NO_TEXT)
+    for table, _prefix in _TABLES:
+        _recreate_trigger(table, include_text_value=False)
+
+    for table, prefix in _TABLES:
+        _replace_check_not_valid(
+            table,
+            f"{prefix}_typed_value_shape",
+            _SHAPE_CHECK_NO_TEXT,
+        )
+        _replace_check_not_valid(
+            table,
+            f"{prefix}_typed_value_format",
+            _FORMAT_CHECK_NO_TEXT,
+        )
+
+    op.drop_column("submissions", "text_value")
+    op.drop_column("verification_jobs", "text_value")
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    op.add_column("submissions", sa.Column("text_value", sa.Text(), nullable=True))
+    op.add_column(
+        "verification_jobs",
+        sa.Column("text_value", sa.Text(), nullable=True),
+    )
+
+    for table, prefix in _TABLES:
+        _replace_check_not_valid(
+            table,
+            f"{prefix}_typed_value_shape",
+            _SHAPE_CHECK_WITH_TEXT,
+        )
+        _replace_check_not_valid(
+            table,
+            f"{prefix}_typed_value_format",
+            _FORMAT_CHECK_WITH_TEXT,
+        )
+
+    op.execute(_TRIGGER_FUNCTION_WITH_TEXT)
+    for table, _prefix in _TABLES:
+        _recreate_trigger(table, include_text_value=True)

--- a/api/alembic/versions/0044_validate_retire_text_value_kind.py
+++ b/api/alembic/versions/0044_validate_retire_text_value_kind.py
@@ -1,0 +1,44 @@
+"""validate text-value-kind retirement constraints
+
+Validates the typed-value shape and format CHECK constraints that 0043 added
+``NOT VALID``. Runs in its own transaction so the validation scan does not hold
+locks during the constraint swap (matches the 0036 / 0037 and 0041 / 0042
+pattern).
+
+Revision ID: 0044_validate_retire_text_value_kind
+Revises: 0043_retire_text_value_kind
+Create Date: 2026-06-22
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0044_validate_retire_text_value_kind"
+down_revision: str | None = "0043_retire_text_value_kind"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_CONSTRAINTS = {
+    "submissions": (
+        "ck_submissions_typed_value_shape",
+        "ck_submissions_typed_value_format",
+    ),
+    "verification_jobs": (
+        "ck_verification_jobs_typed_value_shape",
+        "ck_verification_jobs_typed_value_format",
+    ),
+}
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+
+    for table, constraints in _CONSTRAINTS.items():
+        for constraint in constraints:
+            op.execute(f"ALTER TABLE {table} VALIDATE CONSTRAINT {constraint}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -67,7 +67,6 @@ def _mock_job(value: str = "https://github.com/user/repo") -> SimpleNamespace:
         github_url=value,
         token_value=None,
         deployed_url=None,
-        text_value=None,
     )
 
 

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -64,7 +64,6 @@ def _make_mock_submission(
         github_url="https://github.com/user/repo",
         token_value=None,
         deployed_url=None,
-        text_value=None,
         extracted_username="user",
         is_validated=is_validated,
         validated_at=datetime.now(UTC) if is_validated else None,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -142,7 +142,6 @@ class SubmissionValueKind(StrEnum):
     GITHUB_URL = "github_url"
     TOKEN = "token"
     DEPLOYED_URL = "deployed_url"
-    TEXT = "text"
 
 
 class Submission(TimestampMixin, Base):
@@ -173,7 +172,6 @@ class Submission(TimestampMixin, Base):
                 AND github_url IS NOT NULL
                 AND token_value IS NULL
                 AND deployed_url IS NULL
-                AND text_value IS NULL
                 AND submitted_value = github_url
             )
             OR (
@@ -181,7 +179,6 @@ class Submission(TimestampMixin, Base):
                 AND token_value IS NOT NULL
                 AND github_url IS NULL
                 AND deployed_url IS NULL
-                AND text_value IS NULL
                 AND submitted_value = token_value
             )
             OR (
@@ -189,16 +186,7 @@ class Submission(TimestampMixin, Base):
                 AND deployed_url IS NOT NULL
                 AND github_url IS NULL
                 AND token_value IS NULL
-                AND text_value IS NULL
                 AND submitted_value = deployed_url
-            )
-            OR (
-                submission_value_kind = 'text'
-                AND text_value IS NOT NULL
-                AND github_url IS NULL
-                AND token_value IS NULL
-                AND deployed_url IS NULL
-                AND submitted_value = text_value
             )
             """,
             name="ck_submissions_typed_value_shape",
@@ -216,10 +204,6 @@ class Submission(TimestampMixin, Base):
             AND (
                 token_value IS NULL
                 OR length(btrim(token_value)) > 0
-            )
-            AND (
-                text_value IS NULL
-                OR length(btrim(text_value)) > 0
             )
             """,
             name="ck_submissions_typed_value_format",
@@ -267,7 +251,6 @@ class Submission(TimestampMixin, Base):
     github_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     token_value: Mapped[str | None] = mapped_column(Text, nullable=True)
     deployed_url: Mapped[str | None] = mapped_column(Text, nullable=True)
-    text_value: Mapped[str | None] = mapped_column(Text, nullable=True)
     extracted_username: Mapped[str | None] = mapped_column(
         String(255),
         nullable=True,
@@ -321,7 +304,6 @@ class VerificationJob(TimestampMixin, Base):
                 AND github_url IS NOT NULL
                 AND token_value IS NULL
                 AND deployed_url IS NULL
-                AND text_value IS NULL
                 AND submitted_value = github_url
             )
             OR (
@@ -329,7 +311,6 @@ class VerificationJob(TimestampMixin, Base):
                 AND token_value IS NOT NULL
                 AND github_url IS NULL
                 AND deployed_url IS NULL
-                AND text_value IS NULL
                 AND submitted_value = token_value
             )
             OR (
@@ -337,16 +318,7 @@ class VerificationJob(TimestampMixin, Base):
                 AND deployed_url IS NOT NULL
                 AND github_url IS NULL
                 AND token_value IS NULL
-                AND text_value IS NULL
                 AND submitted_value = deployed_url
-            )
-            OR (
-                submission_value_kind = 'text'
-                AND text_value IS NOT NULL
-                AND github_url IS NULL
-                AND token_value IS NULL
-                AND deployed_url IS NULL
-                AND submitted_value = text_value
             )
             """,
             name="ck_verification_jobs_typed_value_shape",
@@ -364,10 +336,6 @@ class VerificationJob(TimestampMixin, Base):
             AND (
                 token_value IS NULL
                 OR length(btrim(token_value)) > 0
-            )
-            AND (
-                text_value IS NULL
-                OR length(btrim(text_value)) > 0
             )
             """,
             name="ck_verification_jobs_typed_value_format",
@@ -417,7 +385,6 @@ class VerificationJob(TimestampMixin, Base):
     github_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     token_value: Mapped[str | None] = mapped_column(Text, nullable=True)
     deployed_url: Mapped[str | None] = mapped_column(Text, nullable=True)
-    text_value: Mapped[str | None] = mapped_column(Text, nullable=True)
     extracted_username: Mapped[str | None] = mapped_column(String(255), nullable=True)
     cloud_provider: Mapped[str | None] = mapped_column(String(16), nullable=True)
     result_submission_id: Mapped[int | None] = mapped_column(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
@@ -32,7 +32,6 @@ class SubmittedValueColumns(Protocol):
     github_url: str | None
     token_value: str | None
     deployed_url: str | None
-    text_value: str | None
     submitted_value: str
 
 
@@ -44,7 +43,6 @@ class SubmittedValue:
     github_url: str | None = None
     token_value: str | None = None
     deployed_url: str | None = None
-    text_value: str | None = None
 
     @property
     def as_text(self) -> str:
@@ -55,8 +53,6 @@ class SubmittedValue:
                 value = self.token_value
             case SubmissionValueKind.DEPLOYED_URL:
                 value = self.deployed_url
-            case SubmissionValueKind.TEXT:
-                value = self.text_value
         if value is None:
             raise ValueError(f"Missing value for {self.kind.value}")
         return value
@@ -68,7 +64,6 @@ class SubmittedValue:
             "github_url": self.github_url,
             "token_value": self.token_value,
             "deployed_url": self.deployed_url,
-            "text_value": self.text_value,
         }
 
     def to_payload(self) -> dict[str, str | None]:
@@ -94,7 +89,6 @@ class SubmittedValue:
                 payload_map.get("deployed_url"),
                 "deployed_url",
             ),
-            text_value=_optional_str(payload_map.get("text_value"), "text_value"),
             legacy_value=_optional_str(
                 payload_map.get("submitted_value"),
                 "submitted_value",
@@ -121,8 +115,6 @@ class SubmittedValue:
             case SubmissionValueKind.DEPLOYED_URL:
                 _validate_http_url(value, field_name="deployed API URL")
                 return cls(kind=kind, deployed_url=value)
-            case SubmissionValueKind.TEXT:
-                return cls(kind=kind, text_value=value)
 
     @classmethod
     def from_columns(
@@ -132,7 +124,6 @@ class SubmittedValue:
         github_url: str | None,
         token_value: str | None,
         deployed_url: str | None,
-        text_value: str | None,
         legacy_value: str | None = None,
     ) -> SubmittedValue:
         normalized_kind = (
@@ -143,7 +134,6 @@ class SubmittedValue:
             github_url=github_url,
             token_value=token_value,
             deployed_url=deployed_url,
-            text_value=text_value,
         )
         if legacy_value is not None and legacy_value != value:
             raise ValueError("Legacy submitted_value does not match typed value")
@@ -152,7 +142,6 @@ class SubmittedValue:
             github_url=github_url,
             token_value=token_value,
             deployed_url=deployed_url,
-            text_value=text_value,
         )
 
 
@@ -179,7 +168,6 @@ def submission_value_from_columns(row: SubmittedValueColumns) -> SubmittedValue:
         github_url=row.github_url,
         token_value=row.token_value,
         deployed_url=row.deployed_url,
-        text_value=row.text_value,
         legacy_value=row.submitted_value,
     )
 
@@ -198,13 +186,11 @@ def _single_value_for_kind(
     github_url: str | None,
     token_value: str | None,
     deployed_url: str | None,
-    text_value: str | None,
 ) -> str:
     values = {
         SubmissionValueKind.GITHUB_URL: github_url,
         SubmissionValueKind.TOKEN: token_value,
         SubmissionValueKind.DEPLOYED_URL: deployed_url,
-        SubmissionValueKind.TEXT: text_value,
     }
     value = values[kind]
     other_values = [item for item_kind, item in values.items() if item_kind != kind]

--- a/packages/learn-to-cloud-shared/tests/test_submission_values.py
+++ b/packages/learn-to-cloud-shared/tests/test_submission_values.py
@@ -48,7 +48,6 @@ def test_github_url_value_uses_github_column() -> None:
         "github_url": "https://github.com/user",
         "token_value": None,
         "deployed_url": None,
-        "text_value": None,
     }
 
 
@@ -98,7 +97,6 @@ def test_payload_round_trip_rejects_legacy_mismatch() -> None:
         "github_url": "https://github.com/user",
         "token_value": None,
         "deployed_url": None,
-        "text_value": None,
         "submitted_value": "https://github.com/other",
     }
 


### PR DESCRIPTION
Closes #565. Follow-up to #560 / PR #563.

## What this does

After the three dead submission types were removed, nothing mapped to the `text` submitted-value kind anymore. The `text_value` column on `submissions` and `verification_jobs`, plus every check-constraint branch and trigger branch that referenced it, were dead weight. This change removes that path end to end.

## Database (two migrations, the repo's two-step pattern)

- **0043** (the swap):
  - Guards at apply time that no `submissions`, `verification_jobs`, or `requirements` row uses `submission_value_kind = 'text'` or a non-null `text_value`, and raises a clear error instead of dropping data silently.
  - Recreates the shared `set_typed_submitted_value` trigger function and both triggers without the `text` branch / `text_value` column, so the column has no dangling dependency.
  - Replaces the `*_typed_value_shape` and `*_typed_value_format` check constraints on both tables with versions that no longer mention `text_value` (added `NOT VALID`).
  - Drops the `text_value` column from both tables.
- **0044**: validates the four new constraints in its own transaction.

## Application code

- Removed `SubmissionValueKind.TEXT`, the `SubmittedValue.text_value` field, and the `text` branches from the typed-value helper, the ORM models, and the model-level check constraints.
- Updated the two tests that pinned `text_value` in their column dictionaries.

## Safety

- **Production checked first.** Queried prod before writing the migration: zero rows in `submissions`, `verification_jobs`, or `requirements` use the text kind or a non-null `text_value`.
- **No silent data loss.** The migration guards at apply time and raises if an unexpected row is ever found.
- **Rolling deploy.** Dropping the column is the usual destructive-column tradeoff this repo accepts (a brief window where draining old pods may error). The code that referenced `text_value` is removed in the same change.

## Verification

- Ran `alembic upgrade head`, then a full `downgrade` back to 0042, then `upgrade head` again against a local Postgres. Confirmed the column, the constraints, and the trigger branch are removed on upgrade and fully restored on downgrade.
- `uv run poe check` passes (ruff lint/format, ty type check, squawk migration lint, all 512 tests).