### PR TITLE
fix: rename Join the Community to Ask the Community, drop stale Disco…

### DIFF
--- a/api/src/learn_to_cloud/rendering/context.py
+++ b/api/src/learn_to_cloud/rendering/context.py
@@ -104,7 +104,7 @@ _X_SVG = (
 HELP_LINKS: list[dict[str, str]] = [
     {
         "url": "https://github.com/learntocloud/learn-to-cloud-app/discussions",
-        "label": "Join the Community",
+        "label": "Ask the Community",
         "color": "text-indigo-500 dark:text-indigo-400",
         "icon": (
             '<svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none"'

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase7/networking.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase7/networking.yaml
@@ -28,7 +28,7 @@ learning_steps:
   title: Attend one tech event
   description: Now go use the introduction you practiced. Attend one tech event. In-person is ideal, but online is fine if needed. The goal is practice and relationship building, not instant job offers.
   checklist:
-  - "**Find an event.** Search Meetup, local cloud or DevOps user groups, your cloud provider's community days, or online communities like the Learn to Cloud Discord"
+  - "**Find an event.** Search Meetup, local cloud or DevOps user groups, your cloud provider's community days, or check the [Learn to Cloud Discussions](https://github.com/learntocloud/learn-to-cloud-app/discussions) for what others are attending"
   - "**Show up.** Go in with low pressure. Your only job is to have a few genuine conversations"
   - "**Use your introduction when it fits.** You practiced it for a reason, so lean on it when a conversation starts, and pay attention to how it lands"
   - "**Talk about the work you actually care about.** Bring up something you've explored or focused on, see how people respond, and let their reactions spark more of your own exploration"


### PR DESCRIPTION
…rd mention

The Need Help section on the dashboard linked to GitHub Discussions under the label "Join the Community". That label now reads "Ask the Community" to better match what the link is for.

Phase 7's networking content also mentioned an "online community like the Learn to Cloud Discord", but that Discord server doesn't exist. That mention is removed and replaced with a link to the GitHub Discussions page instead.

## Summary

<!-- What does this PR do and why? -->

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.
