### PR TITLE
Durable verification 1/3: single generic orchestrator

### DIFF
--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -18,7 +18,6 @@ from learn_to_cloud_shared.core.config import get_worker_settings
 from learn_to_cloud_shared.core.database import create_engine, create_session_maker
 from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE, configure_logging
 from learn_to_cloud_shared.core.observability import configure_observability
-from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
@@ -86,28 +85,12 @@ configure_observability()
 
 app = df.DFApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
-_DEFAULT_ORCHESTRATOR_NAME = "verification_orchestrator"
-# BACKGROUND submission types: phase 3+ verifications that involve LLM
-# grading, multi-task fan-out, or external probes with retries and run on
-# the Durable Functions path. The INLINE phase 0-2 types (github_profile,
-# profile_readme, repo_fork, ctf_token, networking_token) run inside the
-# FastAPI request instead and are intentionally absent. Execution mode is
-# declared per type in verification/dispatcher.py (_VALIDATOR_REGISTRY);
-# this map only picks the orchestrator name for the background types.
-#
-# Each background type maps to its own per-phase orchestration (issue
-# #429): phases 3 and 6 run the canonical grading-capable workflow,
-# phases 4 and 5 run the deterministic (never-grades) workflow.
-_ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE = {
-    SubmissionType.JOURNAL_API_VERIFIER: (
-        "verify_phase3_journal_api_verifier_orchestrator"
-    ),
-    SubmissionType.DEPLOYED_API: "verify_phase4_deployed_api_orchestrator",
-    SubmissionType.DEVOPS_ANALYSIS: "verify_phase5_devops_orchestrator",
-    SubmissionType.SECURITY_SCANNING: "verify_phase6_security_orchestrator",
-    SubmissionType.CAREER_REFLECTION: "verify_phase7_career_orchestrator",
-    SubmissionType.DEPLOYMENT_ARCHITECTURE: ("verify_phase4_architecture_orchestrator"),
-}
+# Every submission type runs through this one orchestrator. Routing to the
+# right validator happens inside the verify activity via the dispatcher
+# registry (verification/dispatcher.py _VALIDATOR_REGISTRY), and LLM grading
+# is data-driven -- the grading step runs only when the verify step emits
+# grading requests, so deterministic phases pass straight through.
+_ORCHESTRATOR_NAME = "verification_orchestrator"
 _VERIFY_RETRY_OPTIONS = df.RetryOptions(
     first_retry_interval_in_milliseconds=5000,
     max_number_of_attempts=3,
@@ -286,23 +269,6 @@ def _log_verification_job_completed(
             "verification_completed": result.get("verification_completed"),
             "error_code": result.get("code"),
         },
-    )
-
-
-def _orchestrator_name_for_submission_type(submission_type: str) -> str:
-    """Pick the Durable orchestrator for a verification's submission type.
-
-    Phase D.3 dropped ``submission_type`` from ``verification_jobs``;
-    callers resolve it via the linked requirement (see
-    :func:`start_verification_job`).
-    """
-    try:
-        enum_value = SubmissionType(submission_type)
-    except ValueError:
-        return _DEFAULT_ORCHESTRATOR_NAME
-    return _ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE.get(
-        enum_value,
-        _DEFAULT_ORCHESTRATOR_NAME,
     )
 
 
