### PR TITLE
fix: show validated requirements as complete on gated phases (#593)

### DIFF
--- a/api/src/learn_to_cloud/templates/pages/dashboard.html
+++ b/api/src/learn_to_cloud/templates/pages/dashboard.html
@@ -52,7 +52,11 @@
             {% if phase.progress and phase.progress.status == "completed" %}
             <span class="text-xs font-medium text-green-600 dark:text-green-400">Complete ✓</span>
             {% elif phase.progress and phase.progress.status == "in_progress" %}
+            {% if phase.progress.steps_completed == 0 and phase.progress.hands_on_validated > 0 %}
+            <span class="text-xs text-gray-500 dark:text-gray-400">{{ phase.progress.hands_on_validated }}/{{ phase.progress.hands_on_required }} hands-on</span>
+            {% else %}
             <span class="text-xs text-gray-500 dark:text-gray-400">{{ phase.progress.steps_completed }}/{{ phase.progress.steps_required }} steps</span>
+            {% endif %}
             {% else %}
             <span class="text-xs text-gray-400 dark:text-gray-500">Not started</span>
             {% endif %}

--- a/api/src/learn_to_cloud/templates/pages/phase.html
+++ b/api/src/learn_to_cloud/templates/pages/phase.html
@@ -61,10 +61,30 @@
     </div>
     <div class="space-y-2">
         {% for req in requirements %}
+        {% set submission = submissions_by_req.get(req.slug) %}
+        {% set is_verified = submission and submission.is_validated %}
+        {% if is_verified %}
+        {# Already validated before the phase was gated — keep showing it as
+           complete so the card matches the progress percentage. #}
+        {% set fb = feedback_by_req.get(req.slug, {}) if feedback_by_req is defined else {} %}
+        {% set feedback_tasks = fb.get('tasks', []) if fb else [] %}
+        <div id="requirement-{{ req.slug }}">
+            <div class="flex items-center gap-3 rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 px-4 py-2.5">
+                <span class="text-green-600 dark:text-green-400">✓</span>
+                <span class="text-sm font-medium text-green-800 dark:text-green-200">{{ req.name }}</span>
+            </div>
+            {% if feedback_tasks %}
+            {% with requirement_slug=req.slug %}
+            {% include "partials/verification_feedback.html" %}
+            {% endwith %}
+            {% endif %}
+        </div>
+        {% else %}
         <div class="flex items-center gap-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 px-4 py-2.5 opacity-50">
             <span class="text-gray-400 dark:text-gray-500">🔒</span>
             <span class="text-sm text-gray-500 dark:text-gray-400">{{ req.name }}</span>
         </div>
+        {% endif %}
         {% endfor %}
     </div>
     {% else %}

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -1,0 +1,146 @@
+"""Rendered-HTML tests for phase and dashboard templates.
+
+These guard issue #593: a hands-on requirement that was validated before its
+phase became gated must still render as complete (not blanket-locked), and the
+dashboard tile must not label a hands-on-only phase as "0/N steps".
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from learn_to_cloud.core.templates import templates
+
+_ENV = templates.env
+
+
+def _base_ctx(**overrides: object) -> dict[str, object]:
+    ctx: dict[str, object] = dict(
+        request=SimpleNamespace(url=SimpleNamespace(path="/")),
+        static_url=lambda p: f"/static/{p}",
+        frontend_telemetry=None,
+        now=datetime(2026, 1, 1),
+        user=SimpleNamespace(
+            github_username="tester", first_name="Tester", avatar_url=None
+        ),
+    )
+    ctx.update(overrides)
+    return ctx
+
+
+def _render(template_name: str, **ctx: object) -> str:
+    return _ENV.get_template(template_name).render(**_base_ctx(**ctx))
+
+
+def _requirement(slug: str, name: str) -> SimpleNamespace:
+    return SimpleNamespace(uuid=f"uuid-{slug}", slug=slug, name=name)
+
+
+@pytest.mark.unit
+class TestPhaseVerificationLocked:
+    """The gated (`verification_locked`) branch of pages/phase.html."""
+
+    def _render_phase(
+        self,
+        requirements: list[SimpleNamespace],
+        submissions_by_req: dict[str, object],
+    ) -> str:
+        return _render(
+            "pages/phase.html",
+            phase=SimpleNamespace(name="Phase 6", description="", order=6),
+            topics=[],
+            progress=None,
+            requirements=requirements,
+            submissions_by_req=submissions_by_req,
+            feedback_by_req={},
+            active_jobs_by_req={},
+            verification_status_tokens_by_req={},
+            derived_urls_by_req={},
+            verification_locked=True,
+            prerequisite_phase_id=5,
+        )
+
+    def test_validated_requirement_renders_as_complete_when_locked(self):
+        """A validated requirement shows the green verified row, not a padlock."""
+        req = _requirement("security-scanning", "Enable Security Scanning")
+        submission = SimpleNamespace(is_validated=True, validation_message=None)
+
+        html = self._render_phase([req], {"security-scanning": submission})
+
+        assert 'id="requirement-security-scanning"' in html
+        assert "Enable Security Scanning" in html
+        assert "text-green-800 dark:text-green-200" in html
+        # The gating banner still appears for the phase overall.
+        assert "Phase 5 verification required" in html
+
+    def test_unvalidated_requirement_stays_locked_when_gated(self):
+        """A not-yet-validated requirement keeps the padlock row."""
+        req = _requirement("ci-status", "CI Status")
+
+        html = self._render_phase([req], {})
+
+        assert "🔒" in html
+        assert "opacity-50" in html
+        assert "text-green-800 dark:text-green-200" not in html
+
+    def test_mixed_shows_validated_complete_and_other_locked(self):
+        """Validated and unvalidated requirements render differently."""
+        done = _requirement("security-scanning", "Enable Security Scanning")
+        todo = _requirement("ci-status", "CI Status")
+        submission = SimpleNamespace(is_validated=True, validation_message=None)
+
+        html = self._render_phase([done, todo], {"security-scanning": submission})
+
+        assert 'id="requirement-security-scanning"' in html
+        assert "text-green-800 dark:text-green-200" in html  # the validated one
+        assert "opacity-50" in html  # the locked one
+
+
+@pytest.mark.unit
+class TestDashboardTileLabel:
+    """The in-progress tile label in pages/dashboard.html."""
+
+    def _render_dashboard(self, progress: object) -> str:
+        phase = SimpleNamespace(order=6, name="Phase 6", progress=progress)
+        dashboard = SimpleNamespace(
+            phases=[phase],
+            overall_percentage=3.0,
+            phases_completed=0,
+            total_phases=8,
+            is_program_complete=False,
+            continue_phase=None,
+        )
+        return _render("pages/dashboard.html", dashboard=dashboard)
+
+    def test_hands_on_only_phase_shows_hands_on_label(self):
+        """Zero steps + validated hands-on shows a hands-on label, not steps."""
+        progress = SimpleNamespace(
+            status="in_progress",
+            steps_completed=0,
+            steps_required=28,
+            hands_on_validated=1,
+            hands_on_required=1,
+            percentage=3.4,
+        )
+
+        html = self._render_dashboard(progress)
+
+        assert "1/1 hands-on" in html
+        assert "0/28 steps" not in html
+
+    def test_step_progress_phase_shows_steps_label(self):
+        """Nonzero step progress keeps the steps label."""
+        progress = SimpleNamespace(
+            status="in_progress",
+            steps_completed=5,
+            steps_required=28,
+            hands_on_validated=0,
+            hands_on_required=1,
+            percentage=17.0,
+        )
+
+        html = self._render_dashboard(progress)
+
+        assert "5/28 steps" in html
+        assert "hands-on" not in html


### PR DESCRIPTION
Fixes #593.

## Problem
Sequential phase gating (`is_phase_verification_locked`) gates a phase's entire hands-on requirement list on the *prerequisite* phase being fully verified. The templates then blanket-rendered **every** requirement as 🔒 locked, including ones the user had already validated. Meanwhile `PhaseProgress.percentage` counts those validated requirements, so the progress bar ("3% complete") and the requirement cards (all locked) contradicted each other. The dashboard tile also showed a misleading "0/N steps" for a phase whose only progress was a validated hands-on requirement.

## Is it real?
Verified live via the dog-food agent: both symptoms reproduce. Verified against the **production** DB: **0 users** are currently in this state, because the submit-time gate prevents forming it. It is a **latent** bug that triggers when a prerequisite phase is reset or invalidated (e.g. the reset-submissions skills, a content-sync adding a new prereq requirement) *after* a later requirement was validated. Fixing defensively.

## Changes
- **`phase.html`**: in the `verification_locked` branch, render already-validated requirements as the green ✓ verified row (matching the percentage); keep only unvalidated requirements 🔒 locked. The gating banner still shows.
- **`dashboard.html`**: for an in-progress phase with `steps_completed == 0` and `hands_on_validated > 0`, show "N/M hands-on" instead of "0/M steps".
- **Tests**: new rendered-HTML tests in `api/tests/rendering/test_template_rendering.py` covering both branches.

## Validation
`uv run poe check` passes (536 + 18 tests, lint/format/type-check clean).