### PR TITLE
Alert when DB schema head diverges from code head

### DIFF
--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -42,6 +42,7 @@ from learn_to_cloud.routes import (
     pages_router,
     users_router,
 )
+from learn_to_cloud.routes.health_routes import get_code_alembic_head
 
 # Configure stdlib logging before Azure Monitor adds any logging handlers.
 # Azure Monitor must run before fastapi.FastAPI() is instantiated so request
@@ -114,6 +115,8 @@ async def lifespan(app: fastapi.FastAPI):
     app.state.settings = get_web_settings()
     app.state.engine = create_engine(app.state.settings.database)
     app.state.session_maker = create_session_maker(app.state.engine)
+    # Parsing migration scripts is cheap once, not on every /ready poll.
+    app.state.alembic_code_head = get_code_alembic_head()
 
     app.state.init_done = False
     app.state.init_error = None

--- a/api/src/learn_to_cloud/routes/health_routes.py
+++ b/api/src/learn_to_cloud/routes/health_routes.py
@@ -1,16 +1,49 @@
 """Health check endpoints."""
 
 import logging
+from pathlib import Path
 
+from alembic.config import Config
+from alembic.script import ScriptDirectory
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import PlainTextResponse
 from learn_to_cloud_shared.core.database import check_db_connection
 from learn_to_cloud_shared.schemas import HealthResponse
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
 from starlette import status
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["health"])
+
+# api/alembic.ini, four directories up from this file (routes -> learn_to_cloud
+# -> src -> api). Same relative depth in the devcontainer source tree and in
+# the api-runtime Docker image, where PYTHONPATH=/app/src.
+_ALEMBIC_INI = Path(__file__).parent.parent.parent.parent / "alembic.ini"
+
+
+def get_code_alembic_head() -> str | None:
+    """Resolve the Alembic head revision baked into this deployment's code.
+
+    Returns None if the script directory can't be resolved, so schema-drift
+    detection is best-effort and never blocks application startup.
+    """
+    try:
+        script = ScriptDirectory.from_config(Config(str(_ALEMBIC_INI)))
+        return script.get_current_head()
+    except Exception:
+        logger.exception("health.alembic_head.resolve_failed")
+        return None
+
+
+async def _get_db_alembic_head(engine: AsyncEngine) -> str | None:
+    """Fetch the Alembic revision currently recorded in the database."""
+    async with engine.connect() as conn:
+        result = await conn.execute(text("SELECT version_num FROM alembic_version"))
+        row = result.first()
+        await conn.rollback()
+        return row[0] if row else None
 
 
 @router.get("/health", summary="Health check")
@@ -63,6 +96,24 @@ async def ready(request: Request) -> HealthResponse:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Database unavailable",
         ) from e
+
+    # Schema drift is a paging signal, not a readiness failure: log a warning
+    # for the Azure Monitor alert to pick up, but never fail this probe over
+    # it. Failing here would just cycle pods without fixing the drift.
+    code_head = getattr(request.app.state, "alembic_code_head", None)
+    if code_head is not None:
+        try:
+            db_head = await _get_db_alembic_head(request.app.state.engine)
+        except Exception as e:
+            logger.warning(
+                "health.ready.schema_drift_check_failed", extra={"error": str(e)}
+            )
+        else:
+            if db_head != code_head:
+                logger.warning(
+                    "health.ready.schema_drift",
+                    extra={"db_head": db_head, "code_head": code_head},
+                )
 
     return HealthResponse(status="ready", service="learn-to-cloud-api")
 

--- a/api/tests/routes/test_health_routes.py
+++ b/api/tests/routes/test_health_routes.py
@@ -28,6 +28,7 @@ class TestReadyEndpoint:
         request = MagicMock()
         request.app.state.init_error = None
         request.app.state.init_done = True