@@ -494,13 +460,16 @@ def _persist_step(
 
 
 def _run_verification_orchestration(context: df.DurableOrchestrationContext):
-    """Canonical verification workflow: prepare -> verify -> grade -> persist.
+    """The verification workflow for every submission type.
 
-    The LLM grading step is data-driven: it runs only when the verify
-    step produced grading requests, so phases that never grade simply
-    pass through it. Used by the grading-capable phases (3 and 6), the
-    default orchestrator, and every drain-only legacy orchestrator, whose
-    in-flight jobs recorded this exact activity sequence.
+    prepare -> verify -> grade -> persist. The LLM grading step is
+    data-driven: it runs only when the verify step produced grading
+    requests, so deterministic phases (which never emit grading requests)
+    pass straight through it. Routing to the right validator happens inside
+    the verify activity via the dispatcher registry.
+
+    Kept as a plain generator (separate from the decorated trigger) so the
+    orchestration tests can drive it directly.
     """
     outcome = yield from _prepare_step(context)
     if isinstance(outcome, _TerminalOutcome):
@@ -510,119 +479,9 @@ def _run_verification_orchestration(context: df.DurableOrchestrationContext):
     return (yield from _persist_step(context, outcome, run_result))
 
 
-def _deterministic_verification(context: df.DurableOrchestrationContext):
-    """Workflow for phases that never LLM-grade (phases 4 and 5).
-
-    prepare -> verify -> persist, with no ``collect_llm_grading_requests``
-    call. These verification jobs are short-lived and low-volume, so the
-    orchestrator name is not versioned; the rare case of a job being
-    mid-flight across a deploy is acceptable and recoverable by resubmitting.
-    """
-    outcome = yield from _prepare_step(context)
-    if isinstance(outcome, _TerminalOutcome):
-        return outcome.result
-    run_result = yield from _verify_step(context, outcome)
-    return (yield from _persist_step(context, outcome, run_result))
-
-
 @app.orchestration_trigger(context_name="context")
 def verification_orchestrator(context: df.DurableOrchestrationContext):
-    """Run the default verification workflow for unmapped submission types."""
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_github_profile_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 0 GitHub profile jobs.
-
-    Phase 0-2 verifications now run synchronously in FastAPI (see
-    ``api/src/learn_to_cloud/routes/htmx_routes.py``). This trigger stays
-    registered so any orchestration started before the cutover can still
-    complete cleanly. Safe to remove after Durable retention expires.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_profile_readme_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 0 profile README jobs.
-
-    See :func:`verify_github_profile_orchestrator` for rationale.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_repo_fork_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 0 repo fork jobs.
-
-    See :func:`verify_github_profile_orchestrator` for rationale.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_ctf_token_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 1 CTF token jobs.
-
-    See :func:`verify_github_profile_orchestrator` for rationale.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_networking_token_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 2 networking token jobs.
-
-    See :func:`verify_github_profile_orchestrator` for rationale.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase3_ci_status_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 3 ci_status jobs.
-
-    See :func:`verify_github_profile_orchestrator` for rationale.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase3_journal_api_verifier_orchestrator(
-    context: df.DurableOrchestrationContext,
-):
-    """Run Phase 3 journal API verification (CI gate + LLM rubric review)."""
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase4_deployed_api_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 4 deployed API verification (deterministic, no LLM grading)."""
-    return (yield from _deterministic_verification(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase5_devops_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 5 DevOps verification (deterministic, no LLM grading)."""
-    return (yield from _deterministic_verification(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase6_security_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 6 security verification (probes + LLM rubric review)."""
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase7_career_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 7 career reflection verification (LLM rubric review)."""
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase4_architecture_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 4 capstone architecture alignment (deploy.sh vs description)."""
+    """Run the verification workflow for every submission type."""
     return (yield from _run_verification_orchestration(context))
 
 
@@ -881,10 +740,9 @@ async def start_verification_job(
                 )
 
         submission_type_str = prepared.requirement.submission_type.value
-        orchestrator_name = _orchestrator_name_for_submission_type(submission_type_str)
         _set_verification_span_attributes(job_id=job_id)
         instance_id = await client.start_new(
-            orchestrator_name,
+            _ORCHESTRATOR_NAME,
             instance_id=job_id,
             client_input=prepared.to_payload(),
         )
@@ -893,7 +751,7 @@ async def start_verification_job(
             extra={
                 "job_id": job_id,
                 "instance_id": instance_id,
-                "orchestrator_name": orchestrator_name,
+                "orchestrator_name": _ORCHESTRATOR_NAME,
                 "requirement_slug": prepared.requirement.slug,
                 "submission_type": submission_type_str,
             },

--- a/apps/verification-functions/tests/test_orchestrations.py
+++ b/apps/verification-functions/tests/test_orchestrations.py
@@ -1,12 +1,12 @@
-"""Per-phase orchestration workflow tests (issue #429).
+"""Verification orchestration workflow tests.
 
-The Durable orchestration generators are driven manually here: a fake
+The Durable orchestration generator is driven manually here: a fake
 context records each yielded activity call, and the test feeds back the
-activity result. This asserts the exact sequence of activity calls each
-workflow makes, including the determinism-critical difference that the
-deterministic workflow (phases 4 and 5) never calls
-``collect_llm_grading_requests`` while the graded workflow (phases 3 and
-6) does.
+activity result. This asserts the exact sequence of activity calls the
+single workflow makes. LLM grading is data-driven -- the workflow calls
+``collect_llm_grading_requests`` for every submission type and only grades
+when that activity returns requests, so deterministic phases pass straight
+through with an empty request list.
 """
 
 from __future__ import annotations
@@ -16,7 +16,6 @@ from typing import Any
 from uuid import uuid4
 
 import function_app
-from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.testing.requirement_factories import (
     deployed_api_requirement,
     journal_api_verifier_requirement,
@@ -162,8 +161,7 @@ def _sequence(calls: list[_RecordedCall]) -> list[tuple[str, str]]:
 
 
 class TestCanonicalWorkflow:
-    """The grading-capable workflow used by phases 3 and 6, the default
-    orchestrator, and the drain-only legacy orchestrators."""
+    """The single verification workflow used by every submission type."""
 
     def test_grades_when_requests_present(self) -> None:
         payload = _graded_payload()
@@ -251,18 +249,24 @@ class TestCanonicalWorkflow:
         assert result == terminal
 
 
-class TestDeterministicWorkflow:
-    def test_never_calls_collect_llm_grading(self) -> None:
+class TestDeterministicSubmissionTypes:
+    """Deterministic types (e.g. phase 4 deployed_api) run the same single
+    workflow: they call ``collect_llm_grading_requests``, get an empty list,
+    and skip grading -- no separate deterministic orchestrator."""
+
+    def test_passes_through_grading_with_no_requests(self) -> None:
         payload = _deterministic_payload()
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
-        responder = _make_responder(payload)
-        calls, result = _drive(function_app._deterministic_verification(ctx), responder)
+        responder = _make_responder(payload, llm_requests=[])
+        calls, result = _drive(
+            function_app._run_verification_orchestration(ctx), responder
+        )
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
             ("activity_with_retry", "execute_requirement_verification"),
+            ("activity", "collect_llm_grading_requests"),
             ("activity_with_retry", "persist_verification_result"),
         ]
-        assert all(call.name != "collect_llm_grading_requests" for call in calls)
         assert result == {
             "job_id": "job-1",
             "status": "completed",
@@ -274,55 +278,19 @@ class TestDeterministicWorkflow:
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
         terminal = {"job_id": "job-1", "status": "completed", "submission_id": 1}
         responder = _make_responder(payload, terminal=terminal)
-        calls, result = _drive(function_app._deterministic_verification(ctx), responder)
+        calls, result = _drive(
+            function_app._run_verification_orchestration(ctx), responder
+        )
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
         ]
         assert result == terminal
 
 
-class TestOrchestratorNameMapping:
-    def test_phase4_and_phase5_map_to_deterministic_orchestrators(self) -> None:
-        names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
-        assert (
-            names[SubmissionType.DEPLOYED_API]
-            == "verify_phase4_deployed_api_orchestrator"
-        )
-        assert (
-            names[SubmissionType.DEVOPS_ANALYSIS] == "verify_phase5_devops_orchestrator"
-        )
-
-    def test_phase3_and_phase6_map_to_canonical_orchestrators(self) -> None:
-        names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
-        assert (
-            names[SubmissionType.JOURNAL_API_VERIFIER]
-            == "verify_phase3_journal_api_verifier_orchestrator"
-        )
-        assert (
-            names[SubmissionType.SECURITY_SCANNING]
-            == "verify_phase6_security_orchestrator"
-        )
-
-    def test_phase7_maps_to_career_orchestrator(self) -> None:
-        names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
-        assert (
-            names[SubmissionType.CAREER_REFLECTION]
-            == "verify_phase7_career_orchestrator"
-        )
-
-    def test_deployment_architecture_maps_to_phase4_architecture_orchestrator(
-        self,
-    ) -> None:
-        names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
-        assert (
-            names[SubmissionType.DEPLOYMENT_ARCHITECTURE]
-            == "verify_phase4_architecture_orchestrator"
-        )
-
-    def test_every_mapped_name_is_registered(self) -> None:
-        """Guards against pointing the resolver at a non-existent orchestrator."""
-        for name in function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE.values():
-            assert hasattr(function_app, name), f"missing orchestrator: {name}"
+class TestSingleOrchestrator:
+    def test_all_submission_types_use_one_orchestrator(self) -> None:
+        assert function_app._ORCHESTRATOR_NAME == "verification_orchestrator"
+        assert hasattr(function_app, function_app._ORCHESTRATOR_NAME)
 
 
 class TestContentFilterClassification:


### PR DESCRIPTION
**Stack: 1 of 3** — base `main`

First layer of moving the entire verification system onto Durable Functions so nothing runs inline in the FastAPI request.

## What
Collapse the per-phase / drain-only orchestrators into one generic `verification_orchestrator` (prepare → verify → grade → persist). LLM grading is already data-driven (`collect_llm_grading_requests`; empty list = skip), so deterministic phases just emit no grading requests and pass through — the old deterministic-vs-graded split was redundant.

- `apps/verification-functions/function_app.py`: single `_ORCHESTRATOR_NAME = "verification_orchestrator"`; removed the submission-type→orchestrator map, `_orchestrator_name_for_submission_type()`, `_deterministic_verification()`, and all per-phase orchestrator triggers. `start_verification_job` always starts the one orchestrator.
- Tests updated accordingly.

Infra audit: no infra/monitoring references to the removed orchestrator names.

## Stack
1. **single-orchestrator** ← this PR
2. api-always-durable (base: this branch)
3. remove-inline (base: api-always-durable)

Do not merge yet — under manual review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>