### PR TITLE
feat: add Phase 4 deployment_architecture verification (#604)

### DIFF
--- a/api/alembic/versions/0047_add_deployment_architecture_type.py
+++ b/api/alembic/versions/0047_add_deployment_architecture_type.py
@@ -1,0 +1,122 @@
+"""add deployment_architecture submission type (text value kind)
+
+Phase 4 capstone gains an additional ``deployment_architecture`` submission
+type whose value is the learner's free-text architecture description (stored in
+``text_value``, reusing the ``text`` value kind reintroduced in 0045). This
+migration extends only the ``requirements`` type-to-kind CHECK constraint so
+``deployment_architecture`` maps to the ``text`` value kind. The typed-value
+shape/format constraints and trigger on ``submissions`` / ``verification_jobs``
+already handle the ``text`` kind (0045), so they are untouched.
+
+The swapped CHECK is added ``NOT VALID`` here and validated in the follow-up
+migration 0048 (matches the 0045 / 0046 pattern, keeping the validation scan
+out of this transaction).
+
+Revision ID: 0047_add_deployment_architecture_type
+Revises: 0046_validate_reintroduce_text_value_kind
+Create Date: 2026-07-05
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0047_add_deployment_architecture_type"
+down_revision: str | None = "0046_validate_reintroduce_text_value_kind"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_REQUIREMENTS_CONSTRAINT = "ck_requirements_submission_value_kind_matches_type"
+
+# Type-to-kind check with ``deployment_architecture`` -> ``text`` added.
+_REQUIREMENTS_CHECK_WITH_DEPLOYMENT_ARCH = """
+(
+    submission_type IN (
+        'github_profile',
+        'profile_readme',
+        'repo_fork',
+        'journal_api_verifier',
+        'devops_analysis',
+        'security_scanning',
+        'ci_status'
+    )
+    AND submission_value_kind = 'github_url'
+)
+OR (
+    submission_type IN (
+        'ctf_token',
+        'networking_token',
+        'iac_token'
+    )
+    AND submission_value_kind = 'token'
+)
+OR (
+    submission_type = 'deployed_api'
+    AND submission_value_kind = 'deployed_url'
+)
+OR (
+    submission_type IN (
+        'career_reflection',
+        'deployment_architecture'
+    )
+    AND submission_value_kind = 'text'
+)
+"""
+
+# Prior check, restored on downgrade (career_reflection -> text only).
+_REQUIREMENTS_CHECK_WITHOUT_DEPLOYMENT_ARCH = """
+(
+    submission_type IN (
+        'github_profile',
+        'profile_readme',
+        'repo_fork',
+        'journal_api_verifier',
+        'devops_analysis',
+        'security_scanning',
+        'ci_status'
+    )
+    AND submission_value_kind = 'github_url'
+)
+OR (
+    submission_type IN (
+        'ctf_token',
+        'networking_token',
+        'iac_token'
+    )
+    AND submission_value_kind = 'token'
+)
+OR (
+    submission_type = 'deployed_api'
+    AND submission_value_kind = 'deployed_url'
+)
+OR (
+    submission_type = 'career_reflection'
+    AND submission_value_kind = 'text'
+)
+"""
+
+
+def _swap_requirements_check(condition: str) -> None:
+    op.execute(
+        f"ALTER TABLE requirements DROP CONSTRAINT IF EXISTS {_REQUIREMENTS_CONSTRAINT}"
+    )
+    op.execute(
+        f"""
+        ALTER TABLE requirements
+        ADD CONSTRAINT {_REQUIREMENTS_CONSTRAINT}
+        CHECK ({condition})
+        NOT VALID
+        """
+    )
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+    _swap_requirements_check(_REQUIREMENTS_CHECK_WITH_DEPLOYMENT_ARCH)
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+    _swap_requirements_check(_REQUIREMENTS_CHECK_WITHOUT_DEPLOYMENT_ARCH)

--- a/api/alembic/versions/0048_validate_deployment_architecture_type.py
+++ b/api/alembic/versions/0048_validate_deployment_architecture_type.py
@@ -1,0 +1,33 @@
+"""validate deployment_architecture type-to-kind constraint
+
+Validates the ``requirements`` type-to-kind CHECK constraint that 0047 added
+``NOT VALID``. Runs in its own transaction so the validation scan does not hold
+locks during the constraint swap (matches the 0045 / 0046 pattern).
+
+Revision ID: 0048_validate_deployment_architecture_type
+Revises: 0047_add_deployment_architecture_type
+Create Date: 2026-07-05
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0048_validate_deployment_architecture_type"
+down_revision: str | None = "0047_add_deployment_architecture_type"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_REQUIREMENTS_CONSTRAINT = "ck_requirements_submission_value_kind_matches_type"
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+    op.execute(
+        f"ALTER TABLE requirements VALIDATE CONSTRAINT {_REQUIREMENTS_CONSTRAINT}"
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -24,6 +24,7 @@ from learn_to_cloud_shared.repositories.verification_job_repository import (
 )
 from learn_to_cloud_shared.schemas import (
     CareerReflectionRequirement,
+    DeploymentArchitectureRequirement,
     HandsOnRequirement,
     SubmissionData,
     SubmissionResult,
@@ -323,6 +324,7 @@ async def htmx_submit_verification(
     requirement_slug: Annotated[str, Form(max_length=100)],
     submitted_value: Annotated[str, Form(max_length=2048)] = "",
     answers: Annotated[list[str] | None, Form()] = None,
+    architecture_description: Annotated[str, Form(max_length=20000)] = "",
 ) -> HTMLResponse:
     """Submit a hands-on verification.
 
@@ -382,6 +384,12 @@ async def htmx_submit_verification(
         try:
             if isinstance(requirement, CareerReflectionRequirement):
                 user_input = _combine_reflection_answers(requirement, answers or [])
+            elif isinstance(requirement, DeploymentArchitectureRequirement):
+                user_input = architecture_description.strip()
+                if not user_input:
+                    return _render_card(
+                        error_banner="Please write a description before submitting."
+                    )
             elif is_derivable(requirement.submission_type):
                 user_input = None
             else:

--- a/api/src/learn_to_cloud/templates/partials/requirement_card.html
+++ b/api/src/learn_to_cloud/templates/partials/requirement_card.html
@@ -36,13 +36,14 @@
     </div>
     {% elif not submission or not submission.is_validated %}
     {% set is_reflection = requirement.submission_type == 'career_reflection' %}
+    {% set is_architecture = requirement.submission_type == 'deployment_architecture' %}
     <form
         hx-post="/htmx/github/submit"
         hx-target="#requirement-{{ requirement.slug }}"
         hx-swap="outerHTML"
         hx-indicator="#spinner-{{ requirement.slug }}"
         hx-disabled-elt="find button[type='submit']"
-        class="{% if is_reflection %}flex flex-col gap-4{% else %}flex gap-2{% endif %}"
+        class="{% if is_reflection or is_architecture %}flex flex-col gap-4{% else %}flex gap-2{% endif %}"
     >
         <input type="hidden" name="requirement_slug" value="{{ requirement.slug }}">
 
@@ -66,6 +67,26 @@
             ></textarea>
         </div>
         {% endfor %}
+        {% elif is_architecture %}
+        {# Deployment architecture — one long-text field describing the learner's
+           deploy.sh. Posts as ``architecture_description`` (not the 2048-capped
+           ``submitted_value``) and is graded against the fetched deploy.sh by
+           the LLM rubric. #}
+        <div class="flex flex-col gap-1">
+            <label for="architecture-{{ requirement.slug }}" class="text-sm font-medium text-gray-800 dark:text-gray-200">
+                {{ requirement.type_config.prompt }}
+            </label>
+            <textarea
+                id="architecture-{{ requirement.slug }}"
+                name="architecture_description"
+                rows="8"
+                minlength="{{ requirement.type_config.min_answer_length }}"
+                maxlength="20000"
+                placeholder="Write at least {{ requirement.type_config.min_answer_length }} characters."
+                class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                required
+            ></textarea>
+        </div>
         {% elif requirement.submission_type in ['ctf_token', 'networking_token'] %}
         {# Token input — learner pastes the completion token. #}
         <label for="input-{{ requirement.slug }}" class="sr-only">{{ requirement.name }}</label>

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -659,6 +659,107 @@ class TestHtmxSubmitVerification:
         (call_arg,) = await_args.args
         assert call_arg.id == job.id
 
+    async def test_deployment_architecture_long_description_reaches_derive(self):
+        """A >2048-char architecture description must not be truncated by the
+        shared ``submitted_value`` cap; it flows via ``architecture_description``
+        into ``derive_submission_value`` intact and starts an orchestration."""
+        from learn_to_cloud_shared.testing.requirement_factories import (
+            deployment_architecture_requirement,
+        )
+
+        requirement = deployment_architecture_requirement(
+            slug="deployment-architecture",
+            required_repo="learntocloud/journal-starter",
+        )
+        long_description = "A detailed two-tier deployment description. " * 100
+        assert len(long_description) > 2048
+
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        job = _mock_job()
+        async_result = VerificationJobSubmission(
+            job=cast(VerificationJob, job),
+            created=True,
+            requirement=requirement,
+            github_username="user",
+        )
+        start_result = SimpleNamespace(instance_id=str(job.id))
+        write_session = AsyncMock()
+        request.app.state.session_maker.return_value.__aenter__.return_value = (
+            write_session
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
+                return_value=requirement,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.derive_submission_value",
+                autospec=True,
+                return_value=long_description,
+            ) as mock_derive,
+            patch(
+                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                new_callable=AsyncMock,
+                return_value=async_result,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                new_callable=AsyncMock,
+                return_value=start_result,
+            ) as mock_start,
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = await htmx_submit_verification(
+                request,
+                AsyncMock(),
+                current_user,
+                requirement_slug="deployment-architecture",
+                architecture_description=long_description,
+            )
+
+        assert isinstance(result, HTMLResponse)
+        mock_start.assert_awaited_once()
+        derive_kwargs = mock_derive.call_args.kwargs
+        assert derive_kwargs["user_input"] == long_description.strip()
+
+    async def test_deployment_architecture_empty_description_shows_error(self):
+        from learn_to_cloud_shared.testing.requirement_factories import (
+            deployment_architecture_requirement,
+        )
+
+        requirement = deployment_architecture_requirement(
+            slug="deployment-architecture",
+            required_repo="learntocloud/journal-starter",
+        )
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
+                return_value=requirement,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                new_callable=AsyncMock,
+            ) as mock_create,
+        ):
+            result = await htmx_submit_verification(
+                request,
+                AsyncMock(),
+                current_user,
+                requirement_slug="deployment-architecture",
+                architecture_description="   ",
+            )
+
+        assert isinstance(result, HTMLResponse)
+        mock_create.assert_not_awaited()
+
     async def test_duplicate_submit_skips_durable_start(self):
         """When ``create_verification_job`` returns ``created=False``
         (concurrent submit raced into the same job row), the route does

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -106,6 +106,7 @@ _ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE = {
     SubmissionType.DEVOPS_ANALYSIS: "verify_phase5_devops_orchestrator",
     SubmissionType.SECURITY_SCANNING: "verify_phase6_security_orchestrator",
     SubmissionType.CAREER_REFLECTION: "verify_phase7_career_orchestrator",
+    SubmissionType.DEPLOYMENT_ARCHITECTURE: ("verify_phase4_architecture_orchestrator"),
 }
 _VERIFY_RETRY_OPTIONS = df.RetryOptions(
     first_retry_interval_in_milliseconds=5000,
@@ -616,6 +617,12 @@ def verify_phase6_security_orchestrator(context: df.DurableOrchestrationContext)
 @app.orchestration_trigger(context_name="context")
 def verify_phase7_career_orchestrator(context: df.DurableOrchestrationContext):
     """Run Phase 7 career reflection verification (LLM rubric review)."""
+    return (yield from _run_verification_orchestration(context))
+
+
+@app.orchestration_trigger(context_name="context")
+def verify_phase4_architecture_orchestrator(context: df.DurableOrchestrationContext):
+    """Run Phase 4 capstone architecture alignment (deploy.sh vs description)."""
     return (yield from _run_verification_orchestration(context))
 
 

--- a/apps/verification-functions/tests/test_orchestrations.py
+++ b/apps/verification-functions/tests/test_orchestrations.py
@@ -310,6 +310,15 @@ class TestOrchestratorNameMapping:
             == "verify_phase7_career_orchestrator"
         )
 
+    def test_deployment_architecture_maps_to_phase4_architecture_orchestrator(
+        self,
+    ) -> None:
+        names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
+        assert (
+            names[SubmissionType.DEPLOYMENT_ARCHITECTURE]
+            == "verify_phase4_architecture_orchestrator"
+        )
+
     def test_every_mapped_name_is_registered(self) -> None:
         """Guards against pointing the resolver at a non-existent orchestrator."""
         for name in function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE.values():

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/_phase.yaml
@@ -18,3 +18,4 @@ topics:
 hands_on_verification:
   requirements:
   - deployed-journal-api
+  - deployment-architecture

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/capstone.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/capstone.yaml
@@ -127,8 +127,41 @@ learning_steps:
   done_when: The verifier shows "Deployed API verified!"
   slug: phase4-topic9-practice-verify-and-submit-your
 
-- uuid: 6dd5149a-494d-4f19-a401-fe7a1a71c75c
+- uuid: 8560edaf-a754-485a-93bc-42b20d6b18f6
   order: 8
+  action: 'Practice:'
+  title: Capture your deployment as an idempotent deploy.sh
+  description: Write a `deploy.sh` at the **root** of your journal-starter fork that provisions your deployment end to end. Idempotent means running it again on a clean environment reproduces the same architecture without manual steps.
+  checklist:
+  - "**Network** — create your virtual network, public subnet, and private subnet with their CIDR ranges"
+  - "**Firewall rules** — recreate the inbound and outbound rules for each subnet, keeping the database private"
+  - "**Compute** — provision the API VM (public) and database VM (private) and install their dependencies"
+  - "**App and database** — install and start the Journal API, install PostgreSQL, create the database, and run your schema"
+  - "**Idempotency** — guard steps so re-running does not error on resources that already exist (check-before-create, or `|| true` where appropriate)"
+  tips:
+  - type: tip
+    text: Your deploy.sh does not need to run untouched on every cloud; it should honestly document what you built. The reviewer compares it against your written description, so keep them consistent.
+  done_when: A `deploy.sh` exists at your repository root and reflects the architecture you deployed.
+  slug: phase4-topic9-practice-capture-your-deployment-as-deploy-sh
+
+- uuid: db9a4aa7-4a04-42c5-a661-c54b091ed157
+  order: 9
+  action: 'Reflect:'
+  title: Describe and submit your architecture
+  description: In the app, write a description of the architecture your `deploy.sh` provisions, then submit it. An automated reviewer reads both your `deploy.sh` and your description and checks that they align and that your design is a secure two-tier deployment.
+  checklist:
+  - Explain your network layout, including public and private subnets and their CIDR ranges
+  - Describe how the API and database VMs are placed and how the database stays private
+  - Walk through the traffic flow from the internet to the API and down to the database
+  - Make sure everything you claim is actually done by your `deploy.sh`
+  tips:
+  - type: warning
+    text: The reviewer fails the check if your description claims resources or controls that your `deploy.sh` does not create. Describe what you built, not the ideal design.
+  done_when: The reviewer confirms your description aligns with your deploy.sh.
+  slug: phase4-topic9-reflect-describe-and-submit-your-architecture
+
+- uuid: 6dd5149a-494d-4f19-a401-fe7a1a71c75c
+  order: 10
   action: 'Practice:'
   title: Clean up your cloud resources
   description: Delete all cloud resources you provisioned. Check your cloud console to confirm nothing is still running or incurring charges.
@@ -143,7 +176,7 @@ learning_steps:
   slug: phase4-topic9-practice-clean-up-your-cloud
 
 - uuid: ab084238-bf88-487e-9aa9-45c257463179
-  order: 9
+  order: 11
   action: 'Reflect:'
   title: Share your progress
   description: Push your work to GitHub and write a brief technical writeup covering your architecture decisions, what networking and security controls you implemented, and what you'd do differently. Share it on LinkedIn or with the Learn to Cloud community to get feedback and celebrate your progress.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/capstone.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/capstone.yaml
@@ -141,7 +141,9 @@ learning_steps:
   tips:
   - type: tip
     text: Your deploy.sh does not need to run untouched on every cloud; it should honestly document what you built. The reviewer compares it against your written description, so keep them consistent.
-  done_when: A `deploy.sh` exists at your repository root and reflects the architecture you deployed.
+  - type: warning
+    text: Your journal-starter fork must be **public** so the reviewer can read your `deploy.sh`. A private fork fails with a "repository not found" error.
+  done_when: "A `deploy.sh` exists at your repository root and clearly shows a secure two-tier design: a public API tier, a private database tier that is not reachable from the internet, and the networking and firewall rules that enforce it."
   slug: phase4-topic9-practice-capture-your-deployment-as-deploy-sh
 
 - uuid: db9a4aa7-4a04-42c5-a661-c54b091ed157
@@ -154,6 +156,7 @@ learning_steps:
   - Describe how the API and database VMs are placed and how the database stays private
   - Walk through the traffic flow from the internet to the API and down to the database
   - Make sure everything you claim is actually done by your `deploy.sh`
+  - Write at least a few paragraphs (roughly 300 characters minimum); a one or two sentence summary is rejected as too short
   tips:
   - type: warning
     text: The reviewer fails the check if your description claims resources or controls that your `deploy.sh` does not create. Describe what you built, not the ideal design.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/requirements/deployment-architecture.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/requirements/deployment-architecture.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=../../../schemas/requirement.schema.json
+uuid: e156741f-9226-45ff-8129-704d1e23eeec
+slug: deployment-architecture
+submission_type: deployment_architecture
+name: Explain Your Deployment Architecture
+description: Write an idempotent deploy.sh at the root of your journal-starter fork, then describe your deployment architecture in your own words. An automated reviewer reads your deploy.sh and your description and checks that they match, so describe what you actually built, not what the guide suggested.
+type_config:
+  required_repo: learntocloud/journal-starter
+  min_answer_length: 300
+  deploy_script_path: deploy.sh
+  prompt: Describe the architecture your deploy.sh provisions. Cover your network layout (public and private subnets), how the API and database VMs are placed, the firewall or security rules that keep the database private, and how traffic flows from the internet to your API and down to the database. Be specific about what your script actually does.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/schemas/phase.schema.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/schemas/phase.schema.json
@@ -209,6 +209,81 @@
       "title": "DeployedApiRequirement",
       "type": "object"
     },
+    "DeploymentArchitectureConfig": {
+      "additionalProperties": false,
+      "description": "Config for deployment_architecture requirements.\n\nThe learner writes a free-text architecture description in the app; the\ngrader fetches ``deploy_script_path`` from the learner's fork of\n``required_repo`` and an LLM rubric checks the description against what the\nscript actually provisions.",
+      "properties": {
+        "deploy_script_path": {
+          "default": "deploy.sh",
+          "description": "Repo-relative path to the deployment script to grade.",
+          "title": "Deploy Script Path",
+          "type": "string"
+        },
+        "min_answer_length": {
+          "default": 200,
+          "description": "Minimum characters required for the description.",
+          "minimum": 1,
+          "title": "Min Answer Length",
+          "type": "integer"
+        },
+        "prompt": {
+          "description": "The architecture-description prompt shown to the learner.",
+          "title": "Prompt",
+          "type": "string"
+        },
+        "required_repo": {
+          "description": "Upstream repo (owner/name) the learner forks from.",
+          "title": "Required Repo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "required_repo",
+        "prompt"
+      ],
+      "title": "DeploymentArchitectureConfig",
+      "type": "object"
+    },
+    "DeploymentArchitectureRequirement": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "slug": {
+          "title": "Slug",
+          "type": "string"
+        },
+        "submission_type": {
+          "const": "deployment_architecture",
+          "title": "Submission Type",
+          "type": "string"
+        },
+        "type_config": {
+          "$ref": "#/$defs/DeploymentArchitectureConfig"
+        },
+        "uuid": {
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uuid",
+        "slug",
+        "name",
+        "description",
+        "submission_type",
+        "type_config"
+      ],
+      "title": "DeploymentArchitectureRequirement",
+      "type": "object"
+    },
     "DevopsAnalysisConfig": {
       "additionalProperties": false,
       "description": "Config for devops_analysis requirements.",
@@ -624,6 +699,7 @@
                 "career_reflection": "#/$defs/CareerReflectionRequirement",
                 "ctf_token": "#/$defs/CtfTokenRequirement",
                 "deployed_api": "#/$defs/DeployedApiRequirement",
+                "deployment_architecture": "#/$defs/DeploymentArchitectureRequirement",
                 "devops_analysis": "#/$defs/DevopsAnalysisRequirement",
                 "github_profile": "#/$defs/GithubProfileRequirement",
                 "journal_api_verifier": "#/$defs/JournalApiVerifierRequirement",
@@ -664,6 +740,9 @@
               },
               {
                 "$ref": "#/$defs/CareerReflectionRequirement"
+              },
+              {
+                "$ref": "#/$defs/DeploymentArchitectureRequirement"
               }
             ]
           },

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/schemas/requirement.schema.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/schemas/requirement.schema.json
@@ -209,6 +209,81 @@
       "title": "DeployedApiRequirement",
       "type": "object"
     },
