### PR TITLE
fix: make verification attempt alert query resilient to AppMetrics schema lag

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -319,7 +319,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
 
   criteria {
     query                   = <<-QUERY
-      AppMetrics
+      union isfuzzy=true AppMetrics
       | where Name == "verification.attempt"
       | extend result = tostring(Properties['result'])
       | summarize Total = sum(Sum), Failed = sumif(Sum, result in ("fail", "error"))


### PR DESCRIPTION
## What broke

The dev deploy failed during `terraform apply` because the new `verification_attempt_failure_rate` alert rule's query referenced the `AppMetrics` table, and Azure Monitor's alert validation rejected it with:

```
Failed to resolve table or column expression named 'AppMetrics'
```

## Why it happened

`AppMetrics` is the right table name for our custom `verification.attempt` OTel metric. The table itself only gets recognized by Azure Monitor's alert validation once data has actually started flowing into the workspace, and there's a propagation lag between the first write and when alert validation picks it up. Microsoft's own troubleshooting docs for log search alerts list this exact scenario (custom tables not yet created/recognized because data flow just started) as a known cause of query failures.

I verified this directly against the real dev Log Analytics workspace (`log-ltc-dev-8v4tyz`): the table and data already existed, but validation hadn't caught up yet at apply time.

## The fix

Wrap the query in `union isfuzzy=true AppMetrics` instead of just `AppMetrics`. This is the Microsoft-documented pattern for exactly this situation: if the table can't be resolved yet, the query treats it as zero rows instead of throwing a hard error, so the alert rule still deploys successfully. Once the table is recognized, behavior is identical.

I confirmed this with a live query against the dev workspace: both the old and new query forms return the same result (a real failure rate percentage) now that the table is recognized, so this change does not alter the alert's actual behavior, it only makes deployment resilient to the timing gap.

## Why CI/terraform plan couldn't catch this

This is not something `terraform validate` or `terraform plan` can catch locally. The failure only happens when Azure Monitor's live API validates the KQL query against the real, currently ingested workspace schema, which only happens during `apply`. There's no static check that can predict ingestion timing for a brand-new metric.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>