### PR TITLE
refactor(shared): split verification contract from execution

### DIFF
--- a/api/src/learn_to_cloud/rendering/context.py
+++ b/api/src/learn_to_cloud/rendering/context.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from learn_to_cloud_shared.verification.url_derivation import (
+from learn_to_cloud_shared.submission_derivation import (
     derive_submission_value,
     is_derivable,
 )

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -22,17 +22,17 @@ from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
+from learn_to_cloud_shared.requirements import get_requirement_by_slug
 from learn_to_cloud_shared.schemas import (
     CareerReflectionRequirement,
     DeploymentArchitectureRequirement,
     SubmissionData,
 )
-from learn_to_cloud_shared.submission_values import submission_value_from_columns
-from learn_to_cloud_shared.verification.requirements import get_requirement_by_slug
-from learn_to_cloud_shared.verification.url_derivation import (
+from learn_to_cloud_shared.submission_derivation import (
     derive_submission_value,
     is_derivable,
 )
+from learn_to_cloud_shared.submission_values import submission_value_from_columns
 from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -18,7 +18,7 @@ from learn_to_cloud_shared.models import User
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
-from learn_to_cloud_shared.verification.requirements import (
+from learn_to_cloud_shared.requirements import (
     is_phase_verification_locked,
 )
 

--- a/api/src/learn_to_cloud/services/progress_service.py
+++ b/api/src/learn_to_cloud/services/progress_service.py
@@ -24,6 +24,7 @@ from learn_to_cloud_shared.repositories.progress_repository import (
 from learn_to_cloud_shared.repositories.submission_repository import (
     SubmissionRepository,
 )
+from learn_to_cloud_shared.requirements import load_requirement_index
 from learn_to_cloud_shared.schemas import (
     Phase,
     PhaseOverview,
@@ -33,7 +34,6 @@ from learn_to_cloud_shared.schemas import (
     TopicProgressData,
     UserProgress,
 )
-from learn_to_cloud_shared.verification.requirements import load_requirement_index
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -20,6 +20,11 @@ from learn_to_cloud_shared.repositories.submission_repository import (
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
+from learn_to_cloud_shared.requirements import (
+    RequirementIndex,
+    get_prerequisite_phase,
+    load_requirement_index,
+)
 from learn_to_cloud_shared.schemas import (
     HandsOnRequirement,
     Phase,
@@ -29,11 +34,6 @@ from learn_to_cloud_shared.schemas import (
 from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.verification.execution import (
     to_submission_data,
-)
-from learn_to_cloud_shared.verification.requirements import (
-    RequirementIndex,
-    get_prerequisite_phase,
-    load_requirement_index,
 )
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 

--- a/api/tests/services/test_dashboard_service.py
+++ b/api/tests/services/test_dashboard_service.py
@@ -16,13 +16,13 @@ from uuid import uuid4
 import pytest
 from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
 from learn_to_cloud_shared.models import CurriculumStep, StepProgress, User
+from learn_to_cloud_shared.requirements import load_requirement_index
 from learn_to_cloud_shared.schemas import (
     PhaseOverview,
     PhaseProgress,
     PhaseProgressData,
     UserProgress,
 )
-from learn_to_cloud_shared.verification.requirements import load_requirement_index
 from sqlalchemy import event, select
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/api/tests/services/test_progress_service.py
+++ b/api/tests/services/test_progress_service.py
@@ -172,8 +172,8 @@ class TestPhaseProgressToData:
 class TestFetchUserProgress:
     @pytest.mark.asyncio
     async def test_queries_db_and_returns_progress(self):
+        from learn_to_cloud_shared.requirements import RequirementIndex
         from learn_to_cloud_shared.schemas import PhaseOverview
-        from learn_to_cloud_shared.verification.requirements import RequirementIndex
 
         phase_overview = (
             PhaseOverview(uuid=uuid4(), name="Phase 0", slug="phase0", order=0),

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -12,8 +12,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from learn_to_cloud_shared.models import SubmissionType, SubmissionValueKind
+from learn_to_cloud_shared.requirements import RequirementIndex
 from learn_to_cloud_shared.schemas import HandsOnRequirement, Phase
-from learn_to_cloud_shared.verification.requirements import RequirementIndex
 
 from learn_to_cloud.services.submissions_service import (
     _SMOKE_USER_ID as SMOKE_USER_ID,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/requirements.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/requirements.py
@@ -7,9 +7,9 @@ hot paths that need several lookups should load the index once and
 reuse it to avoid redundant queries.
 
 Phases here are keyed by ``phase.order`` (the int 0..7), matching the
-URL contract and the historical "phase id". Slugs (``"phase0"`` etc.)
-are not used as the index key because callers (sequential gating,
-progress aggregation) think in terms of ordinals.
+URL contract and the numeric phase id. Slugs (``"phase0"`` etc.) are
+not used as the index key because callers (sequential gating, progress
+aggregation) think in terms of ordinals.
 """
 
 from __future__ import annotations

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -1,12 +1,14 @@
-"""Pydantic schemas for API request/response validation.
+"""Shared data types for API validation and cross-service payloads.
 
-This module contains all Pydantic schemas used throughout the application.
-Schemas are used both for API request/response validation and as
-service-layer response models.
-
-All schemas use frozen=True for immutability where appropriate.
+Holds the Pydantic models used for API request/response validation and
+service-layer responses, plus a few lightweight dataclasses (such as
+``RepositoryRef``) that carry structured values between the API and the
+verification runtime. Pydantic models use ``frozen=True`` for immutability
+where appropriate.
 """
 
+from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 from typing import Annotated, Literal, get_args
@@ -912,3 +914,30 @@ class ParsedGitHubUrl(FrozenModel):
     file_path: str | None = None
     is_valid: bool = True
     error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryRef:
+    """A resolved GitHub repository identity (``owner`` + repo ``name``).
+
+    Parsed once from a validated submission value and carried across the
+    verification pipeline so later steps reuse the identity instead of
+    re-deriving it. The payload helpers serialize it across Durable activity
+    boundaries.
+    """
+
+    owner: str
+    repo: str
+
+    def to_payload(self) -> dict[str, str]:
+        """Return a JSON-serializable activity payload."""
+        return {"owner": self.owner, "repo": self.repo}
+
+    @classmethod
+    def from_payload(cls, payload: Mapping[str, object]) -> "RepositoryRef":
+        """Rehydrate a repository reference from a Durable activity payload."""
+        owner = payload.get("owner")
+        repo = payload.get("repo")
+        if not isinstance(owner, str) or not isinstance(repo, str):
+            raise TypeError("RepositoryRef payload requires string 'owner' and 'repo'")
+        return cls(owner=owner, repo=repo)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_derivation.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_derivation.py
@@ -3,22 +3,21 @@
 For repo-backed requirements (fork, CI status, DevOps analysis,
 security scanning) the canonical URL is derived from the authenticated
 user's ``github_username`` plus the requirement's ``required_repo``.
-Profile-based types (``github_profile``, ``profile_readme``) derive
-from ``github_username`` alone.  Keeping this logic on the server
-closes an injection vector (learners can no longer craft arbitrary
-URLs) and removes a fragile copy/paste step from the UI.
+Profile-based types (``github_profile``, ``profile_readme``) derive from
+``github_username`` alone. Deriving the value on the server keeps
+learners from submitting arbitrary URLs and removes a copy/paste step
+from the UI.
 
-The resulting string is what gets persisted in ``Submission.submitted_value``
-and passed to the validators.  Token-based types, the Phase 4 deployed API
-type, and the journal API response type keep their existing free-form input
-and pass through unchanged.
+The resulting string is persisted in ``Submission.submitted_value`` and
+passed to the validators. Token-based types, the deployed API type, and
+the journal API response type accept free-form input and pass through
+unchanged.
 """
 
 from __future__ import annotations
 
 from learn_to_cloud_shared.models import SubmissionType
-from learn_to_cloud_shared.schemas import HandsOnRequirement
-from learn_to_cloud_shared.verification.repo_utils import RepositoryRef
+from learn_to_cloud_shared.schemas import HandsOnRequirement, RepositoryRef
 
 # Derivable types: the server constructs the URL from username + required_repo.
 # The template renders these as read-only fields so the learner cannot edit

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/__init__.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/__init__.py
@@ -1,15 +1,14 @@
 """Verification subsystem for hands-on learning requirements.
 
-Submodules:
-    dispatcher        — Central routing of submissions to verifiers
-    requirements      — Phase requirement registry and gating logic
-    events            — In-process event bus for async verification results
-    github_profile    — GitHub profile/README/fork verification (Phases 0-1)
-    ci_status         — CI test-pass check (Phase 3)
-    token_base        — HMAC token verification for CTF + Networking Lab
-    devops_analysis   — DevOps artifact analysis (Phase 5)
-    security_scanning — Dependabot + CodeQL verification (Phase 6)
-    deployed_api      — Live API challenge-response testing (Phase 4)
-    repo_utils        — Shared GitHub URL parsing and validation
-    tasks/            — Task definitions per phase
+Runs inside the Durable Function verify step. Submodules:
+    dispatcher        - Routes submissions to the matching validator
+    events            - In-process event bus for async verification results
+    github_profile    - GitHub profile/README/fork verification
+    ci_status         - CI test-pass check
+    token_base        - HMAC token verification for CTF + Networking Lab
+    devops_analysis   - DevOps artifact analysis
+    security_scanning - Dependabot + CodeQL verification
+    deployed_api      - Live API challenge-response testing
+    repo_utils        - GitHub URL parsing and identity resolution
+    tasks/            - Task definitions per phase
 """

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployment_architecture.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployment_architecture.py
@@ -15,6 +15,9 @@ from hashlib import sha256
 import httpx
 
 from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
+from learn_to_cloud_shared.submission_derivation import (
+    repository_ref_from_required_repo,
+)
 from learn_to_cloud_shared.verification.evidence import truncate_to_bytes
 from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
 from learn_to_cloud_shared.verification.tasks.base import (
@@ -24,9 +27,6 @@ from learn_to_cloud_shared.verification.tasks.base import (
 )
 from learn_to_cloud_shared.verification.tasks.phase4 import (
     DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK,
-)
-from learn_to_cloud_shared.verification.url_derivation import (
-    repository_ref_from_required_repo,
 )
 
 _DESCRIPTION_EVIDENCE_PATH = "architecture-description.md"

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
@@ -1,27 +1,28 @@
-"""Hands-on verification orchestration module.
+"""Per-submission-type validator registry and routing.
 
-This module provides the central orchestration for Phase 0 through Phase 6
-hands-on verification:
-- Routes submissions to appropriate validators
-- Supports GitHub profile, profile README, repo fork, CTF token, networking token,
-  code analysis, and evidence URL validations
+Runs inside the Durable Function verify step. ``validate_submission`` is
+the single entry point: it looks up the submission type in
+``_VALIDATOR_REGISTRY``, enforces the GitHub-username guard, dispatches to
+the matching validator through a uniform adapter, records verification
+metrics and spans, and returns a ``ValidationResult``.
 
-Phase requirements are defined in phase_requirements.py.
+Supported types include GitHub profile, profile README, repo fork, CTF
+token, networking token, deployed API, DevOps analysis, security
+scanning, career reflection, and deployment architecture.
 
-EXTENSIBILITY:
 To add a new verification type:
-1. Add the SubmissionType enum value in models.py
-2. Add optional fields to HandsOnRequirement in schemas.py if needed
+1. Add the ``SubmissionType`` enum value in models.py.
+2. Add optional fields to ``HandsOnRequirement`` in schemas.py if needed.
 3. Create a validator function (here or in a new module):
-   - async def validate_<type>(url: str, ...) -> ValidationResult
-4. Register a ValidatorDescriptor for it in _VALIDATOR_REGISTRY below:
-   declare its adapter callable, whether it needs a GitHub username, and
-   whether it is repo-backed.
+   ``async def validate_<type>(url: str, ...) -> ValidationResult``.
+4. Register a ``ValidatorDescriptor`` in ``_VALIDATOR_REGISTRY`` below,
+   declaring its adapter, whether it needs a GitHub username, and whether
+   it is repo-backed.
 
-For GitHub-specific validations, see github_profile.py
-For CTF token validation, see ctf.py
-For CI-based code verification, see ci_status.py
-For phase requirements, see requirements.py
+For GitHub-specific validations, see github_profile.py.
+For CTF and networking token validation, see token_base.py.
+For CI-based code verification, see ci_status.py.
+For requirement definitions, see requirements.py.
 """
 
 from collections.abc import Awaitable, Callable

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -8,6 +8,9 @@ from learn_to_cloud_shared.schemas import (
     FrozenModel,
     HandsOnRequirement,
 )
+from learn_to_cloud_shared.submission_derivation import (
+    repository_ref_from_required_repo,
+)
 from learn_to_cloud_shared.verification.career_reflection import (
     collect_career_reflection_evidence,
 )
@@ -32,9 +35,6 @@ from learn_to_cloud_shared.verification.tasks import (
     LLMGradingDecision,
     VerificationTask,
     require_llm_rubric_grader,
-)
-from learn_to_cloud_shared.verification.url_derivation import (
-    repository_ref_from_required_repo,
 )
 from learn_to_cloud_shared.verification_job_executor import (
     VerificationRunResult,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_utils.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_utils.py
@@ -1,18 +1,22 @@
-"""Shared utilities for verification services.
+"""GitHub URL parsing and repository-identity resolution.
 
-GitHub URL parsing, ownership validation, and the base
-VerificationError exception.
+Parses GitHub URLs into their components, extracts owner/repo pairs, and
+resolves the ``RepositoryRef`` identity for a validated submission value.
+Also defines ``VerificationError``, the base exception for verification
+failures.
 """
 
 from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Mapping
-from dataclasses import dataclass
 from urllib.parse import urlparse
 
-from learn_to_cloud_shared.schemas import ParsedGitHubUrl, ValidationResult
+from learn_to_cloud_shared.schemas import (
+    ParsedGitHubUrl,
+    RepositoryRef,
+    ValidationResult,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -97,32 +101,6 @@ def extract_repo_info(repo_url: str) -> tuple[str, str]:
     if not parsed.is_valid or not parsed.repo_name:
         raise ValueError(f"Invalid GitHub repository URL: {repo_url}")
     return parsed.username, parsed.repo_name
-
-
-@dataclass(frozen=True, slots=True)
-class RepositoryRef:
-    """A resolved GitHub repository identity (``owner`` + repo ``name``).
-
-    Carried across the Durable verification pipeline so the repo identity is
-    parsed once from the validated submission value and reused by later steps
-    instead of being re-derived.
-    """
-
-    owner: str
-    repo: str
-
-    def to_payload(self) -> dict[str, str]:
-        """Return a JSON-serializable activity payload."""
-        return {"owner": self.owner, "repo": self.repo}
-
-    @classmethod
-    def from_payload(cls, payload: Mapping[str, object]) -> RepositoryRef:
-        """Rehydrate a repository reference from a Durable activity payload."""
-        owner = payload.get("owner")
-        repo = payload.get("repo")
-        if not isinstance(owner, str) or not isinstance(repo, str):
-            raise TypeError("RepositoryRef payload requires string 'owner' and 'repo'")
-        return cls(owner=owner, repo=repo)
 
 
 def resolve_repository(submitted_value: str) -> RepositoryRef | ValidationResult:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -1,8 +1,7 @@
 """Execute persisted verification jobs outside the FastAPI request path.
 
-PR4 removed the legacy ``status`` enum and the ``mark_*`` lifecycle
-writes. A verification job is now identified by the presence of its row
-in ``verification_jobs``; the outcome lives entirely in the linked
+A verification job is identified by the presence of its row in
+``verification_jobs``; the outcome lives entirely in the linked
 ``Submission``. The executor:
 
 1. ``prepare_verification_job`` validates the persisted job against the
@@ -15,11 +14,11 @@ in ``verification_jobs``; the outcome lives entirely in the linked
    it to the job via ``VerificationJobRepository.link_submission``.
    Idempotent against retries via the ``ALREADY_LINKED`` short-circuit.
 
-After the curriculum-decoupling refactor, the requirement definition
-and ``github_username`` snapshot travel with the orchestration payload
-so the executor never reads ``users`` or any curriculum table. Any
-soft-delete of the requirement between submit and execute is invisible
-here -- validation runs against the submit-time snapshot.
+The requirement definition and ``github_username`` snapshot travel with
+the orchestration payload, so the executor never reads ``users`` or any
+curriculum table. A soft-delete of the requirement between submit and
+execute is invisible here: validation runs against the submit-time
+snapshot.
 """
 
 from __future__ import annotations
@@ -43,7 +42,11 @@ from learn_to_cloud_shared.repositories.verification_job_repository import (
 from learn_to_cloud_shared.schemas import (
     HandsOnRequirement,
     HandsOnRequirementAdapter,
+    RepositoryRef,
     ValidationResult,
+)
+from learn_to_cloud_shared.submission_derivation import (
+    repository_ref_from_required_repo,
 )
 from learn_to_cloud_shared.submission_values import (
     SubmittedValue,
@@ -57,11 +60,7 @@ from learn_to_cloud_shared.verification.execution import (
     persist_validation_result,
 )
 from learn_to_cloud_shared.verification.repo_utils import (
-    RepositoryRef,
     resolve_repository,
-)
-from learn_to_cloud_shared.verification.url_derivation import (
-    repository_ref_from_required_repo,
 )
 
 tracer = trace.get_tracer(__name__)

--- a/packages/learn-to-cloud-shared/tests/services/test_phase_requirements_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_phase_requirements_service.py
@@ -1,18 +1,18 @@
-"""Unit tests for verification.requirements after the slug rename."""
+"""Unit tests for the requirements lookup helpers."""
 
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from learn_to_cloud_shared.schemas import HandsOnRequirement
-from learn_to_cloud_shared.testing.requirement_factories import (
-    journal_api_verifier_requirement,
-)
-from learn_to_cloud_shared.verification.requirements import (
+from learn_to_cloud_shared.requirements import (
     RequirementIndex,
     get_prerequisite_phase,
     get_requirement_by_slug,
     is_phase_verification_locked,
+)
+from learn_to_cloud_shared.schemas import HandsOnRequirement
+from learn_to_cloud_shared.testing.requirement_factories import (
+    journal_api_verifier_requirement,
 )
 
 
@@ -84,7 +84,7 @@ class TestAsyncRequirementLookups:
     async def test_get_requirement_by_slug_found(self):
         by_phase_order = _make_requirements_by_phase_order(3, ["req-a"])
         with patch(
-            "learn_to_cloud_shared.verification.requirements.get_requirements_by_phase_order",
+            "learn_to_cloud_shared.requirements.get_requirements_by_phase_order",
             new_callable=AsyncMock,
             return_value=by_phase_order,
         ):
@@ -95,7 +95,7 @@ class TestAsyncRequirementLookups:
     @pytest.mark.asyncio
     async def test_get_requirement_by_slug_not_found(self):
         with patch(
-            "learn_to_cloud_shared.verification.requirements.get_requirements_by_phase_order",
+            "learn_to_cloud_shared.requirements.get_requirements_by_phase_order",
             new_callable=AsyncMock,
             return_value={},
         ):
@@ -119,12 +119,12 @@ class TestIsPhaseVerificationLocked:
 
         with (
             patch(
-                "learn_to_cloud_shared.verification.requirements.get_requirements_by_phase_order",
+                "learn_to_cloud_shared.requirements.get_requirements_by_phase_order",
                 new_callable=AsyncMock,
                 return_value=by_phase_order,
             ),
             patch(
-                "learn_to_cloud_shared.verification.requirements.SubmissionRepository",
+                "learn_to_cloud_shared.requirements.SubmissionRepository",
                 autospec=True,
             ) as MockRepo,
         ):
@@ -145,12 +145,12 @@ class TestIsPhaseVerificationLocked:
 
         with (
             patch(
-                "learn_to_cloud_shared.verification.requirements.get_requirements_by_phase_order",
+                "learn_to_cloud_shared.requirements.get_requirements_by_phase_order",
                 new_callable=AsyncMock,
                 return_value=by_phase_order,
             ),
             patch(
-                "learn_to_cloud_shared.verification.requirements.SubmissionRepository",
+                "learn_to_cloud_shared.requirements.SubmissionRepository",
                 autospec=True,
             ) as MockRepo,
         ):

--- a/packages/learn-to-cloud-shared/tests/services/test_repo_utils.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_repo_utils.py
@@ -7,9 +7,8 @@ Tests cover:
 
 import pytest
 
-from learn_to_cloud_shared.schemas import ValidationResult
+from learn_to_cloud_shared.schemas import RepositoryRef, ValidationResult
 from learn_to_cloud_shared.verification.repo_utils import (
-    RepositoryRef,
     extract_repo_info,
     resolve_repository,
 )

--- a/packages/learn-to-cloud-shared/tests/services/test_url_derivation.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_url_derivation.py
@@ -1,4 +1,4 @@
-"""Unit tests for services.verification.url_derivation.
+"""Unit tests for submission_derivation.
 
 Covers derive_submission_value for all submission types and the
 is_derivable / fork_name_from_required_repo helpers.
@@ -8,7 +8,7 @@ import pytest
 
 from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.schemas import HandsOnRequirement
-from learn_to_cloud_shared.verification.url_derivation import (
+from learn_to_cloud_shared.submission_derivation import (
     derive_submission_value,
     fork_name_from_required_repo,
     is_derivable,
@@ -79,7 +79,7 @@ class TestForkNameFromRequiredRepo:
 @pytest.mark.unit
 class TestRepositoryRefFromRequiredRepo:
     def test_derives_fork_owner_and_repo(self):
-        from learn_to_cloud_shared.verification.url_derivation import (
+        from learn_to_cloud_shared.submission_derivation import (
             repository_ref_from_required_repo,
         )
 
@@ -88,7 +88,7 @@ class TestRepositoryRefFromRequiredRepo:
         assert ref.repo == "journal-starter"
 
     def test_empty_username_raises(self):
-        from learn_to_cloud_shared.verification.url_derivation import (
+        from learn_to_cloud_shared.submission_derivation import (
             repository_ref_from_required_repo,
         )
 
@@ -96,7 +96,7 @@ class TestRepositoryRefFromRequiredRepo:
             repository_ref_from_required_repo("", "learntocloud/journal-starter")
 
     def test_missing_slash_raises(self):
-        from learn_to_cloud_shared.verification.url_derivation import (
+        from learn_to_cloud_shared.submission_derivation import (
             repository_ref_from_required_repo,
         )
 

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -20,10 +20,13 @@ from learn_to_cloud_shared.repositories.user_repository import UserRepository
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
-from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
+from learn_to_cloud_shared.schemas import (
+    HandsOnRequirement,
+    RepositoryRef,
+    ValidationResult,
+)
 from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.verification.execution import MAX_VALIDATION_MESSAGE_LENGTH
-from learn_to_cloud_shared.verification.repo_utils import RepositoryRef
 from learn_to_cloud_shared.verification_job_executor import (
     VALIDATION_FAILED_ERROR_CODE,
     VERIFICATION_INCOMPLETE_ERROR_CODE,

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from learn_to_cloud_shared.schemas import (
+    RepositoryRef,
     TaskResult,
     ValidationResult,
 )
@@ -15,7 +16,6 @@ from learn_to_cloud_shared.verification.llm_grading import (
     llm_grading_content_filtered_result,
     llm_grading_unavailable_result,
 )
-from learn_to_cloud_shared.verification.repo_utils import RepositoryRef
 from learn_to_cloud_shared.verification.tasks import (
     PHASE3_LLM_TASKS,
     PHASE4_LLM_TASKS,


### PR DESCRIPTION
## What

Fourth PR in the Durable-verification stack. Separates the **verification contract** (what the API needs to render pages and create jobs) from **verification execution** (what only the Durable Function runs).

Before: the API imported from `learn_to_cloud_shared/verification/`, which *looked* like the API reaching into verification internals. It wasn't (the API never calls a validator), but the packaging conflated two concerns.

## Moves

- `verification/requirements.py` -> `requirements.py` (requirement model + phase gating)
- `verification/url_derivation.py` -> `submission_derivation.py` (server-side submission-value derivation)
- `RepositoryRef` dataclass -> `schemas.py` (shared data type, sits with `ParsedGitHubUrl`/`ValidationResult`)

After this, the contract modules import **zero** `verification.*` symbols, and `verification/` holds only Durable-run execution: dispatcher, validators, grading, `repo_utils`.

## Also

- Refreshed top docstrings in every touched file to present tense; dropped stale "PR4 did X" / "Phase 0-6 orchestration" history, including the misleading `dispatcher.py` docstring.

## Notes

- Pure move + re-import + docstring change. No behavior change.
- `uv run poe check` green (api + shared + functions tests).
- Base is `feat/durable-verification/remove-inline` (stacks on #634). **Do not merge** until the lower PRs land and you've reviewed.