### PR TITLE
feat: add public /stats community stats page

### DIFF
--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -34,6 +34,7 @@ from learn_to_cloud.rendering.context import (
 )
 from learn_to_cloud.services.dashboard_service import get_dashboard_data
 from learn_to_cloud.services.progress_service import fetch_phase_progress
+from learn_to_cloud.services.stats_service import get_stats_page_data
 from learn_to_cloud.services.steps_service import get_valid_completed_steps
 from learn_to_cloud.services.submissions_service import get_phase_submission_context
 from learn_to_cloud.services.users_service import get_user_by_id
@@ -306,6 +307,23 @@ async def account_page(
         request,
         "pages/account.html",
         _template_context(request, user=user),
+    )
+
+
+@router.get("/stats", response_class=HTMLResponse, summary="Community stats")
+async def stats_page(
+    request: Request,
+    db: DbSession,
+    user_id: OptionalUserId,
+) -> HTMLResponse:
+    """Public community stats: phase funnel, completers, curriculum updates."""
+    user = await _get_user_or_none(db, user_id)
+    stats = await get_stats_page_data(db)
+
+    return templates.TemplateResponse(
+        request,
+        "pages/stats.html",
+        _template_context(request, user=user, stats=stats),
     )
 
 

--- a/api/src/learn_to_cloud/services/stats_service.py
+++ b/api/src/learn_to_cloud/services/stats_service.py
@@ -23,7 +23,7 @@ from learn_to_cloud_shared.repositories.submission_repository import (
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
 from learn_to_cloud_shared.schemas import (
     CommunityMember,
-    PhaseFunnelRow,
+    FunnelLevel,
     StatsPageData,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -51,14 +51,31 @@ async def get_stats_page_data(db: AsyncSession) -> StatsPageData:
         order for order, total in requirement_counts.items() if total > 0
     )
 
-    funnel = [
-        PhaseFunnelRow(
-            order=order,
-            name=phase_names.get(order, f"Phase {order}"),
-            count=len(completers_by_phase.get(order, set())),
+    total_accounts = await UserRepository(db).count()
+
+    # Build the funnel top-down: total accounts, then each phase, tracking
+    # both share of total (bar width) and conversion from the level above.
+    funnel: list[FunnelLevel] = [
+        FunnelLevel(
+            label="Total accounts",
+            count=total_accounts,
+            pct_of_total=100.0,
+            pct_of_previous=None,
+            is_total=True,
         )
-        for order in completable_orders
     ]
+    prev_count = total_accounts
+    for order in completable_orders:
+        count = len(completers_by_phase.get(order, set()))
+        funnel.append(
+            FunnelLevel(
+                label=f"Phase {order}: {phase_names.get(order, order)}",
+                count=count,
+                pct_of_total=(count / total_accounts * 100) if total_accounts else 0.0,
+                pct_of_previous=(count / prev_count * 100) if prev_count else None,
+            )
+        )
+        prev_count = count
 
     # Graduates completed every completable phase.
     graduate_ids: set[int] = set()
@@ -66,8 +83,6 @@ async def get_stats_page_data(db: AsyncSession) -> StatsPageData:
         graduate_ids = set.intersection(
             *(completers_by_phase.get(order, set()) for order in completable_orders)
         )
-
-    total_accounts = await UserRepository(db).count()
 
     users = await UserRepository(db).get_by_ids(graduate_ids)
     graduates = sorted(

--- a/api/src/learn_to_cloud/services/stats_service.py
+++ b/api/src/learn_to_cloud/services/stats_service.py
@@ -1,0 +1,92 @@
+"""Stats service — assembles the public /stats page payload.
+
+The phase funnel and completer lists come from a single completion
+aggregate (``SubmissionRepository.list_phase_completions``) plus a total
+account count and one batched user load. The latest-commit panel is
+fetched (and cached) separately via the shared GitHub helper.
+"""
+
+import logging
+
+from learn_to_cloud_shared.content_service import (
+    get_curriculum_overview,
+    get_requirement_counts_by_phase,
+)
+from learn_to_cloud_shared.github_updates import get_latest_curriculum_commits
+from learn_to_cloud_shared.repositories.submission_repository import (
+    SubmissionRepository,
+)
+from learn_to_cloud_shared.repositories.user_repository import UserRepository
+from learn_to_cloud_shared.schemas import (
+    CommunityMember,
+    PhaseCompleters,
+    PhaseFunnelRow,
+    StatsPageData,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+async def get_stats_page_data(db: AsyncSession) -> StatsPageData:
+    """Build the full /stats payload."""
+    phases = await get_curriculum_overview(db)
+    phase_names = {phase.order: phase.name for phase in phases}
+
+    requirement_counts = await get_requirement_counts_by_phase(db)
+    completions = await SubmissionRepository(db).list_phase_completions(
+        requirement_counts
+    )
+
+    # Group (phase_order, user_id) rows into per-phase completer id lists.
+    completer_ids_by_phase: dict[int, list[int]] = {}
+    for order, user_id in completions:
+        completer_ids_by_phase.setdefault(order, []).append(user_id)
+
+    total_accounts = await UserRepository(db).count()
+
+    # One batched load resolves every completer across all phases.
+    all_ids = {uid for ids in completer_ids_by_phase.values() for uid in ids}
+    users = await UserRepository(db).get_by_ids(all_ids)
+    member_by_id = {
+        user.id: CommunityMember(
+            github_username=user.github_username,
+            avatar_url=user.avatar_url,
+        )
+        for user in users
+    }
+
+    ordered_phases = sorted(phase_names)
+    funnel = [
+        PhaseFunnelRow(
+            order=order,
+            name=phase_names[order],
+            count=len(completer_ids_by_phase.get(order, [])),
+        )
+        for order in ordered_phases
+    ]
+
+    completers = [
+        PhaseCompleters(
+            order=order,
+            name=phase_names[order],
+            members=sorted(
+                (
+                    member_by_id[uid]
+                    for uid in completer_ids_by_phase.get(order, [])
+                    if uid in member_by_id
+                ),
+                key=lambda m: m.github_username.lower(),
+            ),
+        )
+        for order in ordered_phases
+    ]
+
+    repo_updates = await get_latest_curriculum_commits()
+
+    return StatsPageData(
+        total_accounts=total_accounts,
+        funnel=funnel,
+        completers=completers,
+        repo_updates=repo_updates,
+    )

--- a/api/src/learn_to_cloud/services/stats_service.py
+++ b/api/src/learn_to_cloud/services/stats_service.py
@@ -1,9 +1,13 @@
 """Stats service — assembles the public /stats page payload.
 
-The phase funnel and completer lists come from a single completion
+The phase funnel and the graduate list come from a single completion
 aggregate (``SubmissionRepository.list_phase_completions``) plus a total
-account count and one batched user load. The latest-commit panel is
-fetched (and cached) separately via the shared GitHub helper.
+account count and one batched user load. Because phase submissions are
+gated on the previous phase, completions are nested (completers of phase
+N are a subset of phase N-1), so the funnel is monotone and "graduates"
+are simply the learners who appear in every completable phase. The
+latest-commit panel is fetched (and cached) separately via the shared
+GitHub helper.
 """
 
 import logging
@@ -19,7 +23,6 @@ from learn_to_cloud_shared.repositories.submission_repository import (
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
 from learn_to_cloud_shared.schemas import (
     CommunityMember,
-    PhaseCompleters,
     PhaseFunnelRow,
     StatsPageData,
 )
@@ -38,55 +41,51 @@ async def get_stats_page_data(db: AsyncSession) -> StatsPageData:
         requirement_counts
     )
 
-    # Group (phase_order, user_id) rows into per-phase completer id lists.
-    completer_ids_by_phase: dict[int, list[int]] = {}
+    # Group completions into a per-phase set of completer ids.
+    completers_by_phase: dict[int, set[int]] = {}
     for order, user_id in completions:
-        completer_ids_by_phase.setdefault(order, []).append(user_id)
+        completers_by_phase.setdefault(order, set()).add(user_id)
 
-    total_accounts = await UserRepository(db).count()
+    # Only phases with at least one requirement are "completable".
+    completable_orders = sorted(
+        order for order, total in requirement_counts.items() if total > 0
+    )
 
-    # One batched load resolves every completer across all phases.
-    all_ids = {uid for ids in completer_ids_by_phase.values() for uid in ids}
-    users = await UserRepository(db).get_by_ids(all_ids)
-    member_by_id = {
-        user.id: CommunityMember(
-            github_username=user.github_username,
-            avatar_url=user.avatar_url,
-        )
-        for user in users
-    }
-
-    ordered_phases = sorted(phase_names)
     funnel = [
         PhaseFunnelRow(
             order=order,
-            name=phase_names[order],
-            count=len(completer_ids_by_phase.get(order, [])),
+            name=phase_names.get(order, f"Phase {order}"),
+            count=len(completers_by_phase.get(order, set())),
         )
-        for order in ordered_phases
+        for order in completable_orders
     ]
 
-    completers = [
-        PhaseCompleters(
-            order=order,
-            name=phase_names[order],
-            members=sorted(
-                (
-                    member_by_id[uid]
-                    for uid in completer_ids_by_phase.get(order, [])
-                    if uid in member_by_id
-                ),
-                key=lambda m: m.github_username.lower(),
-            ),
+    # Graduates completed every completable phase.
+    graduate_ids: set[int] = set()
+    if completable_orders:
+        graduate_ids = set.intersection(
+            *(completers_by_phase.get(order, set()) for order in completable_orders)
         )
-        for order in ordered_phases
-    ]
+
+    total_accounts = await UserRepository(db).count()
+
+    users = await UserRepository(db).get_by_ids(graduate_ids)
+    graduates = sorted(
+        (
+            CommunityMember(
+                github_username=user.github_username,
+                avatar_url=user.avatar_url,
+            )
+            for user in users
+        ),
+        key=lambda m: m.github_username.lower(),
+    )
 
     repo_updates = await get_latest_curriculum_commits()
 
     return StatsPageData(
         total_accounts=total_accounts,
         funnel=funnel,
-        completers=completers,
+        graduates=graduates,
         repo_updates=repo_updates,
     )

--- a/api/src/learn_to_cloud/static/css/styles.css
+++ b/api/src/learn_to_cloud/static/css/styles.css
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.2.3 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.2.2 | MIT License | https://tailwindcss.com */
 @layer properties;
 @layer theme, base, components, utilities;
 @layer theme {
@@ -29,11 +29,6 @@
     --color-amber-700: oklch(55.5% 0.163 48.998);
     --color-amber-800: oklch(47.3% 0.137 46.201);
     --color-amber-900: oklch(41.4% 0.112 45.904);
-    --color-yellow-100: oklch(97.3% 0.071 103.193);
-    --color-yellow-400: oklch(85.2% 0.199 91.936);
-    --color-yellow-500: oklch(79.5% 0.184 86.047);
-    --color-yellow-800: oklch(47.6% 0.114 61.907);
-    --color-yellow-900: oklch(42.1% 0.095 57.708);
     --color-green-50: oklch(98.2% 0.018 155.826);
     --color-green-100: oklch(96.2% 0.044 156.743);
     --color-green-200: oklch(92.5% 0.084 155.995);
@@ -44,10 +39,6 @@
     --color-green-700: oklch(52.7% 0.154 150.069);
     --color-green-800: oklch(44.8% 0.119 151.328);
     --color-green-900: oklch(39.3% 0.095 152.535);
-    --color-emerald-50: oklch(97.9% 0.021 166.113);
-    --color-emerald-200: oklch(90.5% 0.093 164.15);
-    --color-emerald-800: oklch(43.2% 0.095 166.913);
-    --color-emerald-900: oklch(37.8% 0.077 168.94);
     --color-blue-50: oklch(97% 0.014 254.604);
     --color-blue-100: oklch(93.2% 0.032 255.585);
     --color-blue-200: oklch(88.2% 0.059 254.128);
@@ -60,16 +51,6 @@
     --color-blue-900: oklch(37.9% 0.146 265.522);
     --color-indigo-400: oklch(67.3% 0.182 276.935);
     --color-indigo-500: oklch(58.5% 0.233 277.117);
-    --color-purple-50: oklch(97.7% 0.014 308.299);
-    --color-purple-100: oklch(94.6% 0.033 307.174);
-    --color-purple-200: oklch(90.2% 0.063 306.703);
-    --color-purple-300: oklch(82.7% 0.119 306.383);
-    --color-purple-400: oklch(71.4% 0.203 305.504);
-    --color-purple-500: oklch(62.7% 0.265 303.9);
-    --color-purple-600: oklch(55.8% 0.288 302.321);
-    --color-purple-700: oklch(49.6% 0.265 301.924);
-    --color-purple-800: oklch(43.8% 0.218 303.724);
-    --color-purple-900: oklch(38.1% 0.176 304.987);
     --color-pink-400: oklch(71.8% 0.202 349.761);
     --color-pink-600: oklch(59.2% 0.249 0.584);
     --color-gray-50: oklch(98.5% 0.002 247.839);
@@ -109,6 +90,7 @@
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
     --tracking-wide: 0.025em;
+    --leading-tight: 1.25;
     --leading-relaxed: 1.625;
     --radius-sm: 0.25rem;
     --radius-md: 0.375rem;
@@ -274,6 +256,9 @@
   .collapse {
     visibility: collapse;
   }
+  .invisible {
+    visibility: hidden;
+  }
   .visible {
     visibility: visible;
   }
@@ -372,6 +357,9 @@
   .mt-4 {
     margin-top: calc(var(--spacing) * 4);
   }
+  .mt-5 {
+    margin-top: calc(var(--spacing) * 5);
+  }
   .mt-6 {
     margin-top: calc(var(--spacing) * 6);
   }
@@ -414,14 +402,20 @@
   .mb-12 {
     margin-bottom: calc(var(--spacing) * 12);
   }
+  .ml-1 {
+    margin-left: calc(var(--spacing) * 1);
+  }
   .ml-4 {
     margin-left: calc(var(--spacing) * 4);
   }
+  .line-clamp-2 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
   .block {
     display: block;
-  }
-  .contents {
-    display: contents;
   }
   .flex {
     display: flex;
@@ -462,6 +456,9 @@
   .h-8 {
     height: calc(var(--spacing) * 8);
   }
+  .h-9 {
+    height: calc(var(--spacing) * 9);
+  }
   .h-16 {
     height: calc(var(--spacing) * 16);
   }
@@ -486,8 +483,11 @@
   .w-8 {
     width: calc(var(--spacing) * 8);
   }
-  .w-24 {
-    width: calc(var(--spacing) * 24);
+  .w-20 {
+    width: calc(var(--spacing) * 20);
+  }
+  .w-28 {
+    width: calc(var(--spacing) * 28);
   }
   .w-48 {
     width: calc(var(--spacing) * 48);
@@ -563,9 +563,6 @@
   }
   .items-start {
     align-items: flex-start;
-  }
-  .items-stretch {
-    align-items: stretch;
   }
   .justify-between {
     justify-content: space-between;
@@ -687,10 +684,6 @@
     border-top-style: var(--tw-border-style);
     border-top-width: 1px;
   }
-  .border-r {
-    border-right-style: var(--tw-border-style);
-    border-right-width: 1px;
-  }
   .border-b {
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 1px;
@@ -703,6 +696,10 @@
     border-left-style: var(--tw-border-style);
     border-left-width: 3px;
   }
+  .border-dashed {
+    --tw-border-style: dashed;
+    border-style: dashed;
+  }
   .border-amber-200 {
     border-color: var(--color-amber-200);
   }
@@ -711,9 +708,6 @@
   }
   .border-blue-500 {
     border-color: var(--color-blue-500);
-  }
-  .border-emerald-200 {
-    border-color: var(--color-emerald-200);
   }
   .border-gray-100 {
     border-color: var(--color-gray-100);
@@ -766,9 +760,6 @@
   .bg-blue-600 {
     background-color: var(--color-blue-600);
   }
-  .bg-emerald-50 {
-    background-color: var(--color-emerald-50);
-  }
   .bg-gray-50 {
     background-color: var(--color-gray-50);
   }
@@ -799,9 +790,6 @@
   .bg-green-500 {
     background-color: var(--color-green-500);
   }
-  .bg-purple-100 {
-    background-color: var(--color-purple-100);
-  }
   .bg-red-50 {
     background-color: var(--color-red-50);
   }
@@ -810,9 +798,6 @@
   }
   .bg-red-600 {
     background-color: var(--color-red-600);
-  }
-  .bg-transparent {
-    background-color: transparent;
   }
   .bg-white {
     background-color: var(--color-white);
@@ -898,8 +883,14 @@
   .pt-6 {
     padding-top: calc(var(--spacing) * 6);
   }
+  .pr-3 {
+    padding-right: calc(var(--spacing) * 3);
+  }
   .pb-4 {
     padding-bottom: calc(var(--spacing) * 4);
+  }
+  .pl-1 {
+    padding-left: calc(var(--spacing) * 1);
   }
   .pl-\[4\.5rem\] {
     padding-left: 4.5rem;
@@ -952,6 +943,10 @@
   .leading-relaxed {
     --tw-leading: var(--leading-relaxed);
     line-height: var(--leading-relaxed);
+  }
+  .leading-tight {
+    --tw-leading: var(--leading-tight);
+    line-height: var(--leading-tight);
   }
   .font-bold {
     --tw-font-weight: var(--font-weight-bold);
@@ -1006,9 +1001,6 @@
   .text-blue-800 {
     color: var(--color-blue-800);
   }
-  .text-emerald-800 {
-    color: var(--color-emerald-800);
-  }
   .text-gray-300 {
     color: var(--color-gray-300);
   }
@@ -1048,9 +1040,6 @@
   .text-orange-500 {
     color: var(--color-orange-500);
   }
-  .text-purple-700 {
-    color: var(--color-purple-700);
-  }
   .text-red-600 {
     color: var(--color-red-600);
   }
@@ -1071,6 +1060,10 @@
   }
   .italic {
     font-style: italic;
+  }
+  .tabular-nums {
+    --tw-numeric-spacing: tabular-nums;
+    font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
   }
   .line-through {
     text-decoration-line: line-through;
@@ -1143,22 +1136,6 @@
   .select-none {
     -webkit-user-select: none;
     user-select: none;
-  }
-  .focus-within\:border-blue-500 {
-    &:focus-within {
-      border-color: var(--color-blue-500);
-    }
-  }
-  .focus-within\:ring-1 {
-    &:focus-within {
-      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
-      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-    }
-  }
-  .focus-within\:ring-blue-500 {
-    &:focus-within {
-      --tw-ring-color: var(--color-blue-500);
-    }
   }
   .hover\:border-blue-500 {
     &:hover {
@@ -1336,9 +1313,24 @@
       height: calc(var(--spacing) * 32);
     }
   }
+  .sm\:w-24 {
+    @media (width >= 40rem) {
+      width: calc(var(--spacing) * 24);
+    }
+  }
+  .sm\:w-44 {
+    @media (width >= 40rem) {
+      width: calc(var(--spacing) * 44);
+    }
+  }
   .sm\:grid-cols-2 {
     @media (width >= 40rem) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+  .sm\:gap-4 {
+    @media (width >= 40rem) {
+      gap: calc(var(--spacing) * 4);
     }
   }
   .sm\:px-6 {
@@ -1349,6 +1341,17 @@
   .sm\:py-12 {
     @media (width >= 40rem) {
       padding-block: calc(var(--spacing) * 12);
+    }
+  }
+  .sm\:text-sm {
+    @media (width >= 40rem) {
+      font-size: var(--text-sm);
+      line-height: var(--tw-leading, var(--text-sm--line-height));
+    }
+  }
+  .lg\:grid-cols-3 {
+    @media (width >= 64rem) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
   .lg\:grid-cols-4 {
@@ -1376,33 +1379,9 @@
       border-color: var(--color-amber-800);
     }
   }
-  .dark\:border-amber-800\/50 {
-    &:where(.dark, .dark *) {
-      border-color: color-mix(in srgb, oklch(47.3% 0.137 46.201) 50%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        border-color: color-mix(in oklab, var(--color-amber-800) 50%, transparent);
-      }
-    }
-  }
   .dark\:border-blue-800 {
     &:where(.dark, .dark *) {
       border-color: var(--color-blue-800);
-    }
-  }
-  .dark\:border-blue-800\/50 {
-    &:where(.dark, .dark *) {
-      border-color: color-mix(in srgb, oklch(42.4% 0.199 265.638) 50%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        border-color: color-mix(in oklab, var(--color-blue-800) 50%, transparent);
-      }
-    }
-  }
-  .dark\:border-emerald-800\/50 {
-    &:where(.dark, .dark *) {
-      border-color: color-mix(in srgb, oklch(43.2% 0.095 166.913) 50%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        border-color: color-mix(in oklab, var(--color-emerald-800) 50%, transparent);
-      }
     }
   }
   .dark\:border-gray-600 {
@@ -1433,14 +1412,6 @@
       border-color: var(--color-red-800);
     }
   }
-  .dark\:border-red-800\/50 {
-    &:where(.dark, .dark *) {
-      border-color: color-mix(in srgb, oklch(44.4% 0.177 26.899) 50%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        border-color: color-mix(in oklab, var(--color-red-800) 50%, transparent);
-      }
-    }
-  }
   .dark\:border-l-blue-400 {
     &:where(.dark, .dark *) {
       border-left-color: var(--color-blue-400);
@@ -1449,14 +1420,6 @@
   .dark\:border-l-green-400 {
     &:where(.dark, .dark *) {
       border-left-color: var(--color-green-400);
-    }
-  }
-  .dark\:bg-amber-800\/40 {
-    &:where(.dark, .dark *) {
-      background-color: color-mix(in srgb, oklch(47.3% 0.137 46.201) 40%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-amber-800) 40%, transparent);
-      }
     }
   }
   .dark\:bg-amber-900 {
@@ -1472,12 +1435,14 @@
       }
     }
   }
-  .dark\:bg-blue-800\/40 {
+  .dark\:bg-blue-500 {
     &:where(.dark, .dark *) {
-      background-color: color-mix(in srgb, oklch(42.4% 0.199 265.638) 40%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-blue-800) 40%, transparent);
-      }
+      background-color: var(--color-blue-500);
+    }
+  }
+  .dark\:bg-blue-900 {
+    &:where(.dark, .dark *) {
+      background-color: var(--color-blue-900);
     }
   }
   .dark\:bg-blue-900\/20 {
@@ -1493,14 +1458,6 @@
       background-color: color-mix(in srgb, oklch(37.9% 0.146 265.522) 40%, transparent);
       @supports (color: color-mix(in lab, red, red)) {
         background-color: color-mix(in oklab, var(--color-blue-900) 40%, transparent);
-      }
-    }
-  }
-  .dark\:bg-emerald-900\/20 {
-    &:where(.dark, .dark *) {
-      background-color: color-mix(in srgb, oklch(37.8% 0.077 168.94) 20%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-emerald-900) 20%, transparent);
       }
     }
   }
@@ -1564,14 +1521,6 @@
       }
     }
   }
-  .dark\:bg-purple-800\/40 {
-    &:where(.dark, .dark *) {
-      background-color: color-mix(in srgb, oklch(43.8% 0.218 303.724) 40%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-purple-800) 40%, transparent);
-      }
-    }
-  }
   .dark\:bg-red-900 {
     &:where(.dark, .dark *) {
       background-color: var(--color-red-900);
@@ -1630,11 +1579,6 @@
   .dark\:text-blue-400 {
     &:where(.dark, .dark *) {
       color: var(--color-blue-400);
-    }
-  }
-  .dark\:text-emerald-200 {
-    &:where(.dark, .dark *) {
-      color: var(--color-emerald-200);
     }
   }
   .dark\:text-gray-100 {
@@ -1700,11 +1644,6 @@
   .dark\:text-orange-400 {
     &:where(.dark, .dark *) {
       color: var(--color-orange-400);
-    }
-  }
-  .dark\:text-purple-300 {
-    &:where(.dark, .dark *) {
-      color: var(--color-purple-300);
     }
   }
   .dark\:text-red-200 {
@@ -1901,6 +1840,16 @@
 .callout-content {
   min-width: 0;
 }
+.phase-description a {
+  color: oklch(54.6% 0.245 262.881);
+  text-decoration: underline;
+}
+.phase-description a:hover {
+  text-decoration: none;
+}
+.dark .phase-description a {
+  color: oklch(70.7% 0.165 254.624);
+}
 .callout-tip {
   background-color: oklch(98.2% 0.018 155.826);
   border-color: oklch(87.1% 0.15 154.449);
@@ -1940,16 +1889,6 @@
   background-color: color-mix(in srgb, oklch(37.9% 0.146 265.522) 20%, transparent);
   border-color: oklch(48.8% 0.243 264.376);
   color: oklch(88.2% 0.059 254.128);
-}
-.phase-description a {
-  color: oklch(54.6% 0.245 262.881);
-  text-decoration: underline;
-}
-.phase-description a:hover {
-  text-decoration: none;
-}
-.dark .phase-description a {
-  color: oklch(70.7% 0.165 254.624);
 }
 @property --tw-rotate-x {
   syntax: "*";
@@ -2032,6 +1971,26 @@
   inherits: false;
 }
 @property --tw-tracking {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ordinal {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-slashed-zero {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-figure {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-spacing {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-fraction {
   syntax: "*";
   inherits: false;
 }
@@ -2184,6 +2143,11 @@
       --tw-leading: initial;
       --tw-font-weight: initial;
       --tw-tracking: initial;
+      --tw-ordinal: initial;
+      --tw-slashed-zero: initial;
+      --tw-numeric-figure: initial;
+      --tw-numeric-spacing: initial;
+      --tw-numeric-fraction: initial;
       --tw-shadow: 0 0 #0000;
       --tw-shadow-color: initial;
       --tw-shadow-alpha: 100%;

--- a/api/src/learn_to_cloud/templates/pages/stats.html
+++ b/api/src/learn_to_cloud/templates/pages/stats.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block title %}Stats - Learn to Cloud{% endblock %}
-{% block description %}Community stats for Learn to Cloud — how many learners have completed each phase, who they are, and the latest curriculum updates.{% endblock %}
+{% block description %}Community stats for Learn to Cloud — how many learners are progressing through each phase, who has finished the whole curriculum, and the latest updates.{% endblock %}
 
 {% block content %}
 <div class="mb-8">
@@ -12,70 +12,76 @@
 
 {# ── Phase funnel ─────────────────────────────────────────────── #}
 <section class="mb-12">
-    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-4">Phase completion</h2>
-    <p class="text-base text-gray-500 dark:text-gray-400 mb-4">
-        Learners who have verified every project in a phase.
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-1">Progress funnel</h2>
+    <p class="text-base text-gray-500 dark:text-gray-400 mb-6">
+        How many learners have verified every project in each phase.
     </p>
 
-    {% set max_count = stats.total_accounts if stats.total_accounts > 0 else 1 %}
-    <div class="space-y-3">
-        <div class="flex items-center gap-3">
-            <div class="w-32 flex-shrink-0 text-sm font-medium text-gray-700 dark:text-gray-300">Total accounts</div>
-            <div class="flex-1 bg-gray-100 dark:bg-gray-800 rounded-md h-8 relative overflow-hidden">
-                <div class="bg-blue-600 h-full rounded-md" style="width: 100%"></div>
+    {% set total = stats.total_accounts if stats.total_accounts > 0 else 1 %}
+    <div class="space-y-2">
+        {# Top of funnel: all accounts #}
+        <div>
+            <div class="relative h-11 rounded-lg bg-blue-600 flex items-center justify-center">
+                <span class="text-sm font-semibold text-white">Total accounts</span>
+                <span class="absolute right-3 text-sm font-semibold text-white tabular-nums">{{ stats.total_accounts }}</span>
             </div>
-            <div class="w-16 flex-shrink-0 text-right text-sm font-semibold text-gray-900 dark:text-white tabular-nums">{{ stats.total_accounts }}</div>
         </div>
 
         {% for row in stats.funnel %}
-        <div class="flex items-center gap-3">
-            <div class="w-32 flex-shrink-0 text-sm font-medium text-gray-700 dark:text-gray-300">
-                <span class="text-gray-400 dark:text-gray-500 font-normal">Phase {{ row.order }}</span>
+        {% set pct = (row.count / total * 100) %}
+        <div>
+            <div class="relative h-11 rounded-lg bg-gray-100 dark:bg-gray-800 overflow-hidden flex items-center justify-center">
+                {# Centered fill creates the tapering funnel shape #}
+                <div class="absolute inset-y-0 left-1/2 -translate-x-1/2 bg-blue-500/80 dark:bg-blue-500/60 rounded-lg"
+                     style="width: {{ pct | round(2) }}%"></div>
+                <span class="relative text-sm font-medium text-gray-800 dark:text-gray-100 px-3 truncate">
+                    <span class="text-gray-500 dark:text-gray-400 font-normal">Phase {{ row.order }}</span>
+                    {{ row.name }}
+                </span>
+                <span class="absolute right-3 text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
+                    {{ row.count }}
+                    <span class="ml-1 text-xs font-normal text-gray-500 dark:text-gray-400">{{ pct | round(1) }}%</span>
+                </span>
             </div>
-            <div class="flex-1 bg-gray-100 dark:bg-gray-800 rounded-md h-8 relative overflow-hidden">
-                <div class="bg-blue-500 h-full rounded-md" style="width: {{ (row.count / max_count * 100) | round(1) }}%"></div>
-                <span class="absolute inset-0 flex items-center px-3 text-xs text-gray-600 dark:text-gray-300 truncate">{{ row.name }}</span>
-            </div>
-            <div class="w-16 flex-shrink-0 text-right text-sm font-semibold text-gray-900 dark:text-white tabular-nums">{{ row.count }}</div>
         </div>
         {% endfor %}
     </div>
+    <p class="mt-3 text-xs text-gray-400 dark:text-gray-500">
+        Percentages are relative to total accounts. Later phases require completing earlier ones, so the funnel narrows as learners advance.
+    </p>
 </section>
 
-{# ── Completers ───────────────────────────────────────────────── #}
+{# ── Curriculum graduates ─────────────────────────────────────── #}
 <section class="mb-12">
-    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-4">Phase completers</h2>
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-1">
+        Curriculum graduates
+        <span class="ml-1 text-base font-normal text-gray-500 dark:text-gray-400">({{ stats.graduates | length }})</span>
+    </h2>
+    <p class="text-base text-gray-500 dark:text-gray-400 mb-4">
+        Learners who have verified every project across all phases.
+    </p>
 
-    <div class="space-y-6">
-        {% for phase in stats.completers %}
-        <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
-            <h3 class="text-base font-semibold text-gray-900 dark:text-white mb-3">
-                <span class="text-gray-400 dark:text-gray-500 font-normal">Phase {{ phase.order }}</span>
-                {{ phase.name }}
-                <span class="ml-1 text-sm font-normal text-gray-500 dark:text-gray-400">({{ phase.members | length }})</span>
-            </h3>
-            {% if phase.members %}
-            <ul class="flex flex-wrap gap-2">
-                {% for member in phase.members %}
-                <li>
-                    <a href="https://github.com/{{ member.github_username }}" target="_blank" rel="noopener noreferrer"
-                       class="inline-flex items-center gap-2 rounded-full border border-gray-200 dark:border-gray-700 py-1 pl-1 pr-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
-                        {% if member.avatar_url %}
-                        <img src="{{ member.avatar_url }}" alt="{{ member.github_username }}" class="h-6 w-6 rounded-full" loading="lazy">
-                        {% else %}
-                        <span class="h-6 w-6 rounded-full bg-gray-200 dark:bg-gray-700 inline-flex items-center justify-center text-xs text-gray-500 dark:text-gray-400">{{ member.github_username[0] | upper }}</span>
-                        {% endif %}
-                        <span class="text-sm text-gray-700 dark:text-gray-300">{{ member.github_username }}</span>
-                    </a>
-                </li>
-                {% endfor %}
-            </ul>
-            {% else %}
-            <p class="text-sm text-gray-500 dark:text-gray-400">No one has completed this phase yet. Be the first!</p>
-            {% endif %}
-        </div>
+    {% if stats.graduates %}
+    <ul class="flex flex-wrap gap-2">
+        {% for member in stats.graduates %}
+        <li>
+            <a href="https://github.com/{{ member.github_username }}" target="_blank" rel="noopener noreferrer"
+               class="inline-flex items-center gap-2 rounded-full border border-gray-200 dark:border-gray-700 py-1 pl-1 pr-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                {% if member.avatar_url %}
+                <img src="{{ member.avatar_url }}" alt="{{ member.github_username }}" class="h-6 w-6 rounded-full" loading="lazy">
+                {% else %}
+                <span class="h-6 w-6 rounded-full bg-gray-200 dark:bg-gray-700 inline-flex items-center justify-center text-xs text-gray-500 dark:text-gray-400">{{ member.github_username[0] | upper }}</span>
+                {% endif %}
+                <span class="text-sm text-gray-700 dark:text-gray-300">{{ member.github_username }}</span>
+            </a>
+        </li>
         {% endfor %}
+    </ul>
+    {% else %}
+    <div class="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 p-6 text-center">
+        <p class="text-sm text-gray-500 dark:text-gray-400">No one has finished the entire curriculum yet. Be the first!</p>
     </div>
+    {% endif %}
 </section>
 
 {# ── Latest curriculum updates ────────────────────────────────── #}

--- a/api/src/learn_to_cloud/templates/pages/stats.html
+++ b/api/src/learn_to_cloud/templates/pages/stats.html
@@ -10,44 +10,51 @@
     </p>
 </div>
 
-{# ── Phase funnel ─────────────────────────────────────────────── #}
+{# ── Progress funnel ──────────────────────────────────────────── #}
 <section class="mb-12">
     <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-1">Progress funnel</h2>
     <p class="text-base text-gray-500 dark:text-gray-400 mb-6">
         How many learners have verified every project in each phase.
     </p>
 
-    {% set total = stats.total_accounts if stats.total_accounts > 0 else 1 %}
-    <div class="space-y-2">
-        {# Top of funnel: all accounts #}
-        <div>
-            <div class="relative h-11 rounded-lg bg-blue-600 flex items-center justify-center">
-                <span class="text-sm font-semibold text-white">Total accounts</span>
-                <span class="absolute right-3 text-sm font-semibold text-white tabular-nums">{{ stats.total_accounts }}</span>
-            </div>
-        </div>
+    <svg viewBox="0 0 100 {{ stats.funnel | length * 20 }}"
+         class="w-full max-w-xl mx-auto text-blue-500 block"
+         preserveAspectRatio="xMidYMid meet" role="img" aria-label="Progress funnel">
+        {% for level in stats.funnel %}
+        {% set i = loop.index0 %}
+        {% set top = level.pct_of_total %}
+        {% set nxt = stats.funnel[i + 1] %}
+        {% set bot = nxt.pct_of_total if nxt else level.pct_of_total %}
+        {% set y0 = i * 20 %}
+        {% set y1 = y0 + 18 %}
+        {% set fill_opacity = 1 - i * 0.09 %}
+        <polygon
+            points="{{ (50 - top / 2) | round(2) }},{{ y0 }} {{ (50 + top / 2) | round(2) }},{{ y0 }} {{ (50 + bot / 2) | round(2) }},{{ y1 }} {{ (50 - bot / 2) | round(2) }},{{ y1 }}"
+            fill="currentColor" style="opacity: {{ fill_opacity if fill_opacity > 0.35 else 0.35 }}"></polygon>
+        <text x="50" y="{{ y0 + 12 }}" text-anchor="middle" font-size="6" font-weight="700" fill="#ffffff">{{ level.count }}</text>
+        {% endfor %}
+    </svg>
 
-        {% for row in stats.funnel %}
-        {% set pct = (row.count / total * 100) %}
-        <div>
-            <div class="relative h-11 rounded-lg bg-gray-100 dark:bg-gray-800 overflow-hidden flex items-center justify-center">
-                {# Centered fill creates the tapering funnel shape #}
-                <div class="absolute inset-y-0 left-1/2 -translate-x-1/2 bg-blue-500/80 dark:bg-blue-500/60 rounded-lg"
-                     style="width: {{ pct | round(2) }}%"></div>
-                <span class="relative text-sm font-medium text-gray-800 dark:text-gray-100 px-3 truncate">
-                    <span class="text-gray-500 dark:text-gray-400 font-normal">Phase {{ row.order }}</span>
-                    {{ row.name }}
-                </span>
-                <span class="absolute right-3 text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
-                    {{ row.count }}
-                    <span class="ml-1 text-xs font-normal text-gray-500 dark:text-gray-400">{{ pct | round(1) }}%</span>
-                </span>
-            </div>
+    <div class="mt-6 space-y-1.5 max-w-xl mx-auto">
+        {% for level in stats.funnel %}
+        <div class="flex items-center justify-between gap-3 text-sm">
+            <span class="{{ 'font-semibold text-gray-900 dark:text-white' if level.is_total else 'font-medium text-gray-700 dark:text-gray-300' }} truncate">
+                {{ level.label }}
+            </span>
+            <span class="flex-shrink-0 tabular-nums text-gray-500 dark:text-gray-400">
+                <span class="font-semibold text-gray-900 dark:text-white">{{ level.count }}</span>
+                {% if not level.is_total %}
+                <span class="ml-1">&middot; {{ level.pct_of_total | round(1) }}% of total</span>
+                {% if level.pct_of_previous is not none %}
+                <span class="ml-1">&middot; {{ level.pct_of_previous | round(0) | int }}% from previous</span>
+                {% endif %}
+                {% endif %}
+            </span>
         </div>
         {% endfor %}
     </div>
-    <p class="mt-3 text-xs text-gray-400 dark:text-gray-500">
-        Percentages are relative to total accounts. Later phases require completing earlier ones, so the funnel narrows as learners advance.
+    <p class="mt-4 text-xs text-gray-400 dark:text-gray-500 text-center">
+        Later phases require completing earlier ones, so the funnel narrows as learners advance.
     </p>
 </section>
 

--- a/api/src/learn_to_cloud/templates/pages/stats.html
+++ b/api/src/learn_to_cloud/templates/pages/stats.html
@@ -17,44 +17,41 @@
         How many learners have verified every project in each phase.
     </p>
 
-    <svg viewBox="0 0 100 {{ stats.funnel | length * 20 }}"
-         class="w-full max-w-xl mx-auto text-blue-500 block"
-         preserveAspectRatio="xMidYMid meet" role="img" aria-label="Progress funnel">
+    <div class="max-w-2xl mx-auto space-y-2" role="img" aria-label="Progress funnel">
         {% for level in stats.funnel %}
-        {% set i = loop.index0 %}
-        {% set top = level.pct_of_total %}
-        {% set nxt = stats.funnel[i + 1] %}
-        {% set bot = nxt.pct_of_total if nxt else level.pct_of_total %}
-        {% set y0 = i * 20 %}
-        {% set y1 = y0 + 18 %}
-        {% set fill_opacity = 1 - i * 0.09 %}
-        <polygon
-            points="{{ (50 - top / 2) | round(2) }},{{ y0 }} {{ (50 + top / 2) | round(2) }},{{ y0 }} {{ (50 + bot / 2) | round(2) }},{{ y1 }} {{ (50 - bot / 2) | round(2) }},{{ y1 }}"
-            fill="currentColor" style="opacity: {{ fill_opacity if fill_opacity > 0.35 else 0.35 }}"></polygon>
-        <text x="50" y="{{ y0 + 12 }}" text-anchor="middle" font-size="6" font-weight="700" fill="#ffffff">{{ level.count }}</text>
-        {% endfor %}
-    </svg>
+        <div class="flex items-center gap-3 sm:gap-4">
+            {# Label #}
+            <div class="w-28 sm:w-44 flex-shrink-0 text-right">
+                <p class="text-xs sm:text-sm leading-tight {{ 'font-semibold text-gray-900 dark:text-white' if level.is_total else 'font-medium text-gray-700 dark:text-gray-300' }}"
+                   title="{{ level.label }}">{{ level.label }}</p>
+            </div>
 
-    <div class="mt-6 space-y-1.5 max-w-xl mx-auto">
-        {% for level in stats.funnel %}
-        <div class="flex items-center justify-between gap-3 text-sm">
-            <span class="{{ 'font-semibold text-gray-900 dark:text-white' if level.is_total else 'font-medium text-gray-700 dark:text-gray-300' }} truncate">
-                {{ level.label }}
-            </span>
-            <span class="flex-shrink-0 tabular-nums text-gray-500 dark:text-gray-400">
-                <span class="font-semibold text-gray-900 dark:text-white">{{ level.count }}</span>
-                {% if not level.is_total %}
-                <span class="ml-1">&middot; {{ level.pct_of_total | round(1) }}% of total</span>
+            {# Centered tapering bar #}
+            <div class="flex-1 flex justify-center min-w-0">
+                <div class="flex items-center justify-center h-9 rounded-md px-2 text-sm font-semibold tabular-nums text-white shadow-sm
+                            {{ 'bg-blue-600 dark:bg-blue-500' if level.is_total else 'bg-blue-500 dark:bg-blue-500' }}"
+                     style="width: {{ level.pct_of_total | round(2) }}%; min-width: 3.25rem; {{ '' if level.is_total else 'opacity: %.2f;' | format(1 - loop.index0 * 0.06 if 1 - loop.index0 * 0.06 > 0.55 else 0.55) }}">
+                    {{ level.count }}
+                </div>
+            </div>
+
+            {# Percentages #}
+            <div class="w-20 sm:w-24 flex-shrink-0 text-left tabular-nums leading-tight">
+                {% if level.is_total %}
+                <p class="text-xs text-gray-400 dark:text-gray-500">accounts</p>
+                {% else %}
+                <p class="text-xs sm:text-sm font-medium text-gray-700 dark:text-gray-300">{{ level.pct_of_total | round(1) }}%</p>
                 {% if level.pct_of_previous is not none %}
-                <span class="ml-1">&middot; {{ level.pct_of_previous | round(0) | int }}% from previous</span>
+                <p class="text-xs text-gray-400 dark:text-gray-500">{{ level.pct_of_previous | round(0) | int }}% of prev</p>
                 {% endif %}
                 {% endif %}
-            </span>
+            </div>
         </div>
         {% endfor %}
     </div>
-    <p class="mt-4 text-xs text-gray-400 dark:text-gray-500 text-center">
+    <p class="mt-5 text-xs text-gray-400 dark:text-gray-500 text-center">
         Later phases require completing earlier ones, so the funnel narrows as learners advance.
+        Percentages show share of total accounts and conversion from the previous phase.
     </p>
 </section>
 

--- a/api/src/learn_to_cloud/templates/pages/stats.html
+++ b/api/src/learn_to_cloud/templates/pages/stats.html
@@ -1,0 +1,110 @@
+{% extends "base.html" %}
+{% block title %}Stats - Learn to Cloud{% endblock %}
+{% block description %}Community stats for Learn to Cloud — how many learners have completed each phase, who they are, and the latest curriculum updates.{% endblock %}
+
+{% block content %}
+<div class="mb-8">
+    <h1 class="text-3xl font-bold text-gray-900 dark:text-white">Community stats</h1>
+    <p class="text-gray-600 dark:text-gray-400 mt-2">
+        How the community is progressing through the curriculum, and what's new.
+    </p>
+</div>
+
+{# ── Phase funnel ─────────────────────────────────────────────── #}
+<section class="mb-12">
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-4">Phase completion</h2>
+    <p class="text-base text-gray-500 dark:text-gray-400 mb-4">
+        Learners who have verified every project in a phase.
+    </p>
+
+    {% set max_count = stats.total_accounts if stats.total_accounts > 0 else 1 %}
+    <div class="space-y-3">
+        <div class="flex items-center gap-3">
+            <div class="w-32 flex-shrink-0 text-sm font-medium text-gray-700 dark:text-gray-300">Total accounts</div>
+            <div class="flex-1 bg-gray-100 dark:bg-gray-800 rounded-md h-8 relative overflow-hidden">
+                <div class="bg-blue-600 h-full rounded-md" style="width: 100%"></div>
+            </div>
+            <div class="w-16 flex-shrink-0 text-right text-sm font-semibold text-gray-900 dark:text-white tabular-nums">{{ stats.total_accounts }}</div>
+        </div>
+
+        {% for row in stats.funnel %}
+        <div class="flex items-center gap-3">
+            <div class="w-32 flex-shrink-0 text-sm font-medium text-gray-700 dark:text-gray-300">
+                <span class="text-gray-400 dark:text-gray-500 font-normal">Phase {{ row.order }}</span>
+            </div>
+            <div class="flex-1 bg-gray-100 dark:bg-gray-800 rounded-md h-8 relative overflow-hidden">
+                <div class="bg-blue-500 h-full rounded-md" style="width: {{ (row.count / max_count * 100) | round(1) }}%"></div>
+                <span class="absolute inset-0 flex items-center px-3 text-xs text-gray-600 dark:text-gray-300 truncate">{{ row.name }}</span>
+            </div>
+            <div class="w-16 flex-shrink-0 text-right text-sm font-semibold text-gray-900 dark:text-white tabular-nums">{{ row.count }}</div>
+        </div>
+        {% endfor %}
+    </div>
+</section>
+
+{# ── Completers ───────────────────────────────────────────────── #}
+<section class="mb-12">
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-4">Phase completers</h2>
+
+    <div class="space-y-6">
+        {% for phase in stats.completers %}
+        <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <h3 class="text-base font-semibold text-gray-900 dark:text-white mb-3">
+                <span class="text-gray-400 dark:text-gray-500 font-normal">Phase {{ phase.order }}</span>
+                {{ phase.name }}
+                <span class="ml-1 text-sm font-normal text-gray-500 dark:text-gray-400">({{ phase.members | length }})</span>
+            </h3>
+            {% if phase.members %}
+            <ul class="flex flex-wrap gap-2">
+                {% for member in phase.members %}
+                <li>
+                    <a href="https://github.com/{{ member.github_username }}" target="_blank" rel="noopener noreferrer"
+                       class="inline-flex items-center gap-2 rounded-full border border-gray-200 dark:border-gray-700 py-1 pl-1 pr-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                        {% if member.avatar_url %}
+                        <img src="{{ member.avatar_url }}" alt="{{ member.github_username }}" class="h-6 w-6 rounded-full" loading="lazy">
+                        {% else %}
+                        <span class="h-6 w-6 rounded-full bg-gray-200 dark:bg-gray-700 inline-flex items-center justify-center text-xs text-gray-500 dark:text-gray-400">{{ member.github_username[0] | upper }}</span>
+                        {% endif %}
+                        <span class="text-sm text-gray-700 dark:text-gray-300">{{ member.github_username }}</span>
+                    </a>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p class="text-sm text-gray-500 dark:text-gray-400">No one has completed this phase yet. Be the first!</p>
+            {% endif %}
+        </div>
+        {% endfor %}
+    </div>
+</section>
+
+{# ── Latest curriculum updates ────────────────────────────────── #}
+<section class="mb-8">
+    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-4">Latest curriculum updates</h2>
+
+    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {% for repo in stats.repo_updates %}
+        <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4 flex flex-col">
+            <a href="{{ repo.url }}" target="_blank" rel="noopener noreferrer"
+               class="text-base font-semibold text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
+                {{ repo.name }}
+            </a>
+            {% if repo.available %}
+            <a href="{{ repo.commit_url }}" target="_blank" rel="noopener noreferrer"
+               class="mt-2 text-sm text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 line-clamp-2">
+                {{ repo.commit_message or "(no commit message)" }}
+            </a>
+            <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                {% if repo.commit_author %}{{ repo.commit_author }}{% endif %}
+                {% if repo.committed_at %}
+                <span class="mx-1">&middot;</span>{{ repo.committed_at.strftime('%b %d, %Y') }}
+                {% endif %}
+            </p>
+            {% else %}
+            <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Latest activity unavailable right now.</p>
+            {% endif %}
+        </div>
+        {% endfor %}
+    </div>
+</section>
+{% endblock %}

--- a/api/src/learn_to_cloud/templates/partials/footer.html
+++ b/api/src/learn_to_cloud/templates/partials/footer.html
@@ -5,6 +5,8 @@
             <span class="mx-1">&middot;</span>
             <a href="/curriculum" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Curriculum</a>
             <span class="mx-1">&middot;</span>
+            <a href="/stats" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Stats</a>
+            <span class="mx-1">&middot;</span>
             <a href="/faq" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">FAQ</a>
             <span class="mx-1">&middot;</span>
             <a href="/privacy" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Privacy</a>

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -30,6 +30,7 @@ from learn_to_cloud.routes.pages_routes import (
     home_page,
     phase_page,
     privacy_page,
+    stats_page,
     terms_page,
     topic_page,
 )
@@ -438,3 +439,32 @@ class TestPublicPages:
             await handler(request, mock_db, user_id=None)
 
         assert template.call_args[0][1] == template_name
+
+
+@pytest.mark.unit
+class TestStatsPage:
+    """Tests for GET /stats (public)."""
+
+    async def test_stats_renders_with_stats_context(self, _patch_templates):
+        request, template = _mock_request(_patch_templates)
+        mock_db = AsyncMock()
+        mock_stats = MagicMock()
+
+        with (
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                autospec=True,
+                return_value=None,
+            ),
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_stats_page_data",
+                autospec=True,
+                return_value=mock_stats,
+            ),
+        ):
+            await stats_page(request, mock_db, user_id=None)
+
+        assert template.call_args[0][1] == "pages/stats.html"
+        ctx = template.call_args[0][2]
+        assert ctx["stats"] is mock_stats
+        assert ctx["user"] is None

--- a/api/tests/services/test_stats_service.py
+++ b/api/tests/services/test_stats_service.py
@@ -1,0 +1,124 @@
+"""Integration tests for stats_service.get_stats_page_data."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from learn_to_cloud_shared.content_service import get_requirement_counts_by_phase
+from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
+from learn_to_cloud_shared.content_yaml_loader import clear_cache
+from learn_to_cloud_shared.models import (
+    CurriculumPhase,
+    CurriculumRequirement,
+    SubmissionValueKind,
+    User,
+)
+from learn_to_cloud_shared.repositories.submission_repository import (
+    SubmissionRepository,
+)
+from learn_to_cloud_shared.submission_values import SubmittedValue
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud.services.stats_service import get_stats_page_data
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+def _value_for_kind(kind: str, seed: str) -> SubmittedValue:
+    value_kind = SubmissionValueKind(kind)
+    kwargs = {
+        SubmissionValueKind.GITHUB_URL: {"github_url": f"https://github.com/{seed}"},
+        SubmissionValueKind.TOKEN: {"token_value": f"token-{seed}"},
+        SubmissionValueKind.DEPLOYED_URL: {
+            "deployed_url": f"https://{seed}.example.com"
+        },
+        SubmissionValueKind.TEXT: {"text_value": f"reflection {seed}"},
+    }[value_kind]
+    return SubmittedValue(kind=value_kind, **kwargs)
+
+
+async def _reqs_by_phase(db: AsyncSession) -> dict[int, list[tuple]]:
+    result = await db.execute(
+        select(
+            CurriculumPhase.order,
+            CurriculumRequirement.uuid,
+            CurriculumRequirement.submission_value_kind,
+        )
+        .join(CurriculumPhase, CurriculumRequirement.phase_uuid == CurriculumPhase.uuid)
+        .where(
+            CurriculumRequirement.deleted_at.is_(None),
+            CurriculumPhase.deleted_at.is_(None),
+        )
+    )
+    by_phase: dict[int, list[tuple]] = {}
+    for order, uuid, kind in result.all():
+        by_phase.setdefault(order, []).append((uuid, kind))
+    return by_phase
+
+
+async def _validate(db: AsyncSession, user_id: int, reqs: list[tuple]) -> None:
+    repo = SubmissionRepository(db)
+    for uuid, kind in reqs:
+        await repo.create(
+            user_id=user_id,
+            requirement_uuid=uuid,
+            submitted_value=_value_for_kind(kind, f"u{user_id}"),
+            extracted_username=None,
+            is_validated=True,
+        )
+
+
+class TestGetStatsPageData:
+    async def test_graduates_are_only_full_curriculum_completers(
+        self, db_session: AsyncSession
+    ):
+        clear_cache()
+        await sync_curriculum_to_db(db_session)
+        reqs_by_phase = await _reqs_by_phase(db_session)
+        counts = await get_requirement_counts_by_phase(db_session)
+        completable = sorted(o for o, c in counts.items() if c > 0)
+
+        # graduate: validates every requirement in every completable phase.
+        db_session.add(User(id=60001, github_username="grad"))
+        # partial: validates only the first completable phase.
+        db_session.add(User(id=60002, github_username="partial"))
+        await db_session.flush()
+
+        for order in completable:
+            await _validate(db_session, 60001, reqs_by_phase[order])
+        await _validate(db_session, 60002, reqs_by_phase[completable[0]])
+        await db_session.flush()
+
+        with patch(
+            "learn_to_cloud.services.stats_service.get_latest_curriculum_commits",
+            new=AsyncMock(return_value=[]),
+        ):
+            stats = await get_stats_page_data(db_session)
+
+        usernames = {m.github_username for m in stats.graduates}
+        assert "grad" in usernames
+        assert "partial" not in usernames
+
+        # Funnel covers exactly the completable phases, first phase counts
+        # both users, and total accounts includes everyone.
+        assert [row.order for row in stats.funnel] == completable
+        first_row = next(r for r in stats.funnel if r.order == completable[0])
+        assert first_row.count >= 2
+        assert stats.total_accounts >= 2
+
+    async def test_no_graduates_when_no_full_completions(
+        self, db_session: AsyncSession
+    ):
+        clear_cache()
+        await sync_curriculum_to_db(db_session)
+
+        db_session.add(User(id=60003, github_username="nobody"))
+        await db_session.flush()
+
+        with patch(
+            "learn_to_cloud.services.stats_service.get_latest_curriculum_commits",
+            new=AsyncMock(return_value=[]),
+        ):
+            stats = await get_stats_page_data(db_session)
+
+        assert stats.graduates == []

--- a/api/tests/services/test_stats_service.py
+++ b/api/tests/services/test_stats_service.py
@@ -99,11 +99,20 @@ class TestGetStatsPageData:
         assert "grad" in usernames
         assert "partial" not in usernames
 
-        # Funnel covers exactly the completable phases, first phase counts
-        # both users, and total accounts includes everyone.
-        assert [row.order for row in stats.funnel] == completable
-        first_row = next(r for r in stats.funnel if r.order == completable[0])
-        assert first_row.count >= 2
+        # Funnel starts with the total-accounts level, then covers exactly
+        # the completable phases; the first phase counts both users.
+        assert stats.funnel[0].is_total is True
+        assert stats.funnel[0].label == "Total accounts"
+        assert stats.funnel[0].pct_of_total == 100.0
+        phase_levels = stats.funnel[1:]
+        assert len(phase_levels) == len(completable)
+        assert all(
+            f"Phase {order}" in lvl.label
+            for order, lvl in zip(completable, phase_levels, strict=True)
+        )
+        first_phase_level = phase_levels[0]
+        assert first_phase_level.count >= 2
+        assert first_phase_level.pct_of_previous is not None
         assert stats.total_accounts >= 2
 
     async def test_no_graduates_when_no_full_completions(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_db_loader.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_db_loader.py
@@ -386,6 +386,31 @@ async def load_requirements_by_phase_order_from_db(
     return dict(by_phase_order)
 
 
+async def load_requirement_counts_by_phase_from_db(
+    db: AsyncSession,
+) -> dict[int, int]:
+    """Count active requirements per phase via one aggregate query.
+
+    Requirement-side mirror of ``load_required_step_counts_by_phase_from_db``.
+    Backs hands-on totals (``hands_on_required``) and the ``/stats``
+    phase-completion check without assembling the requirement tree.
+    """
+    result = await db.execute(
+        select(CurriculumPhase.order, func.count(CurriculumRequirement.uuid))
+        .select_from(CurriculumRequirement)
+        .join(
+            CurriculumPhase,
+            CurriculumRequirement.phase_uuid == CurriculumPhase.uuid,
+        )
+        .where(
+            CurriculumRequirement.deleted_at.is_(None),
+            CurriculumPhase.deleted_at.is_(None),
+        )
+        .group_by(CurriculumPhase.order)
+    )
+    return {order: count for order, count in result.all()}
+
+
 async def load_required_step_counts_by_phase_from_db(
     db: AsyncSession,
 ) -> dict[int, int]:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py
@@ -26,6 +26,7 @@ from learn_to_cloud_shared.content_db_loader import (
     load_curriculum_overview_from_db,
     load_phase_by_slug_from_db,
     load_required_step_counts_by_phase_from_db,
+    load_requirement_counts_by_phase_from_db,
     load_requirements_by_phase_order_from_db,
     load_topic_containing_step_from_db,
 )
@@ -86,3 +87,8 @@ async def get_requirements_by_phase_order(
 async def get_required_step_counts_by_phase(db: AsyncSession) -> dict[int, int]:
     """Get the count of active required steps per phase order."""
     return await load_required_step_counts_by_phase_from_db(db)
+
+
+async def get_requirement_counts_by_phase(db: AsyncSession) -> dict[int, int]:
+    """Get the count of active hands-on requirements per phase order."""
+    return await load_requirement_counts_by_phase_from_db(db)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/github_updates.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/github_updates.py
@@ -26,6 +26,7 @@ CURRICULUM_REPOS: tuple[tuple[str, str], ...] = (
     ("learntocloud", "learn-to-cloud-app"),
     ("learntocloud", "linux-ctfs"),
     ("learntocloud", "networking-lab"),
+    ("learntocloud", "journal-starter"),
 )
 
 # One shared entry keyed by "owner/repo"; ~10 min is fresh enough for a

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/github_updates.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/github_updates.py
@@ -1,0 +1,109 @@
+"""Latest-commit lookups for the curriculum repos (powers /stats).
+
+Reuses the resilient ``github_api_get`` seam (auth headers, retry, and
+5xx/429 mapping) rather than hand-rolling httpx. Results are cached in a
+short-lived process-level ``TTLCache`` because the /stats page is public
+and the unauthenticated GitHub API is rate limited (60 req/hr/IP). Any
+lookup failure degrades to an ``unavailable`` entry so the page still
+renders.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+import httpx
+from cachetools import TTLCache
+
+from learn_to_cloud_shared.schemas import RepoUpdate
+from learn_to_cloud_shared.verification.github_http import github_api_get
+
+logger = logging.getLogger(__name__)
+
+# Curriculum repos surfaced on /stats, in display order.
+CURRICULUM_REPOS: tuple[tuple[str, str], ...] = (
+    ("learntocloud", "learn-to-cloud-app"),
+    ("learntocloud", "linux-ctfs"),
+    ("learntocloud", "networking-lab"),
+)
+
+# One shared entry keyed by "owner/repo"; ~10 min is fresh enough for a
+# "latest curriculum updates" panel and keeps us well under the rate limit.
+_CACHE: TTLCache[str, RepoUpdate] = TTLCache(maxsize=32, ttl=600)
+
+
+def _parse_commit(owner: str, repo: str, payload: dict) -> RepoUpdate:
+    """Build a RepoUpdate from a GitHub commit JSON object."""
+    commit = payload.get("commit") or {}
+    author = commit.get("author") or {}
+    committer = commit.get("committer") or {}
+    login = (payload.get("author") or {}).get("login")
+
+    committed_at: datetime | None = None
+    raw_date = committer.get("date") or author.get("date")
+    if raw_date:
+        try:
+            committed_at = datetime.fromisoformat(raw_date.replace("Z", "+00:00"))
+        except ValueError:
+            committed_at = None
+
+    message = commit.get("message") or ""
+    first_line = message.splitlines()[0] if message else None
+
+    return RepoUpdate(
+        name=repo,
+        url=f"https://github.com/{owner}/{repo}",
+        available=True,
+        commit_message=first_line,
+        commit_author=login or author.get("name"),
+        commit_url=payload.get("html_url"),
+        committed_at=committed_at,
+    )
+
+
+def _unavailable(owner: str, repo: str) -> RepoUpdate:
+    """Fallback entry when the GitHub lookup fails."""
+    return RepoUpdate(
+        name=repo,
+        url=f"https://github.com/{owner}/{repo}",
+        available=False,
+    )
+
+
+async def _fetch_latest_commit(owner: str, repo: str) -> RepoUpdate:
+    """Fetch the latest commit for one repo, degrading on any failure."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits"
+    try:
+        response = await github_api_get(url, params={"per_page": 1})
+        commits = response.json()
+        if not commits:
+            return _unavailable(owner, repo)
+        return _parse_commit(owner, repo, commits[0])
+    except (httpx.HTTPError, ValueError, KeyError, IndexError) as exc:
+        logger.warning(
+            "stats.github_commit_failed",
+            extra={"repo": f"{owner}/{repo}", "error": str(exc)},
+        )
+        return _unavailable(owner, repo)
+
+
+async def get_latest_curriculum_commits() -> list[RepoUpdate]:
+    """Latest commit per curriculum repo, cached for ~10 minutes.
+
+    Never raises: repos whose lookup fails come back as ``unavailable``.
+    """
+    updates: list[RepoUpdate] = []
+    for owner, repo in CURRICULUM_REPOS:
+        key = f"{owner}/{repo}"
+        cached = _CACHE.get(key)
+        if cached is not None:
+            updates.append(cached)
+            continue
+        update = await _fetch_latest_commit(owner, repo)
+        # Only cache successful lookups so a transient failure doesn't
+        # pin an "unavailable" card for the full TTL.
+        if update.available:
+            _CACHE[key] = update
+        updates.append(update)
+    return updates

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/submission_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/submission_repository.py
@@ -209,3 +209,59 @@ class SubmissionRepository:
             .group_by(CurriculumPhase.order)
         )
         return {order: count for order, count in result.all()}
+
+    async def list_phase_completions(
+        self, requirement_counts_by_phase: dict[int, int]
+    ) -> list[tuple[int, int]]:
+        """List ``(phase_order, user_id)`` for fully-completed phases.
+
+        A phase is "completed" by a user when they have a validated
+        submission for every active requirement in that phase. The
+        ``requirement_counts_by_phase`` map (active requirement totals per
+        phase order, from ``get_requirement_counts_by_phase``) supplies the
+        completion threshold; phases absent from that map or with a
+        non-positive total are treated as not completable and excluded.
+
+        Single aggregate over ``submissions -> requirements -> phases``:
+        groups by phase + user and keeps only groups whose distinct
+        validated requirement count matches the phase total. Drives both
+        the ``/stats`` phase funnel counts and the completer lists.
+        """
+        completable = {
+            order: total
+            for order, total in requirement_counts_by_phase.items()
+            if total > 0
+        }
+        if not completable:
+            return []
+
+        result = await self.db.execute(
+            select(
+                CurriculumPhase.order,
+                Submission.user_id,
+                func.count(func.distinct(Submission.requirement_uuid)).label(
+                    "validated"
+                ),
+            )
+            .select_from(Submission)
+            .join(
+                CurriculumRequirement,
+                Submission.requirement_uuid == CurriculumRequirement.uuid,
+            )
+            .join(
+                CurriculumPhase,
+                CurriculumRequirement.phase_uuid == CurriculumPhase.uuid,
+            )
+            .where(
+                Submission.is_validated.is_(True),
+                CurriculumRequirement.deleted_at.is_(None),
+                CurriculumPhase.deleted_at.is_(None),
+                CurriculumPhase.order.in_(completable.keys()),
+            )
+            .group_by(CurriculumPhase.order, Submission.user_id)
+        )
+        return [
+            (order, user_id)
+            for order, user_id, validated in result.all()
+            if validated >= completable[order]
+        ]

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/user_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/user_repository.py
@@ -1,6 +1,8 @@
 """User repository for database operations."""
 
-from sqlalchemy import delete, select
+from collections.abc import Iterable
+
+from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -27,6 +29,23 @@ class UserRepository:
         """Get a user by their ID (GitHub numeric user ID)."""
         result = await self.db.execute(select(User).where(User.id == user_id))
         return result.scalar_one_or_none()
+
+    async def get_by_ids(self, user_ids: Iterable[int]) -> list[User]:
+        """Batch-fetch users by id in a single query.
+
+        Order is unspecified; callers that need a stable order should sort
+        the result. Returns an empty list for an empty id set.
+        """
+        ids = list(user_ids)
+        if not ids:
+            return []
+        result = await self.db.execute(select(User).where(User.id.in_(ids)))
+        return list(result.scalars().all())
+
+    async def count(self) -> int:
+        """Count all user accounts."""
+        result = await self.db.execute(select(func.count()).select_from(User))
+        return result.scalar_one()
 
     async def get_or_create(
         self,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -626,14 +626,6 @@ class PhaseFunnelRow(FrozenModel):
     count: int
 
 
-class PhaseCompleters(FrozenModel):
-    """Members who fully completed a phase, for the /stats completer list."""
-
-    order: int
-    name: str
-    members: list[CommunityMember]
-
-
 class RepoUpdate(FrozenModel):
     """Latest commit for a curriculum repo (service-layer response model).
 
@@ -655,7 +647,7 @@ class StatsPageData(FrozenModel):
 
     total_accounts: int
     funnel: list[PhaseFunnelRow]
-    completers: list[PhaseCompleters]
+    graduates: list[CommunityMember]
     repo_updates: list[RepoUpdate]
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -618,12 +618,19 @@ class CommunityMember(FrozenModel):
     avatar_url: str | None = None
 
 
-class PhaseFunnelRow(FrozenModel):
-    """One row of the /stats phase funnel: how many completed a phase."""
+class FunnelLevel(FrozenModel):
+    """One level of the /stats progress funnel.
 
-    order: int
-    name: str
+    ``pct_of_total`` is relative to total accounts (drives the funnel
+    width); ``pct_of_previous`` is the conversion from the level above
+    (``None`` for the top level).
+    """
+
+    label: str
     count: int
+    pct_of_total: float
+    pct_of_previous: float | None = None
+    is_total: bool = False
 
 
 class RepoUpdate(FrozenModel):
@@ -646,7 +653,7 @@ class StatsPageData(FrozenModel):
     """Complete /stats payload (service-layer response model)."""
 
     total_accounts: int
-    funnel: list[PhaseFunnelRow]
+    funnel: list[FunnelLevel]
     graduates: list[CommunityMember]
     repo_updates: list[RepoUpdate]
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -611,6 +611,54 @@ class DashboardData(FrozenModel):
     continue_phase: ContinuePhaseData | None = None
 
 
+class CommunityMember(FrozenModel):
+    """A learner shown publicly on the /stats page."""
+
+    github_username: str
+    avatar_url: str | None = None
+
+
+class PhaseFunnelRow(FrozenModel):
+    """One row of the /stats phase funnel: how many completed a phase."""
+
+    order: int
+    name: str
+    count: int
+
+
+class PhaseCompleters(FrozenModel):
+    """Members who fully completed a phase, for the /stats completer list."""
+
+    order: int
+    name: str
+    members: list[CommunityMember]
+
+
+class RepoUpdate(FrozenModel):
+    """Latest commit for a curriculum repo (service-layer response model).
+
+    ``available`` is False when the GitHub lookup failed (rate limit,
+    network error); the page still renders the repo with a fallback.
+    """
+
+    name: str
+    url: str
+    available: bool = True
+    commit_message: str | None = None
+    commit_author: str | None = None
+    commit_url: str | None = None
+    committed_at: datetime | None = None
+
+
+class StatsPageData(FrozenModel):
+    """Complete /stats payload (service-layer response model)."""
+
+    total_accounts: int
+    funnel: list[PhaseFunnelRow]
+    completers: list[PhaseCompleters]
+    repo_updates: list[RepoUpdate]
+
+
 class PhaseProgress(FrozenModel):
     """User's progress for a single phase.
 

--- a/packages/learn-to-cloud-shared/tests/repositories/test_stats_aggregates.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_stats_aggregates.py
@@ -1,0 +1,147 @@
+"""Integration tests for stats aggregates (phase completion + counts)."""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud_shared.content_service import get_requirement_counts_by_phase
+from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
+from learn_to_cloud_shared.content_yaml_loader import clear_cache
+from learn_to_cloud_shared.models import (
+    CurriculumPhase,
+    CurriculumRequirement,
+    SubmissionValueKind,
+)
+from learn_to_cloud_shared.repositories.submission_repository import (
+    SubmissionRepository,
+)
+from learn_to_cloud_shared.repositories.user_repository import UserRepository
+from learn_to_cloud_shared.submission_values import SubmittedValue
+
+pytestmark = pytest.mark.integration
+
+
+def _value_for_kind(kind: str, seed: str) -> SubmittedValue:
+    """Build a schema-valid SubmittedValue for a requirement's value kind."""
+    value_kind = SubmissionValueKind(kind)
+    match value_kind:
+        case SubmissionValueKind.GITHUB_URL:
+            return SubmittedValue(
+                kind=value_kind, github_url=f"https://github.com/{seed}"
+            )
+        case SubmissionValueKind.TOKEN:
+            return SubmittedValue(kind=value_kind, token_value=f"token-{seed}")
+        case SubmissionValueKind.DEPLOYED_URL:
+            return SubmittedValue(
+                kind=value_kind, deployed_url=f"https://{seed}.example.com"
+            )
+        case SubmissionValueKind.TEXT:
+            return SubmittedValue(kind=value_kind, text_value=f"reflection {seed}")
+
+
+@pytest.fixture()
+async def reqs_by_phase(db_session: AsyncSession) -> dict[int, list[tuple]]:
+    """Sync curriculum; return {phase_order: [(uuid, value_kind), ...]}."""
+    clear_cache()
+    await sync_curriculum_to_db(db_session)
+    result = await db_session.execute(
+        select(
+            CurriculumPhase.order,
+            CurriculumRequirement.uuid,
+            CurriculumRequirement.submission_value_kind,
+        )
+        .join(
+            CurriculumPhase,
+            CurriculumRequirement.phase_uuid == CurriculumPhase.uuid,
+        )
+        .where(
+            CurriculumRequirement.deleted_at.is_(None),
+            CurriculumPhase.deleted_at.is_(None),
+        )
+    )
+    by_phase: dict[int, list[tuple]] = {}
+    for order, uuid, kind in result.all():
+        by_phase.setdefault(order, []).append((uuid, kind))
+    return by_phase
+
+
+async def _validate_all(
+    db_session: AsyncSession, user_id: int, reqs: list[tuple]
+) -> None:
+    repo = SubmissionRepository(db_session)
+    for uuid, kind in reqs:
+        await repo.create(
+            user_id=user_id,
+            requirement_uuid=uuid,
+            submitted_value=_value_for_kind(kind, f"u{user_id}"),
+            extracted_username=None,
+            is_validated=True,
+        )
+
+
+class TestListPhaseCompletions:
+    async def test_user_appears_only_when_all_requirements_validated(
+        self, db_session: AsyncSession, reqs_by_phase
+    ):
+        # A phase with a single requirement (easy full completion).
+        single_phase = next(
+            order for order, reqs in reqs_by_phase.items() if len(reqs) == 1
+        )
+        user_id = 50001
+        await UserRepository(db_session).upsert(
+            user_id, github_username="fullcompleter"
+        )
+        await _validate_all(db_session, user_id, reqs_by_phase[single_phase])
+        await db_session.flush()
+
+        counts = await get_requirement_counts_by_phase(db_session)
+        completions = await SubmissionRepository(db_session).list_phase_completions(
+            counts
+        )
+
+        assert (single_phase, user_id) in completions
+
+    async def test_partial_completion_excluded(
+        self, db_session: AsyncSession, reqs_by_phase
+    ):
+        # A phase with more than one requirement; validate only the first.
+        multi_phase = next(
+            order for order, reqs in reqs_by_phase.items() if len(reqs) > 1
+        )
+        user_id = 50002
+        await UserRepository(db_session).upsert(user_id, github_username="partial")
+        await _validate_all(db_session, user_id, reqs_by_phase[multi_phase][:1])
+        await db_session.flush()
+
+        counts = await get_requirement_counts_by_phase(db_session)
+        completions = await SubmissionRepository(db_session).list_phase_completions(
+            counts
+        )
+
+        assert (multi_phase, user_id) not in completions
+
+    async def test_empty_counts_returns_empty(self, db_session: AsyncSession):
+        repo = SubmissionRepository(db_session)
+        assert await repo.list_phase_completions({}) == []
+
+    async def test_deleted_requirements_do_not_inflate_threshold(
+        self, db_session: AsyncSession, reqs_by_phase
+    ):
+        # Validate every active requirement in a multi-req phase, then
+        # soft-delete one requirement row. The user validated all *active*
+        # requirements, so they should still count as a completer for the
+        # threshold derived from active counts.
+        multi_phase = next(
+            order for order, reqs in reqs_by_phase.items() if len(reqs) > 1
+        )
+        user_id = 50003
+        await UserRepository(db_session).upsert(user_id, github_username="activeonly")
+        await _validate_all(db_session, user_id, reqs_by_phase[multi_phase])
+        await db_session.flush()
+
+        counts = await get_requirement_counts_by_phase(db_session)
+        completions = await SubmissionRepository(db_session).list_phase_completions(
+            counts
+        )
+
+        assert (multi_phase, user_id) in completions

--- a/packages/learn-to-cloud-shared/tests/repositories/test_user_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_user_repository.py
@@ -91,3 +91,30 @@ class TestDelete:
         """Deleting a non-existent user should not raise."""
         repo = UserRepository(db_session)
         await repo.delete(88888888)
+
+
+class TestGetByIds:
+    async def test_returns_matching_users(self, db_session: AsyncSession):
+        repo = UserRepository(db_session)
+        await repo.upsert(41001, github_username="ida")
+        await repo.upsert(41002, github_username="idb")
+        await db_session.flush()
+
+        users = await repo.get_by_ids([41001, 41002, 99999999])
+        ids = {u.id for u in users}
+        assert ids == {41001, 41002}
+
+    async def test_returns_empty_for_empty_input(self, db_session: AsyncSession):
+        repo = UserRepository(db_session)
+        assert await repo.get_by_ids([]) == []
+
+
+class TestCount:
+    async def test_counts_users(self, db_session: AsyncSession):
+        repo = UserRepository(db_session)
+        before = await repo.count()
+        await repo.upsert(42001, github_username="counta")
+        await repo.upsert(42002, github_username="countb")
+        await db_session.flush()
+
+        assert await repo.count() == before + 2

--- a/packages/learn-to-cloud-shared/tests/test_github_updates.py
+++ b/packages/learn-to-cloud-shared/tests/test_github_updates.py
@@ -1,0 +1,89 @@
+"""Unit tests for the curriculum GitHub commit helper (/stats panel)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from learn_to_cloud_shared import github_updates
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    github_updates._CACHE.clear()
+    yield
+    github_updates._CACHE.clear()
+
+
+def _commit_payload() -> list[dict]:
+    return [
+        {
+            "html_url": "https://github.com/learntocloud/x/commit/abc",
+            "author": {"login": "octocat"},
+            "commit": {
+                "message": "Fix things\n\nlonger body",
+                "author": {"name": "Octo Cat", "date": "2026-01-02T03:04:05Z"},
+                "committer": {"date": "2026-01-02T03:04:05Z"},
+            },
+        }
+    ]
+
+
+def _mock_response(payload: list[dict]) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = payload
+    return response
+
+
+async def test_parses_latest_commit_per_repo():
+    with patch.object(
+        github_updates,
+        "github_api_get",
+        new=AsyncMock(return_value=_mock_response(_commit_payload())),
+    ):
+        updates = await github_updates.get_latest_curriculum_commits()
+
+    assert len(updates) == len(github_updates.CURRICULUM_REPOS)
+    first = updates[0]
+    assert first.available is True
+    assert first.commit_message == "Fix things"  # first line only
+    assert first.commit_author == "octocat"
+    assert first.commit_url == "https://github.com/learntocloud/x/commit/abc"
+    assert first.committed_at is not None
+
+
+async def test_degrades_gracefully_on_http_error():
+    with patch.object(
+        github_updates,
+        "github_api_get",
+        new=AsyncMock(side_effect=httpx.ConnectError("boom")),
+    ):
+        updates = await github_updates.get_latest_curriculum_commits()
+
+    assert len(updates) == len(github_updates.CURRICULUM_REPOS)
+    assert all(u.available is False for u in updates)
+    assert all(u.commit_message is None for u in updates)
+
+
+async def test_empty_commit_list_is_unavailable():
+    with patch.object(
+        github_updates,
+        "github_api_get",
+        new=AsyncMock(return_value=_mock_response([])),
+    ):
+        updates = await github_updates.get_latest_curriculum_commits()
+
+    assert all(u.available is False for u in updates)
+
+
+async def test_successful_lookups_are_cached():
+    mock_get = AsyncMock(return_value=_mock_response(_commit_payload()))
+    with patch.object(github_updates, "github_api_get", new=mock_get):
+        await github_updates.get_latest_curriculum_commits()
+        first_call_count = mock_get.await_count
+        await github_updates.get_latest_curriculum_commits()
+
+    # Second call served entirely from cache — no further HTTP calls.
+    assert mock_get.await_count == first_call_count


### PR DESCRIPTION
## What
Adds a public **`/stats`** page (linked from the footer) with three sections:

1. **Phase funnel** — total accounts, then per phase the count of learners who validated **every** requirement in that phase (independent per-phase count, not latest progress).
2. **Completers** — github username + avatar of everyone who fully completed each phase.
3. **Latest curriculum updates** — latest commit (message, author, date, link) for `learn-to-cloud-app`, `linux-ctfs`, `networking-lab`.

## How (built on existing plumbing)
- GitHub calls reuse `verification/github_http.github_api_get` (auth headers, retry, 5xx/429 mapping). Results are cached in a short-lived `cachetools.TTLCache` (~10 min) and degrade gracefully to an "unavailable" card on failure, so the page always renders.
- Funnel + completers come from **one** aggregate, `SubmissionRepository.list_phase_completions`, which returns `(phase_order, user_id)` for fully-completed phases. The service groups these into counts (funnel) and id-lists (completers), then resolves users with a single batched load.

## Small, generally-useful additions
- `UserRepository.count()` and `UserRepository.get_by_ids()` (were missing).
- `content_service.get_requirement_counts_by_phase()` — requirement-side mirror of the existing `get_required_step_counts_by_phase`.

## Tests
- Repo aggregate: full vs partial completion, empty counts, active-only threshold.
- `UserRepository.count` / `get_by_ids`.
- GitHub helper: commit parsing, graceful degrade, empty list, cache hit.
- `/stats` route renders for anonymous users.
- Full quality gate (`uv run poe check`) green.

## Notes
- Public page displays github usernames + avatars of phase completers (confirmed intended).
- Found and filed a pre-existing bug in passing: `get_github_headers` sets `Authorization = "******"` (a literal, not the token) — see #600. Out of scope here; this page degrades to unauthenticated + cache regardless.