### PR TITLE
feat(verification): declarative engine core + evidence carrier (#630 PR1)

### DIFF
--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -1,0 +1,250 @@
+"""The declarative verification engine.
+
+Plain shared-package code (no Durable imports) that the Durable activities
+call. A submission type maps to a :class:`VerificationProfile`: an ordered
+list of :class:`Step`s, each naming a registered **check** (code) plus typed
+**params** (data). :func:`run_profile` looks up the profile, runs its steps in
+order, short-circuits on a failed gate, accumulates
+:class:`EvidenceBundle`s, and produces one aggregate ``ValidationResult``.
+
+Checks are registered by name in ``_CHECK_REGISTRY`` via
+:func:`register_check`. Adding a verification behavior becomes "register a
+check, declare a profile," not "touch an orchestrator and a validator."
+
+Transitional: submission types that have not been migrated to a declared
+profile run a single ``legacy_validate`` step backed by
+``validate_submission`` (the per-type dispatcher). That fallthrough and this
+note are removed once every type resolves to a real profile.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, replace
+from typing import Literal
+
+from pydantic import Field
+
+from learn_to_cloud_shared.github_target import GitHubTarget
+from learn_to_cloud_shared.schemas import FrozenModel, TaskResult, ValidationResult
+from learn_to_cloud_shared.verification.dispatcher import (
+    ValidatorDescriptor,
+    descriptor_for,
+    validate_submission,
+)
+from learn_to_cloud_shared.verification.repo_files import RepoFiles
+from learn_to_cloud_shared.verification.tasks.base import (
+    EvidenceBundle,
+    LLMRubricGraderConfig,
+)
+from learn_to_cloud_shared.verification_job_executor import (
+    PreparedVerificationJob,
+    VerificationRunResult,
+)
+
+# ---------------------------------------------------------------------------
+# Step params: per-check models in a discriminated union keyed by ``check``.
+# ---------------------------------------------------------------------------
+
+
+class LegacyValidateParams(FrozenModel):
+    """Params for the transitional ``legacy_validate`` check (no config)."""
+
+    check: Literal["legacy_validate"] = "legacy_validate"
+
+
+# The per-check discriminated union. With one member today it is a plain
+# alias; as PR2+ register more checks (files_present, fetch_files,
+# llm_rubric_review, ...) this becomes
+# ``Annotated[LegacyValidateParams | ..., Field(discriminator="check")]``.
+StepParams = LegacyValidateParams
+
+
+# ---------------------------------------------------------------------------
+# Engine primitives.
+# ---------------------------------------------------------------------------
+
+
+class Step(FrozenModel):
+    """One ordered gate in a profile: a registered check plus its params.
+
+    ``check`` is the registry key (which code runs); ``params`` is the typed
+    per-check config. They are kept separate, per the engine sketch, so the
+    dispatch key and the param schema evolve independently.
+    """
+
+    check: str
+    params: StepParams
+    task_id: str
+
+
+class StepResult(FrozenModel):
+    """Outcome of running one step.
+
+    ``evidence`` is contributed to the run's bundle and made visible to later
+    steps. ``stop_on_fail`` lets a failed gate short-circuit the remaining
+    steps. ``validation_result`` is the transitional passthrough used by the
+    ``legacy_validate`` step to carry a full dispatcher result unchanged; it is
+    removed once every type is migrated to task-level results.
+    """
+
+    passed: bool
+    task_result: TaskResult | None = None
+    evidence: list[EvidenceBundle] = Field(default_factory=list)
+    stop_on_fail: bool = True
+    validation_result: ValidationResult | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StepContext:
+    """Everything a check may read. Carries runtime clients, so not a model."""
+
+    job: PreparedVerificationJob
+    repository: GitHubTarget | None
+    submitted_value: str
+    evidence_so_far: tuple[EvidenceBundle, ...] = ()
+    repo_files: RepoFiles | None = None
+
+
+@dataclass(frozen=True)
+class VerificationProfile(ValidatorDescriptor):
+    """A submission type's declared workflow.
+
+    Extends the dispatcher's :class:`ValidatorDescriptor` with an ordered step
+    list and the terminal LLM step's persona/rubric. A profile with no steps
+    falls back to the transitional ``legacy_validate`` step.
+    """
+
+    steps: tuple[Step, ...] = ()
+    system_prompt: str | None = None
+    rubric: LLMRubricGraderConfig | None = None
+
+
+CheckFn = Callable[[StepContext, StepParams], Awaitable[StepResult]]
+
+_CHECK_REGISTRY: dict[str, CheckFn] = {}
+
+
+def register_check(name: str) -> Callable[[CheckFn], CheckFn]:
+    """Register a check under ``name``. Raises if the name is already taken."""
+
+    def decorator(fn: CheckFn) -> CheckFn:
+        if name in _CHECK_REGISTRY:
+            raise ValueError(f"Check already registered: {name}")
+        _CHECK_REGISTRY[name] = fn
+        return fn
+
+    return decorator
+
+
+def check_for(name: str) -> CheckFn:
+    """Return the check registered under ``name`` or raise ``KeyError``."""
+    try:
+        return _CHECK_REGISTRY[name]
+    except KeyError:
+        raise KeyError(f"No check registered for {name!r}") from None
+
+
+# ---------------------------------------------------------------------------
+# Transitional legacy check: delegate to the per-type dispatcher.
+# ---------------------------------------------------------------------------
+
+
+@register_check("legacy_validate")
+async def _check_legacy_validate(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Run the per-type validator via the dispatcher (transitional)."""
+    result = await validate_submission(
+        requirement=context.job.requirement,
+        submitted_value=context.submitted_value,
+        target=context.repository,
+        expected_username=context.job.github_username,
+    )
+    return StepResult(
+        passed=result.is_valid,
+        stop_on_fail=True,
+        validation_result=result,
+    )
+
+
+_LEGACY_STEP = Step(
+    check="legacy_validate",
+    params=LegacyValidateParams(),
+    task_id="legacy_validate",
+)
+
+
+def _steps_for(descriptor: ValidatorDescriptor | None) -> tuple[Step, ...]:
+    """Resolve the step list, falling back to the transitional legacy step."""
+    if isinstance(descriptor, VerificationProfile) and descriptor.steps:
+        return descriptor.steps
+    return (_LEGACY_STEP,)
+
+
+def _aggregate(step_results: list[StepResult]) -> ValidationResult:
+    """Fold step results into one ``ValidationResult``.
+
+    A ``validation_result`` passthrough (the legacy step) is authoritative and
+    returned unchanged. Migrated profiles aggregate from per-step task results.
+    """
+    for result in step_results:
+        if result.validation_result is not None:
+            return result.validation_result
+
+    task_results = [r.task_result for r in step_results if r.task_result is not None]
+    passed = all(r.passed for r in step_results)
+    message = (
+        "Verification succeeded."
+        if passed
+        else "Verification failed. Review the task feedback and try again."
+    )
+    return ValidationResult(
+        is_valid=passed,
+        message=message,
+        task_results=task_results or None,
+        verification_completed=True,
+    )
+
+
+async def run_profile(
+    job: PreparedVerificationJob,
+    *,
+    repo_files: RepoFiles | None = None,
+) -> VerificationRunResult:
+    """Run a submission type's profile and return the aggregate result.
+
+    Steps run in order; a failed gate with ``stop_on_fail`` short-circuits the
+    rest. Evidence bundles accumulate across steps, are visible to later steps
+    via ``evidence_so_far``, and are carried on the returned run result.
+    """
+    descriptor = descriptor_for(job.requirement.submission_type)
+    steps = _steps_for(descriptor)
+
+    context = StepContext(
+        job=job,
+        repository=job.target,
+        submitted_value=job.typed_submitted_value.as_text,
+        repo_files=repo_files,
+    )
+
+    step_results: list[StepResult] = []
+    bundles: list[EvidenceBundle] = []
+    for step in steps:
+        result = await check_for(step.check)(context, step.params)
+        step_results.append(result)
+        if result.evidence:
+            bundles.extend(result.evidence)
+            context = replace(
+                context,
+                evidence_so_far=(*context.evidence_so_far, *result.evidence),
+            )
+        if not result.passed and result.stop_on_fail:
+            break
+
+    return VerificationRunResult(
+        job=job,
+        validation_result=_aggregate(step_results),
+        evidence=bundles or None,
+    )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/evidence.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/evidence.py
@@ -1,7 +1,23 @@
-"""Shared bounded repository evidence collection helpers."""
+"""Shared bounded evidence collection.
+
+Split into three jobs so a phase composes them instead of each phase
+carrying its own collector:
+
+1. **cap** (:func:`apply_evidence_cap`) - given (path, content) pairs and a
+   task's :class:`EvidencePolicy`, enforce ``max_files`` /
+   ``max_file_size_bytes`` / ``max_total_bytes`` and build the
+   :class:`EvidenceBundle`. No network.
+2. **get-content**, keyed by :class:`EvidenceSource`: ``repo_files`` fetches
+   from GitHub (:func:`collect_repo_file_evidence`); ``submitted_text`` is a
+   no-network passthrough (:func:`collect_submitted_text_evidence`). A phase
+   may use either or both.
+3. **selection** per phase lives with the profile/task (which paths, which
+   source), not here.
+"""
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from hashlib import sha256
 
 from learn_to_cloud_shared.verification.repo_files import RepoFiles
@@ -12,31 +28,36 @@ from learn_to_cloud_shared.verification.tasks.base import (
 )
 
 
-async def collect_repo_file_evidence(
-    repo_files: RepoFiles,
-    owner: str,
-    repo: str,
-    paths: list[str],
+def apply_evidence_cap(
     task: VerificationTask,
-    branch: str = "main",
+    pairs: Iterable[tuple[str, str]],
 ) -> EvidenceBundle:
-    """Collect repository files within a task's evidence limits."""
+    """Build a bundle from (path, content) pairs within the task's caps.
+
+    Deduplicates by path, keeps at most ``max_files``, truncates any item
+    over ``max_file_size_bytes``, and stops once ``max_total_bytes`` would be
+    exceeded. Pure and network-free so every source shares one cap policy.
+    """
+    policy = task.evidence
     items: list[EvidenceItem] = []
     total_bytes = 0
+    seen: set[str] = set()
 
-    for path in list(dict.fromkeys(paths))[: task.evidence.max_files]:
-        content = await repo_files.file(owner, repo, path, branch)
-        if content is None:
+    for path, content in pairs:
+        if path in seen:
             continue
+        seen.add(path)
+        if len(items) >= policy.max_files:
+            break
 
         encoded = content.encode("utf-8")
         truncated = False
-        if len(encoded) > task.evidence.max_file_size_bytes:
-            content = truncate_to_bytes(content, task.evidence.max_file_size_bytes)
+        if len(encoded) > policy.max_file_size_bytes:
+            content = truncate_to_bytes(content, policy.max_file_size_bytes)
             encoded = content.encode("utf-8")
             truncated = True
 
-        if total_bytes + len(encoded) > task.evidence.max_total_bytes:
+        if total_bytes + len(encoded) > policy.max_total_bytes:
             break
 
         total_bytes += len(encoded)
@@ -51,10 +72,37 @@ async def collect_repo_file_evidence(
 
     return EvidenceBundle(
         task_id=task.id,
-        source=task.evidence.source,
+        source=policy.source,
         items=items,
         total_bytes=total_bytes,
     )
+
+
+async def collect_repo_file_evidence(
+    repo_files: RepoFiles,
+    owner: str,
+    repo: str,
+    paths: list[str],
+    task: VerificationTask,
+    branch: str = "main",
+) -> EvidenceBundle:
+    """Fetch repository files (get-content) and apply the shared cap."""
+    fetched: list[tuple[str, str]] = []
+    for path in dict.fromkeys(paths):
+        content = await repo_files.file(owner, repo, path, branch)
+        if content is None:
+            continue
+        fetched.append((path, content))
+    return apply_evidence_cap(task, fetched)
+
+
+def collect_submitted_text_evidence(
+    task: VerificationTask,
+    text: str,
+    path: str = "submission.txt",
+) -> EvidenceBundle:
+    """Wrap free-form submitted text as evidence (no-network passthrough)."""
+    return apply_evidence_cap(task, [(path, text)])
 
 
 _TRUNCATION_MARKER = "\n\n[FILE TRUNCATED - exceeded size limit]"

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -24,7 +24,7 @@ snapshot.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from uuid import UUID
 
 from opentelemetry import trace
@@ -55,6 +55,7 @@ from learn_to_cloud_shared.verification.dispatcher import (
 from learn_to_cloud_shared.verification.execution import (
     persist_validation_result,
 )
+from learn_to_cloud_shared.verification.tasks.base import EvidenceBundle
 
 tracer = trace.get_tracer(__name__)
 
@@ -209,27 +210,53 @@ class VerificationJobPreparation:
 
 @dataclass(frozen=True, slots=True)
 class VerificationRunResult:
-    """Serializable validation result for a prepared verification job."""
+    """Serializable validation result for a prepared verification job.
+
+    ``evidence`` carries the :class:`EvidenceBundle`s gathered by the engine's
+    steps so grading can read file contents without re-fetching. It is
+    round-tripped between activities but stripped before the terminal DB write
+    (see :meth:`without_evidence`) so file contents never reach Postgres.
+    Defaults to ``None`` for the legacy path that gathers no evidence.
+    """
 
     job: PreparedVerificationJob
     validation_result: ValidationResult
+    evidence: list[EvidenceBundle] | None = None
 
     def to_payload(self) -> dict[str, object]:
         """Return a JSON-serializable activity payload."""
         return {
             "job": self.job.to_payload(),
             "validation_result": self.validation_result.model_dump(mode="json"),
+            "evidence": (
+                [bundle.model_dump(mode="json") for bundle in self.evidence]
+                if self.evidence is not None
+                else None
+            ),
         }
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, object]) -> VerificationRunResult:
         """Rehydrate a validation result from a Durable activity payload."""
+        raw_evidence = payload.get("evidence")
+        evidence = (
+            [EvidenceBundle.model_validate(bundle) for bundle in raw_evidence]
+            if isinstance(raw_evidence, list)
+            else None
+        )
         return cls(
             job=PreparedVerificationJob.from_payload(_expect_mapping(payload["job"])),
             validation_result=ValidationResult.model_validate(
                 payload["validation_result"]
             ),
+            evidence=evidence,
         )
+
+    def without_evidence(self) -> VerificationRunResult:
+        """Return a copy with evidence dropped, for the terminal DB write."""
+        if self.evidence is None:
+            return self
+        return replace(self, evidence=None)
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_run_result_evidence.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_run_result_evidence.py
@@ -1,0 +1,70 @@
+"""Round-trip and strip tests for VerificationRunResult.evidence carrier."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from learn_to_cloud_shared.schemas import ValidationResult
+from learn_to_cloud_shared.testing.requirement_factories import (
+    repo_fork_requirement,
+)
+from learn_to_cloud_shared.verification.tasks.base import (
+    EvidenceBundle,
+    EvidenceItem,
+)
+from learn_to_cloud_shared.verification_job_executor import (
+    PreparedVerificationJob,
+    VerificationRunResult,
+)
+
+
+def _run_result(evidence) -> VerificationRunResult:
+    return VerificationRunResult(
+        job=PreparedVerificationJob(
+            id=uuid4(),
+            user_id=1,
+            github_username="alice",
+            requirement=repo_fork_requirement(required_repo="owner/repo"),
+            submitted_value="https://github.com/alice/repo",
+        ),
+        validation_result=ValidationResult(is_valid=True, message="ok"),
+        evidence=evidence,
+    )
+
+
+@pytest.mark.unit
+class TestVerificationRunResultEvidence:
+    def test_defaults_to_none(self) -> None:
+        result = VerificationRunResult(
+            job=_run_result(None).job,
+            validation_result=ValidationResult(is_valid=True, message="ok"),
+        )
+        assert result.evidence is None
+
+    def test_none_evidence_round_trips(self) -> None:
+        restored = VerificationRunResult.from_payload(_run_result(None).to_payload())
+        assert restored.evidence is None
+
+    def test_evidence_round_trips(self) -> None:
+        bundle = EvidenceBundle(
+            task_id="t1",
+            source="repo_files",
+            items=[EvidenceItem(path="a.txt", content="hi", sha256="abc")],
+            total_bytes=2,
+        )
+        restored = VerificationRunResult.from_payload(
+            _run_result([bundle]).to_payload()
+        )
+        assert restored.evidence == [bundle]
+
+    def test_without_evidence_strips_bundles(self) -> None:
+        bundle = EvidenceBundle(task_id="t1", source="repo_files")
+        stripped = _run_result([bundle]).without_evidence()
+        assert stripped.evidence is None
+        assert stripped.validation_result.is_valid is True
+
+    def test_without_evidence_is_noop_when_already_none(self) -> None:
+        result = _run_result(None)
+        assert result.without_evidence() is result

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -1,0 +1,210 @@
+"""Tests for the declarative verification engine."""
+
+from uuid import uuid4
+
+import pytest
+
+from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
+from learn_to_cloud_shared.testing.requirement_factories import (
+    career_reflection_requirement,
+    repo_fork_requirement,
+)
+from learn_to_cloud_shared.verification import engine as engine_module
+from learn_to_cloud_shared.verification.engine import (
+    LegacyValidateParams,
+    Step,
+    StepContext,
+    StepResult,
+    VerificationProfile,
+    check_for,
+    register_check,
+    run_profile,
+)
+from learn_to_cloud_shared.verification.tasks.base import (
+    EvidenceBundle,
+    EvidenceItem,
+)
+from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
+
+
+def _job(requirement=None) -> PreparedVerificationJob:
+    return PreparedVerificationJob(
+        id=uuid4(),
+        user_id=1,
+        github_username="learner",
+        requirement=requirement or repo_fork_requirement(),
+        submitted_value="https://github.com/learner/test-repo",
+    )
+
+
+def _step(check: str, task_id: str) -> Step:
+    return Step(check=check, params=LegacyValidateParams(), task_id=task_id)
+
+
+def _profile(*steps: Step) -> VerificationProfile:
+    return VerificationProfile(
+        adapter=_unused_adapter,
+        requires_username=False,
+        steps=steps,
+    )
+
+
+async def _unused_adapter(requirement, target, submitted_value, username):
+    raise AssertionError("adapter should not be called by the engine")
+
+
+@pytest.mark.asyncio
+async def test_legacy_step_passes_dispatcher_result_through(monkeypatch):
+    sentinel = ValidationResult(
+        is_valid=True,
+        message="dispatcher said so",
+        task_results=[TaskResult(task_name="t", passed=True, feedback="f")],
+    )
+
+    async def fake_validate(**kwargs):
+        return sentinel
+
+    monkeypatch.setattr(engine_module, "validate_submission", fake_validate)
+
+    result = await run_profile(_job(career_reflection_requirement()))
+
+    assert result.validation_result is sentinel
+    assert result.evidence is None
+
+
+@pytest.mark.asyncio
+async def test_run_profile_uses_declared_steps(monkeypatch):
+    bundle = EvidenceBundle(
+        task_id="gate",
+        source="repo_files",
+        items=[EvidenceItem(path="a.txt", content="x")],
+    )
+
+    @register_check("test_gate_pass")
+    async def _gate(context: StepContext, params) -> StepResult:
+        return StepResult(
+            passed=True,
+            task_result=TaskResult(task_name="Gate", passed=True, feedback="ok"),
+            evidence=[bundle],
+        )
+
+    monkeypatch.setattr(
+        engine_module,
+        "descriptor_for",
+        lambda _t: _profile(_step("test_gate_pass", "gate")),
+    )
+
+    result = await run_profile(_job())
+
+    assert result.validation_result.is_valid is True
+    assert result.validation_result.task_results == [
+        TaskResult(task_name="Gate", passed=True, feedback="ok")
+    ]
+    assert result.evidence == [bundle]
+
+
+@pytest.mark.asyncio
+async def test_failed_gate_short_circuits(monkeypatch):
+    ran: list[str] = []
+
+    @register_check("hard_fail")
+    async def _first(context: StepContext, params) -> StepResult:
+        ran.append("first")
+        return StepResult(passed=False, stop_on_fail=True)
+
+    @register_check("never_runs")
+    async def _second(context: StepContext, params) -> StepResult:
+        ran.append("second")
+        return StepResult(passed=True)
+
+    monkeypatch.setattr(
+        engine_module,
+        "descriptor_for",
+        lambda _t: _profile(_step("hard_fail", "a"), _step("never_runs", "b")),
+    )
+
+    result = await run_profile(_job())
+
+    assert ran == ["first"]
+    assert result.validation_result.is_valid is False
+
+
+@pytest.mark.asyncio
+async def test_stop_on_fail_false_continues(monkeypatch):
+    ran: list[str] = []
+
+    @register_check("soft_fail")
+    async def _soft(context: StepContext, params) -> StepResult:
+        ran.append("soft")
+        return StepResult(passed=False, stop_on_fail=False)
+
+    @register_check("after_soft")
+    async def _after(context: StepContext, params) -> StepResult:
+        ran.append("after")
+        return StepResult(passed=True)
+
+    monkeypatch.setattr(
+        engine_module,
+        "descriptor_for",
+        lambda _t: _profile(_step("soft_fail", "a"), _step("after_soft", "b")),
+    )
+
+    result = await run_profile(_job())
+
+    assert ran == ["soft", "after"]
+    assert result.validation_result.is_valid is False
+
+
+@pytest.mark.asyncio
+async def test_later_step_sees_prior_evidence(monkeypatch):
+    seen: list[int] = []
+    bundle = EvidenceBundle(task_id="a", source="repo_files")
+
+    @register_check("emit_evidence")
+    async def _emit(context: StepContext, params) -> StepResult:
+        return StepResult(passed=True, evidence=[bundle])
+
+    @register_check("read_evidence")
+    async def _read(context: StepContext, params) -> StepResult:
+        seen.append(len(context.evidence_so_far))
+        return StepResult(passed=True)
+
+    monkeypatch.setattr(
+        engine_module,
+        "descriptor_for",
+        lambda _t: _profile(_step("emit_evidence", "a"), _step("read_evidence", "b")),
+    )
+
+    await run_profile(_job())
+
+    assert seen == [1]
+
+
+@pytest.mark.asyncio
+async def test_unregistered_descriptor_falls_back_to_legacy(monkeypatch):
+    called: dict[str, object] = {}
+
+    async def fake_validate(**kwargs):
+        called.update(kwargs)
+        return ValidationResult(is_valid=True, message="legacy ran")
+
+    monkeypatch.setattr(engine_module, "validate_submission", fake_validate)
+    monkeypatch.setattr(engine_module, "descriptor_for", lambda _t: None)
+
+    result = await run_profile(_job())
+
+    assert result.validation_result.message == "legacy ran"
+    assert called["expected_username"] == "learner"
+
+
+def test_register_check_rejects_duplicates():
+    with pytest.raises(ValueError, match="already registered"):
+
+        @register_check("legacy_validate")
+        async def _dupe(context, params):  # pragma: no cover - registration fails
+            return StepResult(passed=True)
+
+
+def test_check_for_unknown_raises():
+    with pytest.raises(KeyError):
+        check_for("does-not-exist")

--- a/packages/learn-to-cloud-shared/tests/verification/test_evidence.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_evidence.py
@@ -1,0 +1,98 @@
+"""Tests for the evidence collector split (cap + per-source getters)."""
+
+import pytest
+
+from learn_to_cloud_shared.verification.evidence import (
+    apply_evidence_cap,
+    collect_repo_file_evidence,
+    collect_submitted_text_evidence,
+)
+from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+from learn_to_cloud_shared.verification.tasks.base import (
+    EvidencePolicy,
+    IndicatorGraderConfig,
+    VerificationTask,
+)
+
+
+def _task(
+    *,
+    source: str = "repo_files",
+    max_files: int = 10,
+    max_file_size_bytes: int = 50 * 1024,
+    max_total_bytes: int = 200 * 1024,
+) -> VerificationTask:
+    return VerificationTask(
+        id="task-1",
+        phase_id=3,
+        name="Test task",
+        evidence=EvidencePolicy(
+            source=source,
+            max_files=max_files,
+            max_file_size_bytes=max_file_size_bytes,
+            max_total_bytes=max_total_bytes,
+        ),
+        grader=IndicatorGraderConfig(),
+    )
+
+
+def test_apply_evidence_cap_deduplicates_paths():
+    bundle = apply_evidence_cap(
+        _task(),
+        [("a.txt", "one"), ("a.txt", "two"), ("b.txt", "three")],
+    )
+    assert [item.path for item in bundle.items] == ["a.txt", "b.txt"]
+    assert bundle.items[0].content == "one"
+
+
+def test_apply_evidence_cap_limits_file_count():
+    bundle = apply_evidence_cap(
+        _task(max_files=2),
+        [("a", "1"), ("b", "2"), ("c", "3")],
+    )
+    assert [item.path for item in bundle.items] == ["a", "b"]
+
+
+def test_apply_evidence_cap_truncates_large_file():
+    bundle = apply_evidence_cap(
+        _task(max_file_size_bytes=100),
+        [("big.txt", "x" * 500)],
+    )
+    assert bundle.items[0].truncated is True
+    assert len(bundle.items[0].content.encode("utf-8")) <= 100
+
+
+def test_apply_evidence_cap_stops_at_total_budget():
+    bundle = apply_evidence_cap(
+        _task(max_total_bytes=10),
+        [("a", "xxxxx"), ("b", "yyyyy"), ("c", "zzzzz")],
+    )
+    assert [item.path for item in bundle.items] == ["a", "b"]
+    assert bundle.total_bytes == 10
+
+
+def test_apply_evidence_cap_sets_source_and_task_id():
+    bundle = apply_evidence_cap(_task(source="submitted_text"), [("a", "1")])
+    assert bundle.task_id == "task-1"
+    assert bundle.source == "submitted_text"
+
+
+def test_collect_submitted_text_evidence_is_passthrough():
+    bundle = collect_submitted_text_evidence(_task(source="submitted_text"), "hello")
+    assert bundle.source == "submitted_text"
+    assert bundle.items[0].content == "hello"
+    assert bundle.items[0].path == "submission.txt"
+
+
+@pytest.mark.asyncio
+async def test_collect_repo_file_evidence_skips_missing_and_caps():
+    repo_files = InMemoryRepoFiles({"present.txt": "here", "second.txt": "also"})
+    bundle = await collect_repo_file_evidence(
+        repo_files,
+        "owner",
+        "repo",
+        ["present.txt", "missing.txt", "second.txt"],
+        _task(max_files=1),
+    )
+    assert [item.path for item in bundle.items] == ["present.txt"]
+    assert bundle.source == "repo_files"


### PR DESCRIPTION
First PR in the #630 stack: move verification onto a declarative, registry-driven engine. This one is **additive substrate only**, nothing calls the engine in production yet, so all phases behave identically and CI stays green.

## What's here

- **`verification/engine.py`** (new): the engine primitives, all plain shared-package code with no Durable imports.
  - `Step` (registry key `check` + typed `params` + `task_id`), `StepResult` (`passed`, `task_result`, `evidence`, `stop_on_fail`, transitional `validation_result` passthrough), `StepContext` (job, repository target, submitted value, `evidence_so_far`, injected `repo_files`).
  - `register_check` / `check_for` name-keyed check registry; `CheckFn` type.
  - `VerificationProfile` extending the dispatcher's `ValidatorDescriptor` with `steps`, `system_prompt`, `rubric`.
  - `run_profile(job)`: looks up the profile, runs steps in order, short-circuits on a failed gate (`stop_on_fail`), accumulates `EvidenceBundle`s, and aggregates one `ValidationResult`.
- **Transitional `legacy_validate` check**: delegates to `validate_submission`, so every not-yet-migrated submission type runs through the engine with identical behavior. Removed in the final stack PR once every type resolves to a real profile.
- **`VerificationRunResult.evidence`** carrier: optional, default `None`, round-tripped in `to_payload`/`from_payload`, and stripped via `without_evidence()` before the terminal DB write so file contents never reach Postgres.
- **Evidence collector split** (`evidence.py`): a shared `apply_evidence_cap` (dedup + `max_files`/`max_file_size_bytes`/`max_total_bytes`), plus per-source getters (`collect_repo_file_evidence` for GitHub, `collect_submitted_text_evidence` no-network passthrough). Existing callers keep the same `collect_repo_file_evidence` signature.

## Design decision (the one #630 defers to PR1)

Per-check params use a **discriminated union keyed by `check`** (mirrors the existing `GraderConfig` union). Only `legacy_validate` exists today; the union grows as later PRs register `files_present`, `fetch_files`, `llm_rubric_review`, etc.

## Tests

- `test_engine.py`: legacy passthrough, declared-step execution, short-circuit on failed gate, `stop_on_fail=False` continuation, evidence visibility to later steps, legacy fallback for unregistered descriptors, duplicate-registration guard.
- `test_evidence.py`: cap dedup/limit/truncate/total-budget, source+task_id, submitted-text passthrough, repo-file skip-missing + cap.
- `test_verification_run_result_evidence.py`: default None, round-trip (with/without evidence), `without_evidence()` strip.

`uv run poe check` green (515 shared+api, 15 functions).

## Not in this PR (later in the stack)

Rewiring the Durable orchestrator/activities to call `run_profile`, collapsing the 13 orchestrators to one, deleting the self-gating grading probe, migrating each phase to a profile, and removing the inline path + `ExecutionMode`.

Do not merge automatically; @madebygps reviews and merges manually.