+    "DeploymentArchitectureConfig": {
+      "additionalProperties": false,
+      "description": "Config for deployment_architecture requirements.\n\nThe learner writes a free-text architecture description in the app; the\ngrader fetches ``deploy_script_path`` from the learner's fork of\n``required_repo`` and an LLM rubric checks the description against what the\nscript actually provisions.",
+      "properties": {
+        "deploy_script_path": {
+          "default": "deploy.sh",
+          "description": "Repo-relative path to the deployment script to grade.",
+          "title": "Deploy Script Path",
+          "type": "string"
+        },
+        "min_answer_length": {
+          "default": 200,
+          "description": "Minimum characters required for the description.",
+          "minimum": 1,
+          "title": "Min Answer Length",
+          "type": "integer"
+        },
+        "prompt": {
+          "description": "The architecture-description prompt shown to the learner.",
+          "title": "Prompt",
+          "type": "string"
+        },
+        "required_repo": {
+          "description": "Upstream repo (owner/name) the learner forks from.",
+          "title": "Required Repo",
+          "type": "string"
+        }
+      },
+      "required": [
+        "required_repo",
+        "prompt"
+      ],
+      "title": "DeploymentArchitectureConfig",
+      "type": "object"
+    },
+    "DeploymentArchitectureRequirement": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "slug": {
+          "title": "Slug",
+          "type": "string"
+        },
+        "submission_type": {
+          "const": "deployment_architecture",
+          "title": "Submission Type",
+          "type": "string"
+        },
+        "type_config": {
+          "$ref": "#/$defs/DeploymentArchitectureConfig"
+        },
+        "uuid": {
+          "format": "uuid",
+          "title": "Uuid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uuid",
+        "slug",
+        "name",
+        "description",
+        "submission_type",
+        "type_config"
+      ],
+      "title": "DeploymentArchitectureRequirement",
+      "type": "object"
+    },
     "DevopsAnalysisConfig": {
       "additionalProperties": false,
       "description": "Config for devops_analysis requirements.",
@@ -584,6 +659,7 @@
       "career_reflection": "#/$defs/CareerReflectionRequirement",
       "ctf_token": "#/$defs/CtfTokenRequirement",
       "deployed_api": "#/$defs/DeployedApiRequirement",
+      "deployment_architecture": "#/$defs/DeploymentArchitectureRequirement",
       "devops_analysis": "#/$defs/DevopsAnalysisRequirement",
       "github_profile": "#/$defs/GithubProfileRequirement",
       "journal_api_verifier": "#/$defs/JournalApiVerifierRequirement",
@@ -624,6 +700,9 @@
     },
     {
       "$ref": "#/$defs/CareerReflectionRequirement"
+    },
+    {
+      "$ref": "#/$defs/DeploymentArchitectureRequirement"
     }
   ]
 }

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -109,6 +109,9 @@ class SubmissionType(StrEnum):
     # Phase 4: Cloud deployment validation
     DEPLOYED_API = "deployed_api"
 
