### PR TITLE
Add availability web test + Sev1 alert for API (#605)

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -42,6 +42,84 @@ resource "azurerm_monitor_action_group" "critical" {
 }
 
 # ---------------------------------------------------------------------------
+# Availability test (synthetic uptime probe)
+# ---------------------------------------------------------------------------
+
+# Every alert below is a scheduled query over telemetry the app emits while it
+# is running, so none of them fire on a "hard down" outage: a boot crashloop, an
+# ingress/TLS/DNS breakage, or a full platform outage where zero telemetry
+# flows. This standard web test is the one signal that pings the app from
+# outside and pages when it is completely unreachable.
+#
+# It targets /health (pure liveness, always 200) and NOT /ready, which returns
+# 503 on transient DB/schema issues that already have their own alerts; pointing
+# the availability test at /ready would double-page and add noise.
+resource "azurerm_application_insights_standard_web_test" "availability" {
+  name                    = "webtest-ltc-availability-${var.environment}"
+  resource_group_name     = azurerm_resource_group.main.name
+  location                = azurerm_resource_group.main.location
+  application_insights_id = azurerm_application_insights.main.id
+  description             = "Synthetic uptime probe against https://learntocloud.guide/health"
+  enabled                 = true
+  frequency               = 300
+  timeout                 = 30
+  retry_enabled           = true
+  tags                    = local.tags
+
+  # Central US (Chicago) + West US (San Jose). Two regions is enough coverage
+  # for a dev learning platform; full 3+ geo coverage is out of scope.
+  geo_locations = ["us-il-ch1-azr", "us-ca-sjc-azr"]
+
+  request {
+    url                              = "https://learntocloud.guide/health"
+    http_verb                        = "GET"
+    parse_dependent_requests_enabled = false
+    follow_redirects_enabled         = true
+  }
+
+  validation_rules {
+    expected_status_code = 200
+    ssl_check_enabled    = true
+  }
+}
+
+resource "azurerm_monitor_metric_alert" "availability" {
+  name                = "alert-ltc-availability-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  description         = "Alert when the availability web test reports less than 100% success (API unreachable)"
+  severity            = 1
+  enabled             = true
+  frequency           = "PT5M"
+  window_size         = "PT5M"
+  tags                = local.tags
+
+  # Web-test metric alerts must be scoped to both the web test and the App
+  # Insights component the results land in.
+  scopes = [
+    azurerm_application_insights_standard_web_test.availability.id,
+    azurerm_application_insights.main.id,
+  ]
+
+  criteria {
+    metric_namespace = "microsoft.insights/components"
+    metric_name      = "availabilityResults/availabilityPercentage"
+    aggregation      = "Average"
+    operator         = "LessThan"
+    threshold        = 100
+
+    dimension {
+      name     = "availabilityResult/name"
+      operator = "Include"
+      values   = [azurerm_application_insights_standard_web_test.availability.name]
+    }
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.critical.id
+  }
+}
+
+# ---------------------------------------------------------------------------
 # Log Alerts (scheduled query rules v2)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #605

## What

Adds the one signal the current monitoring stack lacks: a synthetic uptime probe that pages when the API is completely unreachable.

Every existing alert in `infra/monitoring.tf` is a scheduled query over `requests`/`traces`/`AppMetrics`, all of which need the app running and emitting telemetry. None fire on a hard-down outage (boot crashloop, ingress/TLS/DNS breakage, full platform outage).

## Changes (`infra/monitoring.tf`)

- **`azurerm_application_insights_standard_web_test.availability`** targeting `https://learntocloud.guide/health` (pure liveness, always 200; NOT `/ready`, which 503s on transient DB issues that already have their own alerts and would double-page). Frequency 5 min, two geo locations (Central US `us-il-ch1-azr` + West US `us-ca-sjc-azr`), success = HTTP 200, SSL check on.
- **`azurerm_monitor_metric_alert.availability`** named `alert-ltc-availability-${var.environment}` (matches what the `check-prod` skill already expects) on `availabilityResults/availabilityPercentage < 100`, severity 1, scoped to `[web_test, appi.main]`, wired to the existing `ag-ltc-critical` action group.

## Validation

- `terraform fmt` + `terraform validate` clean. Azure-backed `terraform plan` runs in CI on this PR.
- **review-terraform:** purely additive `azurerm_*` resources, no `azuread_*`/Graph, nothing pre-existing to import, no auth/identity or state-destructive changes.

## Out of scope

- 3+ geo synthetic coverage.
- Dedicated restart / boot-crashloop alert (separate follow-up).

## Post-deploy

- Confirm `AppAvailabilityResults` starts populating and the Sev1 alert resolves to healthy.