### PR TITLE
fix: tolerate unknown submission_type in content loader (#603)

### DIFF
--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_db_loader.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_db_loader.py
@@ -36,6 +36,7 @@ from learn_to_cloud_shared.models import (
     CurriculumTopic,
 )
 from learn_to_cloud_shared.schemas import (
+    KNOWN_HANDS_ON_SUBMISSION_TYPES,
     HandsOnRequirement,
     HandsOnRequirementAdapter,
     LearningObjective,
@@ -382,6 +383,8 @@ async def load_requirements_by_phase_order_from_db(
         phase_order = phase_order_by_uuid.get(row.phase_uuid)
         if phase_order is None:
             continue
+        if not _is_known_requirement(row):
+            continue
         by_phase_order[phase_order].append(_build_requirement(row))
     return dict(by_phase_order)
 
@@ -468,6 +471,8 @@ def _assemble_phases(
 
     requirements_by_phase: dict[UUID, list] = defaultdict(list)
     for req_row in requirement_rows:
+        if not _is_known_requirement(req_row):
+            continue
         requirements_by_phase[req_row.phase_uuid].append(_build_requirement(req_row))
 
     phases: list[Phase] = []
@@ -549,6 +554,28 @@ def _build_requirement(row: CurriculumRequirement):
             "type_config": row.type_config or {},
         }
     )
+
+
+def _is_known_requirement(row: CurriculumRequirement) -> bool:
+    """Tolerant-reader gate for a requirement row.
+
+    During a rolling deploy the DB can already hold a ``submission_type``
+    this revision's discriminated union doesn't know yet. Skip-and-log those
+    rows instead of letting ``_build_requirement`` 500 every phase page.
+    Rows with a known type still build strictly, so a genuinely malformed
+    ``type_config`` for a known type continues to raise.
+    """
+    if row.submission_type in KNOWN_HANDS_ON_SUBMISSION_TYPES:
+        return True
+    logger.warning(
+        "content_db_loader.skipping_unknown_submission_type",
+        extra={
+            "requirement_slug": row.slug,
+            "submission_type": row.submission_type,
+            "requirement_uuid": str(row.uuid),
+        },
+    )
+    return False
 
 
 def _build_phase(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -9,7 +9,7 @@ All schemas use frozen=True for immutability where appropriate.
 
 from datetime import datetime
 from enum import StrEnum
-from typing import Annotated, Literal
+from typing import Annotated, Literal, get_args
 from uuid import UUID
 
 from pydantic import (
@@ -377,6 +377,23 @@ HandsOnRequirement = Annotated[
 # rehydrating requirements from JSON/dict payloads (e.g., durable
 # verification jobs).
 HandsOnRequirementAdapter = TypeAdapter(HandsOnRequirement)
+
+
+# The submission types this code version can render, derived from the
+# discriminated union's members so it can never drift from the union. Used by
+# the content loader as a tolerant reader: during a rolling deploy the DB may
+# already hold a newer submission_type this revision doesn't know, and those
+# rows must be ignored rather than 500 the whole page.
+def _known_submission_types() -> frozenset[str]:
+    union = get_args(HandsOnRequirement)[0]
+    tags: set[str] = set()
+    for member in get_args(union):
+        literal = get_args(member.model_fields["submission_type"].annotation)[0]
+        tags.add(literal.value if isinstance(literal, SubmissionType) else str(literal))
+    return frozenset(tags)
+
+
+KNOWN_HANDS_ON_SUBMISSION_TYPES: frozenset[str] = _known_submission_types()
 
 
 class HealthResponse(BaseModel):

--- a/packages/learn-to-cloud-shared/tests/services/test_content_db_loader.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_db_loader.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 from sqlalchemy import event, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -342,6 +343,144 @@ async def test_requirement_rehydrates_to_correct_subclass(
     rebuilt = phase99.hands_on_verification.requirements[0]
     assert isinstance(rebuilt, RepoForkRequirement)
     assert rebuilt.required_repo == "owner/repo"
+
+
+# ---------------------------------------------------------------------------
+# Tolerant reader: unknown submission_type during a rolling deploy (#603)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_phase_with_requirements(
+    db_session: AsyncSession,
+    *,
+    order: int,
+    requirements: list[CurriculumRequirement],
+) -> CurriculumPhase:
+    now = datetime.now(UTC)
+    phase = CurriculumPhase(
+        uuid=uuid4(),
+        slug=f"phase{order}",
+        name=f"Phase {order}",
+        description="d",
+        short_description="sd",
+        order=order,
+        deleted_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(phase)
+    await db_session.flush()
+    for i, req in enumerate(requirements, start=1):
+        req.phase_uuid = phase.uuid
+        req.order = i
+        db_session.add(req)
+    await db_session.flush()
+    db_session.expire_all()
+    return phase
+
+
+def _make_requirement(
+    *,
+    slug: str,
+    submission_type: str,
+    submission_value_kind: str,
+    type_config: dict,
+) -> CurriculumRequirement:
+    now = datetime.now(UTC)
+    return CurriculumRequirement(
+        uuid=uuid4(),
+        phase_uuid=uuid4(),  # overwritten by _seed_phase_with_requirements
+        slug=slug,
+        name=slug,
+        description="desc",
+        submission_type=submission_type,
+        submission_value_kind=submission_value_kind,
+        order=0,
+        type_config=type_config,
+        deleted_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+async def test_unknown_submission_type_is_skipped_not_raised(
+    db_session: AsyncSession,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A submission_type the code doesn't know (but the DB allows) is skipped.
+
+    Reproduces the deploy-skew case: `ci_status` passes the requirements CHECK
+    constraint (with `github_url`) but is not a tag in the discriminated union.
+    The phase must still load and render only the known requirement.
+    """
+    known = _make_requirement(
+        slug="known-fork",
+        submission_type="repo_fork",
+        submission_value_kind="github_url",
+        type_config={"required_repo": "owner/repo"},
+    )
+    unknown = _make_requirement(
+        slug="unknown-type",
+        submission_type="ci_status",
+        submission_value_kind="github_url",
+        type_config={},
+    )
+    phase = await _seed_phase_with_requirements(
+        db_session, order=97, requirements=[known, unknown]
+    )
+
+    with caplog.at_level("WARNING"):
+        phases = await load_all_phases_from_db(db_session)
+
+    loaded = next(p for p in phases if p.uuid == phase.uuid)
+    assert loaded.hands_on_verification is not None
+    slugs = [r.slug for r in loaded.hands_on_verification.requirements]
+    assert slugs == ["known-fork"]
+    assert any(
+        "skipping_unknown_submission_type" in record.message
+        for record in caplog.records
+    )
+
+
+async def test_unknown_submission_type_skipped_in_requirement_index_loader(
+    db_session: AsyncSession,
+) -> None:
+    """The phase-order requirement loader also skips unknown types."""
+    known = _make_requirement(
+        slug="known-fork-2",
+        submission_type="repo_fork",
+        submission_value_kind="github_url",
+        type_config={"required_repo": "owner/repo"},
+    )
+    unknown = _make_requirement(
+        slug="unknown-type-2",
+        submission_type="ci_status",
+        submission_value_kind="github_url",
+        type_config={},
+    )
+    await _seed_phase_with_requirements(
+        db_session, order=96, requirements=[known, unknown]
+    )
+
+    by_order = await load_requirements_by_phase_order_from_db(db_session)
+    loaded_slugs = [r.slug for r in by_order.get(96, [])]
+    assert loaded_slugs == ["known-fork-2"]
+
+
+async def test_malformed_config_for_known_type_still_raises(
+    db_session: AsyncSession,
+) -> None:
+    """The gate only skips unknown types; a known type with bad config raises."""
+    bad = _make_requirement(
+        slug="bad-fork",
+        submission_type="repo_fork",
+        submission_value_kind="github_url",
+        type_config={},  # missing required_repo
+    )
+    await _seed_phase_with_requirements(db_session, order=95, requirements=[bad])
+
+    with pytest.raises(ValidationError):
+        await load_all_phases_from_db(db_session)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/learn-to-cloud-shared/tests/test_schemas.py
+++ b/packages/learn-to-cloud-shared/tests/test_schemas.py
@@ -1,0 +1,24 @@
+"""Unit tests for schema-derived constants."""
+
+from __future__ import annotations
+
+from learn_to_cloud_shared.schemas import KNOWN_HANDS_ON_SUBMISSION_TYPES
+
+
+def test_known_submission_types_matches_union() -> None:
+    """The derived constant must list exactly the union's submission types."""
+    assert KNOWN_HANDS_ON_SUBMISSION_TYPES == {
+        "github_profile",
+        "profile_readme",
+        "repo_fork",
+        "ctf_token",
+        "networking_token",
+        "journal_api_verifier",
+        "deployed_api",
+        "devops_analysis",
+        "security_scanning",
+        "career_reflection",
+    }
+    # A type the DB CHECK allows but the union doesn't know must be absent,
+    # so the content loader treats it as unknown (issue #603).
+    assert "ci_status" not in KNOWN_HANDS_ON_SUBMISSION_TYPES


### PR DESCRIPTION
Closes #603.

## Problem
During a rolling deploy, the migration job runs `sync_curriculum` and writes new `submission_type` rows into the DB **before** the new API image is deployed and drained. For the rollout window the old revision serves traffic against a DB it can't fully deserialize: `_build_requirement` raises a pydantic `ValidationError` (`union_tag_invalid`), and since every requirement is built together, one unparseable row **500s every phase-loading page** (home, `/dashboard`, `/phase/*`). This happened in prod on 2026-06-30 during the Phase 7 rollout. Emergency rollbacks reintroduce the same skew, so no fixed deploy ordering fixes all cases.

## Fix
Make the content loader a **tolerant reader**:
- Add `KNOWN_HANDS_ON_SUBMISSION_TYPES` in `schemas.py`, **derived from the discriminated union members** so it is a single source of truth that can't drift from the union.
- In `content_db_loader.py`, `_is_known_requirement()` skips + logs any requirement row whose `submission_type` isn't in that set, applied at both build sites (`load_requirements_by_phase_order_from_db` and `_assemble_phases`).
- Known types still go through `_build_requirement` unchanged, so a genuinely malformed `type_config` for a *known* type still raises (this is an explicit membership gate, not a blanket `try/except`).

## Tradeoff (called out)
The only side effect is a **transient count mismatch**: `load_requirement_counts_by_phase_from_db` (a SQL aggregate) still counts the unknown row while the rendered list skips it, so a phase may briefly show "N-1 of N" during a rollout. It self-heals once the new revision drains. Verified no downstream `KeyError`/assert: lookups use `.get()` / index-by-slug, and a skipped requirement can't be submitted against.

## Out of scope
- deploy.yml `sync_curriculum` reordering (issue's optional secondary hardening).
- The same adapter is also called in `content_yaml_loader.py` (authoring) and `verification_job_executor.py` (Durable job rehydration); neither is on the phase-page 500 path, so both are left as-is.

## Tests
- `ci_status` fixture (allowed by the requirements CHECK constraint with `github_url`, but absent from the union) reproduces "known to DB, unknown to code": skipped via both loader entry points.
- Malformed config for a known type still raises.
- Drift-guard unit test that the derived set matches the union tags.

`uv run poe check` passes (static + api 237, shared 553, functions 18).