+    # Phase 4: Capstone architecture alignment (deploy.sh vs description)
+    DEPLOYMENT_ARCHITECTURE = "deployment_architecture"
+
     # Phase 5: DevOps analysis
     DEVOPS_ANALYSIS = "devops_analysis"
 
@@ -651,7 +654,10 @@ class CurriculumRequirement(TimestampMixin, Base):
                 AND submission_value_kind = 'deployed_url'
             )
             OR (
-                submission_type = 'career_reflection'
+                submission_type IN (
+                    'career_reflection',
+                    'deployment_architecture'
+                )
                 AND submission_value_kind = 'text'
             )
             """,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -271,6 +271,29 @@ class CareerReflectionConfig(StrictFrozenModel):
     )
 
 
+class DeploymentArchitectureConfig(RepoConfig):
+    """Config for deployment_architecture requirements.
+
+    The learner writes a free-text architecture description in the app; the
+    grader fetches ``deploy_script_path`` from the learner's fork of
+    ``required_repo`` and an LLM rubric checks the description against what the
+    script actually provisions.
+    """
+
+    prompt: str = Field(
+        description="The architecture-description prompt shown to the learner.",
+    )
+    min_answer_length: int = Field(
+        default=200,
+        ge=1,
+        description="Minimum characters required for the description.",
+    )
+    deploy_script_path: str = Field(
+        default="deploy.sh",
+        description="Repo-relative path to the deployment script to grade.",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Hands-on requirement subclasses, one per active SubmissionType
 # (issue #470)
@@ -359,6 +382,11 @@ class CareerReflectionRequirement(_RequirementBase):
     type_config: CareerReflectionConfig
 
 
+class DeploymentArchitectureRequirement(_RequirementBase):
+    submission_type: Literal[SubmissionType.DEPLOYMENT_ARCHITECTURE]
+    type_config: DeploymentArchitectureConfig
+
+
 HandsOnRequirement = Annotated[
     GithubProfileRequirement
     | ProfileReadmeRequirement
@@ -369,7 +397,8 @@ HandsOnRequirement = Annotated[
     | DeployedApiRequirement
     | DevopsAnalysisRequirement
     | SecurityScanningRequirement
-    | CareerReflectionRequirement,
+    | CareerReflectionRequirement
+    | DeploymentArchitectureRequirement,
     Field(discriminator="submission_type"),
 ]
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
@@ -25,7 +25,10 @@ _TOKEN_TYPES = {
     "iac_token",
 }
 _DEPLOYED_URL_TYPES = {SubmissionType.DEPLOYED_API.value}
-_TEXT_TYPES = {SubmissionType.CAREER_REFLECTION.value}
+_TEXT_TYPES = {
+    SubmissionType.CAREER_REFLECTION.value,
+    SubmissionType.DEPLOYMENT_ARCHITECTURE.value,
+}
 
 # Upper bound on stored free-text answers, guarding against abuse. The
 # three reflection answers are combined into one blob before storage.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/testing/requirement_factories.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/testing/requirement_factories.py
@@ -34,6 +34,8 @@ from learn_to_cloud_shared.schemas import (
     CtfTokenRequirement,
     DeployedApiConfig,
     DeployedApiRequirement,
+    DeploymentArchitectureConfig,
+    DeploymentArchitectureRequirement,
     DevopsAnalysisConfig,
     DevopsAnalysisRequirement,
     GithubProfileRequirement,
@@ -223,6 +225,31 @@ def career_reflection_requirement(
     )
 
 
+def deployment_architecture_requirement(
+    *,
+    slug: str = "deployment-architecture",
+    name: str = "Test deployment architecture requirement",
+    description: str = "Test description",
+    required_repo: str = "owner/journal-starter",
+    min_answer_length: int = 200,
+    deploy_script_path: str = "deploy.sh",
+    prompt: str = "Describe your deployment architecture.",
+) -> DeploymentArchitectureRequirement:
+    return DeploymentArchitectureRequirement(
+        uuid=uuid4(),
+        slug=slug,
+        submission_type=SubmissionType.DEPLOYMENT_ARCHITECTURE,
+        name=name,
+        description=description,
+        type_config=DeploymentArchitectureConfig(
+            required_repo=required_repo,
+            prompt=prompt,
+            min_answer_length=min_answer_length,
+            deploy_script_path=deploy_script_path,
+        ),
+    )
+
+
 def make_requirement(
     submission_type: SubmissionType,
     *,
@@ -291,6 +318,13 @@ def make_requirement(
         case SubmissionType.CAREER_REFLECTION:
             return career_reflection_requirement(
                 slug=slug, name=name, description=description
+            )
+        case SubmissionType.DEPLOYMENT_ARCHITECTURE:
+            return deployment_architecture_requirement(
+                slug=slug,
+                name=name,
+                description=description,
+                required_repo=required_repo or "owner/journal-starter",
             )
         case _:
             raise ValueError(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployment_architecture.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployment_architecture.py
@@ -1,0 +1,189 @@
+"""Phase 4 capstone deployment-architecture verification.
+
+Hybrid of Phase 7 (free-text + LLM rubric) and Phase 3 (repo-file evidence):
+the learner writes an architecture description in the app, and the grader
+fetches ``deploy.sh`` from their fork of the required repo. The deterministic
+stage confirms the description meets a minimum length and that the deploy
+script exists in the repo tree; the LLM rubric then judges whether the
+description aligns with what the script actually provisions.
+"""
+
+from __future__ import annotations
+
+from hashlib import sha256
+
+import httpx
+
+from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
+from learn_to_cloud_shared.verification.evidence import truncate_to_bytes
+from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
+from learn_to_cloud_shared.verification.tasks.base import (
+    EvidenceBundle,
+    EvidenceItem,
+    VerificationTask,
+)
+from learn_to_cloud_shared.verification.tasks.phase4 import (
+    DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK,
+)
+from learn_to_cloud_shared.verification.url_derivation import (
+    repository_ref_from_required_repo,
+)
+
+_DESCRIPTION_EVIDENCE_PATH = "architecture-description.md"
+
+
+def _deployment_architecture_config(requirement: HandsOnRequirement) -> object | None:
+    """Return the deployment_architecture type_config, or None if misconfigured."""
+    cfg = getattr(requirement, "type_config", None)
+    if cfg is None or getattr(cfg, "deploy_script_path", None) is None:
+        return None
+    return cfg
+
+
+def _top_level_shell_scripts(file_paths: list[str]) -> list[str]:
+    """Return repo-root ``*.sh`` paths (no directory separator)."""
+    return sorted(
+        path for path in file_paths if "/" not in path and path.endswith(".sh")
+    )
+
+
+async def validate_deployment_architecture(
+    requirement: HandsOnRequirement,
+    description: str,
+    github_username: str,
+    repo_files: RepoFiles | None = None,
+) -> ValidationResult:
+    """Deterministic gate for the deployment architecture submission.
+
+    Confirms the description meets the configured minimum length and that the
+    deploy script exists in the learner's fork before handing the real
+    judgement to the LLM rubric grader. Missing script or repo yields an
+    actionable failure; transient GitHub errors bubble up so the dispatcher
+    records them as operational failures.
+    """
+    cfg = _deployment_architecture_config(requirement)
+    if cfg is None or not requirement.required_repo:
+        return ValidationResult(
+            is_valid=False,
+            message=(
+                "Requirement configuration error: missing deployment "
+                "architecture config or required_repo."
+            ),
+            verification_completed=True,
+        )
+
+    min_length: int = getattr(cfg, "min_answer_length", 200)
+    deploy_script_path: str = getattr(cfg, "deploy_script_path", "deploy.sh")
+
+    stripped = description.strip()
+    if len(stripped) < min_length:
+        return ValidationResult(
+            is_valid=False,
+            message=(
+                f"Your architecture description is too short. Write at least "
+                f"{min_length} characters describing your deployment."
+            ),
+            verification_completed=True,
+        )
+
+    try:
+        repo = repository_ref_from_required_repo(
+            github_username, requirement.required_repo
+        )
+    except ValueError as exc:
+        return ValidationResult(
+            is_valid=False,
+            message=f"Requirement configuration error: {exc}",
+            verification_completed=True,
+        )
+
+    repo_files = repo_files or default_repo_files()
+    try:
+        file_paths = await repo_files.tree(repo.owner, repo.repo)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            return ValidationResult(
+                is_valid=False,
+                message=(
+                    f"Repository '{repo.owner}/{repo.repo}' not found. Make sure "
+                    "you forked it and the fork is public."
+                ),
+                verification_completed=True,
+                repo_exists=False,
+            )
+        raise
+
+    if deploy_script_path not in file_paths:
+        other_scripts = _top_level_shell_scripts(file_paths)
+        if other_scripts:
+            found = ", ".join(other_scripts)
+            hint = (
+                f" Found {found}, but this check grades '{deploy_script_path}'. "
+                f"Rename or add '{deploy_script_path}' at the repository root."
+            )
+        else:
+            hint = (
+                f" Add an idempotent '{deploy_script_path}' at the repository "
+                "root that provisions your deployment."
+            )
+        return ValidationResult(
+            is_valid=False,
+            message=f"Could not find '{deploy_script_path}' in your repository.{hint}",
+            verification_completed=True,
+        )
+
+    return ValidationResult(
+        is_valid=True,
+        message="Description received and deploy script found. Reviewing alignment.",
+    )
+
+
+async def collect_deployment_architecture_evidence(
+    owner: str,
+    repo: str,
+    description: str,
+    task: VerificationTask = DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK,
+    deploy_script_path: str = "deploy.sh",
+    repo_files: RepoFiles | None = None,
+) -> EvidenceBundle:
+    """Bundle the deploy script and the architecture description for grading."""
+    repo_files = repo_files or default_repo_files()
+    items: list[EvidenceItem] = []
+    total_bytes = 0
+
+    script_content = await repo_files.file(owner, repo, deploy_script_path)
+    if script_content is not None:
+        items.append(
+            _bounded_item(
+                deploy_script_path, script_content, task.evidence.max_file_size_bytes
+            )
+        )
+        total_bytes += len(items[-1].content.encode("utf-8"))
+
+    description_item = _bounded_item(
+        _DESCRIPTION_EVIDENCE_PATH, description, task.evidence.max_file_size_bytes
+    )
+    items.append(description_item)
+    total_bytes += len(description_item.content.encode("utf-8"))
+
+    return EvidenceBundle(
+        task_id=task.id,
+        source=task.evidence.source,
+        items=items,
+        total_bytes=total_bytes,
+    )
+
+
+def _bounded_item(path: str, content: str, max_bytes: int) -> EvidenceItem:
+    encoded = content.encode("utf-8")
+    truncated = False
+    if len(encoded) > max_bytes:
+        content = truncate_to_bytes(content, max_bytes)
+        encoded = content.encode("utf-8")
+        truncated = True
+    return EvidenceItem(
+        path=path,
+        content=content,
+        sha256=sha256(encoded).hexdigest(),
+        truncated=truncated,
+    )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
@@ -36,6 +36,9 @@ from learn_to_cloud_shared.verification.career_reflection import (
 )
 from learn_to_cloud_shared.verification.ci_status import verify_ci_status
 from learn_to_cloud_shared.verification.deployed_api import validate_deployed_api
+from learn_to_cloud_shared.verification.deployment_architecture import (
+    validate_deployment_architecture,
+)
 from learn_to_cloud_shared.verification.devops_analysis import run_devops_workflow
 from learn_to_cloud_shared.verification.github_profile import (
     validate_github_profile,
@@ -221,6 +224,14 @@ async def _adapt_career_reflection(
     return validate_career_reflection(submitted_value)
 
 
+async def _adapt_deployment_architecture(
+    requirement: HandsOnRequirement, submitted_value: str, username: str
+) -> ValidationResult:
+    return await validate_deployment_architecture(
+        requirement, submitted_value, username
+    )
+
+
 # Single source of truth: each active submission type maps to one descriptor.
 # Lookups use ``.get(...)`` so an unregistered type surfaces as the explicit
 # "Unknown submission type" result instead of raising.
@@ -283,6 +294,12 @@ _VALIDATOR_REGISTRY: dict[SubmissionType, ValidatorDescriptor] = {
         adapter=_adapt_career_reflection,
         execution_mode=ExecutionMode.BACKGROUND,
         requires_username=False,
+        repo_backed=False,
+    ),
+    SubmissionType.DEPLOYMENT_ARCHITECTURE: ValidatorDescriptor(
+        adapter=_adapt_deployment_architecture,
+        execution_mode=ExecutionMode.BACKGROUND,
+        requires_username=True,
         repo_backed=False,
     ),
 }

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -11,6 +11,9 @@ from learn_to_cloud_shared.schemas import (
 from learn_to_cloud_shared.verification.career_reflection import (
     collect_career_reflection_evidence,
 )
+from learn_to_cloud_shared.verification.deployment_architecture import (
+    collect_deployment_architecture_evidence,
+)
 from learn_to_cloud_shared.verification.journal_api import (
     collect_journal_api_implementation_evidence,
 )
@@ -20,6 +23,8 @@ from learn_to_cloud_shared.verification.security_scanning import (
 )
 from learn_to_cloud_shared.verification.tasks import (
     PHASE3_LLM_TASKS,
+    PHASE4_LLM_TASKS,
+    PHASE4_REQUIREMENT_SLUG,
     PHASE6_LLM_TASKS,
     PHASE7_LLM_TASKS,
     PHASE7_REQUIREMENT_SLUG,
@@ -27,6 +32,9 @@ from learn_to_cloud_shared.verification.tasks import (
     LLMGradingDecision,
     VerificationTask,
     require_llm_rubric_grader,
+)
+from learn_to_cloud_shared.verification.url_derivation import (
+    repository_ref_from_required_repo,
 )
 from learn_to_cloud_shared.verification_job_executor import (
     VerificationRunResult,
@@ -64,6 +72,9 @@ async def collect_llm_grading_requests(
         return _collect_phase7_requests(run_result, tasks)
 
     repo_files = repo_files or default_repo_files()
+
+    if run_result.job.requirement.slug == PHASE4_REQUIREMENT_SLUG:
+        return await _collect_phase4_requests(run_result, tasks, repo_files)
 
     if run_result.job.requirement.slug == "security-scanning":
         return await _collect_phase6_requests(run_result, tasks, repo_files)
@@ -241,6 +252,56 @@ async def _collect_phase3_requests(
     return requests
 
 
+async def _collect_phase4_requests(
+    run_result: VerificationRunResult,
+    tasks: list[VerificationTask],
+    repo_files: RepoFiles,
+) -> list[LLMGradingRequest]:
+    if not run_result.validation_result.is_valid:
+        return []
+
+    requirement = run_result.job.requirement
+    github_username = run_result.job.github_username
+    if not github_username or not requirement.required_repo:
+        return []
+
+    try:
+        repo = repository_ref_from_required_repo(
+            github_username, requirement.required_repo
+        )
+    except ValueError:
+        return []
+
+    description = run_result.job.typed_submitted_value.as_text
+    deploy_script_path = getattr(
+        requirement.type_config, "deploy_script_path", "deploy.sh"
+    )
+    requests: list[LLMGradingRequest] = []
+    for task in tasks:
+        evidence = await collect_deployment_architecture_evidence(
+            repo.owner,
+            repo.repo,
+            description,
+            task,
+            deploy_script_path=deploy_script_path,
+            repo_files=repo_files,
+        )
+        requests.append(
+            LLMGradingRequest(
+                task=task,
+                message=_build_grading_message(
+                    run_result=run_result,
+                    task=task,
+                    owner=repo.owner,
+                    repo=repo.repo,
+                    evidence=evidence.model_dump(mode="json"),
+                ),
+                thread_id=f"{run_result.job.id}-{task.id}",
+            )
+        )
+    return requests
+
+
 def _collect_phase7_requests(
     run_result: VerificationRunResult,
     tasks: list[VerificationTask],
@@ -364,4 +425,6 @@ def _llm_tasks_for_requirement(
         return PHASE3_LLM_TASKS
     if requirement.slug == PHASE7_REQUIREMENT_SLUG:
         return PHASE7_LLM_TASKS
+    if requirement.slug == PHASE4_REQUIREMENT_SLUG:
+        return PHASE4_LLM_TASKS
     return []

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/__init__.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/__init__.py
@@ -20,6 +20,12 @@ from learn_to_cloud_shared.verification.tasks.phase3 import (
     PHASE3_FINAL_REQUIREMENT_SLUG,
     PHASE3_LLM_TASKS,
 )
+from learn_to_cloud_shared.verification.tasks.phase4 import (
+    DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK,
+    PHASE4_LLM_TASKS,
+    PHASE4_REQUIREMENT_SLUG,
+    PHASE4_TASKS,
+)
 from learn_to_cloud_shared.verification.tasks.phase5 import (
     PHASE5_REQUIREMENT_SLUG,
     PHASE5_TASKS,
@@ -51,6 +57,10 @@ __all__ = [
     "JOURNAL_API_FINAL_RUBRIC_TASK",
     "PHASE3_FINAL_REQUIREMENT_SLUG",
     "PHASE3_LLM_TASKS",
+    "DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK",
+    "PHASE4_REQUIREMENT_SLUG",
+    "PHASE4_LLM_TASKS",
+    "PHASE4_TASKS",
     "PHASE5_REQUIREMENT_SLUG",
     "PHASE5_TASKS",
     "PHASE6_REQUIREMENT_SLUG",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase4.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase4.py
@@ -1,0 +1,69 @@
+"""Phase 4 capstone task definitions: architecture alignment rubric grading.
+
+The learner writes a free-text description of their deployment architecture in
+the app and commits an idempotent ``deploy.sh`` to their fork. The LLM rubric
+grader reads both the script and the description and judges whether the
+description honestly reflects what the script provisions, and whether the
+result is a secure two-tier deployment.
+"""
+
+from __future__ import annotations
+
+from learn_to_cloud_shared.verification.tasks.base import (
+    EvidencePolicy,
+    LLMRubricGraderConfig,
+    VerificationTask,
+)
+
+PHASE4_REQUIREMENT_SLUG = "deployment-architecture"
+
+DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK = VerificationTask(
+    id="deployment-architecture-rubric",
+    phase_id=4,
+    requirement_slug=PHASE4_REQUIREMENT_SLUG,
+    name="Deployment Architecture Alignment Review",
+    criteria=[
+        (
+            "The architecture description MUST align with what deploy.sh "
+            "actually provisions and configures, not with an idealized or "
+            "generic setup"
+        ),
+        (
+            "Reject descriptions that claim resources, networking, or security "
+            "controls that deploy.sh does not create or configure"
+        ),
+        (
+            "deploy.sh MUST provision a two-tier architecture: a public tier "
+            "for the API and a separate private tier for the database"
+        ),
+        (
+            "The deployment MUST show meaningful security controls, for example "
+            "the database not being publicly reachable, restricted inbound "
+            "rules, or TLS termination for the API"
+        ),
+        (
+            "The description MUST be specific about the learner's own design "
+            "(networking, compute, database, and how traffic flows), not a "
+            "generic restatement of the task"
+        ),
+        (
+            "Reject empty, placeholder, copy-pasted, or obviously low-effort "
+            "descriptions; grade only the supplied deploy.sh and description"
+        ),
+    ],
+    evidence=EvidencePolicy(
+        source="repo_files",
+        max_files=2,
+        max_file_size_bytes=30 * 1024,
+        max_total_bytes=60 * 1024,
+    ),
+    grader=LLMRubricGraderConfig(
+        rubric_id="phase4-deployment-architecture-v1",
+        prompt_version="2026-07-05",
+        passing_score=0.7,
+        model="gpt-5-mini",
+    ),
+)
+
+PHASE4_TASKS: list[VerificationTask] = []
+PHASE4_LLM_TASKS = [DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK]

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/url_derivation.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/url_derivation.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.schemas import HandsOnRequirement
+from learn_to_cloud_shared.verification.repo_utils import RepositoryRef
 
 # Derivable types: the server constructs the URL from username + required_repo.
 # The template renders these as read-only fields so the learner cannot edit
@@ -41,6 +42,7 @@ _PASS_THROUGH_TYPES: frozenset[SubmissionType] = frozenset(
         SubmissionType.NETWORKING_TOKEN,
         SubmissionType.DEPLOYED_API,
         SubmissionType.CAREER_REFLECTION,
+        SubmissionType.DEPLOYMENT_ARCHITECTURE,
     }
 )
 
@@ -64,6 +66,27 @@ def fork_name_from_required_repo(required_repo: str) -> str:
             f"required_repo must be in 'owner/name' format, got: {required_repo!r}"
         )
     return required_repo.rsplit("/", 1)[-1]
+
+
+def repository_ref_from_required_repo(
+    github_username: str,
+    required_repo: str,
+) -> RepositoryRef:
+    """Resolve the learner's fork identity from their username + ``required_repo``.
+
+    Used by verification types that are not ``repo_backed`` (their submitted
+    value is free text, not a repo URL) but still need to inspect the learner's
+    fork of ``required_repo`` (e.g. ``deployment_architecture``). The fork is
+    assumed to live at ``<username>/<repo-name>``, matching how
+    ``derive_submission_value`` builds repo-backed URLs.
+
+    Raises ``ValueError`` if ``required_repo`` is not ``owner/name`` or the
+    username is empty.
+    """
+    if not github_username:
+        raise ValueError("github_username is required to resolve the fork repo")
+    fork = fork_name_from_required_repo(required_repo)
+    return RepositoryRef(owner=github_username, repo=fork)
 
 
 def derive_submission_value(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -33,6 +33,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.models import (
     Submission,
+    SubmissionType,
     VerificationJob,
 )
 from learn_to_cloud_shared.repositories.verification_job_repository import (
@@ -59,6 +60,9 @@ from learn_to_cloud_shared.verification.execution import (
 from learn_to_cloud_shared.verification.repo_utils import (
     RepositoryRef,
     resolve_repository,
+)
+from learn_to_cloud_shared.verification.url_derivation import (
+    repository_ref_from_required_repo,
 )
 
 tracer = trace.get_tracer(__name__)
@@ -469,7 +473,21 @@ def _resolve_repository_ref(job: PreparedVerificationJob) -> RepositoryRef | Non
     Later async steps (LLM grading) reuse this instead of re-parsing the
     submission URL. Non-repo types and unparseable values yield ``None``;
     the carried value is purely an optimization, so callers still guard on it.
+
+    ``deployment_architecture`` is a special case: its submitted value is the
+    learner's free-text description, not a repo URL, so the repo is derived
+    from the ``github_username`` snapshot plus the requirement's
+    ``required_repo`` fork name instead.
     """
