### PR TITLE
fix: strip whitespace from lab tokens before base64 decode

### DIFF
--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/token_base.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/token_base.py
@@ -50,9 +50,12 @@ def verify_lab_token(
     For networking labs, cloud_provider is extracted from challenge_type.
     """
     try:
-        # Decode
+        # Decode. Strip all whitespace first: terminals/editors can wrap or
+        # copy tokens with embedded newlines, tabs, or stray spaces, and
+        # base64 with validate=True rejects any of those otherwise.
+        cleaned_token = "".join(token.split())
         try:
-            decoded = base64.b64decode(token, validate=True).decode("utf-8")
+            decoded = base64.b64decode(cleaned_token, validate=True).decode("utf-8")
             token_data = json.loads(decoded)
         except (ValueError, json.JSONDecodeError, binascii.Error):
             return _fail("Invalid token format. Could not decode the token.")

--- a/packages/learn-to-cloud-shared/tests/services/test_token_verification_base.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_token_verification_base.py
@@ -61,6 +61,27 @@ class TestVerifyLabToken:
         assert result.is_valid is False
         assert "Could not decode" in result.message
 
+    def test_token_with_embedded_newline(self):
+        """Terminals (e.g. Rich console output) can wrap a long token and
+        insert a literal newline. The token should still verify once
+        whitespace is stripped."""
+        payload = _valid_payload()
+        token = _make_signed_token(payload)
+        midpoint = len(token) // 2
+        wrapped_token = token[:midpoint] + "\n" + token[midpoint:]
+        result = verify_lab_token(
+            wrapped_token, "testuser", required_challenges=5, display_name="Test"
+        )
+        assert result.is_valid is True
+
+    def test_token_with_surrounding_whitespace(self):
+        payload = _valid_payload()
+        token = _make_signed_token(payload)
+        result = verify_lab_token(
+            f"  {token}\n", "testuser", required_challenges=5, display_name="Test"
+        )
+        assert result.is_valid is True
+
     def test_invalid_json(self):
         token = base64.b64encode(b"not json").decode()
         result = verify_lab_token(token, "testuser", required_challenges=5)


### PR DESCRIPTION
Terminal output (e.g. Rich's Console.print) can wrap long tokens and insert a literal newline in the copied text, causing valid tokens to fail 'Could not decode the token.' verification. Strip all internal whitespace, not just leading/trailing, before decoding.

Fixes learntocloud/linux-ctfs#120

## Summary

<!-- What does this PR do and why? -->

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.
