### PR TITLE
Add VS Code task to migrate and sync curriculum

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,11 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "API: migrate + sync curriculum",
+      "type": "shell",
+      "command": "cd ${workspaceFolder}/api && uv run alembic upgrade head && uv run python -m learn_to_cloud_shared.cli.sync_curriculum",
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
Adds a one-click "API: migrate + sync curriculum" VS Code task that runs the Alembic migration and curriculum sync against the local database.

Editor convenience only; no application code changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>