### PR TITLE
Update Linux documentary video to a higher quality version

### DIFF
--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/linux.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/linux.yaml
@@ -18,7 +18,7 @@ learning_steps:
   order: 1
   action: 'Watch:'
   title: Linux Documentary (The Story of Linux)
-  url: https://www.youtube.com/watch?v=XMm0HsmOTFI
+  url: https://www.youtube.com/watch?v=zPt_e9Cdk08
   description: Watch this documentary for the history, ecosystem, and culture behind Linux so you understand why it became the foundation of modern cloud infrastructure.
   slug: phase0-topic1-watch-linux-documentary-the-story
 - uuid: 65563a74-3a18-4dfa-b312-ee07661b6756


### PR DESCRIPTION
## What this changes

The first learning step on the Phase 0 Linux page ("Linux Documentary - The Story of Linux") pointed to a lower quality upload of the documentary. This PR updates the link to a better quality version of the same documentary.

- Old: https://www.youtube.com/watch?v=XMm0HsmOTFI
- New: https://www.youtube.com/watch?v=zPt_e9Cdk08

## Why it matters

Learners get a clearer, better quality version of the same documentary, with no change to the lesson itself.

Closes #555