### PR TITLE
fix: isolate tests from local .env OAuth/session values

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -20,6 +20,13 @@ os.environ.setdefault(
 os.environ.setdefault("GITHUB__TOKEN", "test_github_token")
 os.environ.setdefault("LABS__VERIFICATION_SECRET", "test_ctf_secret_must_be_32_chars!")
 os.environ.setdefault("ENVIRONMENT", "development")
+# Env vars beat a developer's local .env in pydantic-settings' source
+# priority (init kwargs > env vars > dotenv > secrets file), so pinning
+# these here keeps tests isolated from real OAuth/session values that may
+# be set in a local .env for running the app.
+os.environ.setdefault("OAUTH__CLIENT_ID", "")
+os.environ.setdefault("OAUTH__CLIENT_SECRET", "")
+os.environ.setdefault("SESSION__SECRET_KEY", "")
 
 from collections.abc import AsyncGenerator
 

--- a/packages/learn-to-cloud-shared/tests/conftest.py
+++ b/packages/learn-to-cloud-shared/tests/conftest.py
@@ -10,6 +10,13 @@ os.environ.setdefault(
 os.environ.setdefault("GITHUB__TOKEN", "test_github_token")
 os.environ.setdefault("LABS__VERIFICATION_SECRET", "test_ctf_secret_must_be_32_chars!")
 os.environ.setdefault("ENVIRONMENT", "development")
+# Env vars beat a developer's local .env in pydantic-settings' source
+# priority (init kwargs > env vars > dotenv > secrets file), so pinning
+# these here keeps tests isolated from real OAuth/session values that may
+# be set in a local .env for running the app.
+os.environ.setdefault("OAUTH__CLIENT_ID", "")
+os.environ.setdefault("OAUTH__CLIENT_SECRET", "")
+os.environ.setdefault("SESSION__SECRET_KEY", "")
 
 import pytest
 import pytest_asyncio


### PR DESCRIPTION
## Problem
`TestWebSettingsValidation::test_development_does_not_require_oauth` and `test_production_requires_session_secret` in `packages/learn-to-cloud-shared/tests/core/test_config.py` fail locally when a developer has a real `api/.env` with `OAUTH__CLIENT_ID` set, even though they never touched that code.

## Root cause
`WebSettings` uses `env_file=".env"` (resolved relative to cwd). pydantic-settings' source priority is:

`init kwargs > os.environ > .env file > secrets file`

Tests construct `WebSettings(...)` without passing `oauth`/`session`, expecting pydantic's field defaults (empty string). But since no env var is set, the `.env` file's real `OAUTH__CLIENT_ID` wins over the empty field default, breaking the assertion. This is invisible in CI since `.env` is gitignored and never exists there.

## Fix
Both `conftest.py` files already guard against this exact class of bug for `DATABASE__URL`, `GITHUB__TOKEN`, `LABS__VERIFICATION_SECRET`, and `ENVIRONMENT` via `os.environ.setdefault(...)` — since env vars beat dotenv values, this pins them regardless of what's in a local `.env`. It just missed `OAUTH__CLIENT_ID`, `OAUTH__CLIENT_SECRET`, and `SESSION__SECRET_KEY`. Added those to the existing pattern in both `api/tests/conftest.py` and `packages/learn-to-cloud-shared/tests/conftest.py`.

## Verification
- `packages/learn-to-cloud-shared/tests/core/test_config.py`: 23/23 passed (previously 2 failing with a real `OAUTH__CLIENT_ID` in local `.env`)
- Full unit suites (excluding `integration`, which need local Postgres): shared package 447 passed, 1 skipped; api 228 passed — no regressions

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>