### PR TITLE
fix: raise foundry verifier deployment capacity to 50K TPM (#621)

### DIFF
--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -141,7 +141,7 @@ variable "foundry_model_sku_name" {
 variable "foundry_model_capacity" {
   description = "Foundry model deployment capacity. For Azure OpenAI Standard/GlobalStandard, this is in thousands of tokens per minute."
   type        = number
-  default     = 1
+  default     = 50
 
   validation {
     condition     = var.foundry_model_capacity > 0


### PR DESCRIPTION
## What

Bumps `foundry_model_capacity` default from `1` to `50` in `infra/variables.tf`.

## Why

Issue #621: a learner hit "Automated grading is temporarily unavailable" on Phase 3 (Verify Journal API Implementation) in production.

App Insights telemetry (`verification.llm_grading.failed`, 2026-07-08 21:08 UTC) showed the real cause: **HTTP 429 `rate_limit_exceeded`** from the `gpt-5-mini-verifier` Foundry deployment in eastus2.

The deployment was provisioned at **capacity 1 (= 1K TPM)**. A single gpt-5-mini grading call plus its up-to-4 retries (`_LLM_RETRY_OPTIONS`) within one minute exceeds 1K TPM, so every attempt stays rate-limited, the `ChatClientException` bubbles up, and `llm_grading_failed` converts it to the generic user-facing message.

## Details

- Subscription quota for `OpenAI.GlobalStandard.gpt-5-mini` in eastus2: **limit 3000**, ~101 used — ample headroom, so 50 is safe and conservative.
- Isolated occurrence: only 1 `llm_grading.failed` event in the last ~2 days.
- No behavior/code change; infra capacity only. Requires `terraform apply` to take effect.

Fixes #621