### PR TITLE
refactor(verification): route verify through engine run_profile (#630 PR2)

### DIFF
--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -34,11 +34,11 @@ from learn_to_cloud_shared.verification.llm_grading import (
 from learn_to_cloud_shared.verification.llm_grading import (
     collect_llm_grading_requests as collect_llm_requests,
 )
+from learn_to_cloud_shared.verification.engine import run_profile
 from learn_to_cloud_shared.verification_job_executor import (
     PreparedVerificationJob,
     VerificationJobNotFoundError,
     VerificationRunResult,
-    run_verification,
 )
 from learn_to_cloud_shared.verification_job_executor import (
     persist_verification_result as persist_prepared_verification_result,
@@ -533,7 +533,16 @@ async def execute_requirement_verification(
             _activity_payload(job_payload)
         )
         _set_prepared_job_span_attributes(prepared_job)
-        run_result = await run_verification(prepared_job)
+        run_result = await run_profile(prepared_job)
+        span = otel_trace.get_current_span()
+        if span.is_recording():
+            span.set_attribute(
+                "verification.is_valid", run_result.validation_result.is_valid
+            )
+            span.set_attribute(
+                "verification.completed",
+                run_result.validation_result.verification_completed,
+            )
         result_payload = run_result.to_payload()
         _set_result_span_attributes(result_payload)
         return result_payload

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -22,8 +22,11 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from typing import Literal
+from uuid import UUID
 
+from opentelemetry import trace
 from pydantic import Field
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.github_target import GitHubTarget
 from learn_to_cloud_shared.schemas import FrozenModel, TaskResult, ValidationResult
@@ -39,8 +42,14 @@ from learn_to_cloud_shared.verification.tasks.base import (
 )
 from learn_to_cloud_shared.verification_job_executor import (
     PreparedVerificationJob,
+    VerificationJobExecutionResult,
+    VerificationJobNotFoundError,
     VerificationRunResult,
+    persist_verification_result,
+    prepare_verification_job,
 )
+
+_tracer = trace.get_tracer(__name__)
 
 # ---------------------------------------------------------------------------
 # Step params: per-check models in a discriminated union keyed by ``check``.
@@ -248,3 +257,44 @@ async def run_profile(
         validation_result=_aggregate(step_results),
         evidence=bundles or None,
     )
+
+
+async def execute_verification_job(
+    job_id: UUID | str,
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+    prepared_input: PreparedVerificationJob,
+) -> VerificationJobExecutionResult:
+    """Run one persisted verification job end-to-end (prepare, run, persist).
+
+    A non-grading convenience over the individual primitives. Production
+    sequences the same steps (plus grading) as separate Durable activities;
+    this collapses them for callers that want a single deterministic run.
+    """
+    normalized_job_id = job_id if isinstance(job_id, UUID) else UUID(job_id)
+
+    with _tracer.start_as_current_span(
+        "execute_verification_job",
+        attributes={"verification.job_id": str(normalized_job_id)},
+    ) as span:
+        preparation = await prepare_verification_job(
+            normalized_job_id,
+            session_maker=session_maker,
+            prepared_input=prepared_input,
+        )
+        if preparation.terminal_result is not None:
+            span.set_attribute(
+                "verification.status",
+                preparation.terminal_result.status,
+            )
+            return preparation.terminal_result
+        if preparation.job is None:
+            raise VerificationJobNotFoundError(str(normalized_job_id))
+
+        run_result = await run_profile(preparation.job)
+        result = await persist_verification_result(
+            run_result,
+            session_maker=session_maker,
+        )
+        span.set_attribute("verification.status", result.status)
+        return result

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -9,7 +9,7 @@ A verification job is identified by the presence of its row in
    already has a linked Submission (Durable replay after a successful
    prior run), returns the same execution result without doing more
    work.
-2. ``run_verification`` runs the validator (no DB writes).
+2. ``run_profile`` runs the engine (no DB writes).
 3. ``persist_verification_result`` writes the ``Submission`` and links
    it to the job via ``VerificationJobRepository.link_submission``.
    Idempotent against retries via the ``ALREADY_LINKED`` short-circuit.
@@ -48,9 +48,6 @@ from learn_to_cloud_shared.submission_derivation import build_target
 from learn_to_cloud_shared.submission_values import (
     SubmittedValue,
     submission_value_from_columns,
-)
-from learn_to_cloud_shared.verification.dispatcher import (
-    validate_submission,
 )
 from learn_to_cloud_shared.verification.execution import (
     persist_validation_result,
@@ -450,35 +447,6 @@ async def _load_job_state(
     )
 
 
-async def run_verification(
-    job: PreparedVerificationJob,
-) -> VerificationRunResult:
-    """Run the requirement validator without writing database state."""
-    with tracer.start_as_current_span(
-        "run_verification",
-        attributes={
-            "verification.job_id": str(job.id),
-            "requirement.slug": job.requirement.slug,
-            "submission.type": job.requirement.submission_type.value,
-        },
-    ) as span:
-        validation_result = await validate_submission(
-            requirement=job.requirement,
-            submitted_value=job.typed_submitted_value.as_text,
-            target=job.target,
-            expected_username=job.github_username,
-        )
-        span.set_attribute("verification.is_valid", validation_result.is_valid)
-        span.set_attribute(
-            "verification.completed",
-            validation_result.verification_completed,
-        )
-        return VerificationRunResult(
-            job=job,
-            validation_result=validation_result,
-        )
-
-
 async def persist_verification_result(
     run_result: VerificationRunResult,
     *,
@@ -491,6 +459,9 @@ async def persist_verification_result(
     :class:`~learn_to_cloud_shared.repositories.verification_job_repository.LinkResult.ALREADY_LINKED`
     case from ``link_submission``.
     """
+    # Evidence bundles (file contents) are a between-activities transport only;
+    # drop them before the terminal write so they never reach Postgres.
+    run_result = run_result.without_evidence()
     job = run_result.job
     validation_result = run_result.validation_result
 
@@ -577,39 +548,3 @@ async def persist_verification_result(
             verification_completed=validation_result.verification_completed,
             message=_MESSAGE_BY_OUTCOME[outcome],
         )
-
-
-async def execute_verification_job(
-    job_id: UUID | str,
-    *,
-    session_maker: async_sessionmaker[AsyncSession],
-    prepared_input: PreparedVerificationJob,
-) -> VerificationJobExecutionResult:
-    """Run one persisted verification job end-to-end."""
-    normalized_job_id = _coerce_job_id(job_id)
-
-    with tracer.start_as_current_span(
-        "execute_verification_job",
-        attributes={"verification.job_id": str(normalized_job_id)},
-    ) as span:
-        preparation = await prepare_verification_job(
-            normalized_job_id,
-            session_maker=session_maker,
-            prepared_input=prepared_input,
-        )
-        if preparation.terminal_result is not None:
-            span.set_attribute(
-                "verification.status",
-                preparation.terminal_result.status,
-            )
-            return preparation.terminal_result
-        if preparation.job is None:
-            raise VerificationJobNotFoundError(str(normalized_job_id))
-
-        run_result = await run_verification(preparation.job)
-        result = await persist_verification_result(
-            run_result,
-            session_maker=session_maker,
-        )
-        span.set_attribute("verification.status", result.status)
-        return result

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -26,6 +26,10 @@ from learn_to_cloud_shared.schemas import (
     ValidationResult,
 )
 from learn_to_cloud_shared.submission_values import SubmittedValue
+from learn_to_cloud_shared.verification.engine import (
+    execute_verification_job,
+    run_profile,
+)
 from learn_to_cloud_shared.verification.execution import MAX_VALIDATION_MESSAGE_LENGTH
 from learn_to_cloud_shared.verification_job_executor import (
     VALIDATION_FAILED_ERROR_CODE,
@@ -34,10 +38,8 @@ from learn_to_cloud_shared.verification_job_executor import (
     PreparedVerificationJob,
     VerificationJobNotFoundError,
     VerificationRunResult,
-    execute_verification_job,
     persist_verification_result,
     prepare_verification_job,
-    run_verification,
 )
 
 pytestmark = pytest.mark.integration
@@ -183,10 +185,10 @@ async def test_split_verification_primitives_prepare_run_and_persist(
     assert preparation.job.to_payload()["id"] == str(job_id)
 
     with patch(
-        "learn_to_cloud_shared.verification_job_executor.validate_submission",
+        "learn_to_cloud_shared.verification.engine.validate_submission",
         validation,
     ):
-        run_result = await run_verification(preparation.job)
+        run_result = await run_profile(preparation.job)
 
     assert await _count_submissions(session_maker) == 0
     assert run_result.to_payload()["job"] == preparation.job.to_payload()
@@ -220,7 +222,7 @@ async def test_execute_verification_job_marks_success_and_links_submission(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor.validate_submission",
+            "learn_to_cloud_shared.verification.engine.validate_submission",
             validation,
         ),
     ):
@@ -262,7 +264,7 @@ async def test_execute_verification_job_marks_user_validation_failure(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor.validate_submission",
+            "learn_to_cloud_shared.verification.engine.validate_submission",
             validation,
         ),
     ):
@@ -301,7 +303,7 @@ async def test_execute_verification_job_marks_server_error(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor.validate_submission",
+            "learn_to_cloud_shared.verification.engine.validate_submission",
             validation,
         ),
     ):
@@ -339,7 +341,7 @@ async def test_execute_verification_job_truncates_persisted_error_messages(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor.validate_submission",
+            "learn_to_cloud_shared.verification.engine.validate_submission",
             validation,
         ),
     ):
@@ -401,7 +403,7 @@ async def test_execute_verification_job_is_idempotent_for_terminal_jobs(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification_job_executor.validate_submission",
+            "learn_to_cloud_shared.verification.engine.validate_submission",
             validation,
         ),
     ):


### PR DESCRIPTION
Stacked on #640 (PR1). **Base is `feat/verification-engine-core`, not `main`.** Merge #640 first.

## What

Makes the declarative engine live. The `execute_requirement_verification` Durable activity now calls `run_profile` instead of `run_verification`.

For a plain `ValidatorDescriptor` (every phase today), `run_profile` runs the single transitional `legacy_validate` step, which calls `validate_submission` with identical arguments and returns the same `ValidationResult`. So **no phase changes behavior**; this is a pure routing swap onto the engine.

## Changes

- Verify activity: `run_verification` -> `run_profile`; span attrs set explicitly at the activity.
- Delete `run_verification` (superseded).
- Move `execute_verification_job` from the executor into `engine.py` (it composes `run_profile` + prepare/persist; sits at the engine layer and keeps the executor->engine import direction one-way).
- `persist_verification_result` strips evidence bundles before the terminal DB write (defense-in-depth; no-op today, load-bearing once profiles emit evidence in PR3+).
- Tests repointed to patch `validate_submission` where the legacy check imports it (`verification.engine`) and import moved symbols from the engine.

## Not in scope (deliberate)

Grading is left alone. The self-gating `collect_llm_grading_requests` probe stays until phases declare `llm_rubric_review` steps (PR3-6). Deleting it now would regress LLM grading for phases 3/4/6/7 in intermediate merges.

## Validation

`uv run poe check` green: 515 shared+api, 15 functions, all static.

Part of the #630 engine stack. Do not merge before #640.