### PR TITLE
feat: replace phase 0 github_profile with browser-based profile README

### DIFF
--- a/api/tests/rendering/test_context.py
+++ b/api/tests/rendering/test_context.py
@@ -251,13 +251,13 @@ def _make_requirement(
 
 @pytest.mark.unit
 class TestBuildRequirementCardContext:
-    def test_derivable_github_profile_populates_derived_url(self):
-        req = _make_requirement(SubmissionType.GITHUB_PROFILE)
+    def test_derivable_profile_readme_populates_derived_url(self):
+        req = _make_requirement(SubmissionType.PROFILE_README)
         ctx = build_requirement_card_context(
             requirement=req,
             github_username="alice",
         )
-        assert ctx["derived_url"] == "https://github.com/alice"
+        assert ctx["derived_url"] == "https://github.com/alice/alice"
 
     def test_derivable_journal_api_verifier_uses_required_repo(self):
         req = _make_requirement(

--- a/api/tests/services/test_durable_verification_client.py
+++ b/api/tests/services/test_durable_verification_client.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 from azure.core.exceptions import ClientAuthenticationError
 from learn_to_cloud_shared.testing.requirement_factories import (
-    github_profile_requirement,
+    profile_readme_requirement,
 )
 from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
 
@@ -45,8 +45,8 @@ def _prepared(job_id=None) -> PreparedVerificationJob:
         id=job_id or uuid4(),
         user_id=42,
         github_username="testuser",
-        requirement=github_profile_requirement(),
-        submitted_value="https://github.com/testuser",
+        requirement=profile_readme_requirement(),
+        submitted_value="https://github.com/testuser/testuser",
     )
 
 

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -341,7 +341,7 @@ class TestCreateVerificationJob:
         """Types that used to run inline (phases 0-2) now create a job too."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
-            submission_type=SubmissionType.GITHUB_PROFILE,
+            submission_type=SubmissionType.PROFILE_README,
         )
         mock_job = MagicMock()
 

--- a/packages/learn-to-cloud-shared/scripts/hoist_requirements_to_files.py
+++ b/packages/learn-to-cloud-shared/scripts/hoist_requirements_to_files.py
@@ -49,7 +49,6 @@ CONTENT_DIR = (
 # inline requirement should be moved into ``type_config``. Fields not
 # listed are left at the top level of the new requirement file.
 _TYPE_CONFIG_FIELDS: dict[str, list[str]] = {
-    "github_profile": [],
     "profile_readme": [],
     "repo_fork": ["required_repo"],
     "ctf_token": ["placeholder"],

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/_phase.yaml
@@ -7,7 +7,7 @@ short_description: Build your beginner-friendly IT foundation across Linux, netw
 order: 0
 hands_on_verification:
   requirements:
-  - github-profile
+  - profile-readme
 topics:
 - prepare-to-learn
 - linux

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/requirements/github-profile.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/requirements/github-profile.yaml
@@ -1,6 +1,0 @@
-# yaml-language-server: $schema=../../../schemas/requirement.schema.json
-uuid: a30a1809-d20a-41f1-bab3-7755cfd3621b
-slug: github-profile
-submission_type: github_profile
-name: Create a Public GitHub Profile
-description: Create a public GitHub profile that you will use to submit verification work in every phase.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/requirements/profile-readme.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/requirements/profile-readme.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../../../schemas/requirement.schema.json
+uuid: 96327def-780b-4209-8ef1-b0d85b34357f
+slug: profile-readme
+submission_type: profile_readme
+name: Create Your GitHub Profile README
+description: On github.com, create a new repository named exactly after your username. GitHub turns it into your profile README automatically, and you will use this same account to submit verification work in every phase.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/_phase.yaml
@@ -7,7 +7,6 @@ short_description: Build practical Linux and Bash skills with Git, cloud CLI, SS
 order: 1
 hands_on_verification:
   requirements:
-  - profile-readme
   - linux-ctfs-fork
   - linux-ctfs-token
 topics:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/developer-setup.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/developer-setup.yaml
@@ -11,7 +11,7 @@ learning_objectives:
   text: Install VS Code and practice core terminal commands on your operating system.
   order: 2
 - uuid: 37069f97-e291-4273-ac57-64c319654725
-  text: Create and update a profile README using a local-to-remote Git workflow.
+  text: Update your profile README locally and push changes using a local-to-remote Git workflow.
   order: 3
 learning_steps:
 - uuid: 6e5bfcf7-e17c-416e-9681-f6d717d338e5
@@ -64,9 +64,9 @@ learning_steps:
 - uuid: 21e322f4-9fae-4609-af79-13fb33f828a0
   order: 6
   action: 'Practice:'
-  title: Adding a profile README
+  title: Review your profile README repository
   url: https://docs.github.com/account-and-profile/how-tos/profile-customization/managing-your-profile-readme
-  description: Follow this guide to create the special repository that powers your GitHub profile README.
+  description: In Phase 0 you created your profile README repository on GitHub. Open it and review the README that powers your profile before you start editing it locally.
   slug: phase1-topic1-practice-adding-a-profile-readme
 - uuid: 4a41c7e9-a0aa-4ab4-b47d-8760d92c6ffc
   order: 7

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/requirements/profile-readme.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/requirements/profile-readme.yaml
@@ -1,6 +1,0 @@
-# yaml-language-server: $schema=../../../schemas/requirement.schema.json
-uuid: 96327def-780b-4209-8ef1-b0d85b34357f
-slug: profile-readme
-submission_type: profile_readme
-name: Create a Developer Profile README
-description: Create your profile README repository and add a clear introduction, goals, and cloud-learning focus.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/schemas/phase.schema.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/schemas/phase.schema.json
@@ -342,48 +342,9 @@
     },
     "EmptyConfig": {
       "additionalProperties": false,
-      "description": "No type-specific config (used by github_profile, profile_readme).",
+      "description": "No type-specific config (used by profile_readme).",
       "properties": {},
       "title": "EmptyConfig",
-      "type": "object"
-    },
-    "GithubProfileRequirement": {
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "title": "Description",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "type": "string"
-        },
-        "slug": {
-          "title": "Slug",
-          "type": "string"
-        },
-        "submission_type": {
-          "const": "github_profile",
-          "title": "Submission Type",
-          "type": "string"
-        },
-        "type_config": {
-          "$ref": "#/$defs/EmptyConfig"
-        },
-        "uuid": {
-          "format": "uuid",
-          "title": "Uuid",
-          "type": "string"
-        }
-      },
-      "required": [
-        "uuid",
-        "slug",
-        "name",
-        "description",
-        "submission_type"
-      ],
-      "title": "GithubProfileRequirement",
       "type": "object"
     },
     "JournalApiVerifierConfig": {
@@ -701,7 +662,6 @@
                 "deployed_api": "#/$defs/DeployedApiRequirement",
                 "deployment_architecture": "#/$defs/DeploymentArchitectureRequirement",
                 "devops_analysis": "#/$defs/DevopsAnalysisRequirement",
-                "github_profile": "#/$defs/GithubProfileRequirement",
                 "journal_api_verifier": "#/$defs/JournalApiVerifierRequirement",
                 "networking_token": "#/$defs/NetworkingTokenRequirement",
                 "profile_readme": "#/$defs/ProfileReadmeRequirement",
@@ -711,9 +671,6 @@
               "propertyName": "submission_type"
             },
             "oneOf": [
-              {
-                "$ref": "#/$defs/GithubProfileRequirement"
-              },
               {
                 "$ref": "#/$defs/ProfileReadmeRequirement"
               },

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/schemas/requirement.schema.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/schemas/requirement.schema.json
@@ -342,48 +342,9 @@
     },
     "EmptyConfig": {
       "additionalProperties": false,
-      "description": "No type-specific config (used by github_profile, profile_readme).",
+      "description": "No type-specific config (used by profile_readme).",
       "properties": {},
       "title": "EmptyConfig",
-      "type": "object"
-    },
-    "GithubProfileRequirement": {
-      "additionalProperties": false,
-      "properties": {
-        "description": {
-          "title": "Description",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "type": "string"
-        },
-        "slug": {
-          "title": "Slug",
-          "type": "string"
-        },
-        "submission_type": {
-          "const": "github_profile",
-          "title": "Submission Type",
-          "type": "string"
-        },
-        "type_config": {
-          "$ref": "#/$defs/EmptyConfig"
-        },
-        "uuid": {
-          "format": "uuid",
-          "title": "Uuid",
-          "type": "string"
-        }
-      },
-      "required": [
-        "uuid",
-        "slug",
-        "name",
-        "description",
-        "submission_type"
-      ],
-      "title": "GithubProfileRequirement",
       "type": "object"
     },
     "JournalApiVerifierConfig": {
@@ -661,7 +622,6 @@
       "deployed_api": "#/$defs/DeployedApiRequirement",
       "deployment_architecture": "#/$defs/DeploymentArchitectureRequirement",
       "devops_analysis": "#/$defs/DevopsAnalysisRequirement",
-      "github_profile": "#/$defs/GithubProfileRequirement",
       "journal_api_verifier": "#/$defs/JournalApiVerifierRequirement",
       "networking_token": "#/$defs/NetworkingTokenRequirement",
       "profile_readme": "#/$defs/ProfileReadmeRequirement",
@@ -671,9 +631,6 @@
     "propertyName": "submission_type"
   },
   "oneOf": [
-    {
-      "$ref": "#/$defs/GithubProfileRequirement"
-    },
     {
       "$ref": "#/$defs/ProfileReadmeRequirement"
     },

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -92,11 +92,10 @@ class SubmissionType(StrEnum):
     4. Add optional fields to HandsOnRequirement schema if needed
     """
 
-    # Phase 0: GitHub profile setup
-    GITHUB_PROFILE = "github_profile"
-
-    # Phase 1: Profile README, repo fork, and CTF completion
+    # Phase 0: Profile README
     PROFILE_README = "profile_readme"
+
+    # Phase 1: repo fork and CTF completion
     REPO_FORK = "repo_fork"
     CTF_TOKEN = "ctf_token"
 
@@ -607,6 +606,10 @@ class CurriculumRequirement(TimestampMixin, Base):
 
     __tablename__ = "requirements"
     __table_args__ = (
+        # 'github_profile' is a retired submission type kept in this list on
+        # purpose: soft-deleted historical rows still carry it, so tightening the
+        # constraint would require deleting data. The type is gone from the
+        # SubmissionType enum and the tolerant content loader skips it.
         CheckConstraint(
             """
             (

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -190,12 +190,12 @@ class UserResponse(UserBase):
 # Variation between submission types lives inside ``type_config``.
 # Pydantic validates per-type config via a discriminated union, so YAML
 # authors get parse errors for mismatched fields (e.g., placeholder on a
-# github_profile requirement).
+# profile_readme requirement).
 # ---------------------------------------------------------------------------
 
 
 class EmptyConfig(StrictFrozenModel):
-    """No type-specific config (used by github_profile, profile_readme)."""
+    """No type-specific config (used by profile_readme)."""
 
 
 class RepoConfig(StrictFrozenModel):
@@ -317,11 +317,6 @@ class _RequirementBase(StrictFrozenModel):
         return getattr(cfg, "placeholder", None) if cfg is not None else None
 
 
-class GithubProfileRequirement(_RequirementBase):
-    submission_type: Literal[SubmissionType.GITHUB_PROFILE]
-    type_config: EmptyConfig = Field(default_factory=EmptyConfig)
-
-
 class ProfileReadmeRequirement(_RequirementBase):
     submission_type: Literal[SubmissionType.PROFILE_README]
     type_config: EmptyConfig = Field(default_factory=EmptyConfig)
@@ -373,8 +368,7 @@ class DeploymentArchitectureRequirement(_RequirementBase):
 
 
 HandsOnRequirement = Annotated[
-    GithubProfileRequirement
-    | ProfileReadmeRequirement
+    ProfileReadmeRequirement
     | RepoForkRequirement
     | CtfTokenRequirement
     | NetworkingTokenRequirement

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_derivation.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_derivation.py
@@ -23,7 +23,6 @@ from learn_to_cloud_shared.schemas import HandsOnRequirement
 # them before submitting.
 _DERIVABLE_TYPES: frozenset[SubmissionType] = frozenset(
     {
-        SubmissionType.GITHUB_PROFILE,
         SubmissionType.PROFILE_README,
         SubmissionType.REPO_FORK,
         SubmissionType.JOURNAL_API_VERIFIER,
@@ -108,9 +107,6 @@ def build_target(
 
     sub_type = requirement.submission_type
 
-    if sub_type == SubmissionType.GITHUB_PROFILE:
-        return GitHubTarget(owner=github_username)
-
     if sub_type == SubmissionType.PROFILE_README:
         return GitHubTarget(owner=github_username, repo=github_username)
 
@@ -148,9 +144,6 @@ def derive_submission_value(
             ``required_repo``).
     """
     sub_type = requirement.submission_type
-
-    if sub_type == SubmissionType.GITHUB_PROFILE:
-        return f"https://github.com/{github_username}"
 
     if sub_type == SubmissionType.PROFILE_README:
         return f"https://github.com/{github_username}/{github_username}"

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
@@ -11,7 +11,6 @@ from learn_to_cloud_shared.models import SubmissionType, SubmissionValueKind
 from learn_to_cloud_shared.schemas import HandsOnRequirement
 
 _GITHUB_URL_TYPES = {
-    SubmissionType.GITHUB_PROFILE.value,
     SubmissionType.PROFILE_README.value,
     SubmissionType.REPO_FORK.value,
     SubmissionType.JOURNAL_API_VERIFIER.value,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/testing/requirement_factories.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/testing/requirement_factories.py
@@ -38,7 +38,6 @@ from learn_to_cloud_shared.schemas import (
     DeploymentArchitectureRequirement,
     DevopsAnalysisConfig,
     DevopsAnalysisRequirement,
-    GithubProfileRequirement,
     JournalApiVerifierConfig,
     JournalApiVerifierRequirement,
     NetworkingTokenConfig,
@@ -49,21 +48,6 @@ from learn_to_cloud_shared.schemas import (
     SecurityScanningConfig,
     SecurityScanningRequirement,
 )
-
-
-def github_profile_requirement(
-    *,
-    slug: str = "github-profile",
-    name: str = "Test GitHub profile requirement",
-    description: str = "Test description",
-) -> GithubProfileRequirement:
-    return GithubProfileRequirement(
-        uuid=uuid4(),
-        slug=slug,
-        submission_type=SubmissionType.GITHUB_PROFILE,
-        name=name,
-        description=description,
-    )
 
 
 def profile_readme_requirement(
@@ -267,10 +251,6 @@ def make_requirement(
     responsible for passing the right combinations.
     """
     match submission_type:
-        case SubmissionType.GITHUB_PROFILE:
-            return github_profile_requirement(
-                slug=slug, name=name, description=description
-            )
         case SubmissionType.PROFILE_README:
             return profile_readme_requirement(
                 slug=slug, name=name, description=description

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/__init__.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/__init__.py
@@ -3,7 +3,7 @@
 Runs inside the Durable Function verify step. Submodules:
     dispatcher        - Routes submissions to the matching validator
     events            - In-process event bus for async verification results
-    github_profile    - GitHub profile/README/fork verification
+    github_profile    - Profile README/fork verification
     ci_status         - CI test-pass check
     token_base        - HMAC token verification for CTF + Networking Lab
     devops_analysis   - DevOps artifact analysis

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/dispatcher.py
@@ -46,7 +46,6 @@ from learn_to_cloud_shared.verification.deployment_architecture import (
 from learn_to_cloud_shared.verification.devops_analysis import run_devops_workflow
 from learn_to_cloud_shared.verification.errors import VerificationError
 from learn_to_cloud_shared.verification.github_profile import (
-    validate_github_profile,
     validate_profile_readme,
     validate_repo_fork,
 )
@@ -158,17 +157,6 @@ class ValidatorDescriptor:
     requires_username: bool
 
 
-async def _adapt_github_profile(
-    requirement: HandsOnRequirement,
-    target: GitHubTarget | None,
-    submitted_value: str,
-    username: str,
-) -> ValidationResult:
-    if target is None:
-        return _MISSING_TARGET
-    return await validate_github_profile(target)
-
-
 async def _adapt_profile_readme(
     requirement: HandsOnRequirement,
     target: GitHubTarget | None,
@@ -267,10 +255,6 @@ async def _adapt_deployment_architecture(
 # Lookups use ``.get(...)`` so an unregistered type surfaces as the explicit
 # "Unknown submission type" result instead of raising.
 _VALIDATOR_REGISTRY: dict[SubmissionType, ValidatorDescriptor] = {
-    SubmissionType.GITHUB_PROFILE: ValidatorDescriptor(
-        adapter=_adapt_github_profile,
-        requires_username=True,
-    ),
     SubmissionType.PROFILE_README: ValidatorDescriptor(
         adapter=_adapt_profile_readme,
         requires_username=True,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
@@ -1,9 +1,9 @@
 """GitHub-specific validation for hands-on verification.
 
-Validates the learner's GitHub profile, profile README repository, and repo
-forks. Each validator receives the ``GitHubTarget`` constructed from the
-learner's username plus the requirement (see ``submission_derivation``), so it
-checks existence and fork lineage without parsing a URL back into an identity.
+Validates the learner's profile README repository and repo forks. Each
+validator receives the ``GitHubTarget`` constructed from the learner's username
+plus the requirement (see ``submission_derivation``), so it checks existence and
+fork lineage without parsing a URL back into an identity.
 
 For the GitHub HTTP plumbing (retry, headers, error mapping), see
 ``github_http.py``. For the existence/metadata seam these validators build on,
@@ -33,7 +33,6 @@ __all__ = [
     "check_repo_is_fork_of",
     "default_github_metadata",
     "github_error_to_validation_result",
-    "validate_github_profile",
     "validate_profile_readme",
     "validate_repo_fork",
 ]
@@ -148,32 +147,6 @@ async def check_repo_is_fork_of(
             message=f"Unexpected error: {e!s}",
             verification_completed=False,
         )
-
-
-async def validate_github_profile(
-    target: GitHubTarget,
-    metadata: GitHubMetadata | None = None,
-) -> ValidationResult:
-    """Confirm the learner's GitHub profile page exists.
-
-    The profile is built from the authenticated username, so the identity is
-    guaranteed by construction; this only checks that the page resolves.
-    """
-    result = await check_github_url_exists(target.url, metadata)
-    if not result.is_valid:
-        return result.model_copy(
-            update={
-                "message": f"Could not find GitHub profile. {result.message}",
-                "username_match": True,
-                "repo_exists": False,
-            }
-        )
-    return ValidationResult(
-        is_valid=True,
-        message=f"GitHub profile verified for @{target.owner}",
-        username_match=True,
-        repo_exists=True,
-    )
 
 
 async def validate_profile_readme(

--- a/packages/learn-to-cloud-shared/tests/services/test_content_sync.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_sync.py
@@ -66,12 +66,12 @@ def _make_topic(uuid_str: str, slug: str, order: int = 0) -> Topic:
 
 
 def _make_requirement(uuid_str: str, req_id: str) -> object:
-    """Build a GithubProfileRequirement via the adapter."""
+    """Build a ProfileReadmeRequirement via the adapter."""
     return HandsOnRequirementAdapter.validate_python(
         {
             "uuid": uuid_str,
             "slug": req_id,
-            "submission_type": "github_profile",
+            "submission_type": "profile_readme",
             "name": f"Requirement {req_id}",
             "description": "Test requirement",
         }
@@ -84,7 +84,7 @@ def _make_phase(
     phase_int_id: int = 0,
     topic: Topic | None = None,
     requirement_uuid: str | None = None,
-    requirement_id: str = "github-profile",
+    requirement_id: str = "profile-readme",
 ) -> Phase:
     req = None
     if requirement_uuid:
@@ -323,9 +323,9 @@ async def test_submission_type_change_is_refused(
     different_type_req = HandsOnRequirementAdapter.validate_python(
         {
             "uuid": req_uuid,
-            "slug": "github-profile",
+            "slug": "profile-readme",
             "submission_type": "repo_fork",
-            "name": "Requirement github-profile",
+            "name": "Requirement profile-readme",
             "description": "Test requirement",
             "type_config": {"required_repo": "owner/repo"},
         }
@@ -340,7 +340,7 @@ async def test_submission_type_change_is_refused(
         topic_slugs=[topic.slug],
         topics=[topic],
         hands_on_verification=PhaseHandsOnVerificationOverview(
-            requirement_slugs=["github-profile"],
+            requirement_slugs=["profile-readme"],
             requirements=[different_type_req],
         ),
     )

--- a/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
@@ -3,7 +3,6 @@
 Tests cover:
 - _parse_retry_after header parsing
 - get_github_headers with and without token
-- validate_github_profile existence check against a constructed target
 - validate_profile_readme existence check against a constructed target
 - validate_repo_fork lineage check against a constructed target
 
@@ -25,7 +24,6 @@ from learn_to_cloud_shared.verification.github_http import (
 )
 from learn_to_cloud_shared.verification.github_metadata import InMemoryGitHubMetadata
 from learn_to_cloud_shared.verification.github_profile import (
-    validate_github_profile,
     validate_profile_readme,
     validate_repo_fork,
 )
@@ -82,37 +80,6 @@ class TestGetGitHubHeaders:
         ):
             headers = get_github_headers()
         assert "Authorization" not in headers
-
-
-# ---------------------------------------------------------------------------
-# validate_github_profile
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestValidateGitHubProfile:
-    @pytest.mark.asyncio
-    async def test_profile_exists_succeeds(self):
-        metadata = InMemoryGitHubMetadata(existing_urls={"https://github.com/testuser"})
-        result = await validate_github_profile(GitHubTarget(owner="testuser"), metadata)
-        assert result.is_valid is True
-        assert result.username_match is True
-
-    @pytest.mark.asyncio
-    async def test_profile_not_found_fails(self):
-        metadata = InMemoryGitHubMetadata(existing_urls=set())
-        result = await validate_github_profile(GitHubTarget(owner="testuser"), metadata)
-        assert result.is_valid is False
-        assert result.username_match is True
-
-    @pytest.mark.asyncio
-    async def test_server_error_propagated(self):
-        metadata = InMemoryGitHubMetadata(
-            url_error=GitHubServerError("GitHub service temporarily unavailable")
-        )
-        result = await validate_github_profile(GitHubTarget(owner="testuser"), metadata)
-        assert result.is_valid is False
-        assert result.verification_completed is False
 
 
 # ---------------------------------------------------------------------------

--- a/packages/learn-to-cloud-shared/tests/services/test_hands_on_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_hands_on_verification_service.py
@@ -215,7 +215,6 @@ class TestValidateSubmissionUsernameRequirements:
     @pytest.mark.parametrize(
         "submission_type",
         [
-            SubmissionType.GITHUB_PROFILE,
             SubmissionType.PROFILE_README,
             SubmissionType.REPO_FORK,
             SubmissionType.CTF_TOKEN,
@@ -270,18 +269,18 @@ class TestValidateSubmissionUsernameRequirements:
 
 
 @pytest.mark.unit
-class TestDispatchGitHubProfile:
+class TestDispatchProfileReadme:
     @pytest.mark.asyncio
-    async def test_github_profile_routes_correctly(self):
-        requirement = _make_requirement(SubmissionType.GITHUB_PROFILE)
+    async def test_profile_readme_routes_correctly(self):
+        requirement = _make_requirement(SubmissionType.PROFILE_README)
         with patch(
-            "learn_to_cloud_shared.verification.dispatcher.validate_github_profile",
+            "learn_to_cloud_shared.verification.dispatcher.validate_profile_readme",
             autospec=True,
         ) as mock:
             mock.return_value = ValidationResult(is_valid=True, message="Verified!")
             result = await validate_submission(
                 requirement=requirement,
-                submitted_value="https://github.com/testuser",
+                submitted_value="https://github.com/testuser/testuser",
                 target=build_target(requirement, "testuser"),
                 expected_username="testuser",
             )

--- a/packages/learn-to-cloud-shared/tests/services/test_url_derivation.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_url_derivation.py
@@ -35,7 +35,6 @@ class TestIsDerivable:
     @pytest.mark.parametrize(
         "sub_type",
         [
-            SubmissionType.GITHUB_PROFILE,
             SubmissionType.PROFILE_README,
             SubmissionType.REPO_FORK,
             SubmissionType.JOURNAL_API_VERIFIER,
@@ -78,15 +77,6 @@ class TestForkNameFromRequiredRepo:
 
 @pytest.mark.unit
 class TestBuildTarget:
-    def test_github_profile_builds_profile_target(self):
-        from learn_to_cloud_shared.submission_derivation import build_target
-
-        target = build_target(_req(SubmissionType.GITHUB_PROFILE), "alice")
-        assert target is not None
-        assert target.owner == "alice"
-        assert target.repo is None
-        assert target.forked_from is None
-
     def test_profile_readme_builds_self_repo_target(self):
         from learn_to_cloud_shared.submission_derivation import build_target
 
@@ -113,15 +103,11 @@ class TestBuildTarget:
     def test_missing_username_returns_none(self):
         from learn_to_cloud_shared.submission_derivation import build_target
 
-        assert build_target(_req(SubmissionType.GITHUB_PROFILE), None) is None
+        assert build_target(_req(SubmissionType.PROFILE_README), None) is None
 
 
 @pytest.mark.unit
 class TestDeriveSubmissionValue:
-    def test_github_profile(self):
-        req = _req(SubmissionType.GITHUB_PROFILE)
-        assert derive_submission_value(req, "octocat") == "https://github.com/octocat"
-
     def test_profile_readme(self):
         req = _req(SubmissionType.PROFILE_README)
         assert (
@@ -221,10 +207,10 @@ class TestDeriveSubmissionValue:
         tries to post a crafted URL, the server ignores it and rebuilds the
         canonical URL from their github_username.
         """
-        req = _req(SubmissionType.GITHUB_PROFILE)
+        req = _req(SubmissionType.PROFILE_README)
         assert (
             derive_submission_value(
                 req, "alice", user_input="https://evil.example.com/pwn"
             )
-            == "https://github.com/alice"
+            == "https://github.com/alice/alice"
         )

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_payload_roundtrip.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_payload_roundtrip.py
@@ -15,7 +15,7 @@ import pytest
 
 from learn_to_cloud_shared.testing.requirement_factories import (
     deployed_api_requirement,
-    github_profile_requirement,
+    profile_readme_requirement,
     repo_fork_requirement,
 )
 from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
@@ -39,13 +39,13 @@ class TestPreparedVerificationJobRoundTrip:
         assert restored.requirement.type_config.required_repo == "owner/repo"
         assert type(restored.requirement) is type(job.requirement)
 
-    def test_github_profile_requirement_round_trip(self) -> None:
+    def test_profile_readme_requirement_round_trip(self) -> None:
         job = PreparedVerificationJob(
             id=uuid4(),
             user_id=1,
             github_username="bob",
-            requirement=github_profile_requirement(slug="profile"),
-            submitted_value="https://github.com/bob",
+            requirement=profile_readme_requirement(slug="profile"),
+            submitted_value="https://github.com/bob/bob",
         )
         payload = job.to_payload()
         restored = PreparedVerificationJob.from_payload(payload)

--- a/packages/learn-to-cloud-shared/tests/test_schemas.py
+++ b/packages/learn-to-cloud-shared/tests/test_schemas.py
@@ -8,7 +8,6 @@ from learn_to_cloud_shared.schemas import KNOWN_HANDS_ON_SUBMISSION_TYPES
 def test_known_submission_types_matches_union() -> None:
     """The derived constant must list exactly the union's submission types."""
     assert KNOWN_HANDS_ON_SUBMISSION_TYPES == {
-        "github_profile",
         "profile_readme",
         "repo_fork",
         "ctf_token",

--- a/packages/learn-to-cloud-shared/tests/test_submission_values.py
+++ b/packages/learn-to-cloud-shared/tests/test_submission_values.py
@@ -11,7 +11,7 @@ from learn_to_cloud_shared.testing.requirement_factories import (
     career_reflection_requirement,
     ctf_token_requirement,
     deployed_api_requirement,
-    github_profile_requirement,
+    profile_readme_requirement,
 )
 
 
@@ -19,7 +19,7 @@ from learn_to_cloud_shared.testing.requirement_factories import (
 @pytest.mark.parametrize(
     ("submission_type", "expected"),
     [
-        (SubmissionType.GITHUB_PROFILE, SubmissionValueKind.GITHUB_URL),
+        (SubmissionType.PROFILE_README, SubmissionValueKind.GITHUB_URL),
         (SubmissionType.JOURNAL_API_VERIFIER, SubmissionValueKind.GITHUB_URL),
         (SubmissionType.CTF_TOKEN, SubmissionValueKind.TOKEN),
         (SubmissionType.DEPLOYED_API, SubmissionValueKind.DEPLOYED_URL),
@@ -39,7 +39,7 @@ def test_value_kind_for_submission_type(
 @pytest.mark.unit
 def test_github_url_value_uses_github_column() -> None:
     value = SubmittedValue.from_raw(
-        github_profile_requirement(),
+        profile_readme_requirement(),
         " https://github.com/user ",
     )
 
@@ -122,7 +122,7 @@ def test_deployed_url_value_uses_deployed_url_column() -> None:
 )
 def test_github_url_requires_github_url(raw_value: str) -> None:
     with pytest.raises(ValueError, match="GitHub URL"):
-        SubmittedValue.from_raw(github_profile_requirement(), raw_value)
+        SubmittedValue.from_raw(profile_readme_requirement(), raw_value)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Rebuilt on clean post-#636 main (the closed #637 was written against the pre-durable-stack architecture).

## What
Retire the `github_profile` hands-on submission type and make phase 0's gate the browser-based **Create Your GitHub Profile README** task. `profile_readme` moves from phase 1 to phase 0, keeping its uuid/slug (non-destructive relocation).

## Content
- Phase 0 gate: `github-profile` -> `profile-readme`; requirement reframed as 'on github.com, create a repo named after your username'.
- Phase 1 gate: drop `profile-readme` (now phase 0); developer-setup steps reworded to *update* the README locally and review the repo made in phase 0.

## Code
`github_profile` removed from: `SubmissionType` enum, `schemas.py` union (`GithubProfileRequirement`), `dispatcher.py` registry + adapter, `submission_derivation.py`, `submission_values.py`, `requirement_factories.py`, `hoist_requirements_to_files.py`, and `validate_github_profile` in `github_profile.py`. JSON content schemas regenerated.

## Why the CHECK constraint keeps 'github_profile'
Soft-deleted historical requirement rows still carry it; tightening would require deleting data. The tolerant content loader skips unknown types, so no migration or data deletion is needed.

## Validation
`uv run poe check` green (495 shared+api, 15 functions tests; ruff/ty/squawk pass).

Do not merge; @madebygps reviews manually.