### PR TITLE
fix: scope availability metric alert to a single target resource type (#612)

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -93,12 +93,13 @@ resource "azurerm_monitor_metric_alert" "availability" {
   window_size         = "PT5M"
   tags                = local.tags
 
-  # Web-test metric alerts must be scoped to both the web test and the App
-  # Insights component the results land in.
-  scopes = [
-    azurerm_application_insights_standard_web_test.availability.id,
-    azurerm_application_insights.main.id,
-  ]
+  # A metric alert can only span a single target resource type. Scope it to the
+  # App Insights component (where the availabilityResults metric lands) and set
+  # target_resource_type/location explicitly; mixing the web-test resource type
+  # into scopes makes Azure reject the alert with a 400.
+  scopes                   = [azurerm_application_insights.main.id]
+  target_resource_type     = "microsoft.insights/components"
+  target_resource_location = azurerm_resource_group.main.location
 
   criteria {
     metric_namespace = "microsoft.insights/components"


### PR DESCRIPTION
## Problem

`terraform apply` failed on `azurerm_monitor_metric_alert.availability` with a 400:

> You can't define a scope that is different from the selected target resource type.

The alert listed both the standard web test and the App Insights component in `scopes`, which are different resource types. Azure requires a metric alert to resolve to a single target resource type.

## Fix

- Scope the alert to the App Insights component only (`azurerm_application_insights.main.id`), where the `availabilityResults/availabilityPercentage` metric lands.
- Set `target_resource_type = "microsoft.insights/components"` and `target_resource_location` explicitly.
- The existing `dimension` filter on the web test name keeps the alert firing only on this web test's availability failures.

`terraform validate` passes.

Fixes #612