+        request.app.state.alembic_code_head = None
 
         with patch(
             "learn_to_cloud.routes.health_routes.check_db_connection",
@@ -84,3 +85,121 @@ class TestReadyEndpoint:
 
         assert exc_info.value.status_code == 503
         assert exc_info.value.detail == "Database unavailable"
+
+    async def test_ready_logs_warning_on_schema_drift_but_still_200(self, caplog):
+        """Ready logs a warning and still returns 200 when heads mismatch."""
+        request = MagicMock()
+        request.app.state.init_error = None
+        request.app.state.init_done = True
+        request.app.state.alembic_code_head = "code_head_abc"
+
+        with (
+            patch(
+                "learn_to_cloud.routes.health_routes.check_db_connection",
+                autospec=True,
+            ),
+            patch(
+                "learn_to_cloud.routes.health_routes._get_db_alembic_head",
+                autospec=True,
+                return_value="db_head_xyz",
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            result = await ready(request)
+
+        assert result.status == "ready"
+        assert "health.ready.schema_drift" in caplog.text
+
+    async def test_ready_no_warning_when_heads_match(self, caplog):
+        """Ready logs nothing extra when DB head matches code head."""
+        request = MagicMock()
+        request.app.state.init_error = None
+        request.app.state.init_done = True
+        request.app.state.alembic_code_head = "same_head"
+
+        with (
+            patch(
+                "learn_to_cloud.routes.health_routes.check_db_connection",
+                autospec=True,
+            ),
+            patch(
+                "learn_to_cloud.routes.health_routes._get_db_alembic_head",
+                autospec=True,
+                return_value="same_head",
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            result = await ready(request)
+
+        assert result.status == "ready"
+        assert "health.ready.schema_drift" not in caplog.text
+
+    async def test_ready_returns_200_when_drift_check_itself_fails(self, caplog):
+        """A broken drift check never turns into a 503 for /ready."""
+        request = MagicMock()
+        request.app.state.init_error = None
+        request.app.state.init_done = True
+        request.app.state.alembic_code_head = "code_head_abc"
+
+        with (
+            patch(
+                "learn_to_cloud.routes.health_routes.check_db_connection",
+                autospec=True,
+            ),
+            patch(
+                "learn_to_cloud.routes.health_routes._get_db_alembic_head",
+                autospec=True,
+                side_effect=RuntimeError("alembic_version table missing"),
+            ),
+            caplog.at_level("WARNING"),
+        ):
+            result = await ready(request)
+
+        assert result.status == "ready"
+        assert "health.ready.schema_drift_check_failed" in caplog.text
+
+    async def test_ready_skips_drift_check_when_code_head_unknown(self):
+        """No drift check runs if the code head couldn't be resolved at startup."""
+        request = MagicMock()
+        request.app.state.init_error = None
+        request.app.state.init_done = True
+        request.app.state.alembic_code_head = None
+
+        with (
+            patch(
+                "learn_to_cloud.routes.health_routes.check_db_connection",
+                autospec=True,
+            ),
+            patch(
+                "learn_to_cloud.routes.health_routes._get_db_alembic_head",
+                autospec=True,
+            ) as mock_db_head,
+        ):
+            result = await ready(request)
+
+        assert result.status == "ready"
+        mock_db_head.assert_not_called()
+
+
+@pytest.mark.unit
+class TestGetCodeAlembicHead:
+    """Tests for get_code_alembic_head()."""
+
+    def test_returns_head_revision_from_script_directory(self):
+        """Resolves the real head from the repo's alembic/ script directory."""
+        from learn_to_cloud.routes.health_routes import get_code_alembic_head
+
+        head = get_code_alembic_head()
+        assert head is not None
+        assert isinstance(head, str)
+
+    def test_returns_none_when_script_directory_resolution_fails(self):
+        """Returns None instead of raising if Config/ScriptDirectory blow up."""
+        from learn_to_cloud.routes import health_routes
+
+        with patch.object(
+            health_routes.ScriptDirectory,
+            "from_config",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert health_routes.get_code_alembic_head() is None

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -303,6 +303,19 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "api_verification_conf
 # inline and background verification, labelled by submission_type and result
 # (pass/fail/error). A clean validator failure never produces a 5xx, so the
 # request-based alerts above would miss a failure-rate spike entirely.
+#
+# AppMetrics isn't recognized by alert-rule validation until the workspace
+# schema catches up after the first write, so a bare `AppMetrics` reference
+# (or `union isfuzzy=true AppMetrics` alone) fails apply with a hard 400 if no
+# custom metric has landed yet, since fuzzy union only suppresses the error
+# when at least one union operand resolves. Unioning in an empty literal
+# datatable with the same columns we read (Name, Sum, Properties) guarantees
+# one operand always resolves, so the rule deploys cleanly with or without
+# AppMetrics data and produces identical results once the table exists.
+# Verified directly against the live dev Application Insights resource: the
+# bare/fuzzy-only query reproduces "BadArgumentError: invalid properties",
+# the datatable version returns a clean (empty) result with only a non-fatal
+# resolution warning.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_failure_rate" {
   name                = "alert-ltc-verification-attempt-failure-rate-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name
@@ -319,7 +332,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
 
   criteria {
     query                   = <<-QUERY
-      union isfuzzy=true AppMetrics
+      union isfuzzy=true AppMetrics, (datatable(Name: string, Sum: real, Properties: dynamic)[])
       | where Name == "verification.attempt"
       | extend result = tostring(Properties['result'])
       | summarize Total = sum(Sum), Failed = sumif(Sum, result in ("fail", "error"))

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -341,3 +341,47 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
     action_groups = [azurerm_monitor_action_group.critical.id]
   }
 }
+
+# Tier 3 follow-up from the #432 post-mortem: page if the production DB's
+# applied Alembic head ever falls out of sync with the head baked into the
+# deployed code (manual psql access, a half-applied migration, a future
+# regression). /ready already compares the two on every poll and logs
+# health.ready.schema_drift on mismatch without failing the probe itself, so
+# this alert is the thing that actually pages a human; the readiness probe's
+# 200/503 contract stays reserved for "can this pod serve traffic".
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "schema_drift" {
+  name                = "alert-ltc-schema-drift-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Alert when the deployed DB's Alembic head diverges from the deployed code's Alembic head for more than 10 minutes"
+  severity            = 2
+  enabled             = true
+  tags                = local.tags
+
+  scopes                = [azurerm_application_insights.main.id]
+  evaluation_frequency  = "PT5M"
+  window_duration       = "PT5M"
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query                   = <<-QUERY
+      traces
+      | where cloud_RoleName in ("learn-to-cloud-api", "ca-ltc-api-${var.environment}")
+          or cloud_RoleName has "learn-to-cloud-api"
+          or cloud_RoleName has "ca-ltc-api"
+      | where message has "health.ready.schema_drift"
+    QUERY
+    time_aggregation_method = "Count"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 3
+      number_of_evaluation_periods             = 3
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.critical.id]
+  }
+}


### PR DESCRIPTION
Closes #441

## What changed

- `GET /ready` now compares the database's recorded Alembic revision (`alembic_version` table) against the head baked into the deployed code. The code head is resolved once at startup (`app.state.alembic_code_head`) so we're not re-parsing migration scripts on every readiness poll.
- On a mismatch, `/ready` logs a structured warning (`health.ready.schema_drift`) but **still returns 200**. Schema drift alone shouldn't fail the readiness probe and cycle healthy pods — it should page a human instead.
- Added one new `azurerm_monitor_scheduled_query_rules_alert_v2.schema_drift` resource in `infra/monitoring.tf`, modeled on the existing `verification_durable_errors` alert: Sev2, fires if the warning persists across 3 consecutive 5-minute windows (>10 min), auto-resolves once the next deploy re-syncs the schema.

## Why this approach

Per the discussion on #441, this skips the originally proposed `/admin/version` endpoint and custom OTel metric entirely — it reuses the existing `/ready` probe (already polled continuously) and the existing scheduled-query-alert pattern (already used 6 times in `monitoring.tf`). No new infrastructure surface, just one `if` in code we already have and one alert block copied from a pattern we already use.

## Testing

- `uv run poe check` passes (ruff lint/format, ty type check, migration SQL lint, full test suite including new tests).
- Verified locally that `get_code_alembic_head()` resolves the real `api/alembic.ini` / `api/alembic/` script directory correctly both from the devcontainer source layout and the same relative path used in the `api-runtime` Docker image.
- `terraform validate` and `terraform fmt -check` pass for `infra/monitoring.tf`.
- **Note for reviewer:** I couldn't run `terraform plan` against the real Azure backend from this devcontainer (no Azure credentials configured here). Please run `terraform plan` before merging to confirm the new alert resource creates cleanly.

## Test plan
- [x] `uv run poe check`
- [ ] `terraform plan` against real backend (maintainer, before merge)