+    if job.requirement.submission_type == SubmissionType.DEPLOYMENT_ARCHITECTURE:
+        if not job.github_username or not job.requirement.required_repo:
+            return None
+        try:
+            return repository_ref_from_required_repo(
+                job.github_username, job.requirement.required_repo
+            )
+        except ValueError:
+            return None
     if not is_repo_backed(job.requirement.submission_type):
         return None
     resolved = resolve_repository(job.typed_submitted_value.as_text)

--- a/packages/learn-to-cloud-shared/tests/services/test_url_derivation.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_url_derivation.py
@@ -53,6 +53,7 @@ class TestIsDerivable:
             SubmissionType.NETWORKING_TOKEN,
             SubmissionType.DEPLOYED_API,
             SubmissionType.CAREER_REFLECTION,
+            SubmissionType.DEPLOYMENT_ARCHITECTURE,
         ],
     )
     def test_non_derivable_types(self, sub_type: SubmissionType):
@@ -73,6 +74,34 @@ class TestForkNameFromRequiredRepo:
     def test_missing_slash_raises(self):
         with pytest.raises(ValueError, match="owner/name"):
             fork_name_from_required_repo("journal-starter")
+
+
+@pytest.mark.unit
+class TestRepositoryRefFromRequiredRepo:
+    def test_derives_fork_owner_and_repo(self):
+        from learn_to_cloud_shared.verification.url_derivation import (
+            repository_ref_from_required_repo,
+        )
+
+        ref = repository_ref_from_required_repo("alice", "learntocloud/journal-starter")
+        assert ref.owner == "alice"
+        assert ref.repo == "journal-starter"
+
+    def test_empty_username_raises(self):
+        from learn_to_cloud_shared.verification.url_derivation import (
+            repository_ref_from_required_repo,
+        )
+
+        with pytest.raises(ValueError, match="github_username is required"):
+            repository_ref_from_required_repo("", "learntocloud/journal-starter")
+
+    def test_missing_slash_raises(self):
+        from learn_to_cloud_shared.verification.url_derivation import (
+            repository_ref_from_required_repo,
+        )
+
+        with pytest.raises(ValueError, match="owner/name"):
+            repository_ref_from_required_repo("alice", "journal-starter")
 
 
 @pytest.mark.unit
