### PR TITLE
docs: add stacked PR guidance for agents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,18 @@ Workflow:
 
 These prefixes must stay in sync with the `pull_request.branches` globs in `.github/workflows/deploy.yml`, so stacked PRs (base != `main`) still run CI.
 
+## Stacked PRs
+
+Split a large, tightly-coupled change into a chain of small PRs when reviewers benefit from seeing it in stages. Use the `gh-stack` extension (installed) and its skill at `.agents/skills/gh-stack/SKILL.md` to create and sync the stack. Do not hand-manage rebases.
+
+Rules:
+
+1. Chain off `main`: bottom PR base = `main`, each higher PR base = the branch below it. Only stack work that genuinely depends on the branch below; independent work gets its own top-level branch off `main`.
+2. Never squash-merge a stacked PR. Squash rewrites the base into a new SHA and gives every PR above it phantom conflicts (this exact bug hit PRs #632-#636). Merge stacked PRs with **Create a merge commit** (the only method that preserves GitHub's indirect auto-merge and clean retargeting). Reserve **Squash and merge** for standalone single PRs.
+3. Rebase-and-merge also rewrites SHAs on GitHub, so after each lower PR lands, the next PR up still needs one rebase onto `main`. Let `gh-stack` do that sync; do not force-push `main`.
+4. Auto-delete head branches is ON, so GitHub auto-retargets the next PR's base to `main` when a merged branch is deleted. Still confirm the base before merging.
+5. Every merge to `main` that touches a deploy path (`api/**`, `apps/verification-functions/**`, `infra/**`, `packages/learn-to-cloud-shared/**`, etc.) triggers a full build + terraform + deploy. `concurrency: cancel-in-progress` collapses back-to-back merges into roughly one real deploy, so merge a ready stack in quick succession rather than spacing merges out.
+
 
 ## Code Comments and Docstrings
 


### PR DESCRIPTION
Codifies how to run stacked PRs in this repo after the #632-#636 squash-conflict incident.

## What
New **Stacked PRs** section in `.github/copilot-instructions.md`:
- Chain off `main` (bottom base = main, each higher PR base = branch below); only stack genuinely dependent work.
- **Never squash-merge a stacked PR** (root cause of the #632-#636 phantom conflicts). Use **Create a merge commit** for stacks; keep squash for standalone PRs.
- Rebase-and-merge rewrites SHAs, so upper PRs still need one rebase per lower merge; let `gh-stack` sync, never force-push `main`.
- Auto-delete head branches now **ON**, so GitHub auto-retargets the next PR to `main`.
- Deploy fires per merge to `main`; `concurrency: cancel-in-progress` collapses back-to-back merges, so merge a ready stack quickly.

## Repo setting changed
Enabled **Automatically delete head branches** (`delete_branch_on_merge=true`) so GitHub auto-retargets stacked PRs on merge.

Docs-only; no code paths touched.