### PR TITLE
Durable verification 2/3: API always creates a VerificationJob

### DIFF
--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -25,9 +25,7 @@ from learn_to_cloud_shared.repositories.verification_job_repository import (
 from learn_to_cloud_shared.schemas import (
     CareerReflectionRequirement,
     DeploymentArchitectureRequirement,
-    HandsOnRequirement,
     SubmissionData,
-    SubmissionResult,
 )
 from learn_to_cloud_shared.submission_values import submission_value_from_columns
 from learn_to_cloud_shared.verification.execution import (
@@ -69,7 +67,6 @@ from learn_to_cloud.services.submissions_service import (
     InvalidSubmittedValueError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
-    SyncVerificationResult,
     VerificationJobSubmission,
     create_verification_job,
 )
@@ -328,16 +325,10 @@ async def htmx_submit_verification(
 ) -> HTMLResponse:
     """Submit a hands-on verification.
 
-    Routes to one of two execution paths based on the requirement's
-    submission type:
-
-    * Sync (phases 0-2) — :func:`create_verification_job` runs validation
-      inside this request and persists the ``Submission`` row. The response
-      reloads the page so the just-updated card and any newly-unlocked
-      requirement render with fresh server-side state.
-    * Async (phases 3-6) — :func:`create_verification_job` returns a
-      ``VerificationJobSubmission`` and we start a Durable orchestration,
-      then return a spinner card that polls for status.
+    Every submission type runs through Durable Functions:
+    :func:`create_verification_job` validates the request and creates a
+    ``VerificationJob``; we start the Durable orchestration and return a
+    spinner card that polls for status.
     """
     user_id = current_user.user_id
     github_username = current_user.github_username
@@ -408,9 +399,9 @@ async def htmx_submit_verification(
     else:
         derived_value = submitted_value
 
-    # ── Dispatch to sync or async execution path ───────────────────────
+    # ── Create the Durable verification job ────────────────────────────
     try:
-        dispatch_result = await create_verification_job(
+        job_submission = await create_verification_job(
             session_maker=session_maker,
             user_id=user_id,
             requirement_slug=requirement_slug,
@@ -437,51 +428,13 @@ async def htmx_submit_verification(
             ),
         )
 
-    if isinstance(dispatch_result, SyncVerificationResult):
-        return _render_sync_result(
-            user_id=user_id,
-            requirement=requirement,
-            result=dispatch_result.submission_result,
-        )
-
     return await _start_async_job_and_render(
         session_maker=session_maker,
         user_id=user_id,
         requirement_slug=requirement_slug,
-        job_submission=dispatch_result,
+        job_submission=job_submission,
         render_card=_render_card,
     )
-
-
-def _render_sync_result(
-    *,
-    user_id: int,
-    requirement: HandsOnRequirement | None,
-    result: SubmissionResult,
-) -> HTMLResponse:
-    """Render the response for a sync verification that already finished.
-
-    The ``Submission`` row is already persisted; we reload the phase page
-    so the card, progress bar, and any newly-unlocked next requirement
-    all render from fresh server state. Reload trigger matches the
-    pattern used by :func:`_reload_verification_html` for async
-    completion so behavior is consistent across paths.
-    """
-    logger.info(
-        "htmx.submit.sync_completed",
-        extra={
-            "user_id": user_id,
-            "submission_id": result.submission.id,
-            "requirement_slug": requirement.slug if requirement is not None else None,
-            "submission_type": (
-                requirement.submission_type.value if requirement is not None else None
-            ),
-            "is_valid": result.is_valid,
-            "verification_completed": result.submission.verification_completed,
-            "is_server_error": result.is_server_error,
-        },
-    )
-    return HTMLResponse(_reload_verification_html())
 
 
 async def _start_async_job_and_render(

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -25,12 +25,9 @@ from learn_to_cloud_shared.schemas import (
     Phase,
     PhaseSubmissionContext,
     SubmissionData,
-    SubmissionResult,
 )
 from learn_to_cloud_shared.submission_values import SubmittedValue
-from learn_to_cloud_shared.verification.dispatcher import is_inline
 from learn_to_cloud_shared.verification.execution import (
-    execute_sync_submission_validation,
     to_submission_data,
 )
 from learn_to_cloud_shared.verification.requirements import (
@@ -153,24 +150,6 @@ class VerificationJobSubmission:
     github_username: str | None
 
 
-@dataclass(frozen=True, slots=True)
-class SyncVerificationResult:
-    """Result of running a sync verification inside the FastAPI request.
-
-    Returned by :func:`create_verification_job` for submission types whose
-    validators finish in well under a second (phases 0-2). No Durable
-    Functions orchestration is started — the ``Submission`` row is already
-    persisted by the time this is returned.
-    """
-
-    submission_result: SubmissionResult
-
-
-# Tagged union returned by ``create_verification_job``. Callers use
-# ``isinstance`` to pick the rendering path.
-SubmissionDispatchResult = VerificationJobSubmission | SyncVerificationResult
-
-
 async def _check_submission_preconditions(
     session_maker: async_sessionmaker[AsyncSession],
     user_id: int,
@@ -232,13 +211,13 @@ async def create_verification_job(
     requirement_slug: str,
     submitted_value: str,
     github_username: str | None,
-) -> SubmissionDispatchResult:
-    """Validate request preconditions and dispatch to the right execution path.
+) -> VerificationJobSubmission:
+    """Validate request preconditions and create the Durable verification job.
 
-    Returns a :class:`SyncVerificationResult` for submission types whose
-    validators run inside the FastAPI request (phases 0-2). Returns a
-    :class:`VerificationJobSubmission` for types that go through Durable
-    Functions (phases 3-6).
+    Every submission type runs through Durable Functions: this validates the
+    request, creates (or reuses) the ``VerificationJob`` row, and returns a
+    :class:`VerificationJobSubmission` for the caller to start the
+    orchestration.
     """
     ctx = await _check_submission_preconditions(
         session_maker,
@@ -250,16 +229,6 @@ async def create_verification_job(
         typed_value = SubmittedValue.from_raw(ctx.requirement, submitted_value)
     except ValueError as exc:
         raise InvalidSubmittedValueError(str(exc)) from exc
-
-    if is_inline(ctx.requirement.submission_type):
-        submission_result = await execute_sync_submission_validation(
-            session_maker=session_maker,
-            user_id=user_id,
-            requirement=ctx.requirement,
-            submitted_value=typed_value.as_text,
-            github_username=github_username,
-        )
-        return SyncVerificationResult(submission_result=submission_result)
 
     async with session_maker() as write_session:
         repo = VerificationJobRepository(write_session)

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -20,7 +20,6 @@ from uuid import uuid4
 import pytest
 from fastapi.responses import HTMLResponse
 from learn_to_cloud_shared.models import SubmissionValueKind, VerificationJob
-from learn_to_cloud_shared.schemas import SubmissionResult
 
 from learn_to_cloud.core.auth import AuthenticatedUser
 from learn_to_cloud.routes.htmx_routes import (
@@ -38,7 +37,6 @@ from learn_to_cloud.services.durable_verification_client import (
 )
 from learn_to_cloud.services.steps_service import StepValidationError
 from learn_to_cloud.services.submissions_service import (
-    SyncVerificationResult,
     VerificationJobSubmission,
 )
 from learn_to_cloud.services.users_service import UserNotFoundError
@@ -489,116 +487,6 @@ class TestHtmxSubmitVerification:
         _, _, context = _patch_templates.TemplateResponse.call_args.args
         assert context["server_error"] is True
         assert context["server_error_retryable"] is True
-
-    async def test_sync_submit_returns_reload_trigger(self):
-        """Sync submission types finish in-request and return a page-reload
-        snippet so the next requirement re-renders with fresh server state."""
-        request = _mock_request()
-        current_user = AuthenticatedUser(user_id=1, github_username="user")
-        submission = SimpleNamespace(
-            id=42,
-            requirement_slug="req-1",
-            submission_type=SimpleNamespace(value="github_profile"),
-            verification_completed=True,
-        )
-        sync_result = SyncVerificationResult(
-            submission_result=cast(
-                SubmissionResult,
-                SimpleNamespace(
-                    submission=submission,
-                    is_valid=True,
-                    is_server_error=False,
-                ),
-            ),
-        )
-
-        with (
-            patch(
-                "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "learn_to_cloud.routes.htmx_routes.derive_submission_value",
-                autospec=True,
-                return_value="https://github.com/user",
-            ),
-            patch(
-                "learn_to_cloud.routes.htmx_routes.create_verification_job",
-                new_callable=AsyncMock,
-                return_value=sync_result,
-            ) as mock_create_job,
-            patch(
-                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
-                new_callable=AsyncMock,
-            ) as mock_start,
-            patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
-            ) as mock_repo_class,
-        ):
-            result = await htmx_submit_verification(
-                request,
-                AsyncMock(),
-                current_user,
-                requirement_slug="req-1",
-                submitted_value="https://github.com/user",
-            )
-
-        assert isinstance(result, HTMLResponse)
-        # Page reload trigger (matches the async terminal pattern).
-        assert "location.reload()" in bytes(result.body).decode()
-        # Critical: sync path must never touch Durable or VerificationJob.
-        mock_start.assert_not_awaited()
-        mock_repo_class.assert_not_called()
-        mock_create_job.assert_awaited_once()
-
-    async def test_sync_submit_failure_also_returns_reload_trigger(self):
-        """A failed sync verification still reloads so the failed card is
-        re-rendered from the persisted Submission state."""
-        request = _mock_request()
-        current_user = AuthenticatedUser(user_id=1, github_username="user")
-        submission = SimpleNamespace(
-            id=43,
-            requirement_slug="req-1",
-            submission_type=SimpleNamespace(value="github_profile"),
-            verification_completed=True,
-        )
-        sync_result = SyncVerificationResult(
-            submission_result=cast(
-                SubmissionResult,
-                SimpleNamespace(
-                    submission=submission,
-                    is_valid=False,
-                    is_server_error=False,
-                ),
-            ),
-        )
-
-        with (
-            patch(
-                "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
-                return_value=MagicMock(),
-            ),
-            patch(
-                "learn_to_cloud.routes.htmx_routes.derive_submission_value",
-                autospec=True,
-                return_value="https://github.com/user",
-            ),
-            patch(
-                "learn_to_cloud.routes.htmx_routes.create_verification_job",
-                new_callable=AsyncMock,
-                return_value=sync_result,
-            ),
-        ):
-            result = await htmx_submit_verification(
-                request,
-                AsyncMock(),
-                current_user,
-                requirement_slug="req-1",
-                submitted_value="https://github.com/user",
-            )
-
-        assert isinstance(result, HTMLResponse)
-        assert "location.reload()" in bytes(result.body).decode()
 
     async def test_async_submit_still_returns_processing_card(self):
         """Regression: async submissions must keep using the

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -22,7 +22,6 @@ from learn_to_cloud.services.submissions_service import (
     AlreadyValidatedError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
-    SyncVerificationResult,
     VerificationJobSubmission,
     create_verification_job,
     get_phase_submission_context,
@@ -336,14 +335,15 @@ class TestSequentialPhaseGating:
 
 
 @pytest.mark.unit
-class TestSyncDispatchBranch:
+class TestCreateVerificationJob:
     @pytest.mark.asyncio
-    async def test_sync_type_runs_in_process_and_returns_sync_result(self):
+    async def test_formerly_inline_type_creates_verification_job(self):
+        """Types that used to run inline (phases 0-2) now create a job too."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.GITHUB_PROFILE,
         )
-        sentinel_result = MagicMock(name="SubmissionResult")
+        mock_job = MagicMock()
 
         with (
             patch(
@@ -359,15 +359,16 @@ class TestSyncDispatchBranch:
                 "learn_to_cloud.services.submissions_service.VerificationJobRepository",
                 autospec=True,
             ) as mock_job_repo_class,
-            patch(
-                "learn_to_cloud.services.submissions_service.execute_sync_submission_validation",
-                new_callable=AsyncMock,
-                return_value=sentinel_result,
-            ) as mock_sync_execute,
         ):
             mock_repo = MagicMock()
             mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
             mock_repo_class.return_value = mock_repo
+
+            mock_job_repo = MagicMock()
+            mock_job_repo.create_or_get_active = AsyncMock(
+                return_value=(mock_job, True)
+            )
+            mock_job_repo_class.return_value = mock_job_repo
 
             result = await create_verification_job(
                 session_maker=mock_session_maker,
@@ -377,13 +378,13 @@ class TestSyncDispatchBranch:
                 github_username="user",
             )
 
-        assert isinstance(result, SyncVerificationResult)
-        assert result.submission_result is sentinel_result
-        mock_sync_execute.assert_awaited_once()
-        mock_job_repo_class.assert_not_called()
+        assert isinstance(result, VerificationJobSubmission)
+        assert result.job is mock_job
+        assert result.created is True
+        mock_job_repo.create_or_get_active.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_async_type_returns_verification_job_submission(self):
+    async def test_returns_verification_job_submission(self):
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.JOURNAL_API_VERIFIER,
@@ -404,10 +405,6 @@ class TestSyncDispatchBranch:
                 "learn_to_cloud.services.submissions_service.VerificationJobRepository",
                 autospec=True,
             ) as mock_job_repo_class,
-            patch(
-                "learn_to_cloud.services.submissions_service.execute_sync_submission_validation",
-                new_callable=AsyncMock,
-            ) as mock_sync_execute,
         ):
             mock_repo = MagicMock()
             mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
@@ -430,11 +427,10 @@ class TestSyncDispatchBranch:
         assert isinstance(result, VerificationJobSubmission)
         assert result.job is mock_job
         assert result.created is True
-        mock_sync_execute.assert_not_awaited()
         mock_job_repo.create_or_get_active.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_sync_preconditions_still_enforced(self):
+    async def test_preconditions_still_enforced(self):
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.CTF_TOKEN,
@@ -451,9 +447,9 @@ class TestSyncDispatchBranch:
                 autospec=True,
             ) as mock_repo_class,
             patch(
-                "learn_to_cloud.services.submissions_service.execute_sync_submission_validation",
-                new_callable=AsyncMock,
-            ) as mock_sync_execute,
+                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
+                autospec=True,
+            ) as mock_job_repo_class,
         ):
             mock_repo = MagicMock()
             mock_repo.get_by_user_and_requirement = AsyncMock(
@@ -470,7 +466,7 @@ class TestSyncDispatchBranch:
                     github_username="user",
                 )
 
-        mock_sync_execute.assert_not_awaited()
+        mock_job_repo_class.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -18,7 +18,6 @@ from learn_to_cloud_shared.core.config import get_worker_settings
 from learn_to_cloud_shared.core.database import create_engine, create_session_maker
 from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE, configure_logging
 from learn_to_cloud_shared.core.observability import configure_observability
-from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
@@ -86,28 +85,12 @@ configure_observability()
 
 app = df.DFApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
-_DEFAULT_ORCHESTRATOR_NAME = "verification_orchestrator"
-# BACKGROUND submission types: phase 3+ verifications that involve LLM
-# grading, multi-task fan-out, or external probes with retries and run on
-# the Durable Functions path. The INLINE phase 0-2 types (github_profile,
-# profile_readme, repo_fork, ctf_token, networking_token) run inside the
-# FastAPI request instead and are intentionally absent. Execution mode is
-# declared per type in verification/dispatcher.py (_VALIDATOR_REGISTRY);
-# this map only picks the orchestrator name for the background types.
-#
-# Each background type maps to its own per-phase orchestration (issue
-# #429): phases 3 and 6 run the canonical grading-capable workflow,
-# phases 4 and 5 run the deterministic (never-grades) workflow.
-_ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE = {
-    SubmissionType.JOURNAL_API_VERIFIER: (
-        "verify_phase3_journal_api_verifier_orchestrator"
-    ),
-    SubmissionType.DEPLOYED_API: "verify_phase4_deployed_api_orchestrator",
-    SubmissionType.DEVOPS_ANALYSIS: "verify_phase5_devops_orchestrator",
-    SubmissionType.SECURITY_SCANNING: "verify_phase6_security_orchestrator",
-    SubmissionType.CAREER_REFLECTION: "verify_phase7_career_orchestrator",
-    SubmissionType.DEPLOYMENT_ARCHITECTURE: ("verify_phase4_architecture_orchestrator"),
-}
+# Every submission type runs through this one orchestrator. Routing to the
+# right validator happens inside the verify activity via the dispatcher
+# registry (verification/dispatcher.py _VALIDATOR_REGISTRY), and LLM grading
+# is data-driven -- the grading step runs only when the verify step emits
+# grading requests, so deterministic phases pass straight through.
+_ORCHESTRATOR_NAME = "verification_orchestrator"
 _VERIFY_RETRY_OPTIONS = df.RetryOptions(
     first_retry_interval_in_milliseconds=5000,
     max_number_of_attempts=3,
@@ -286,23 +269,6 @@ def _log_verification_job_completed(
             "verification_completed": result.get("verification_completed"),
             "error_code": result.get("code"),
         },
-    )
-
-
-def _orchestrator_name_for_submission_type(submission_type: str) -> str:
-    """Pick the Durable orchestrator for a verification's submission type.
-
-    Phase D.3 dropped ``submission_type`` from ``verification_jobs``;
-    callers resolve it via the linked requirement (see
-    :func:`start_verification_job`).
-    """
-    try:
-        enum_value = SubmissionType(submission_type)
-    except ValueError:
-        return _DEFAULT_ORCHESTRATOR_NAME
-    return _ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE.get(
-        enum_value,
-        _DEFAULT_ORCHESTRATOR_NAME,
     )
 
 
@@ -494,13 +460,16 @@ def _persist_step(
 
 
 def _run_verification_orchestration(context: df.DurableOrchestrationContext):
-    """Canonical verification workflow: prepare -> verify -> grade -> persist.
+    """The verification workflow for every submission type.
 
-    The LLM grading step is data-driven: it runs only when the verify
-    step produced grading requests, so phases that never grade simply
-    pass through it. Used by the grading-capable phases (3 and 6), the
-    default orchestrator, and every drain-only legacy orchestrator, whose
-    in-flight jobs recorded this exact activity sequence.
+    prepare -> verify -> grade -> persist. The LLM grading step is
+    data-driven: it runs only when the verify step produced grading
+    requests, so deterministic phases (which never emit grading requests)
+    pass straight through it. Routing to the right validator happens inside
+    the verify activity via the dispatcher registry.
+
+    Kept as a plain generator (separate from the decorated trigger) so the
+    orchestration tests can drive it directly.
     """
     outcome = yield from _prepare_step(context)
     if isinstance(outcome, _TerminalOutcome):
@@ -510,119 +479,9 @@ def _run_verification_orchestration(context: df.DurableOrchestrationContext):
     return (yield from _persist_step(context, outcome, run_result))
 
 
-def _deterministic_verification(context: df.DurableOrchestrationContext):
-    """Workflow for phases that never LLM-grade (phases 4 and 5).
-
-    prepare -> verify -> persist, with no ``collect_llm_grading_requests``
-    call. These verification jobs are short-lived and low-volume, so the
-    orchestrator name is not versioned; the rare case of a job being
-    mid-flight across a deploy is acceptable and recoverable by resubmitting.
-    """
-    outcome = yield from _prepare_step(context)
-    if isinstance(outcome, _TerminalOutcome):
-        return outcome.result
-    run_result = yield from _verify_step(context, outcome)
-    return (yield from _persist_step(context, outcome, run_result))
-
-
 @app.orchestration_trigger(context_name="context")
 def verification_orchestrator(context: df.DurableOrchestrationContext):
-    """Run the default verification workflow for unmapped submission types."""
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_github_profile_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 0 GitHub profile jobs.
-
-    Phase 0-2 verifications now run synchronously in FastAPI (see
-    ``api/src/learn_to_cloud/routes/htmx_routes.py``). This trigger stays
-    registered so any orchestration started before the cutover can still
-    complete cleanly. Safe to remove after Durable retention expires.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_profile_readme_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 0 profile README jobs.
-
-    See :func:`verify_github_profile_orchestrator` for rationale.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_repo_fork_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 0 repo fork jobs.
-
-    See :func:`verify_github_profile_orchestrator` for rationale.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_ctf_token_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 1 CTF token jobs.
-
-    See :func:`verify_github_profile_orchestrator` for rationale.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_networking_token_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 2 networking token jobs.
-
-    See :func:`verify_github_profile_orchestrator` for rationale.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase3_ci_status_orchestrator(context: df.DurableOrchestrationContext):
-    """Drain-only orchestrator for in-flight phase 3 ci_status jobs.
-
-    See :func:`verify_github_profile_orchestrator` for rationale.
-    """
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase3_journal_api_verifier_orchestrator(
-    context: df.DurableOrchestrationContext,
-):
-    """Run Phase 3 journal API verification (CI gate + LLM rubric review)."""
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase4_deployed_api_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 4 deployed API verification (deterministic, no LLM grading)."""
-    return (yield from _deterministic_verification(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase5_devops_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 5 DevOps verification (deterministic, no LLM grading)."""
-    return (yield from _deterministic_verification(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase6_security_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 6 security verification (probes + LLM rubric review)."""
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase7_career_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 7 career reflection verification (LLM rubric review)."""
-    return (yield from _run_verification_orchestration(context))
-
-
-@app.orchestration_trigger(context_name="context")
-def verify_phase4_architecture_orchestrator(context: df.DurableOrchestrationContext):
-    """Run Phase 4 capstone architecture alignment (deploy.sh vs description)."""
+    """Run the verification workflow for every submission type."""
     return (yield from _run_verification_orchestration(context))
 
 
@@ -881,10 +740,9 @@ async def start_verification_job(
                 )
 
         submission_type_str = prepared.requirement.submission_type.value
-        orchestrator_name = _orchestrator_name_for_submission_type(submission_type_str)
         _set_verification_span_attributes(job_id=job_id)
         instance_id = await client.start_new(
-            orchestrator_name,
+            _ORCHESTRATOR_NAME,
             instance_id=job_id,
             client_input=prepared.to_payload(),
         )
@@ -893,7 +751,7 @@ async def start_verification_job(
             extra={
                 "job_id": job_id,
                 "instance_id": instance_id,
-                "orchestrator_name": orchestrator_name,
+                "orchestrator_name": _ORCHESTRATOR_NAME,
                 "requirement_slug": prepared.requirement.slug,
                 "submission_type": submission_type_str,
             },

--- a/apps/verification-functions/tests/test_orchestrations.py
+++ b/apps/verification-functions/tests/test_orchestrations.py
@@ -1,12 +1,12 @@
-"""Per-phase orchestration workflow tests (issue #429).
+"""Verification orchestration workflow tests.
 
-The Durable orchestration generators are driven manually here: a fake
+The Durable orchestration generator is driven manually here: a fake
 context records each yielded activity call, and the test feeds back the
-activity result. This asserts the exact sequence of activity calls each
-workflow makes, including the determinism-critical difference that the
-deterministic workflow (phases 4 and 5) never calls
-``collect_llm_grading_requests`` while the graded workflow (phases 3 and
-6) does.
+activity result. This asserts the exact sequence of activity calls the
+single workflow makes. LLM grading is data-driven -- the workflow calls
+``collect_llm_grading_requests`` for every submission type and only grades
+when that activity returns requests, so deterministic phases pass straight
+through with an empty request list.
 """
 
 from __future__ import annotations
@@ -16,7 +16,6 @@ from typing import Any
 from uuid import uuid4
 
 import function_app
-from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.testing.requirement_factories import (
     deployed_api_requirement,
     journal_api_verifier_requirement,
@@ -162,8 +161,7 @@ def _sequence(calls: list[_RecordedCall]) -> list[tuple[str, str]]:
 
 
 class TestCanonicalWorkflow:
-    """The grading-capable workflow used by phases 3 and 6, the default
-    orchestrator, and the drain-only legacy orchestrators."""
+    """The single verification workflow used by every submission type."""
 
     def test_grades_when_requests_present(self) -> None:
         payload = _graded_payload()
@@ -251,18 +249,24 @@ class TestCanonicalWorkflow:
         assert result == terminal
 
 
-class TestDeterministicWorkflow:
-    def test_never_calls_collect_llm_grading(self) -> None:
+class TestDeterministicSubmissionTypes:
+    """Deterministic types (e.g. phase 4 deployed_api) run the same single
+    workflow: they call ``collect_llm_grading_requests``, get an empty list,
+    and skip grading -- no separate deterministic orchestrator."""
+
+    def test_passes_through_grading_with_no_requests(self) -> None:
         payload = _deterministic_payload()
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
-        responder = _make_responder(payload)
-        calls, result = _drive(function_app._deterministic_verification(ctx), responder)
+        responder = _make_responder(payload, llm_requests=[])
+        calls, result = _drive(
+            function_app._run_verification_orchestration(ctx), responder
+        )
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
             ("activity_with_retry", "execute_requirement_verification"),
+            ("activity", "collect_llm_grading_requests"),
             ("activity_with_retry", "persist_verification_result"),
         ]
-        assert all(call.name != "collect_llm_grading_requests" for call in calls)
         assert result == {
             "job_id": "job-1",
             "status": "completed",
@@ -274,55 +278,19 @@ class TestDeterministicWorkflow:
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
         terminal = {"job_id": "job-1", "status": "completed", "submission_id": 1}
         responder = _make_responder(payload, terminal=terminal)
-        calls, result = _drive(function_app._deterministic_verification(ctx), responder)
+        calls, result = _drive(
+            function_app._run_verification_orchestration(ctx), responder
+        )
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
         ]
         assert result == terminal
 
 
-class TestOrchestratorNameMapping:
-    def test_phase4_and_phase5_map_to_deterministic_orchestrators(self) -> None:
-        names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
-        assert (
-            names[SubmissionType.DEPLOYED_API]
-            == "verify_phase4_deployed_api_orchestrator"
-        )
-        assert (
-            names[SubmissionType.DEVOPS_ANALYSIS] == "verify_phase5_devops_orchestrator"
-        )
-
-    def test_phase3_and_phase6_map_to_canonical_orchestrators(self) -> None:
-        names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
-        assert (
-            names[SubmissionType.JOURNAL_API_VERIFIER]
-            == "verify_phase3_journal_api_verifier_orchestrator"
-        )
-        assert (
-            names[SubmissionType.SECURITY_SCANNING]
-            == "verify_phase6_security_orchestrator"
-        )
-
-    def test_phase7_maps_to_career_orchestrator(self) -> None:
-        names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
-        assert (
-            names[SubmissionType.CAREER_REFLECTION]
-            == "verify_phase7_career_orchestrator"
-        )
-
-    def test_deployment_architecture_maps_to_phase4_architecture_orchestrator(
-        self,
-    ) -> None:
-        names = function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE
-        assert (
-            names[SubmissionType.DEPLOYMENT_ARCHITECTURE]
-            == "verify_phase4_architecture_orchestrator"
-        )
-
-    def test_every_mapped_name_is_registered(self) -> None:
-        """Guards against pointing the resolver at a non-existent orchestrator."""
-        for name in function_app._ORCHESTRATOR_NAMES_BY_SUBMISSION_TYPE.values():
-            assert hasattr(function_app, name), f"missing orchestrator: {name}"
+class TestSingleOrchestrator:
+    def test_all_submission_types_use_one_orchestrator(self) -> None:
+        assert function_app._ORCHESTRATOR_NAME == "verification_orchestrator"
+        assert hasattr(function_app, function_app._ORCHESTRATOR_NAME)
 
 
 class TestContentFilterClassification:


### PR DESCRIPTION
**Stack: 2 of 3** — base `feat/durable-verification/single-orchestrator` (PR #632)

Second layer: the API no longer runs any verification inline. Every submit creates a `VerificationJob` and hands off to the Durable orchestrator; the UI shows the spinner + HTMX polling for all phases.

## What
- `services/submissions_service.py`: `create_verification_job()` always returns `VerificationJobSubmission` (dropped the inline branch). Removed `SyncVerificationResult` and the `SubmissionDispatchResult` union; removed `is_inline` / `execute_sync_submission_validation` imports.
- `routes/htmx_routes.py`: submit handler always calls `_start_async_job_and_render`; removed `_render_sync_result()` and the sync-result branch.
- Tests updated (formerly-inline types now assert a job is created; removed sync-only tests).

Durable dedupe (`VerificationJobRepository.create_or_get_active`, partial unique index) replaces the inline advisory lock, so no double-submit protection is lost.

## Stack
1. single-orchestrator (#632)
2. **api-always-durable** ← this PR
3. remove-inline (base: this branch)

Do not merge yet — under manual review.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>