### PR TITLE
fix: restore aiohttp dependency required by azure.identity.aio

### DIFF
--- a/packages/learn-to-cloud-shared/pyproject.toml
+++ b/packages/learn-to-cloud-shared/pyproject.toml
@@ -15,6 +15,7 @@ version = "0.1.0"
 description = "Shared Learn to Cloud domain, database, and verification code"
 requires-python = ">=3.13"
 dependencies = [
+    "aiohttp>=3.14.1",
     "asyncpg>=0.31.0",
     "azure-identity>=1.25.2",
     "azure-monitor-opentelemetry>=1.8.6",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/azure_auth.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/azure_auth.py
@@ -2,6 +2,11 @@
 
 Uses ManagedIdentityCredential (native async) for direct IMDS access.
 The SDK handles token caching, retries, and refresh internally.
+
+Note: azure.identity.aio's default async transport requires the `aiohttp`
+package at runtime, even though azure-identity does not declare it as a
+dependency. Keep `aiohttp` pinned in pyproject.toml or this raises
+`ImportError: aiohttp package is not installed` on first token request.
 """
 
 from __future__ import annotations

--- a/uv.lock
+++ b/uv.lock
@@ -940,6 +940,7 @@ name = "learn-to-cloud-shared"
 version = "0.1.0"
 source = { editable = "packages/learn-to-cloud-shared" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "asyncpg" },
     { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
@@ -972,6 +973,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "azure-identity", specifier = ">=1.25.2" },
     { name = "azure-monitor-opentelemetry", specifier = ">=1.8.6" },


### PR DESCRIPTION
## Problem
Deploy run [28541701786](https://github.com/learntocloud/learn-to-cloud-app/actions/runs/28541701786/job/84617964632) failed at the migration job step:

```
ImportError: aiohttp package is not installed
```

## Root cause
PR #590 ("chore: remove dead code") removed `aiohttp` from `packages/learn-to-cloud-shared/pyproject.toml` as an apparently-unused dependency.

It's actually required at runtime: `azure.identity.aio.ManagedIdentityCredential` (used in `core/database.py` for the migration job's managed-identity Postgres auth) builds its async pipeline via `azure-identity`'s `build_async_pipeline()`, which defaults to `AioHttpTransport` when no transport is passed. That transport lazily imports `aiohttp`, and `azure-identity` does not declare it as a dependency (verified via its wheel metadata: only `azure-core`, `cryptography`, `msal`, `msal-extensions`, `typing-extensions`). So nothing pulls it in transitively — it must be declared explicitly.

## Fix
- Restore `aiohttp>=3.14.1` in `packages/learn-to-cloud-shared/pyproject.toml`
- Regenerate `uv.lock`
- Add a code comment in `azure_auth.py` explaining why this dependency is required, to prevent it from being removed again as "unused"

## Verification
- `uv sync --locked` succeeds in `api/`
- `import aiohttp` succeeds in the synced venv
- Shared package test suite passes (534 passed; 2 pre-existing failures in `test_config.py` are caused by a local `.env` leaking `OAUTH__CLIENT_ID` into the test env, unrelated to this change)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>