### PR TITLE
Replace phase 0 github_profile with browser-based profile README

### DIFF
--- a/api/tests/rendering/test_context.py
+++ b/api/tests/rendering/test_context.py
@@ -251,13 +251,13 @@ def _make_requirement(
 
 @pytest.mark.unit
 class TestBuildRequirementCardContext:
-    def test_derivable_github_profile_populates_derived_url(self):
-        req = _make_requirement(SubmissionType.GITHUB_PROFILE)
+    def test_derivable_profile_readme_populates_derived_url(self):
+        req = _make_requirement(SubmissionType.PROFILE_README)
         ctx = build_requirement_card_context(
             requirement=req,
             github_username="alice",
         )
-        assert ctx["derived_url"] == "https://github.com/alice"
+        assert ctx["derived_url"] == "https://github.com/alice/alice"
 
     def test_derivable_journal_api_verifier_uses_required_repo(self):
         req = _make_requirement(

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -498,7 +498,7 @@ class TestHtmxSubmitVerification:
         submission = SimpleNamespace(
             id=42,
             requirement_slug="req-1",
-            submission_type=SimpleNamespace(value="github_profile"),
+            submission_type=SimpleNamespace(value="profile_readme"),
             verification_completed=True,
         )
         sync_result = SyncVerificationResult(
@@ -559,7 +559,7 @@ class TestHtmxSubmitVerification:
         submission = SimpleNamespace(
             id=43,
             requirement_slug="req-1",
-            submission_type=SimpleNamespace(value="github_profile"),
+            submission_type=SimpleNamespace(value="profile_readme"),
             verification_completed=True,
         )
         sync_result = SyncVerificationResult(

--- a/api/tests/services/test_durable_verification_client.py
+++ b/api/tests/services/test_durable_verification_client.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 from azure.core.exceptions import ClientAuthenticationError
 from learn_to_cloud_shared.testing.requirement_factories import (
-    github_profile_requirement,
+    profile_readme_requirement,
 )
 from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
 
@@ -45,8 +45,8 @@ def _prepared(job_id=None) -> PreparedVerificationJob:
         id=job_id or uuid4(),
         user_id=42,
         github_username="testuser",
-        requirement=github_profile_requirement(),
-        submitted_value="https://github.com/testuser",
+        requirement=profile_readme_requirement(),
+        submitted_value="https://github.com/testuser/testuser",
     )
 
 

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -341,7 +341,7 @@ class TestSyncDispatchBranch:
     async def test_sync_type_runs_in_process_and_returns_sync_result(self):
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
-            submission_type=SubmissionType.GITHUB_PROFILE,
+            submission_type=SubmissionType.PROFILE_README,
         )
         sentinel_result = MagicMock(name="SubmissionResult")
 

--- a/packages/learn-to-cloud-shared/scripts/hoist_requirements_to_files.py
+++ b/packages/learn-to-cloud-shared/scripts/hoist_requirements_to_files.py
@@ -49,7 +49,6 @@ CONTENT_DIR = (
 # inline requirement should be moved into ``type_config``. Fields not
 # listed are left at the top level of the new requirement file.
 _TYPE_CONFIG_FIELDS: dict[str, list[str]] = {
-    "github_profile": [],
     "profile_readme": [],
     "repo_fork": ["required_repo"],
     "ctf_token": ["placeholder"],

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/_phase.yaml
@@ -7,7 +7,7 @@ short_description: Build your beginner-friendly IT foundation across Linux, netw
 order: 0
 hands_on_verification:
   requirements:
-  - github-profile
+  - profile-readme
 topics:
 - prepare-to-learn
 - linux

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/requirements/github-profile.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/requirements/github-profile.yaml
@@ -1,6 +1,0 @@
-# yaml-language-server: $schema=../../../schemas/requirement.schema.json
-uuid: a30a1809-d20a-41f1-bab3-7755cfd3621b
-slug: github-profile
-submission_type: github_profile
-name: Create a Public GitHub Profile
-description: Create a public GitHub profile that you will use to submit verification work in every phase.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/requirements/profile-readme.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/requirements/profile-readme.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../schemas/requirement.schema.json
+uuid: 96327def-780b-4209-8ef1-b0d85b34357f
+slug: profile-readme
+submission_type: profile_readme
+name: Create Your GitHub Profile README
+description: On github.com, create a new repository named exactly after your username. GitHub turns it into your profile README automatically, and you will use this same account to submit verification work in every phase.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/_phase.yaml
@@ -7,7 +7,6 @@ short_description: Build practical Linux and Bash skills with Git, cloud CLI, SS
 order: 1
 hands_on_verification:
   requirements:
-  - profile-readme
   - linux-ctfs-fork
   - linux-ctfs-token
 topics:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/developer-setup.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/developer-setup.yaml
@@ -11,7 +11,7 @@ learning_objectives:
   text: Install VS Code and practice core terminal commands on your operating system.
   order: 2
 - uuid: 37069f97-e291-4273-ac57-64c319654725
-  text: Create and update a profile README using a local-to-remote Git workflow.
+  text: Update your profile README locally and push changes using a local-to-remote Git workflow.
   order: 3
 learning_steps:
 - uuid: 6e5bfcf7-e17c-416e-9681-f6d717d338e5
@@ -64,9 +64,9 @@ learning_steps:
 - uuid: 21e322f4-9fae-4609-af79-13fb33f828a0
   order: 6
   action: 'Practice:'
-  title: Adding a profile README
+  title: Review your profile README repository
   url: https://docs.github.com/account-and-profile/how-tos/profile-customization/managing-your-profile-readme
-  description: Follow this guide to create the special repository that powers your GitHub profile README.
+  description: In Phase 0 you created your profile README repository on GitHub. Open it and review the README that powers your profile before you start editing it locally.
   slug: phase1-topic1-practice-adding-a-profile-readme
 - uuid: 4a41c7e9-a0aa-4ab4-b47d-8760d92c6ffc
   order: 7

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/requirements/profile-readme.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/requirements/profile-readme.yaml
@@ -1,6 +1,0 @@
-# yaml-language-server: $schema=../../../schemas/requirement.schema.json
-uuid: 96327def-780b-4209-8ef1-b0d85b34357f
-slug: profile-readme
-submission_type: profile_readme
-name: Create a Developer Profile README
-description: Create your profile README repository and add a clear introduction, goals, and cloud-learning focus.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -92,11 +92,10 @@ class SubmissionType(StrEnum):
     4. Add optional fields to HandsOnRequirement schema if needed
     """
 
-    # Phase 0: GitHub profile setup
-    GITHUB_PROFILE = "github_profile"
-
-    # Phase 1: Profile README, repo fork, and CTF completion
+    # Phase 0: Profile README setup
     PROFILE_README = "profile_readme"
+
+    # Phase 1: repo fork and CTF completion
     REPO_FORK = "repo_fork"
     CTF_TOKEN = "ctf_token"
 
@@ -626,6 +625,9 @@ class CurriculumRequirement(TimestampMixin, Base):
     """
 
     __tablename__ = "requirements"
+    # 'github_profile' remains permitted below even though the app no longer
+    # produces it: soft-deleted historical requirement rows still carry that
+    # submission_type, so the constraint must keep accepting it.
     __table_args__ = (
         CheckConstraint(
             """

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -192,12 +192,12 @@ class UserResponse(UserBase):
 # Variation between submission types lives inside ``type_config``.
 # Pydantic validates per-type config via a discriminated union, so YAML
 # authors get parse errors for mismatched fields (e.g., placeholder on a
-# github_profile requirement).
+# profile_readme requirement).
 # ---------------------------------------------------------------------------
 
 
 class EmptyConfig(StrictFrozenModel):
-    """No type-specific config (used by github_profile, profile_readme)."""
+    """No type-specific config (used by profile_readme)."""
 
 
 class RepoConfig(StrictFrozenModel):
@@ -332,11 +332,6 @@ class _RequirementBase(StrictFrozenModel):
         return getattr(cfg, "placeholder", None) if cfg is not None else None
 
 
-class GithubProfileRequirement(_RequirementBase):
-    submission_type: Literal[SubmissionType.GITHUB_PROFILE]
-    type_config: EmptyConfig = Field(default_factory=EmptyConfig)
-
-
 class ProfileReadmeRequirement(_RequirementBase):
     submission_type: Literal[SubmissionType.PROFILE_README]
     type_config: EmptyConfig = Field(default_factory=EmptyConfig)
@@ -388,8 +383,7 @@ class DeploymentArchitectureRequirement(_RequirementBase):
 
 
 HandsOnRequirement = Annotated[
-    GithubProfileRequirement
-    | ProfileReadmeRequirement
+    ProfileReadmeRequirement
     | RepoForkRequirement
     | CtfTokenRequirement
     | NetworkingTokenRequirement

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
@@ -11,7 +11,6 @@ from learn_to_cloud_shared.models import SubmissionType, SubmissionValueKind
 from learn_to_cloud_shared.schemas import HandsOnRequirement
 
 _GITHUB_URL_TYPES = {
-    SubmissionType.GITHUB_PROFILE.value,
     SubmissionType.PROFILE_README.value,
     SubmissionType.REPO_FORK.value,
     SubmissionType.JOURNAL_API_VERIFIER.value,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/testing/requirement_factories.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/testing/requirement_factories.py
@@ -38,7 +38,6 @@ from learn_to_cloud_shared.schemas import (
     DeploymentArchitectureRequirement,
     DevopsAnalysisConfig,
     DevopsAnalysisRequirement,
-    GithubProfileRequirement,
     JournalApiVerifierConfig,
     JournalApiVerifierRequirement,
     NetworkingTokenConfig,
@@ -49,21 +48,6 @@ from learn_to_cloud_shared.schemas import (
     SecurityScanningConfig,
     SecurityScanningRequirement,
 )
-
-
-def github_profile_requirement(
-    *,
-    slug: str = "github-profile",
-    name: str = "Test GitHub profile requirement",
-    description: str = "Test description",
-) -> GithubProfileRequirement:
-    return GithubProfileRequirement(
-        uuid=uuid4(),
-        slug=slug,
-        submission_type=SubmissionType.GITHUB_PROFILE,
-        name=name,
-        description=description,
-    )
 
 
 def profile_readme_requirement(
@@ -267,10 +251,6 @@ def make_requirement(
     responsible for passing the right combinations.
     """
     match submission_type:
-        case SubmissionType.GITHUB_PROFILE:
-            return github_profile_requirement(
-                slug=slug, name=name, description=description
-            )
         case SubmissionType.PROFILE_README:
             return profile_readme_requirement(
                 slug=slug, name=name, description=description

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/__init__.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/__init__.py
@@ -4,7 +4,7 @@ Submodules:
     dispatcher        — Central routing of submissions to verifiers
     requirements      — Phase requirement registry and gating logic
     events            — In-process event bus for async verification results
-    github_profile    — GitHub profile/README/fork verification (Phases 0-1)
+    github_profile    — README/fork verification (Phases 0-1)
     ci_status         — CI test-pass check (Phase 3)
     token_base        — HMAC token verification for CTF + Networking Lab
     devops_analysis   — DevOps artifact analysis (Phase 5)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
@@ -41,7 +41,6 @@ from learn_to_cloud_shared.verification.deployment_architecture import (
 )
 from learn_to_cloud_shared.verification.devops_analysis import run_devops_workflow
 from learn_to_cloud_shared.verification.github_profile import (
-    validate_github_profile,
     validate_profile_readme,
     validate_repo_fork,
 )
@@ -155,12 +154,6 @@ class ValidatorDescriptor:
     repo_backed: bool
 
 
-async def _adapt_github_profile(
-    requirement: HandsOnRequirement, submitted_value: str, username: str
-) -> ValidationResult:
-    return await validate_github_profile(submitted_value, username)
-
-
 async def _adapt_profile_readme(
     requirement: HandsOnRequirement, submitted_value: str, username: str
 ) -> ValidationResult:
@@ -236,12 +229,6 @@ async def _adapt_deployment_architecture(
 # Lookups use ``.get(...)`` so an unregistered type surfaces as the explicit
 # "Unknown submission type" result instead of raising.
 _VALIDATOR_REGISTRY: dict[SubmissionType, ValidatorDescriptor] = {
-    SubmissionType.GITHUB_PROFILE: ValidatorDescriptor(
-        adapter=_adapt_github_profile,
-        execution_mode=ExecutionMode.INLINE,
-        requires_username=True,
-        repo_backed=False,
-    ),
     SubmissionType.PROFILE_README: ValidatorDescriptor(
         adapter=_adapt_profile_readme,
         execution_mode=ExecutionMode.INLINE,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
@@ -1,8 +1,7 @@
 """GitHub-specific validation utilities for hands-on verification.
 
 This module handles all GitHub-specific validations including:
-- GitHub profile verification (Phase 0)
-- Profile README verification (Phase 1)
+- Profile README verification (Phase 0)
 - Repository fork verification (Phase 1)
 
 For URL parsing, see ``repo_utils.parse_github_url``.
@@ -34,7 +33,6 @@ __all__ = [
     "default_github_metadata",
     "github_error_to_validation_result",
     "parse_github_url",
-    "validate_github_profile",
     "validate_profile_readme",
     "validate_repo_fork",
 ]
@@ -149,60 +147,6 @@ async def check_repo_is_fork_of(
             message=f"Unexpected error: {e!s}",
             verification_completed=False,
         )
-
-
-async def validate_github_profile(
-    github_url: str,
-    expected_username: str,
-    metadata: GitHubMetadata | None = None,
-) -> ValidationResult:
-    """Validate a GitHub profile URL submission.
-
-    The URL should be like: https://github.com/username
-    And the username should match the expected_username (case-insensitive).
-    """
-    parsed = parse_github_url(github_url)
-
-    if not parsed.is_valid or not parsed.username:
-        return ValidationResult(
-            is_valid=False,
-            message=parsed.error or "Could not extract username from URL",
-            username_match=False,
-            repo_exists=False,
-        )
-
-    username = parsed.username
-    username_match = username.lower() == expected_username.lower()
-
-    if not username_match:
-        return ValidationResult(
-            is_valid=False,
-            message=(
-                f"GitHub username '{username}' does not match "
-                f"your account username '{expected_username}'"
-            ),
-            username_match=False,
-            repo_exists=False,
-        )
-
-    profile_url = f"https://github.com/{username}"
-    result = await check_github_url_exists(profile_url, metadata)
-
-    if not result.is_valid:
-        return result.model_copy(
-            update={
-                "message": f"Could not find GitHub profile. {result.message}",
-                "username_match": True,
-                "repo_exists": False,
-            }
-        )
-
-    return ValidationResult(
-        is_valid=True,
-        message=f"GitHub profile verified for @{username}",
-        username_match=True,
-        repo_exists=True,
-    )
 
 
 async def validate_profile_readme(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/url_derivation.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/url_derivation.py
@@ -3,7 +3,7 @@
 For repo-backed requirements (fork, CI status, DevOps analysis,
 security scanning) the canonical URL is derived from the authenticated
 user's ``github_username`` plus the requirement's ``required_repo``.
-Profile-based types (``github_profile``, ``profile_readme``) derive
+Profile-based types (``profile_readme``) derive
 from ``github_username`` alone.  Keeping this logic on the server
 closes an injection vector (learners can no longer craft arbitrary
 URLs) and removes a fragile copy/paste step from the UI.
@@ -25,7 +25,6 @@ from learn_to_cloud_shared.verification.repo_utils import RepositoryRef
 # them before submitting.
 _DERIVABLE_TYPES: frozenset[SubmissionType] = frozenset(
     {
-        SubmissionType.GITHUB_PROFILE,
         SubmissionType.PROFILE_README,
         SubmissionType.REPO_FORK,
         SubmissionType.JOURNAL_API_VERIFIER,
@@ -111,9 +110,6 @@ def derive_submission_value(
             ``required_repo``).
     """
     sub_type = requirement.submission_type
-
-    if sub_type == SubmissionType.GITHUB_PROFILE:
-        return f"https://github.com/{github_username}"
 
     if sub_type == SubmissionType.PROFILE_README:
         return f"https://github.com/{github_username}/{github_username}"

--- a/packages/learn-to-cloud-shared/tests/services/test_content_sync.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_sync.py
@@ -66,12 +66,12 @@ def _make_topic(uuid_str: str, slug: str, order: int = 0) -> Topic:
 
 
 def _make_requirement(uuid_str: str, req_id: str) -> object:
-    """Build a GithubProfileRequirement via the adapter."""
+    """Build a ProfileReadmeRequirement via the adapter."""
     return HandsOnRequirementAdapter.validate_python(
         {
             "uuid": uuid_str,
             "slug": req_id,
-            "submission_type": "github_profile",
+            "submission_type": "profile_readme",
             "name": f"Requirement {req_id}",
             "description": "Test requirement",
         }
@@ -84,7 +84,7 @@ def _make_phase(
     phase_int_id: int = 0,
     topic: Topic | None = None,
     requirement_uuid: str | None = None,
-    requirement_id: str = "github-profile",
+    requirement_id: str = "profile-readme",
 ) -> Phase:
     req = None
     if requirement_uuid:
@@ -323,9 +323,9 @@ async def test_submission_type_change_is_refused(
     different_type_req = HandsOnRequirementAdapter.validate_python(
         {
             "uuid": req_uuid,
-            "slug": "github-profile",
+            "slug": "profile-readme",
             "submission_type": "repo_fork",
-            "name": "Requirement github-profile",
+            "name": "Requirement profile-readme",
             "description": "Test requirement",
             "type_config": {"required_repo": "owner/repo"},
         }
@@ -340,7 +340,7 @@ async def test_submission_type_change_is_refused(
         topic_slugs=[topic.slug],
         topics=[topic],
         hands_on_verification=PhaseHandsOnVerificationOverview(
-            requirement_slugs=["github-profile"],
+            requirement_slugs=["profile-readme"],
             requirements=[different_type_req],
         ),
     )

--- a/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
@@ -4,7 +4,6 @@ Tests cover:
 - parse_github_url URL parsing and normalization
 - _parse_retry_after header parsing
 - get_github_headers with and without token
-- validate_github_profile ownership and existence checks
 - validate_profile_readme URL, ownership, and repo name checks
 - validate_repo_fork URL, ownership, and fork verification
 
@@ -26,7 +25,6 @@ from learn_to_cloud_shared.verification.github_http import (
 from learn_to_cloud_shared.verification.github_metadata import InMemoryGitHubMetadata
 from learn_to_cloud_shared.verification.github_profile import (
     parse_github_url,
-    validate_github_profile,
     validate_profile_readme,
     validate_repo_fork,
 )
@@ -181,62 +179,6 @@ class TestParseGitHubUrl:
 
     def test_github_com_only_invalid(self):
         result = parse_github_url("https://github.com/")
-        assert result.is_valid is False
-
-
-# ---------------------------------------------------------------------------
-# validate_github_profile
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestValidateGitHubProfile:
-    @pytest.mark.asyncio
-    async def test_non_github_url_fails(self):
-        result = await validate_github_profile("https://linkedin.com/user", "testuser")
-        assert result.is_valid is False
-        assert result.username_match is False
-
-    @pytest.mark.asyncio
-    async def test_username_mismatch_fails(self):
-        result = await validate_github_profile(
-            "https://github.com/otheruser", "testuser"
-        )
-        assert result.is_valid is False
-        assert "does not match" in result.message
-
-    @pytest.mark.asyncio
-    async def test_profile_exists_succeeds(self):
-        metadata = InMemoryGitHubMetadata(existing_urls={"https://github.com/testuser"})
-        result = await validate_github_profile(
-            "https://github.com/testuser", "testuser", metadata
-        )
-        assert result.is_valid is True
-        assert result.username_match is True
-
-    @pytest.mark.asyncio
-    async def test_profile_not_found_fails(self):
-        metadata = InMemoryGitHubMetadata(existing_urls=set())
-        result = await validate_github_profile(
-            "https://github.com/testuser", "testuser", metadata
-        )
-        assert result.is_valid is False
-        assert result.username_match is True
-
-    @pytest.mark.asyncio
-    async def test_server_error_propagated(self):
-        metadata = InMemoryGitHubMetadata(
-            url_error=GitHubServerError("GitHub service temporarily unavailable")
-        )
-        result = await validate_github_profile(
-            "https://github.com/testuser", "testuser", metadata
-        )
-        assert result.is_valid is False
-        assert result.verification_completed is False
-
-    @pytest.mark.asyncio
-    async def test_empty_username_in_url_fails(self):
-        result = await validate_github_profile("https://github.com/", "testuser")
         assert result.is_valid is False
 
 

--- a/packages/learn-to-cloud-shared/tests/services/test_hands_on_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_hands_on_verification_service.py
@@ -216,7 +216,6 @@ class TestValidateSubmissionUsernameRequirements:
     @pytest.mark.parametrize(
         "submission_type",
         [
-            SubmissionType.GITHUB_PROFILE,
             SubmissionType.PROFILE_README,
             SubmissionType.REPO_FORK,
             SubmissionType.CTF_TOKEN,
@@ -271,21 +270,21 @@ class TestValidateSubmissionUsernameRequirements:
 
 
 @pytest.mark.unit
-class TestDispatchGitHubProfile:
+class TestDispatchProfileReadme:
     @pytest.mark.asyncio
-    async def test_github_profile_routes_correctly(self):
-        requirement = _make_requirement(SubmissionType.GITHUB_PROFILE)
+    async def test_profile_readme_routes_correctly(self):
+        requirement = _make_requirement(SubmissionType.PROFILE_README)
         with patch(
-            "learn_to_cloud_shared.verification.dispatcher.validate_github_profile",
+            "learn_to_cloud_shared.verification.dispatcher.validate_profile_readme",
             autospec=True,
         ) as mock:
             mock.return_value = ValidationResult(is_valid=True, message="Verified!")
             result = await validate_submission(
                 requirement=requirement,
-                submitted_value="https://github.com/testuser",
+                submitted_value="https://github.com/testuser/testuser",
                 expected_username="testuser",
             )
-        mock.assert_called_once_with("https://github.com/testuser", "testuser")
+        mock.assert_called_once_with("https://github.com/testuser/testuser", "testuser")
         assert result.is_valid is True
 
 

--- a/packages/learn-to-cloud-shared/tests/services/test_url_derivation.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_url_derivation.py
@@ -35,7 +35,6 @@ class TestIsDerivable:
     @pytest.mark.parametrize(
         "sub_type",
         [
-            SubmissionType.GITHUB_PROFILE,
             SubmissionType.PROFILE_README,
             SubmissionType.REPO_FORK,
             SubmissionType.JOURNAL_API_VERIFIER,
@@ -106,10 +105,6 @@ class TestRepositoryRefFromRequiredRepo:
 
 @pytest.mark.unit
 class TestDeriveSubmissionValue:
-    def test_github_profile(self):
-        req = _req(SubmissionType.GITHUB_PROFILE)
-        assert derive_submission_value(req, "octocat") == "https://github.com/octocat"
-
     def test_profile_readme(self):
         req = _req(SubmissionType.PROFILE_README)
         assert (
@@ -209,10 +204,10 @@ class TestDeriveSubmissionValue:
         tries to post a crafted URL, the server ignores it and rebuilds the
         canonical URL from their github_username.
         """
-        req = _req(SubmissionType.GITHUB_PROFILE)
+        req = _req(SubmissionType.PROFILE_README)
         assert (
             derive_submission_value(
                 req, "alice", user_input="https://evil.example.com/pwn"
             )
-            == "https://github.com/alice"
+            == "https://github.com/alice/alice"
         )

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_payload_roundtrip.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_payload_roundtrip.py
@@ -15,7 +15,7 @@ import pytest
 
 from learn_to_cloud_shared.testing.requirement_factories import (
     deployed_api_requirement,
-    github_profile_requirement,
+    profile_readme_requirement,
     repo_fork_requirement,
 )
 from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
@@ -39,13 +39,13 @@ class TestPreparedVerificationJobRoundTrip:
         assert restored.requirement.required_repo == "owner/repo"
         assert type(restored.requirement) is type(job.requirement)
 
-    def test_github_profile_requirement_round_trip(self) -> None:
+    def test_profile_readme_requirement_round_trip(self) -> None:
         job = PreparedVerificationJob(
             id=uuid4(),
             user_id=1,
             github_username="bob",
-            requirement=github_profile_requirement(slug="profile"),
-            submitted_value="https://github.com/bob",
+            requirement=profile_readme_requirement(slug="profile"),
+            submitted_value="https://github.com/bob/bob",
         )
         payload = job.to_payload()
         restored = PreparedVerificationJob.from_payload(payload)

--- a/packages/learn-to-cloud-shared/tests/test_schemas.py
+++ b/packages/learn-to-cloud-shared/tests/test_schemas.py
@@ -8,7 +8,6 @@ from learn_to_cloud_shared.schemas import KNOWN_HANDS_ON_SUBMISSION_TYPES
 def test_known_submission_types_matches_union() -> None:
     """The derived constant must list exactly the union's submission types."""
     assert KNOWN_HANDS_ON_SUBMISSION_TYPES == {
-        "github_profile",
         "profile_readme",
         "repo_fork",
         "ctf_token",
@@ -21,5 +20,8 @@ def test_known_submission_types_matches_union() -> None:
         "deployment_architecture",
     }
     # A type the DB CHECK allows but the union doesn't know must be absent,
-    # so the content loader treats it as unknown (issue #603).
+    # so the content loader treats it as unknown (issue #603). 'github_profile'
+    # is retired from the app but still permitted by the CHECK for historical
+    # soft-deleted rows, so it must not appear here either.
     assert "ci_status" not in KNOWN_HANDS_ON_SUBMISSION_TYPES
+    assert "github_profile" not in KNOWN_HANDS_ON_SUBMISSION_TYPES

--- a/packages/learn-to-cloud-shared/tests/test_submission_values.py
+++ b/packages/learn-to-cloud-shared/tests/test_submission_values.py
@@ -11,7 +11,7 @@ from learn_to_cloud_shared.testing.requirement_factories import (
     career_reflection_requirement,
     ctf_token_requirement,
     deployed_api_requirement,
-    github_profile_requirement,
+    profile_readme_requirement,
 )
 
 
@@ -19,7 +19,7 @@ from learn_to_cloud_shared.testing.requirement_factories import (
 @pytest.mark.parametrize(
     ("submission_type", "expected"),
     [
-        (SubmissionType.GITHUB_PROFILE, SubmissionValueKind.GITHUB_URL),
+        (SubmissionType.PROFILE_README, SubmissionValueKind.GITHUB_URL),
         (SubmissionType.JOURNAL_API_VERIFIER, SubmissionValueKind.GITHUB_URL),
         (SubmissionType.CTF_TOKEN, SubmissionValueKind.TOKEN),
         (SubmissionType.DEPLOYED_API, SubmissionValueKind.DEPLOYED_URL),
@@ -39,7 +39,7 @@ def test_value_kind_for_submission_type(
 @pytest.mark.unit
 def test_github_url_value_uses_github_column() -> None:
     value = SubmittedValue.from_raw(
-        github_profile_requirement(),
+        profile_readme_requirement(),
         " https://github.com/user ",
     )
 
@@ -122,7 +122,7 @@ def test_deployed_url_value_uses_deployed_url_column() -> None:
 )
 def test_github_url_requires_github_url(raw_value: str) -> None:
     with pytest.raises(ValueError, match="GitHub URL"):
-        SubmittedValue.from_raw(github_profile_requirement(), raw_value)
+        SubmittedValue.from_raw(profile_readme_requirement(), raw_value)
 
 
 @pytest.mark.unit

--- a/packages/learn-to-cloud-shared/tests/verification/test_dispatcher.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_dispatcher.py
@@ -18,7 +18,6 @@ from learn_to_cloud_shared.verification.dispatcher import (
 
 # The submission types that run inside the FastAPI request (phases 0-2).
 _EXPECTED_INLINE = {
-    SubmissionType.GITHUB_PROFILE,
     SubmissionType.PROFILE_README,
     SubmissionType.REPO_FORK,
     SubmissionType.CTF_TOKEN,

--- a/packages/learn-to-cloud-shared/tests/verification/test_sync_execution.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_sync_execution.py
@@ -49,7 +49,7 @@ def session_maker(test_engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
 
 async def _make_requirement_in_db(
     session_maker: async_sessionmaker[AsyncSession],
-    submission_type: SubmissionType = SubmissionType.GITHUB_PROFILE,
+    submission_type: SubmissionType = SubmissionType.PROFILE_README,
 ) -> HandsOnRequirement:
     """Sync the real curriculum and return a HandsOnRequirement whose
     UUID is present in the ``requirements`` table.


### PR DESCRIPTION
## What

Retires the `github_profile` hands-on verification type and makes phase 0's gate the profile README task, reframed as creating the repository directly on github.com. Learners still practice the local markdown + Git workflow in phase 1.

The existing `profile-readme` requirement is **relocated** from phase 1 to phase 0 with its **uuid and slug preserved**, so historical `profile_readme` submissions stay linked (users who already did it keep phase-0 credit).

## Why

The old `github_profile` check just HEADed `github.com/<username>`, which can't meaningfully fail for a signed-in learner (the username is their own OAuth identity). It was redundant. The README task is a real, verifiable artifact and a better phase-0 gate.

## Changes

- **Content:** move `profile-readme.yaml` into phase 0, delete `github-profile.yaml`, set phase 0 gate to `[profile-readme]`, remove it from phase 1's gate, reframe phase 1 `developer-setup` README steps to editing locally.
- **Code:** remove `github_profile` from the `SubmissionType` enum, the schema union, the dispatcher registry, url derivation, the submission-value mapping, `validate_github_profile`, and the test factory.
- **DB:** **no migration.** The `requirements` CHECK constraint keeps `github_profile` as a permitted value because soft-deleted historical rows still carry it; the tolerant content loader skips the retired requirement. No production data is deleted.

## Impact on existing learners

~1,145 users passed phase 0 only via `github_profile` and will see phase 0 incomplete going forward. This is accepted. The 297 who also created a README keep phase-0 completion automatically via their existing submission.

## Validation

`uv run poe check` green (563 shared + 239 api + 19 functions tests, ruff/ty/squawk clean).

> Draft. Do not merge — @madebygps reviews and merges manually.