### PR TITLE
fix: graceful handling for /auth/callback transient httpx errors (#606)

### DIFF
--- a/api/src/learn_to_cloud/routes/auth_routes.py
+++ b/api/src/learn_to_cloud/routes/auth_routes.py
@@ -78,14 +78,18 @@ async def callback(request: Request) -> RedirectResponse:
     try:
         t0 = time.perf_counter()
         token = await github.authorize_access_token(request)
-    except (OAuthError, httpx.HTTPStatusError, httpx.ReadTimeout):
+    except (OAuthError, httpx.HTTPError):
         logger.exception("auth.callback.token_exchange_failed")
         return RedirectResponse(url="/", status_code=302)
 
     t1 = time.perf_counter()
-    resp = await github.get("user", token=token)
+    try:
+        resp = await github.get("user", token=token)
+        github_user = resp.json()
+    except httpx.HTTPError:
+        logger.exception("auth.callback.profile_fetch_failed")
+        return RedirectResponse(url="/", status_code=302)
     t2 = time.perf_counter()
-    github_user = resp.json()
 
     github_id = github_user.get("id")
     if github_id is None:

--- a/api/tests/routes/test_auth_routes.py
+++ b/api/tests/routes/test_auth_routes.py
@@ -15,6 +15,7 @@ These are unit tests: no HTTP client, no real OAuth, no database.
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from authlib.integrations.starlette_client import OAuthError
 from fastapi.responses import RedirectResponse
@@ -191,6 +192,45 @@ class TestCallbackRoute:
         assert result.status_code == 302
         assert result.headers["location"] == "/"
         # Session should remain empty
+        assert "user_id" not in request.session
+
+    async def test_callback_handles_connect_timeout_on_token_exchange(self):
+        """httpx.ConnectTimeout during token exchange redirects to / (not 500)."""
+        request = _mock_request(session={})
+        mock_github = MagicMock()
+        mock_github.authorize_access_token = AsyncMock(
+            side_effect=httpx.ConnectTimeout("connect timed out")
+        )
+
+        with patch("learn_to_cloud.routes.auth_routes.oauth") as mock_oauth:
+            mock_oauth.create_client.return_value = mock_github
+
+            result = await callback(request)
+
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 302
+        assert result.headers["location"] == "/"
+        assert "user_id" not in request.session
+
+    async def test_callback_handles_connect_timeout_on_profile_fetch(self):
+        """httpx.ConnectTimeout fetching the user profile redirects to / (not 500)."""
+        request = _mock_request(session={})
+        mock_github = MagicMock()
+        mock_github.authorize_access_token = AsyncMock(
+            return_value={"access_token": "gho_fake"}
+        )
+        mock_github.get = AsyncMock(
+            side_effect=httpx.ConnectTimeout("connect timed out")
+        )
+
+        with patch("learn_to_cloud.routes.auth_routes.oauth") as mock_oauth:
+            mock_oauth.create_client.return_value = mock_github
+
+            result = await callback(request)
+
+        assert isinstance(result, RedirectResponse)
+        assert result.status_code == 302
+        assert result.headers["location"] == "/"
         assert "user_id" not in request.session
 
     async def test_callback_redirects_home_when_github_not_configured(self):


### PR DESCRIPTION
Closes #606

## Problem

`GET /auth/callback` could return an unhandled 500 when a GitHub call timed out during login:

1. The token-exchange `except` tuple caught `httpx.ReadTimeout` but **not `httpx.ConnectTimeout`** (both subclass `httpx.TimeoutException`), so a connect timeout escaped as a raw 500.
2. The `github.get("user")` + `resp.json()` calls after the `try` block were unwrapped, so a timeout/transport error there also 500'd.

User-caused paths (CSRF `MismatchingStateError`, `OAuthError: access_denied`) already subclass `OAuthError` and remain handled gracefully.

## Fix

- Broaden token-exchange `except` to `(OAuthError, httpx.HTTPError)` — covers `ConnectTimeout`, `ReadTimeout`, `HTTPStatusError`, and other transport errors.
- Wrap the profile fetch + `.json()` in `try/except httpx.HTTPError`, logging `auth.callback.profile_fetch_failed` and redirecting to `/` (302).

## Validation

- New unit tests simulate `httpx.ConnectTimeout` from both `authorize_access_token` and `github.get("user")`, asserting a 302 to `/` rather than a 500.
- `uv run poe check` passes.