### PR TITLE
chore: remove dead code

### DIFF
--- a/packages/learn-to-cloud-shared/pyproject.toml
+++ b/packages/learn-to-cloud-shared/pyproject.toml
@@ -15,7 +15,6 @@ version = "0.1.0"
 description = "Shared Learn to Cloud domain, database, and verification code"
 requires-python = ">=3.13"
 dependencies = [
-    "aiohttp>=3.14.1",
     "asyncpg>=0.31.0",
     "azure-identity>=1.25.2",
     "azure-monitor-opentelemetry>=1.8.6",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py
@@ -17,17 +17,13 @@ validators, use ``learn_to_cloud_shared.content_yaml_loader``.
 
 from __future__ import annotations
 
-from uuid import UUID
-
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from learn_to_cloud_shared.content_db_loader import (
     load_all_phases_from_db,
     load_phase_by_slug_from_db,
-    load_topic_by_slugs_from_db,
-    load_topic_by_uuid_from_db,
 )
-from learn_to_cloud_shared.schemas import Phase, Topic
+from learn_to_cloud_shared.schemas import Phase
 
 
 async def get_all_phases(db: AsyncSession) -> tuple[Phase, ...]:
@@ -38,15 +34,3 @@ async def get_all_phases(db: AsyncSession) -> tuple[Phase, ...]:
 async def get_phase_by_slug(db: AsyncSession, slug: str) -> Phase | None:
     """Get a phase by its slug (e.g. ``phase1``)."""
     return await load_phase_by_slug_from_db(db, slug)
-
-
-async def get_topic_by_uuid(db: AsyncSession, topic_uuid: UUID) -> Topic | None:
-    """Get a topic by its UUID."""
-    return await load_topic_by_uuid_from_db(db, topic_uuid)
-
-
-async def get_topic_by_slugs(
-    db: AsyncSession, phase_slug: str, topic_slug: str
-) -> Topic | None:
-    """Get a topic by ``(phase_slug, topic_slug)``."""
-    return await load_topic_by_slugs_from_db(db, phase_slug, topic_slug)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
@@ -81,11 +81,6 @@ async def _get_client() -> httpx.AsyncClient:
     return await _pool.get()
 
 
-async def close_deployed_api_client() -> None:
-    """Close the shared HTTP client (called on application shutdown)."""
-    await _pool.close()
-
-
 def _is_valid_url(value: str) -> bool:
     """Check if a string is a valid HTTPS URL."""
     parsed = urlparse(value)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/execution.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Awaitable, Callable
 
 from opentelemetry import trace
 from sqlalchemy import text
@@ -29,10 +28,6 @@ from learn_to_cloud_shared.verification.github_profile import parse_github_url
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
-SubmissionPersistHook = Callable[
-    [AsyncSession, Submission, ValidationResult],
-    Awaitable[None],
-]
 MAX_VALIDATION_MESSAGE_LENGTH = 1024
 
 
@@ -173,59 +168,6 @@ def build_submission_result(
         repo_exists=validation_result.repo_exists,
         task_results=validation_result.task_results,
     )
-
-
-async def execute_submission_validation(
-    *,
-    session_maker: async_sessionmaker[AsyncSession],
-    user_id: int,
-    requirement: HandsOnRequirement,
-    submitted_value: str,
-    github_username: str | None,
-    after_persist: SubmissionPersistHook | None = None,
-) -> SubmissionResult:
-    """Run validation without holding a DB session, then persist the result."""
-    typed_value = SubmittedValue.from_raw(requirement, submitted_value)
-    with tracer.start_as_current_span(
-        "execute_submission_validation",
-        attributes={
-            "user.id": user_id,
-            "requirement.slug": requirement.slug,
-            "submission.type": requirement.submission_type.value,
-        },
-    ) as span:
-        validation_result = await validate_submission(
-            requirement=requirement,
-            submitted_value=typed_value.as_text,
-            expected_username=github_username,
-        )
-
-        async with session_maker() as write_session:
-            db_submission = await persist_validation_result(
-                write_session,
-                user_id=user_id,
-                requirement=requirement,
-                submitted_value=typed_value,
-                github_username=github_username,
-                validation_result=validation_result,
-            )
-            if after_persist is not None:
-                await after_persist(write_session, db_submission, validation_result)
-            await write_session.commit()
-
-        span.set_attribute("submission.is_valid", validation_result.is_valid)
-        span.set_attribute(
-            "submission.verification_completed",
-            validation_result.verification_completed,
-        )
-
-        _log_submission_completed(
-            user_id=user_id,
-            requirement=requirement,
-            validation_result=validation_result,
-        )
-
-        return build_submission_result(db_submission, validation_result)
 
 
 def _advisory_lock_key(user_id: int, requirement_slug: str) -> str:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/requirements.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/requirements.py
@@ -82,17 +82,6 @@ async def get_requirement_by_slug(
     return idx.by_slug.get(requirement_slug)
 
 
-async def get_requirement_by_uuid(
-    db: AsyncSession, requirement_uuid: UUID
-) -> HandsOnRequirement | None:
-    """Get a specific requirement by its UUID."""
-    idx = await load_requirement_index(db)
-    for req in idx.by_slug.values():
-        if req.uuid == requirement_uuid:
-            return req
-    return None
-
-
 # Sequential gating: these phases require the prior phase's verification
 # to be fully completed before their own verification can be submitted.
 # Key = phase that is gated, Value = phase that must be completed first.

--- a/uv.lock
+++ b/uv.lock
@@ -940,7 +940,6 @@ name = "learn-to-cloud-shared"
 version = "0.1.0"
 source = { editable = "packages/learn-to-cloud-shared" }
 dependencies = [
-    { name = "aiohttp" },
     { name = "asyncpg" },
     { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
@@ -973,7 +972,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "azure-identity", specifier = ">=1.25.2" },
     { name = "azure-monitor-opentelemetry", specifier = ">=1.8.6" },


### PR DESCRIPTION
Removes functions/dependency confirmed to have zero callers repo-wide (verified via grep, including tests):

- `close_deployed_api_client` — never invoked, unlike its `atexit`-registered sibling in `function_app.py`
- `get_topic_by_uuid`, `get_topic_by_slugs` — `content_service.py`, no callers
- `get_requirement_by_uuid` — `verification/requirements.py`, no callers
- `execute_submission_validation` (+ its `SubmissionPersistHook` type alias) — superseded by `execute_sync_submission_validation`/`execute_verification_job`, zero callers even in tests
- `aiohttp` dependency — unused, all HTTP calls go through `httpx`; ran `uv lock` to update `uv.lock`

Full shared-package test suite (531 passed) and api test suite (228 passed) pass after removal.