### PR TITLE
Add issue intake triage automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Report a bug in the app, API, verification flow, or content experience
+title: "[BUG] "
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**System information:**
+- OS: [e.g. macOS, Windows, Linux (Ubuntu)]
+- Browser: [e.g. Chrome 126]
+- Environment: [local / production]
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Run '...'
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+What actually happened, including error messages.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "💬 Community Discussions"
+    url: https://github.com/learntocloud/learn-to-cloud-app/discussions
+    about: "Ask questions, get challenge help, or suggest features in Discussions"

--- a/.github/workflows/new-issue.yaml
+++ b/.github/workflows/new-issue.yaml
@@ -1,0 +1,105 @@
+name: Issue Triage and Intake
+
+on:
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Classify and label issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const title = issue.title?.toLowerCase() || '';
+            const body = issue.body?.toLowerCase() || '';
+            const combined = `${title} ${body}`;
+            const labels = [];
+
+            const isVerification = combined.includes('verify') ||
+              combined.includes('verification') ||
+              combined.includes('phase') ||
+              combined.includes('ctf') ||
+              combined.includes('token') ||
+              combined.includes('progress');
+            const isDocumentation = combined.includes('docs') ||
+              combined.includes('documentation') ||
+              combined.includes('readme') ||
+              combined.includes('typo');
+            const isFeature = combined.includes('feature request') ||
+              combined.includes('enhancement') ||
+              title.includes('[feature]') ||
+              title.startsWith('feature:');
+            const isQuestion = title.startsWith('question:') ||
+              combined.includes('how do i') ||
+              combined.includes('how to') ||
+              combined.includes('can someone help') ||
+              combined.includes('question');
+            const isBug = title.includes('[bug]') ||
+              title.startsWith('bug:') ||
+              combined.includes('bug') ||
+              combined.includes('error') ||
+              combined.includes('fails') ||
+              combined.includes('not working') ||
+              combined.includes('cannot ');
+
+            labels.push('community automation');
+            if (isVerification) labels.push('needs verification');
+            if (isDocumentation) labels.push('documentation');
+            if (isFeature) labels.push('enhancement');
+            if (isQuestion && !isFeature && !isBug) labels.push('question');
+            if (isBug) labels.push('bug');
+            if (!isBug && !isFeature && !isQuestion) labels.push('question');
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: [...new Set(labels)],
+            });
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              assignees: ['madebygps', 'rishabkumar7'],
+            });
+
+      - name: Post intake guidance comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const title = issue.title?.toLowerCase() || '';
+            const body = issue.body?.toLowerCase() || '';
+            const combined = `${title} ${body}`;
+            const isVerification = combined.includes('verify') ||
+              combined.includes('verification') ||
+              combined.includes('phase') ||
+              combined.includes('ctf') ||
+              combined.includes('token') ||
+              combined.includes('progress');
+
+            let message = `Thanks for opening this issue. We've auto-labeled it to speed up triage.\n\n`;
+            message += `A maintainer will review this soon.`;
+
+            if (isVerification) {
+              message += `\n\nTo unblock faster, please add:\n`;
+              message += `- your username\n`;
+              message += `- phase number\n`;
+              message += `- whether this is local or production\n`;
+              message += `- the exact error text and timestamp`;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: message,
+            });


### PR DESCRIPTION
## Summary

This adds lightweight issue intake automation so new and reopened issues are triaged consistently without copying linux-ctfs behavior. The workflow classifies issue content, applies existing repo labels (`community automation`, `bug`, `question`, `enhancement`, `documentation`, `needs verification`), auto-assigns `@madebygps` and `@rishabkumar7`, and posts a short intake comment with extra debugging prompts only for verification-related reports.

It also adds a single streamlined bug template and issue-template config that disables blank issues and points general support/ideas to Discussions.

Fixes: #576

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed. (N/A - no migration or schema changes)