### PR TITLE
Split verification workflow into explicit per-phase orchestrations (#429)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     hooks:
       - id: ty
         name: ty type check
-        entry: bash -c 'uv run --project api ty check --exclude scripts --exclude tests api && (cd packages/learn-to-cloud-shared && uv run --project . ty check --exclude tests .) && uv run --project apps/verification-functions ty check apps/verification-functions'
+        entry: bash -c 'uv run --project api ty check --exclude scripts --exclude tests api && (cd packages/learn-to-cloud-shared && uv run --project . ty check --exclude tests .) && uv run --project apps/verification-functions ty check --exclude apps/verification-functions/tests apps/verification-functions'
         language: system
         files: ^(api|apps/verification-functions|packages/learn-to-cloud-shared)/.*\.py$
         pass_filenames: false

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -9,6 +9,7 @@ import logging
 import os
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from dataclasses import dataclass
 from uuid import UUID
 
 import azure.durable_functions as df
@@ -88,12 +89,18 @@ _DEFAULT_ORCHESTRATOR_NAME = "verification_orchestrator"
 # FastAPI request instead and are intentionally absent. Execution mode is
 # declared per type in verification/dispatcher.py (_VALIDATOR_REGISTRY);
 # this map only picks the orchestrator name for the background types.
+#
+# Each background type maps to its own per-phase orchestration (issue
+# #429): phases 3 and 6 use the graded workflow, phases 4 and 5 use the
+# deterministic workflow. Phases 4 and 5 point at ``_v2`` names because
+# the deterministic workflow dropped an activity call; their legacy names
+# stay registered as drain-only orchestrators for in-flight jobs.
 _ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE = {
     SubmissionType.JOURNAL_API_VERIFIER: (
         "verify_phase3_journal_api_verifier_orchestrator"
     ),
-    SubmissionType.DEPLOYED_API: "verify_phase4_deployed_api_orchestrator",
-    SubmissionType.DEVOPS_ANALYSIS: "verify_phase5_devops_orchestrator",
+    SubmissionType.DEPLOYED_API: "verify_phase4_deployed_api_orchestrator_v2",
+    SubmissionType.DEVOPS_ANALYSIS: "verify_phase5_devops_orchestrator_v2",
     SubmissionType.SECURITY_SCANNING: "verify_phase6_security_orchestrator",
 }
 _VERIFY_RETRY_OPTIONS = df.RetryOptions(
@@ -427,6 +434,200 @@ def _run_verification_orchestration(context: df.DurableOrchestrationContext):
     return result
 
 
+@dataclass(frozen=True)
+class _TerminalOutcome:
+    """Preparation already decided the job's outcome; skip verification."""
+
+    result: object
+
+
+@dataclass(frozen=True)
+class _PreparedOutcome:
+    """Preparation produced a job ready for the verify/persist steps."""
+
+    job_id: str
+    prepared_payload: Mapping[str, object]
+    prepared_job: PreparedVerificationJob
+
+
+_PrepareOutcome = _TerminalOutcome | _PreparedOutcome
+
+
+def _prepare_step(context: df.DurableOrchestrationContext):
+    """Validate and prepare the job. Shared first step for every workflow.
+
+    Yields the ``prepare_verification_job`` activity and returns either a
+    :class:`_TerminalOutcome` (preparation already decided the result) or a
+    :class:`_PreparedOutcome`. Side effects (span attributes, custom
+    status) match the legacy body so phases that keep their orchestrator
+    name replay identically.
+    """
+    input_payload = context.get_input()
+    if not isinstance(input_payload, Mapping):
+        raise TypeError(
+            f"verification orchestration: expected Mapping input, "
+            f"got {type(input_payload).__name__}"
+        )
+    job_id_obj = input_payload.get("id")
+    job_id = job_id_obj if isinstance(job_id_obj, str) else str(job_id_obj)
+    _set_verification_span_attributes(job_id=job_id)
+    context.set_custom_status({"step": "preparing", "job_id": job_id})
+    preparation = yield context.call_activity_with_retry(
+        "prepare_verification_job",
+        _TRANSIENT_RETRY_OPTIONS,
+        input_payload,
+    )
+
+    terminal_result = preparation.get("terminal_result")
+    if terminal_result is not None:
+        result_payload = _activity_payload(terminal_result)
+        _set_result_span_attributes(result_payload)
+        context.set_custom_status(
+            _result_custom_status("completed", job_id, result_payload)
+        )
+        return _TerminalOutcome(result=terminal_result)
+
+    prepared_job = preparation["job"]
+    prepared_job_payload = _activity_payload(prepared_job)
+    prepared_verification_job = PreparedVerificationJob.from_payload(
+        prepared_job_payload
+    )
+    _set_prepared_job_span_attributes(prepared_verification_job)
+    return _PreparedOutcome(
+        job_id=job_id,
+        prepared_payload=prepared_job,
+        prepared_job=prepared_verification_job,
+    )
+
+
+def _verify_step(context: df.DurableOrchestrationContext, outcome: _PreparedOutcome):
+    """Run the requirement verification activity and return its run result."""
+    context.set_custom_status(
+        _job_custom_status("verifying", outcome.job_id, outcome.prepared_job)
+    )
+    run_result = yield context.call_activity_with_retry(
+        "execute_requirement_verification",
+        _VERIFY_RETRY_OPTIONS,
+        outcome.prepared_payload,
+    )
+    return run_result
+
+
+def _llm_grading_step(
+    context: df.DurableOrchestrationContext,
+    outcome: _PreparedOutcome,
+    run_result: object,
+):
+    """Apply LLM rubric grading when the run produced grading requests.
+
+    Used only by graded phases (3 and 6). When no requests are produced
+    the run result passes through unchanged.
+    """
+    llm_requests = yield context.call_activity(
+        "collect_llm_grading_requests",
+        run_result,
+    )
+    if not llm_requests:
+        return run_result
+
+    context.set_custom_status(
+        _job_custom_status("llm_grading", outcome.job_id, outcome.prepared_job)
+    )
+    config_status = yield context.call_activity("ensure_grading_config", None)
+    if not config_status.get("valid"):
+        missing = config_status.get("missing_vars") or []
+        return (
+            yield context.call_activity(
+                "llm_grading_failed",
+                {
+                    "run_result": run_result,
+                    "detail": f"missing grading config: {', '.join(missing)}",
+                    "error_type": "MissingGradingConfig",
+                },
+            )
+        )
+
+    try:
+        decisions: list[dict[str, object]] = []
+        for request_payload in llm_requests:
+            decision_payload = yield context.call_activity_with_retry(
+                "run_llm_grading",
+                _LLM_RETRY_OPTIONS,
+                request_payload,
+            )
+            decisions.append(_activity_payload(decision_payload))
+
+        return (
+            yield context.call_activity(
+                "apply_llm_grading_results",
+                {"run_result": run_result, "decisions": decisions},
+            )
+        )
+    except Exception as exc:
+        return (
+            yield context.call_activity(
+                "llm_grading_failed",
+                {
+                    "run_result": run_result,
+                    "detail": str(exc),
+                    "error_type": type(exc).__name__,
+                },
+            )
+        )
+
+
+def _persist_step(
+    context: df.DurableOrchestrationContext,
+    outcome: _PreparedOutcome,
+    run_result: object,
+):
+    """Persist the final run result and mark the job completed."""
+    context.set_custom_status(
+        _job_custom_status("persisting", outcome.job_id, outcome.prepared_job)
+    )
+    result = yield context.call_activity_with_retry(
+        "persist_verification_result",
+        _TRANSIENT_RETRY_OPTIONS,
+        run_result,
+    )
+    result_payload = _activity_payload(result)
+    _set_result_span_attributes(result_payload)
+    context.set_custom_status(
+        _result_custom_status("completed", outcome.job_id, result_payload)
+    )
+    return result
+
+
+def _graded_verification(context: df.DurableOrchestrationContext):
+    """Workflow for phases that may LLM-grade evidence (phases 3 and 6).
+
+    prepare -> verify -> llm_grading -> persist. The activity sequence is
+    identical to the legacy shared body for a graded job, so phases that
+    adopt this workflow keep their orchestrator name and replay cleanly.
+    """
+    outcome = yield from _prepare_step(context)
+    if isinstance(outcome, _TerminalOutcome):
+        return outcome.result
+    run_result = yield from _verify_step(context, outcome)
+    run_result = yield from _llm_grading_step(context, outcome, run_result)
+    return (yield from _persist_step(context, outcome, run_result))
+
+
+def _deterministic_verification(context: df.DurableOrchestrationContext):
+    """Workflow for phases that never LLM-grade (phases 4 and 5).
+
+    prepare -> verify -> persist. There is no ``collect_llm_grading_requests``
+    call, so this is a breaking change to the recorded activity sequence:
+    the phases adopting it use new (``_v2``) orchestrator names while the
+    legacy names drain in-flight jobs on the legacy body.
+    """
+    outcome = yield from _prepare_step(context)
+    if isinstance(outcome, _TerminalOutcome):
+        return outcome.result
+    run_result = yield from _verify_step(context, outcome)
+    return (yield from _persist_step(context, outcome, run_result))
+
+
 @app.orchestration_trigger(context_name="context")
 def verification_orchestrator(context: df.DurableOrchestrationContext):
     """Run the legacy generic verification workflow."""
@@ -495,25 +696,53 @@ def verify_phase3_journal_api_verifier_orchestrator(
     context: df.DurableOrchestrationContext,
 ):
     """Run Phase 3 journal API verification (CI gate + LLM rubric review)."""
-    return (yield from _run_verification_orchestration(context))
+    return (yield from _graded_verification(context))
 
 
 @app.orchestration_trigger(context_name="context")
 def verify_phase4_deployed_api_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 4 deployed API verification."""
+    """Drain-only orchestrator for phase 4 deployed API jobs started before
+    the per-phase split (issue #429).
+
+    Phase 4 never LLM-grades, so new jobs run the deterministic workflow
+    under :func:`verify_phase4_deployed_api_orchestrator_v2`. Dropping the
+    ``collect_llm_grading_requests`` call changes the recorded activity
+    sequence, so this legacy name stays on the legacy body to replay any
+    in-flight pre-split job cleanly. Safe to remove after Durable retention
+    expires.
+    """
     return (yield from _run_verification_orchestration(context))
+
+
+@app.orchestration_trigger(context_name="context")
+def verify_phase4_deployed_api_orchestrator_v2(
+    context: df.DurableOrchestrationContext,
+):
+    """Run Phase 4 deployed API verification (deterministic, no LLM grading)."""
+    return (yield from _deterministic_verification(context))
 
 
 @app.orchestration_trigger(context_name="context")
 def verify_phase5_devops_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 5 DevOps verification."""
+    """Drain-only orchestrator for phase 5 DevOps jobs started before the
+    per-phase split (issue #429).
+
+    See :func:`verify_phase4_deployed_api_orchestrator` for rationale. New
+    jobs run :func:`verify_phase5_devops_orchestrator_v2`.
+    """
     return (yield from _run_verification_orchestration(context))
 
 
 @app.orchestration_trigger(context_name="context")
+def verify_phase5_devops_orchestrator_v2(context: df.DurableOrchestrationContext):
+    """Run Phase 5 DevOps verification (deterministic, no LLM grading)."""
+    return (yield from _deterministic_verification(context))
+
+
+@app.orchestration_trigger(context_name="context")
 def verify_phase6_security_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 6 security verification."""
-    return (yield from _run_verification_orchestration(context))
+    """Run Phase 6 security verification (probes + LLM rubric review)."""
+    return (yield from _graded_verification(context))
 
 
 @app.activity_trigger(input_name="input_payload")

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -92,16 +92,13 @@ _DEFAULT_ORCHESTRATOR_NAME = "verification_orchestrator"
 #
 # Each background type maps to its own per-phase orchestration (issue
 # #429): phases 3 and 6 run the canonical grading-capable workflow,
-# phases 4 and 5 run the deterministic (never-grades) workflow. Phases 4
-# and 5 point at ``_v2`` names because the deterministic workflow dropped
-# an activity call; their legacy names stay registered as drain-only
-# orchestrators for in-flight jobs.
+# phases 4 and 5 run the deterministic (never-grades) workflow.
 _ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE = {
     SubmissionType.JOURNAL_API_VERIFIER: (
         "verify_phase3_journal_api_verifier_orchestrator"
     ),
-    SubmissionType.DEPLOYED_API: "verify_phase4_deployed_api_orchestrator_v2",
-    SubmissionType.DEVOPS_ANALYSIS: "verify_phase5_devops_orchestrator_v2",
+    SubmissionType.DEPLOYED_API: "verify_phase4_deployed_api_orchestrator",
+    SubmissionType.DEVOPS_ANALYSIS: "verify_phase5_devops_orchestrator",
     SubmissionType.SECURITY_SCANNING: "verify_phase6_security_orchestrator",
 }
 _VERIFY_RETRY_OPTIONS = df.RetryOptions(
@@ -509,10 +506,10 @@ def _run_verification_orchestration(context: df.DurableOrchestrationContext):
 def _deterministic_verification(context: df.DurableOrchestrationContext):
     """Workflow for phases that never LLM-grade (phases 4 and 5).
 
-    prepare -> verify -> persist. There is no ``collect_llm_grading_requests``
-    call, so this is a breaking change to the recorded activity sequence:
-    the phases adopting it use new (``_v2``) orchestrator names while the
-    legacy names drain in-flight jobs on the canonical workflow.
+    prepare -> verify -> persist, with no ``collect_llm_grading_requests``
+    call. These verification jobs are short-lived and low-volume, so the
+    orchestrator name is not versioned; the rare case of a job being
+    mid-flight across a deploy is acceptable and recoverable by resubmitting.
     """
     outcome = yield from _prepare_step(context)
     if isinstance(outcome, _TerminalOutcome):
@@ -594,40 +591,12 @@ def verify_phase3_journal_api_verifier_orchestrator(
 
 @app.orchestration_trigger(context_name="context")
 def verify_phase4_deployed_api_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for phase 4 deployed API jobs started before
-    the per-phase split (issue #429).
-
-    Phase 4 never LLM-grades, so new jobs run the deterministic workflow
-    under :func:`verify_phase4_deployed_api_orchestrator_v2`. Dropping the
-    ``collect_llm_grading_requests`` call changes the recorded activity
-    sequence, so this legacy name stays on the canonical workflow to
-    replay any in-flight pre-split job cleanly. Safe to remove after
-    Durable retention expires.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase4_deployed_api_orchestrator_v2(
-    context: df.DurableOrchestrationContext,
-):
     """Run Phase 4 deployed API verification (deterministic, no LLM grading)."""
     return (yield from _deterministic_verification(context))
 
 
 @app.orchestration_trigger(context_name="context")
 def verify_phase5_devops_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for phase 5 DevOps jobs started before the
-    per-phase split (issue #429).
-
-    See :func:`verify_phase4_deployed_api_orchestrator` for rationale. New
-    jobs run :func:`verify_phase5_devops_orchestrator_v2`.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase5_devops_orchestrator_v2(context: df.DurableOrchestrationContext):
     """Run Phase 5 DevOps verification (deterministic, no LLM grading)."""
     return (yield from _deterministic_verification(context))
 

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -91,10 +91,11 @@ _DEFAULT_ORCHESTRATOR_NAME = "verification_orchestrator"
 # this map only picks the orchestrator name for the background types.
 #
 # Each background type maps to its own per-phase orchestration (issue
-# #429): phases 3 and 6 use the graded workflow, phases 4 and 5 use the
-# deterministic workflow. Phases 4 and 5 point at ``_v2`` names because
-# the deterministic workflow dropped an activity call; their legacy names
-# stay registered as drain-only orchestrators for in-flight jobs.
+# #429): phases 3 and 6 run the canonical grading-capable workflow,
+# phases 4 and 5 run the deterministic (never-grades) workflow. Phases 4
+# and 5 point at ``_v2`` names because the deterministic workflow dropped
+# an activity call; their legacy names stay registered as drain-only
+# orchestrators for in-flight jobs.
 _ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE = {
     SubmissionType.JOURNAL_API_VERIFIER: (
         "verify_phase3_journal_api_verifier_orchestrator"
@@ -327,113 +328,6 @@ def _result_custom_status(
     return status
 
 
-def _run_verification_orchestration(context: df.DurableOrchestrationContext):
-    """Run one verification job workflow.
-
-    Input is a :class:`PreparedVerificationJob` payload dict (with
-    ``id``, ``requirement``, ``submitted_value`` etc.) -- the HTTP
-    starter always builds and posts one. Functions never reads
-    curriculum or users tables.
-    """
-    input_payload = context.get_input()
-    if not isinstance(input_payload, Mapping):
-        raise TypeError(
-            f"verification orchestration: expected Mapping input, "
-            f"got {type(input_payload).__name__}"
-        )
-    job_id_obj = input_payload.get("id")
-    job_id = job_id_obj if isinstance(job_id_obj, str) else str(job_id_obj)
-    _set_verification_span_attributes(job_id=job_id)
-    context.set_custom_status({"step": "preparing", "job_id": job_id})
-    preparation = yield context.call_activity_with_retry(
-        "prepare_verification_job",
-        _TRANSIENT_RETRY_OPTIONS,
-        input_payload,
-    )
-
-    terminal_result = preparation.get("terminal_result")
-    if terminal_result is not None:
-        result_payload = _activity_payload(terminal_result)
-        _set_result_span_attributes(result_payload)
-        context.set_custom_status(
-            _result_custom_status("completed", job_id, result_payload)
-        )
-        return terminal_result
-
-    prepared_job = preparation["job"]
-    prepared_job_payload = _activity_payload(prepared_job)
-    prepared_verification_job = PreparedVerificationJob.from_payload(
-        prepared_job_payload
-    )
-    _set_prepared_job_span_attributes(prepared_verification_job)
-    context.set_custom_status(
-        _job_custom_status("verifying", job_id, prepared_verification_job)
-    )
-    run_result = yield context.call_activity_with_retry(
-        "execute_requirement_verification",
-        _VERIFY_RETRY_OPTIONS,
-        prepared_job,
-    )
-    llm_requests = yield context.call_activity(
-        "collect_llm_grading_requests",
-        run_result,
-    )
-    if llm_requests:
-        context.set_custom_status(
-            _job_custom_status("llm_grading", job_id, prepared_verification_job)
-        )
-        config_status = yield context.call_activity("ensure_grading_config", None)
-        if not config_status.get("valid"):
-            missing = config_status.get("missing_vars") or []
-            run_result = yield context.call_activity(
-                "llm_grading_failed",
-                {
-                    "run_result": run_result,
-                    "detail": f"missing grading config: {', '.join(missing)}",
-                    "error_type": "MissingGradingConfig",
-                },
-            )
-        else:
-            try:
-                decisions: list[dict[str, object]] = []
-                for request_payload in llm_requests:
-                    decision_payload = yield context.call_activity_with_retry(
-                        "run_llm_grading",
-                        _LLM_RETRY_OPTIONS,
-                        request_payload,
-                    )
-                    decisions.append(_activity_payload(decision_payload))
-
-                run_result = yield context.call_activity(
-                    "apply_llm_grading_results",
-                    {"run_result": run_result, "decisions": decisions},
-                )
-            except Exception as exc:
-                run_result = yield context.call_activity(
-                    "llm_grading_failed",
-                    {
-                        "run_result": run_result,
-                        "detail": str(exc),
-                        "error_type": type(exc).__name__,
-                    },
-                )
-
-    context.set_custom_status(
-        _job_custom_status("persisting", job_id, prepared_verification_job)
-    )
-    result = yield context.call_activity_with_retry(
-        "persist_verification_result",
-        _TRANSIENT_RETRY_OPTIONS,
-        run_result,
-    )
-    result_payload = _activity_payload(result)
-    _set_result_span_attributes(result_payload)
-    context.set_custom_status(
-        _result_custom_status("completed", job_id, result_payload)
-    )
-    return result
-
-
 @dataclass(frozen=True)
 class _TerminalOutcome:
     """Preparation already decided the job's outcome; skip verification."""
@@ -450,17 +344,14 @@ class _PreparedOutcome:
     prepared_job: PreparedVerificationJob
 
 
-_PrepareOutcome = _TerminalOutcome | _PreparedOutcome
-
-
 def _prepare_step(context: df.DurableOrchestrationContext):
     """Validate and prepare the job. Shared first step for every workflow.
 
     Yields the ``prepare_verification_job`` activity and returns either a
     :class:`_TerminalOutcome` (preparation already decided the result) or a
     :class:`_PreparedOutcome`. Side effects (span attributes, custom
-    status) match the legacy body so phases that keep their orchestrator
-    name replay identically.
+    status) are kept in the order the canonical workflow has always used
+    so in-flight jobs replay identically.
     """
     input_payload = context.get_input()
     if not isinstance(input_payload, Mapping):
@@ -598,12 +489,14 @@ def _persist_step(
     return result
 
 
-def _graded_verification(context: df.DurableOrchestrationContext):
-    """Workflow for phases that may LLM-grade evidence (phases 3 and 6).
+def _run_verification_orchestration(context: df.DurableOrchestrationContext):
+    """Canonical verification workflow: prepare -> verify -> grade -> persist.
 
-    prepare -> verify -> llm_grading -> persist. The activity sequence is
-    identical to the legacy shared body for a graded job, so phases that
-    adopt this workflow keep their orchestrator name and replay cleanly.
+    The LLM grading step is data-driven: it runs only when the verify
+    step produced grading requests, so phases that never grade simply
+    pass through it. Used by the grading-capable phases (3 and 6), the
+    default orchestrator, and every drain-only legacy orchestrator, whose
+    in-flight jobs recorded this exact activity sequence.
     """
     outcome = yield from _prepare_step(context)
     if isinstance(outcome, _TerminalOutcome):
@@ -619,7 +512,7 @@ def _deterministic_verification(context: df.DurableOrchestrationContext):
     prepare -> verify -> persist. There is no ``collect_llm_grading_requests``
     call, so this is a breaking change to the recorded activity sequence:
     the phases adopting it use new (``_v2``) orchestrator names while the
-    legacy names drain in-flight jobs on the legacy body.
+    legacy names drain in-flight jobs on the canonical workflow.
     """
     outcome = yield from _prepare_step(context)
     if isinstance(outcome, _TerminalOutcome):
@@ -630,7 +523,7 @@ def _deterministic_verification(context: df.DurableOrchestrationContext):
 
 @app.orchestration_trigger(context_name="context")
 def verification_orchestrator(context: df.DurableOrchestrationContext):
-    """Run the legacy generic verification workflow."""
+    """Run the default verification workflow for unmapped submission types."""
     return (yield from _run_verification_orchestration(context))
 
 
@@ -696,7 +589,7 @@ def verify_phase3_journal_api_verifier_orchestrator(
     context: df.DurableOrchestrationContext,
 ):
     """Run Phase 3 journal API verification (CI gate + LLM rubric review)."""
-    return (yield from _graded_verification(context))
+    return (yield from _run_verification_orchestration(context))
 
 
 @app.orchestration_trigger(context_name="context")
@@ -707,9 +600,9 @@ def verify_phase4_deployed_api_orchestrator(context: df.DurableOrchestrationCont
     Phase 4 never LLM-grades, so new jobs run the deterministic workflow
     under :func:`verify_phase4_deployed_api_orchestrator_v2`. Dropping the
     ``collect_llm_grading_requests`` call changes the recorded activity
-    sequence, so this legacy name stays on the legacy body to replay any
-    in-flight pre-split job cleanly. Safe to remove after Durable retention
-    expires.
+    sequence, so this legacy name stays on the canonical workflow to
+    replay any in-flight pre-split job cleanly. Safe to remove after
+    Durable retention expires.
     """
     return (yield from _run_verification_orchestration(context))
 
@@ -742,7 +635,7 @@ def verify_phase5_devops_orchestrator_v2(context: df.DurableOrchestrationContext
 @app.orchestration_trigger(context_name="context")
 def verify_phase6_security_orchestrator(context: df.DurableOrchestrationContext):
     """Run Phase 6 security verification (probes + LLM rubric review)."""
-    return (yield from _graded_verification(context))
+    return (yield from _run_verification_orchestration(context))
 
 
 @app.activity_trigger(input_name="input_payload")

--- a/apps/verification-functions/pyproject.toml
+++ b/apps/verification-functions/pyproject.toml
@@ -24,6 +24,11 @@ learn-to-cloud-shared = { workspace = true }
 
 [dependency-groups]
 dev = [
+    "pytest>=8.4.2",
     "ruff==0.15.12",
     "ty==0.0.34",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = ["-ra", "-v"]

--- a/apps/verification-functions/tests/test_orchestrations.py
+++ b/apps/verification-functions/tests/test_orchestrations.py
@@ -161,14 +161,19 @@ def _sequence(calls: list[_RecordedCall]) -> list[tuple[str, str]]:
     return [call.as_tuple() for call in calls]
 
 
-class TestGradedWorkflow:
+class TestCanonicalWorkflow:
+    """The grading-capable workflow used by phases 3 and 6, the default
+    orchestrator, and the drain-only legacy orchestrators."""
+
     def test_grades_when_requests_present(self) -> None:
         payload = _graded_payload()
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
         responder = _make_responder(
             payload, llm_requests=[{"task": "a"}, {"task": "b"}]
         )
-        calls, result = _drive(function_app._graded_verification(ctx), responder)
+        calls, result = _drive(
+            function_app._run_verification_orchestration(ctx), responder
+        )
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
             ("activity_with_retry", "execute_requirement_verification"),
@@ -189,7 +194,7 @@ class TestGradedWorkflow:
         payload = _graded_payload()
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
         responder = _make_responder(payload, llm_requests=[])
-        calls, _ = _drive(function_app._graded_verification(ctx), responder)
+        calls, _ = _drive(function_app._run_verification_orchestration(ctx), responder)
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
             ("activity_with_retry", "execute_requirement_verification"),
@@ -203,7 +208,7 @@ class TestGradedWorkflow:
         responder = _make_responder(
             payload, llm_requests=[{"task": "a"}], config_valid=False
         )
-        calls, _ = _drive(function_app._graded_verification(ctx), responder)
+        calls, _ = _drive(function_app._run_verification_orchestration(ctx), responder)
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
             ("activity_with_retry", "execute_requirement_verification"),
@@ -221,7 +226,7 @@ class TestGradedWorkflow:
             llm_requests=[{"task": "a"}],
             fail_activity="run_llm_grading",
         )
-        calls, _ = _drive(function_app._graded_verification(ctx), responder)
+        calls, _ = _drive(function_app._run_verification_orchestration(ctx), responder)
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
             ("activity_with_retry", "execute_requirement_verification"),
@@ -237,7 +242,9 @@ class TestGradedWorkflow:
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
         terminal = {"job_id": "job-1", "status": "completed", "submission_id": 1}
         responder = _make_responder(payload, terminal=terminal)
-        calls, result = _drive(function_app._graded_verification(ctx), responder)
+        calls, result = _drive(
+            function_app._run_verification_orchestration(ctx), responder
+        )
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
         ]
@@ -274,10 +281,14 @@ class TestDeterministicWorkflow:
         assert result == terminal
 
 
-class TestLegacyDrainBody:
-    def test_deployed_api_still_calls_collect_on_legacy_body(self) -> None:
-        """In-flight phase 4/5 jobs replay on the legacy body, which keeps
-        the collect call so their recorded history still matches."""
+class TestDrainCompatibility:
+    def test_deterministic_phase_type_still_grades_on_canonical_workflow(
+        self,
+    ) -> None:
+        """A phase 4/5 job started before the split keeps its old orchestrator
+        name, which routes to the canonical workflow. That workflow still makes
+        the ``collect_llm_grading_requests`` call its recorded history expects,
+        so the in-flight job replays cleanly."""
         payload = _deterministic_payload()
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
         responder = _make_responder(payload, llm_requests=[])

--- a/apps/verification-functions/tests/test_orchestrations.py
+++ b/apps/verification-functions/tests/test_orchestrations.py
@@ -281,39 +281,18 @@ class TestDeterministicWorkflow:
         assert result == terminal
 
 
-class TestDrainCompatibility:
-    def test_deterministic_phase_type_still_grades_on_canonical_workflow(
-        self,
-    ) -> None:
-        """A phase 4/5 job started before the split keeps its old orchestrator
-        name, which routes to the canonical workflow. That workflow still makes
-        the ``collect_llm_grading_requests`` call its recorded history expects,
-        so the in-flight job replays cleanly."""
-        payload = _deterministic_payload()
-        ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
-        responder = _make_responder(payload, llm_requests=[])
-        calls, _ = _drive(function_app._run_verification_orchestration(ctx), responder)
-        assert _sequence(calls) == [
-            ("activity_with_retry", "prepare_verification_job"),
-            ("activity_with_retry", "execute_requirement_verification"),
-            ("activity", "collect_llm_grading_requests"),
-            ("activity_with_retry", "persist_verification_result"),
-        ]
-
-
 class TestOrchestratorNameMapping:
-    def test_phase4_and_phase5_use_v2_names(self) -> None:
+    def test_phase4_and_phase5_map_to_deterministic_orchestrators(self) -> None:
         names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
         assert (
             names[SubmissionType.DEPLOYED_API]
-            == "verify_phase4_deployed_api_orchestrator_v2"
+            == "verify_phase4_deployed_api_orchestrator"
         )
         assert (
-            names[SubmissionType.DEVOPS_ANALYSIS]
-            == "verify_phase5_devops_orchestrator_v2"
+            names[SubmissionType.DEVOPS_ANALYSIS] == "verify_phase5_devops_orchestrator"
         )
 
-    def test_phase3_and_phase6_keep_legacy_names(self) -> None:
+    def test_phase3_and_phase6_map_to_canonical_orchestrators(self) -> None:
         names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
         assert (
             names[SubmissionType.JOURNAL_API_VERIFIER]
@@ -328,10 +307,3 @@ class TestOrchestratorNameMapping:
         """Guards against pointing the resolver at a non-existent orchestrator."""
         for name in function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE.values():
             assert hasattr(function_app, name), f"missing orchestrator: {name}"
-
-    def test_legacy_drain_names_remain_registered(self) -> None:
-        for name in (
-            "verify_phase4_deployed_api_orchestrator",
-            "verify_phase5_devops_orchestrator",
-        ):
-            assert hasattr(function_app, name), f"missing drain orchestrator: {name}"

--- a/apps/verification-functions/tests/test_orchestrations.py
+++ b/apps/verification-functions/tests/test_orchestrations.py
@@ -1,0 +1,326 @@
+"""Per-phase orchestration workflow tests (issue #429).
+
+The Durable orchestration generators are driven manually here: a fake
+context records each yielded activity call, and the test feeds back the
+activity result. This asserts the exact sequence of activity calls each
+workflow makes, including the determinism-critical difference that the
+deterministic workflow (phases 4 and 5) never calls
+``collect_llm_grading_requests`` while the graded workflow (phases 3 and
+6) does.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+from typing import Any
+from uuid import uuid4
+
+import function_app
+from learn_to_cloud_shared.models import SubmissionType
+from learn_to_cloud_shared.testing.requirement_factories import (
+    deployed_api_requirement,
+    journal_api_verifier_requirement,
+)
+from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
+
+
+class _RecordedCall:
+    """A single activity call yielded by an orchestration generator."""
+
+    def __init__(self, kind: str, name: str, payload: object) -> None:
+        self.kind = kind
+        self.name = name
+        self.payload = payload
+
+    def as_tuple(self) -> tuple[str, str]:
+        return (self.kind, self.name)
+
+
+class _FakeOrchestrationContext:
+    """Minimal stand-in for ``DurableOrchestrationContext``.
+
+    Records custom-status updates and returns a :class:`_RecordedCall`
+    for each activity invocation so the driver can assert the call
+    sequence and feed back results.
+    """
+
+    def __init__(self, job_input: object) -> None:
+        self._input = job_input
+        self.statuses: list[object] = []
+
+    def get_input(self) -> object:
+        return self._input
+
+    def set_custom_status(self, status: object) -> None:
+        self.statuses.append(status)
+
+    def call_activity(self, name: str, input_: object = None) -> _RecordedCall:
+        return _RecordedCall("activity", name, input_)
+
+    def call_activity_with_retry(
+        self, name: str, retry_options: object, input_: object = None
+    ) -> _RecordedCall:
+        return _RecordedCall("activity_with_retry", name, input_)
+
+
+class _Raise:
+    """Marker telling the driver to throw into the generator (activity failure)."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
+
+
+Responder = Callable[[_RecordedCall], object]
+
+
+def _drive(
+    gen: Generator[_RecordedCall, object, object], responder: Responder
+) -> tuple[list[_RecordedCall], object]:
+    """Run an orchestration generator, feeding each yielded call a result."""
+    calls: list[_RecordedCall] = []
+    try:
+        call = next(gen)
+    except StopIteration as stop:
+        return calls, stop.value
+    while True:
+        calls.append(call)
+        result = responder(call)
+        try:
+            if isinstance(result, _Raise):
+                call = gen.throw(result.exc)
+            else:
+                call = gen.send(result)
+        except StopIteration as stop:
+            return calls, stop.value
+
+
+def _prepared_payload(requirement: Any, value: str) -> dict[str, object]:
+    job = PreparedVerificationJob(
+        id=uuid4(),
+        user_id=1,
+        github_username="alice",
+        requirement=requirement,
+        submitted_value=value,
+    )
+    return job.to_payload()
+
+
+def _graded_payload() -> dict[str, object]:
+    return _prepared_payload(
+        journal_api_verifier_requirement(slug="journal-api-implementation"),
+        "https://github.com/alice/journal",
+    )
+
+
+def _deterministic_payload() -> dict[str, object]:
+    return _prepared_payload(
+        deployed_api_requirement(slug="deployed-api"),
+        "https://api.example.com",
+    )
+
+
+def _make_responder(
+    prepared_payload: dict[str, object],
+    *,
+    llm_requests: list[object] | None = None,
+    config_valid: bool = True,
+    fail_activity: str | None = None,
+    terminal: object | None = None,
+) -> Responder:
+    def responder(call: _RecordedCall) -> object:
+        name = call.name
+        if fail_activity is not None and name == fail_activity:
+            return _Raise(RuntimeError("activity failed"))
+        if name == "prepare_verification_job":
+            if terminal is not None:
+                return {"terminal_result": terminal}
+            return {"job": prepared_payload}
+        if name == "execute_requirement_verification":
+            return {"status": "verified"}
+        if name == "collect_llm_grading_requests":
+            return list(llm_requests or [])
+        if name == "ensure_grading_config":
+            return {
+                "valid": config_valid,
+                "missing_vars": [] if config_valid else ["AZURE_AI_FOUNDRY_ENDPOINT"],
+            }
+        if name == "run_llm_grading":
+            return {"decision": "pass"}
+        if name == "apply_llm_grading_results":
+            return {"status": "graded"}
+        if name == "llm_grading_failed":
+            return {"status": "failed"}
+        if name == "persist_verification_result":
+            return {"job_id": "job-1", "status": "completed", "submission_id": 7}
+        raise AssertionError(f"unexpected activity call: {name}")
+
+    return responder
+
+
+def _sequence(calls: list[_RecordedCall]) -> list[tuple[str, str]]:
+    return [call.as_tuple() for call in calls]
+
+
+class TestGradedWorkflow:
+    def test_grades_when_requests_present(self) -> None:
+        payload = _graded_payload()
+        ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
+        responder = _make_responder(
+            payload, llm_requests=[{"task": "a"}, {"task": "b"}]
+        )
+        calls, result = _drive(function_app._graded_verification(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_job"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity", "collect_llm_grading_requests"),
+            ("activity", "ensure_grading_config"),
+            ("activity_with_retry", "run_llm_grading"),
+            ("activity_with_retry", "run_llm_grading"),
+            ("activity", "apply_llm_grading_results"),
+            ("activity_with_retry", "persist_verification_result"),
+        ]
+        assert result == {
+            "job_id": "job-1",
+            "status": "completed",
+            "submission_id": 7,
+        }
+
+    def test_skips_grading_when_no_requests(self) -> None:
+        payload = _graded_payload()
+        ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
+        responder = _make_responder(payload, llm_requests=[])
+        calls, _ = _drive(function_app._graded_verification(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_job"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity", "collect_llm_grading_requests"),
+            ("activity_with_retry", "persist_verification_result"),
+        ]
+
+    def test_missing_grading_config_fails_gracefully(self) -> None:
+        payload = _graded_payload()
+        ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
+        responder = _make_responder(
+            payload, llm_requests=[{"task": "a"}], config_valid=False
+        )
+        calls, _ = _drive(function_app._graded_verification(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_job"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity", "collect_llm_grading_requests"),
+            ("activity", "ensure_grading_config"),
+            ("activity", "llm_grading_failed"),
+            ("activity_with_retry", "persist_verification_result"),
+        ]
+
+    def test_grading_activity_failure_falls_back(self) -> None:
+        payload = _graded_payload()
+        ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
+        responder = _make_responder(
+            payload,
+            llm_requests=[{"task": "a"}],
+            fail_activity="run_llm_grading",
+        )
+        calls, _ = _drive(function_app._graded_verification(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_job"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity", "collect_llm_grading_requests"),
+            ("activity", "ensure_grading_config"),
+            ("activity_with_retry", "run_llm_grading"),
+            ("activity", "llm_grading_failed"),
+            ("activity_with_retry", "persist_verification_result"),
+        ]
+
+    def test_terminal_preparation_returns_without_verifying(self) -> None:
+        payload = _graded_payload()
+        ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
+        terminal = {"job_id": "job-1", "status": "completed", "submission_id": 1}
+        responder = _make_responder(payload, terminal=terminal)
+        calls, result = _drive(function_app._graded_verification(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_job"),
+        ]
+        assert result == terminal
+
+
+class TestDeterministicWorkflow:
+    def test_never_calls_collect_llm_grading(self) -> None:
+        payload = _deterministic_payload()
+        ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
+        responder = _make_responder(payload)
+        calls, result = _drive(function_app._deterministic_verification(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_job"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity_with_retry", "persist_verification_result"),
+        ]
+        assert all(call.name != "collect_llm_grading_requests" for call in calls)
+        assert result == {
+            "job_id": "job-1",
+            "status": "completed",
+            "submission_id": 7,
+        }
+
+    def test_terminal_preparation_returns_without_verifying(self) -> None:
+        payload = _deterministic_payload()
+        ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
+        terminal = {"job_id": "job-1", "status": "completed", "submission_id": 1}
+        responder = _make_responder(payload, terminal=terminal)
+        calls, result = _drive(function_app._deterministic_verification(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_job"),
+        ]
+        assert result == terminal
+
+
+class TestLegacyDrainBody:
+    def test_deployed_api_still_calls_collect_on_legacy_body(self) -> None:
+        """In-flight phase 4/5 jobs replay on the legacy body, which keeps
+        the collect call so their recorded history still matches."""
+        payload = _deterministic_payload()
+        ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
+        responder = _make_responder(payload, llm_requests=[])
+        calls, _ = _drive(function_app._run_verification_orchestration(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_job"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity", "collect_llm_grading_requests"),
+            ("activity_with_retry", "persist_verification_result"),
+        ]
+
+
+class TestOrchestratorNameMapping:
+    def test_phase4_and_phase5_use_v2_names(self) -> None:
+        names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
+        assert (
+            names[SubmissionType.DEPLOYED_API]
+            == "verify_phase4_deployed_api_orchestrator_v2"
+        )
+        assert (
+            names[SubmissionType.DEVOPS_ANALYSIS]
+            == "verify_phase5_devops_orchestrator_v2"
+        )
+
+    def test_phase3_and_phase6_keep_legacy_names(self) -> None:
+        names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
+        assert (
+            names[SubmissionType.JOURNAL_API_VERIFIER]
+            == "verify_phase3_journal_api_verifier_orchestrator"
+        )
+        assert (
+            names[SubmissionType.SECURITY_SCANNING]
+            == "verify_phase6_security_orchestrator"
+        )
+
+    def test_every_mapped_name_is_registered(self) -> None:
+        """Guards against pointing the resolver at a non-existent orchestrator."""
+        for name in function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE.values():
+            assert hasattr(function_app, name), f"missing orchestrator: {name}"
+
+    def test_legacy_drain_names_remain_registered(self) -> None:
+        for name in (
+            "verify_phase4_deployed_api_orchestrator",
+            "verify_phase5_devops_orchestrator",
+        ):
+            assert hasattr(function_app, name), f"missing drain orchestrator: {name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,12 +31,12 @@ help = "Run all static checks (lint, format, type-check, migration SQL, file hyg
 cmd = "prek run --all-files --show-diff-on-failure"
 
 [tool.poe.tasks.test]
-help = "Run the test suites (with coverage gates) and the verification-functions import smoke test"
+help = "Run the test suites (with coverage gates) and the verification-functions orchestration tests"
 shell = """
 set -e
 (cd api && uv run pytest tests/ --cov=learn_to_cloud --cov-report=term-missing)
 (cd packages/learn-to-cloud-shared && uv run pytest tests/ --cov=learn_to_cloud_shared --cov-report=term-missing)
-(cd apps/verification-functions && uv run python -c "import function_app")
+(cd apps/verification-functions && uv run pytest tests/)
 """
 
 [tool.poe.tasks.check]

--- a/uv.lock
+++ b/uv.lock
@@ -1019,6 +1019,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -1035,6 +1036,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=8.4.2" },
     { name = "ruff", specifier = "==0.15.12" },
     { name = "ty", specifier = "==0.0.34" },
 ]


### PR DESCRIPTION
Closes #429.

## What this does
The Durable Functions verification host used a single shared orchestration generator for every phase. This splits it into explicit per-phase workflows so each phase's shape is obvious and easy to change in the future, without changing what any phase actually does.

## The two workflows
- **Canonical** (phases 3 and 6, plus the default and drain-only legacy orchestrators): prepare, verify, llm_grading, persist. The grading step is data-driven, so it runs only when the verify step produced grading requests.
- **Deterministic** (phases 4 and 5, which never grade): prepare, verify, persist. No grading call at all.

Both are built from the same small step helpers (prepare / verify / llm_grading / persist), so there is one source of truth per step and no duplicated orchestration body.

## A note on replay safety
Durable Functions replays an in-flight orchestration by re-matching each step against its recorded history. The deterministic workflow drops the `collect_llm_grading_requests` step, which changes that recorded sequence for phases 4 and 5.

Production data shows phases 4 and 5 are live but low-volume (about a dozen verification jobs each over their lifetime, zero in flight at the time of this change), and the jobs are short-lived. The only exposure is a job that happens to be mid-orchestration during the exact deploy window, whose worst case is a single resubmit. Given that, phases 4 and 5 simply run the deterministic workflow under their existing orchestrator names; no orchestrator-name versioning or drain-only scaffolding is used.

## Tests
The Functions app had no test suite (only an import smoke check). Added an orchestration test suite that drives each workflow generator and asserts:
- the exact activity-call sequence for the canonical and deterministic workflows,
- the early return when preparation already has a result,
- the grading fallbacks (missing config, grading activity failure),
- that the deterministic workflow never calls `collect_llm_grading_requests`,
- that every orchestrator name the router points at is actually registered.

Wired this suite into the quality gate (`poe test`) in place of the old import smoke test. Full `uv run poe check` passes locally (static + 512 existing tests + 10 new ones).