@@ -162,6 +191,16 @@ class TestDeriveSubmissionValue:
         req = _req(SubmissionType.CAREER_REFLECTION)
         combined = "## Question 0?\n\nMy answer."
         assert derive_submission_value(req, "alice", user_input=combined) == combined
+
+    def test_deployment_architecture_passes_through(self):
+        req = _req(
+            SubmissionType.DEPLOYMENT_ARCHITECTURE,
+            required_repo="learntocloud/journal-starter",
+        )
+        description = "My two-tier deployment: public API, private database."
+        assert (
+            derive_submission_value(req, "alice", user_input=description) == description
+        )
 
     def test_derivable_ignores_user_input(self):
         """Tampered submitted_value for derivable types is silently ignored.

--- a/packages/learn-to-cloud-shared/tests/test_schemas.py
+++ b/packages/learn-to-cloud-shared/tests/test_schemas.py
@@ -18,6 +18,7 @@ def test_known_submission_types_matches_union() -> None:
         "devops_analysis",
         "security_scanning",
         "career_reflection",
+        "deployment_architecture",
     }
     # A type the DB CHECK allows but the union doesn't know must be absent,
     # so the content loader treats it as unknown (issue #603).

--- a/packages/learn-to-cloud-shared/tests/test_submission_values.py
+++ b/packages/learn-to-cloud-shared/tests/test_submission_values.py
@@ -24,6 +24,7 @@ from learn_to_cloud_shared.testing.requirement_factories import (
         (SubmissionType.CTF_TOKEN, SubmissionValueKind.TOKEN),
         (SubmissionType.DEPLOYED_API, SubmissionValueKind.DEPLOYED_URL),
         (SubmissionType.CAREER_REFLECTION, SubmissionValueKind.TEXT),
+        (SubmissionType.DEPLOYMENT_ARCHITECTURE, SubmissionValueKind.TEXT),
         ("ci_status", SubmissionValueKind.GITHUB_URL),
         ("iac_token", SubmissionValueKind.TOKEN),
     ],

--- a/packages/learn-to-cloud-shared/tests/verification/test_deployment_architecture.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_deployment_architecture.py
@@ -1,0 +1,190 @@
+"""Tests for the Phase 4 deployment-architecture deterministic gate and evidence."""
+
+import httpx
+import pytest
+
+from learn_to_cloud_shared.testing.requirement_factories import (
+    deployment_architecture_requirement,
+)
+from learn_to_cloud_shared.verification.deployment_architecture import (
+    collect_deployment_architecture_evidence,
+    validate_deployment_architecture,
+)
+from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+
+_DEPLOY_SH = "#!/usr/bin/env bash\naz group create ...\n"
+_LONG_DESCRIPTION = (
+    "My deployment provisions a public API tier behind a load balancer and a "
+    "private database tier in an isolated subnet. Inbound rules restrict the "
+    "database to the API subnet only, and TLS terminates at the API gateway. "
+    "The deploy.sh script is idempotent and creates the resource group, "
+    "network, compute, and database."
+)
+
+
+def _http_error(status_code: int) -> httpx.HTTPStatusError:
+    response = httpx.Response(
+        status_code=status_code,
+        request=httpx.Request("GET", "https://api.github.com"),
+    )
+    return httpx.HTTPStatusError("error", request=response.request, response=response)
+
+
+@pytest.mark.unit
+class TestValidateDeploymentArchitecture:
+    @pytest.mark.asyncio
+    async def test_happy_path_passes(self):
+        req = deployment_architecture_requirement(min_answer_length=100)
+        repo_files = InMemoryRepoFiles({"deploy.sh": _DEPLOY_SH})
+
+        result = await validate_deployment_architecture(
+            req, _LONG_DESCRIPTION, "alice", repo_files=repo_files
+        )
+
+        assert result.is_valid is True
+
+    @pytest.mark.asyncio
+    async def test_short_description_fails_with_actionable_message(self):
+        req = deployment_architecture_requirement(min_answer_length=200)
+        repo_files = InMemoryRepoFiles({"deploy.sh": _DEPLOY_SH})
+
+        result = await validate_deployment_architecture(
+            req, "too short", "alice", repo_files=repo_files
+        )
+
+        assert result.is_valid is False
+        assert result.verification_completed is True
+        assert "200 characters" in result.message
+
+    @pytest.mark.asyncio
+    async def test_missing_deploy_script_fails(self):
+        req = deployment_architecture_requirement(min_answer_length=100)
+        repo_files = InMemoryRepoFiles({"README.md": "# project\n"})
+
+        result = await validate_deployment_architecture(
+            req, _LONG_DESCRIPTION, "alice", repo_files=repo_files
+        )
+
+        assert result.is_valid is False
+        assert result.verification_completed is True
+        assert "deploy.sh" in result.message
+
+    @pytest.mark.asyncio
+    async def test_missing_deploy_script_suggests_other_shell_script(self):
+        req = deployment_architecture_requirement(min_answer_length=100)
+        repo_files = InMemoryRepoFiles({"setup.sh": _DEPLOY_SH})
+
+        result = await validate_deployment_architecture(
+            req, _LONG_DESCRIPTION, "alice", repo_files=repo_files
+        )
+
+        assert result.is_valid is False
+        assert "setup.sh" in result.message
+
+    @pytest.mark.asyncio
+    async def test_repo_not_found_fails_actionably(self):
+        req = deployment_architecture_requirement(min_answer_length=100)
+        repo_files = InMemoryRepoFiles(tree_error=_http_error(404))
+
+        result = await validate_deployment_architecture(
+            req, _LONG_DESCRIPTION, "alice", repo_files=repo_files
+        )
+
+        assert result.is_valid is False
+        assert result.verification_completed is True
+        assert result.repo_exists is False
+        assert "not found" in result.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_transient_github_error_reraises(self):
+        req = deployment_architecture_requirement(min_answer_length=100)
+        repo_files = InMemoryRepoFiles(tree_error=_http_error(500))
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await validate_deployment_architecture(
+                req, _LONG_DESCRIPTION, "alice", repo_files=repo_files
+            )
+
+
+@pytest.mark.unit
+class TestCollectDeploymentArchitectureEvidence:
+    @pytest.mark.asyncio
+    async def test_bundles_deploy_script_and_description(self):
+        repo_files = InMemoryRepoFiles({"deploy.sh": _DEPLOY_SH})
+
+        bundle = await collect_deployment_architecture_evidence(
+            "alice",
+            "journal-starter",
+            _LONG_DESCRIPTION,
+            repo_files=repo_files,
+        )
+
+        assert bundle.source == "repo_files"
+        paths = [item.path for item in bundle.items]
+        assert "deploy.sh" in paths
+        assert "architecture-description.md" in paths
+        script_item = next(i for i in bundle.items if i.path == "deploy.sh")
+        assert script_item.content == _DEPLOY_SH
+
+    @pytest.mark.asyncio
+    async def test_includes_description_even_when_script_missing(self):
+        repo_files = InMemoryRepoFiles({})
+
+        bundle = await collect_deployment_architecture_evidence(
+            "alice",
+            "journal-starter",
+            _LONG_DESCRIPTION,
+            repo_files=repo_files,
+        )
+
+        paths = [item.path for item in bundle.items]
+        assert paths == ["architecture-description.md"]
+
+
+@pytest.mark.unit
+class TestResolveRepositoryRef:
+    def test_derives_ref_from_username_and_required_repo(self):
+        from uuid import uuid4
+
+        from learn_to_cloud_shared.verification_job_executor import (
+            PreparedVerificationJob,
+            _resolve_repository_ref,
+        )
+
+        req = deployment_architecture_requirement(
+            required_repo="learntocloud/journal-starter"
+        )
+        job = PreparedVerificationJob(
+            id=uuid4(),
+            user_id=1,
+            github_username="alice",
+            requirement=req,
+            submitted_value="my long architecture description",
+        )
+
+        ref = _resolve_repository_ref(job)
+
+        assert ref is not None
+        assert ref.owner == "alice"
+        assert ref.repo == "journal-starter"
+
+    def test_returns_none_when_username_missing(self):
+        from uuid import uuid4
+
+        from learn_to_cloud_shared.verification_job_executor import (
+            PreparedVerificationJob,
+            _resolve_repository_ref,
+        )
+
+        req = deployment_architecture_requirement(
+            required_repo="learntocloud/journal-starter"
+        )
+        job = PreparedVerificationJob(
+            id=uuid4(),
+            user_id=1,
+            github_username="",
+            requirement=req,
+            submitted_value="my long architecture description",
+        )
+
+        assert _resolve_repository_ref(job) is None

--- a/packages/learn-to-cloud-shared/tests/verification/test_dispatcher.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_dispatcher.py
@@ -32,6 +32,7 @@ _EXPECTED_BACKGROUND = {
     SubmissionType.DEPLOYED_API,
     SubmissionType.SECURITY_SCANNING,
     SubmissionType.CAREER_REFLECTION,
+    SubmissionType.DEPLOYMENT_ARCHITECTURE,
 }
 
 # Server-derived GitHub repo URL types (owner/repo parsed from the value).
@@ -109,6 +110,17 @@ def test_deployed_api_does_not_require_username():
     descriptor = descriptor_for(SubmissionType.DEPLOYED_API)
     assert descriptor is not None
     assert descriptor.requires_username is False
+
+
+def test_deployment_architecture_is_background_repo_derived_needs_username():
+    descriptor = descriptor_for(SubmissionType.DEPLOYMENT_ARCHITECTURE)
+    assert descriptor is not None
+    assert descriptor.execution_mode is ExecutionMode.BACKGROUND
+    assert descriptor.requires_username is True
+    # The submitted value is free text, not a repo URL, so it is not
+    # repo-backed even though the validator derives a repo from required_repo.
+    assert descriptor.repo_backed is False
+    assert is_repo_backed(SubmissionType.DEPLOYMENT_ARCHITECTURE) is False
 
 
 def test_registry_covers_every_active_submission_type_exactly_once():

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -18,6 +18,7 @@ from learn_to_cloud_shared.verification.llm_grading import (
 from learn_to_cloud_shared.verification.repo_utils import RepositoryRef
 from learn_to_cloud_shared.verification.tasks import (
     PHASE3_LLM_TASKS,
+    PHASE4_LLM_TASKS,
     PHASE6_LLM_TASKS,
     PHASE7_LLM_TASKS,
     LLMGradingDecision,
@@ -215,6 +216,84 @@ def test_llm_grading_content_filtered_result_asks_learner_to_rephrase():
     assert updated.validation_result.verification_completed is False
     assert "content safety filter" in updated.validation_result.message
     assert "rewrite your answers" in updated.validation_result.message
+
+
+def _phase4_run_result(
+    is_valid: bool = True,
+    github_username: str = "learner",
+    description: str = (
+        "My two-tier deployment: a public API tier and a private database tier "
+        "in an isolated subnet, provisioned idempotently by deploy.sh."
+    ),
+) -> VerificationRunResult:
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        deployment_architecture_requirement,
+    )
+
+    requirement = deployment_architecture_requirement(
+        slug="deployment-architecture",
+        required_repo="learntocloud/journal-starter",
+    )
+    return VerificationRunResult(
+        job=PreparedVerificationJob(
+            id=uuid4(),
+            user_id=1,
+            github_username=github_username,
+            requirement=requirement,
+            submitted_value=description,
+        ),
+        validation_result=ValidationResult(
+            is_valid=is_valid,
+            message="Description received and deploy script found.",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_collect_phase4_requests_bundles_script_and_description():
+    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+
+    description = (
+        "My two-tier deployment provisions a public API and a private database."
+    )
+    run_result = _phase4_run_result(description=description)
+    repo_files = InMemoryRepoFiles({"deploy.sh": "#!/bin/bash\naz group create\n"})
+
+    requests = await collect_llm_grading_requests(run_result, repo_files=repo_files)
+
+    assert len(requests) == len(PHASE4_LLM_TASKS)
+    assert "deploy.sh" in requests[0].message
+    assert description in requests[0].message
+    assert requests[0].task.evidence.source == "repo_files"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_collect_phase4_requests_skips_when_gate_failed():
+    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+
+    repo_files = InMemoryRepoFiles({"deploy.sh": "#!/bin/bash\n"})
+
+    requests = await collect_llm_grading_requests(
+        _phase4_run_result(is_valid=False), repo_files=repo_files
+    )
+
+    assert requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_collect_phase4_requests_skips_when_username_missing():
+    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+
+    repo_files = InMemoryRepoFiles({"deploy.sh": "#!/bin/bash\n"})
+
+    requests = await collect_llm_grading_requests(
+        _phase4_run_result(github_username=""), repo_files=repo_files
+    )
+
+    assert requests == []
 
 
 def _phase7_run_result(


### PR DESCRIPTION
Closes #604.

## What

Adds a new, additional Phase 4 capstone verification requirement,
`deployment_architecture`. The learner writes a natural-language architecture
description in an in-app textarea, and an LLM rubric grades whether it aligns
with the `deploy.sh` fetched from their fork. The existing `deployed_api`
requirement is untouched.

A hybrid of Phase 7 (free-text + LLM rubric) and Phase 3 (repo-file evidence +
LLM):

- New `SubmissionType.DEPLOYMENT_ARCHITECTURE`, reusing the existing `TEXT`
  submission value kind (no new column).
- Registry-driven dispatch: BACKGROUND (Durable Functions), requires username,
  `repo_backed=False` (submitted value is free text, repo derived from
  `github_username` + `required_repo`).
- Deterministic gate: minimum-length description and `deploy.sh` present in the
  repo tree, with actionable feedback for 404/private repos and missing scripts
  (falls back to naming other top-level `*.sh` files).
- LLM rubric task (`gpt-5-mini`, passing_score 0.7) bundling `deploy.sh` and the
  description as evidence, short-circuiting when the gate fails.
- Durable orchestrator `verify_phase4_architecture_orchestrator`.
- Dedicated 20000-char `architecture_description` form field + textarea card
  (avoids the shared 2048-char single-line cap).
- Alembic 0047/0048 extend the requirements CHECK constraint (`NOT VALID` +
  `VALIDATE`).
- Content: `deployment-architecture.yaml` + two new capstone steps.

## Testing

- `uv run poe check` passes (lint, format, ty, squawk, shared/api/functions
  test suites).
- New/updated tests cover the dispatcher registry, deterministic gate
  (short text, missing script, 404/private, happy path, transient error),
  evidence bundling, `_collect_phase4_requests`, submission-value kind,
  URL-derivation pass-through + repo helper, `_resolve_repository_ref`,
  orchestrator mapping, and the htmx route (long description bypasses the
  2048 cap; empty description shows an error).
- Dog-food run confirmed the card renders and submits correctly, degrading
  gracefully when the Functions worker is absent.

Note: the full end-to-end BACKGROUND path (Functions worker + real fork +
Azure OpenAI) was not exercised in CI; it is covered by unit tests.