### PR TITLE
feat(verification): migrate Phase 3 journal API to declarative profile (#630 PR3)

### DIFF
--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -7,7 +7,7 @@ import atexit
 import json
 import logging
 import os
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from uuid import UUID
@@ -381,13 +381,24 @@ def _llm_grading_step(
 ):
     """Apply LLM rubric grading when the run produced grading requests.
 
-    Used only by graded phases (3 and 6). When no requests are produced
-    the run result passes through unchanged.
+    Migrated profiles record their grading requests on the verify result
+    (``grading_requests`` is a list, possibly empty); the orchestrator grades
+    exactly those. Legacy types leave it absent, so we fall back to the
+    transitional grading probe. When no requests result, the run result passes
+    through unchanged.
     """
-    llm_requests = yield context.call_activity(
-        "collect_llm_grading_requests",
-        run_result,
-    )
+    recorded_requests: Sequence[object] | None = None
+    if isinstance(run_result, Mapping):
+        value = _activity_payload(run_result).get("grading_requests")
+        if isinstance(value, list):
+            recorded_requests = value
+    if recorded_requests is None:
+        llm_requests = yield context.call_activity(
+            "collect_llm_grading_requests",
+            run_result,
+        )
+    else:
+        llm_requests = recorded_requests
     if not llm_requests:
         return run_result
 

--- a/apps/verification-functions/tests/test_orchestrations.py
+++ b/apps/verification-functions/tests/test_orchestrations.py
@@ -122,6 +122,7 @@ def _make_responder(
     prepared_payload: dict[str, object],
     *,
     llm_requests: list[object] | None = None,
+    recorded_requests: list[object] | None = None,
     config_valid: bool = True,
     fail_activity: str | None = None,
     terminal: object | None = None,
@@ -135,6 +136,8 @@ def _make_responder(
                 return {"terminal_result": terminal}
             return {"job": prepared_payload}
         if name == "execute_requirement_verification":
+            if recorded_requests is not None:
+                return {"status": "verified", "grading_requests": recorded_requests}
             return {"status": "verified"}
         if name == "collect_llm_grading_requests":
             return list(llm_requests or [])
@@ -187,6 +190,42 @@ class TestCanonicalWorkflow:
             "status": "completed",
             "submission_id": 7,
         }
+
+    def test_uses_recorded_grading_requests_and_skips_probe(self) -> None:
+        # A migrated profile records grading requests on the verify result;
+        # the orchestrator grades those directly and skips the legacy probe.
+        payload = _graded_payload()
+        ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
+        responder = _make_responder(payload, recorded_requests=[{"task": "a"}])
+        calls, result = _drive(
+            function_app._run_verification_orchestration(ctx), responder
+        )
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_job"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity", "ensure_grading_config"),
+            ("activity_with_retry", "run_llm_grading"),
+            ("activity", "apply_llm_grading_results"),
+            ("activity_with_retry", "persist_verification_result"),
+        ]
+        assert result == {
+            "job_id": "job-1",
+            "status": "completed",
+            "submission_id": 7,
+        }
+
+    def test_recorded_empty_requests_skip_grading_and_probe(self) -> None:
+        # A migrated profile whose gate failed records an empty list; the
+        # orchestrator skips grading entirely (no probe, no LLM calls).
+        payload = _graded_payload()
+        ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
+        responder = _make_responder(payload, recorded_requests=[])
+        calls, _ = _drive(function_app._run_verification_orchestration(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_job"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity_with_retry", "persist_verification_result"),
+        ]
 
     def test_skips_grading_when_no_requests(self) -> None:
         payload = _graded_payload()

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
-from typing import Literal
+from typing import Annotated, Literal
 from uuid import UUID
 
 from opentelemetry import trace
@@ -29,16 +29,28 @@ from pydantic import Field
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.github_target import GitHubTarget
+from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.schemas import FrozenModel, TaskResult, ValidationResult
+from learn_to_cloud_shared.verification.ci_status import verify_ci_status
 from learn_to_cloud_shared.verification.dispatcher import (
     ValidatorDescriptor,
     descriptor_for,
     validate_submission,
 )
-from learn_to_cloud_shared.verification.repo_files import RepoFiles
+from learn_to_cloud_shared.verification.evidence import collect_repo_file_evidence
+from learn_to_cloud_shared.verification.grading_requests import (
+    LLMGradingRequest,
+    build_repo_rubric_message,
+)
+from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
 from learn_to_cloud_shared.verification.tasks.base import (
     EvidenceBundle,
     LLMRubricGraderConfig,
+    VerificationTask,
+)
+from learn_to_cloud_shared.verification.tasks.phase3 import (
+    JOURNAL_API_FINAL_RUBRIC_TASK,
+    JOURNAL_API_IMPORTANT_PATHS,
 )
 from learn_to_cloud_shared.verification_job_executor import (
     PreparedVerificationJob,
@@ -62,11 +74,29 @@ class LegacyValidateParams(FrozenModel):
     check: Literal["legacy_validate"] = "legacy_validate"
 
 
-# The per-check discriminated union. With one member today it is a plain
-# alias; as PR2+ register more checks (files_present, fetch_files,
-# llm_rubric_review, ...) this becomes
-# ``Annotated[LegacyValidateParams | ..., Field(discriminator="check")]``.
-StepParams = LegacyValidateParams
+class CIStatusParams(FrozenModel):
+    """Params for the ``github_ci_passing`` gate (workflow file is fixed)."""
+
+    check: Literal["github_ci_passing"] = "github_ci_passing"
+
+
+class LLMRubricReviewParams(FrozenModel):
+    """Params for the terminal ``llm_rubric_review`` step.
+
+    Carries the rubric ``task`` (criteria + grader) and the exact repository
+    ``evidence_paths`` to fetch. Fetching exact paths (no repo-tree listing)
+    keeps evidence deterministic and matches the prescribed capstone files.
+    """
+
+    check: Literal["llm_rubric_review"] = "llm_rubric_review"
+    task: VerificationTask
+    evidence_paths: tuple[str, ...]
+
+
+StepParams = Annotated[
+    LegacyValidateParams | CIStatusParams | LLMRubricReviewParams,
+    Field(discriminator="check"),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -93,8 +123,10 @@ class StepResult(FrozenModel):
     ``evidence`` is contributed to the run's bundle and made visible to later
     steps. ``stop_on_fail`` lets a failed gate short-circuit the remaining
     steps. ``validation_result`` is the transitional passthrough used by the
-    ``legacy_validate`` step to carry a full dispatcher result unchanged; it is
-    removed once every type is migrated to task-level results.
+    ``legacy_validate`` step (and the ``github_ci_passing`` gate) to carry a
+    full dispatcher/gate result unchanged. ``grading_task`` marks that this
+    step requested LLM rubric grading; the engine turns it into a recorded
+    grading request once the deterministic result is aggregated.
     """
 
     passed: bool
@@ -102,6 +134,7 @@ class StepResult(FrozenModel):
     evidence: list[EvidenceBundle] = Field(default_factory=list)
     stop_on_fail: bool = True
     validation_result: ValidationResult | None = None
+    grading_task: VerificationTask | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -178,11 +211,140 @@ async def _check_legacy_validate(
     )
 
 
+# ---------------------------------------------------------------------------
+# Reusable checks.
+# ---------------------------------------------------------------------------
+
+
+@register_check("github_ci_passing")
+async def _check_github_ci_passing(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Gate on a green CI run on the fork's ``main`` branch."""
+    target = context.repository
+    if target is None or not target.repo:
+        return StepResult(
+            passed=False,
+            stop_on_fail=True,
+            validation_result=ValidationResult(
+                is_valid=False,
+                message="Requirement configuration error: missing required_repo",
+                username_match=True,
+                repo_exists=False,
+            ),
+        )
+    result = await verify_ci_status(target.owner, target.repo)
+    return StepResult(
+        passed=result.is_valid,
+        stop_on_fail=True,
+        validation_result=result,
+    )
+
+
+@register_check("llm_rubric_review")
+async def _check_llm_rubric_review(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Fetch exact-path evidence for a terminal LLM rubric review.
+
+    Never a gate: it gathers the bundle the LLM will grade and marks the task
+    for grading. The actual LLM call runs later in the separate durable
+    ``run_llm_grading`` activity, so this step stays pure of any model call.
+    """
+    assert isinstance(params, LLMRubricReviewParams)
+    target = context.repository
+    if target is None or not target.repo:
+        return StepResult(passed=True, stop_on_fail=False)
+    repo_files = context.repo_files or default_repo_files()
+    bundle = await collect_repo_file_evidence(
+        repo_files,
+        target.owner,
+        target.repo,
+        list(params.evidence_paths),
+        params.task,
+    )
+    return StepResult(
+        passed=True,
+        stop_on_fail=False,
+        evidence=[bundle],
+        grading_task=params.task,
+    )
+
+
 _LEGACY_STEP = Step(
     check="legacy_validate",
     params=LegacyValidateParams(),
     task_id="legacy_validate",
 )
+
+
+# ---------------------------------------------------------------------------
+# Profile registry: submission types that have migrated to declared steps.
+# ---------------------------------------------------------------------------
+
+
+async def _profile_steps_adapter(
+    requirement: object,
+    target: object,
+    submitted_value: str,
+    username: str,
+) -> ValidationResult:
+    """Placeholder adapter for profiles; they run declared steps, not this."""
+    raise RuntimeError("VerificationProfile runs declared steps, not an adapter")
+
+
+_PROFILE_REGISTRY: dict[SubmissionType, VerificationProfile] = {}
+
+
+def register_profile(
+    submission_type: SubmissionType, profile: VerificationProfile
+) -> None:
+    """Register a migrated profile for a submission type (raises on dupes)."""
+    if submission_type in _PROFILE_REGISTRY:
+        raise ValueError(f"Profile already registered: {submission_type}")
+    _PROFILE_REGISTRY[submission_type] = profile
+
+
+def profile_for(submission_type: SubmissionType) -> VerificationProfile | None:
+    """Return the migrated profile for a submission type, if any."""
+    return _PROFILE_REGISTRY.get(submission_type)
+
+
+_JOURNAL_API_RUBRIC = JOURNAL_API_FINAL_RUBRIC_TASK.grader
+assert isinstance(_JOURNAL_API_RUBRIC, LLMRubricGraderConfig)
+
+_JOURNAL_API_PROFILE = VerificationProfile(
+    adapter=_profile_steps_adapter,
+    requires_username=True,
+    steps=(
+        Step(
+            check="github_ci_passing",
+            params=CIStatusParams(),
+            task_id="journal-api-implementation-ci",
+        ),
+        Step(
+            check="llm_rubric_review",
+            params=LLMRubricReviewParams(
+                task=JOURNAL_API_FINAL_RUBRIC_TASK,
+                evidence_paths=JOURNAL_API_IMPORTANT_PATHS,
+            ),
+            task_id=JOURNAL_API_FINAL_RUBRIC_TASK.id,
+        ),
+    ),
+    rubric=_JOURNAL_API_RUBRIC,
+)
+
+register_profile(SubmissionType.JOURNAL_API_VERIFIER, _JOURNAL_API_PROFILE)
+
+
+def _resolve_descriptor(job: PreparedVerificationJob) -> ValidatorDescriptor | None:
+    """Prefer a migrated profile, else the dispatcher's legacy descriptor."""
+    profile = profile_for(job.requirement.submission_type)
+    if profile is not None:
+        return profile
+    return descriptor_for(job.requirement.submission_type)
 
 
 def _steps_for(descriptor: ValidatorDescriptor | None) -> tuple[Step, ...]:
@@ -217,6 +379,45 @@ def _aggregate(step_results: list[StepResult]) -> ValidationResult:
     )
 
 
+def _grading_requests_for(
+    job: PreparedVerificationJob,
+    deterministic_result: ValidationResult,
+    step_results: list[StepResult],
+) -> list[LLMGradingRequest]:
+    """Turn steps that requested grading into recorded grading requests.
+
+    Runs after aggregation so the prompt carries the final deterministic
+    result. Empty when a gate failed before the rubric step ran, which is how
+    a migrated profile signals "no grading needed" to the orchestrator.
+    """
+    target = job.target
+    if target is None or not target.repo:
+        return []
+    requests: list[LLMGradingRequest] = []
+    for result in step_results:
+        task = result.grading_task
+        if task is None:
+            continue
+        evidence = result.evidence[0].model_dump(mode="json") if result.evidence else {}
+        message = build_repo_rubric_message(
+            requirement_slug=job.requirement.slug,
+            requirement_name=job.requirement.name,
+            deterministic_result=deterministic_result,
+            owner=target.owner,
+            repo=target.repo,
+            task=task,
+            evidence=evidence,
+        )
+        requests.append(
+            LLMGradingRequest(
+                task=task,
+                message=message,
+                thread_id=f"{job.id}-{task.id}",
+            )
+        )
+    return requests
+
+
 async def run_profile(
     job: PreparedVerificationJob,
     *,
@@ -227,8 +428,12 @@ async def run_profile(
     Steps run in order; a failed gate with ``stop_on_fail`` short-circuits the
     rest. Evidence bundles accumulate across steps, are visible to later steps
     via ``evidence_so_far``, and are carried on the returned run result.
+
+    Migrated profiles record their LLM grading requests on the result
+    (``grading_requests`` is a list, possibly empty); legacy types leave it
+    ``None`` so the orchestrator falls back to the grading probe.
     """
-    descriptor = descriptor_for(job.requirement.submission_type)
+    descriptor = _resolve_descriptor(job)
     steps = _steps_for(descriptor)
 
     context = StepContext(
@@ -252,10 +457,18 @@ async def run_profile(
         if not result.passed and result.stop_on_fail:
             break
 
+    deterministic_result = _aggregate(step_results)
+    grading_requests: list[LLMGradingRequest] | None = None
+    if isinstance(descriptor, VerificationProfile):
+        grading_requests = _grading_requests_for(
+            job, deterministic_result, step_results
+        )
+
     return VerificationRunResult(
         job=job,
-        validation_result=_aggregate(step_results),
+        validation_result=deterministic_result,
         evidence=bundles or None,
+        grading_requests=grading_requests,
     )
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/grading_requests.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/grading_requests.py
@@ -1,0 +1,95 @@
+"""LLM grading request/decision transport plus shared prompt builders.
+
+Kept dependency-light on purpose: it imports only schemas and task
+definitions, never ``verification_job_executor``. That lets the executor
+carry :class:`LLMGradingRequest`s on ``VerificationRunResult`` (so the engine
+can record grading requests on the verify result) without an import cycle,
+and lets both the engine and the legacy grading probe build the LLM prompt
+from one place.
+"""
+
+from __future__ import annotations
+
+import json
+
+from learn_to_cloud_shared.schemas import FrozenModel, ValidationResult
+from learn_to_cloud_shared.verification.tasks import (
+    LLMGradingDecision,
+    VerificationTask,
+    require_llm_rubric_grader,
+)
+
+
+class LLMGradingRequest(FrozenModel):
+    """One durable agent grading request."""
+
+    task: VerificationTask
+    message: str
+    thread_id: str
+
+
+class LLMGradingDecisionPayload(FrozenModel):
+    """A structured LLM decision paired with its task definition."""
+
+    task: VerificationTask
+    decision: LLMGradingDecision
+
+
+def _task_payload(task: VerificationTask) -> dict[str, object]:
+    grader = require_llm_rubric_grader(task)
+    return {
+        "id": task.id,
+        "name": task.name,
+        "criteria": task.criteria,
+        "rubric_id": grader.rubric_id,
+        "prompt_version": grader.prompt_version,
+        "passing_score": grader.passing_score,
+    }
+
+
+def build_repo_rubric_message(
+    *,
+    requirement_slug: str,
+    requirement_name: str,
+    deterministic_result: ValidationResult,
+    owner: str,
+    repo: str,
+    task: VerificationTask,
+    evidence: dict[str, object],
+) -> str:
+    """Build the LLM prompt for a repository-backed rubric review."""
+    payload = {
+        "requirement": {"id": requirement_slug, "name": requirement_name},
+        "task": _task_payload(task),
+        "repository": {"owner": owner, "name": repo},
+        "deterministic_result": deterministic_result.model_dump(mode="json"),
+        "evidence": evidence,
+    }
+    return (
+        "Grade this Learn to Cloud verification task using only the JSON payload. "
+        "Return a structured grading decision that follows the configured schema.\n\n"
+        f"{json.dumps(payload, sort_keys=True)}"
+    )
+
+
+def build_text_rubric_message(
+    *,
+    requirement_slug: str,
+    requirement_name: str,
+    deterministic_result: ValidationResult,
+    task: VerificationTask,
+    evidence: dict[str, object],
+) -> str:
+    """Build the LLM prompt for a free-text (no-repo) rubric review."""
+    payload = {
+        "requirement": {"id": requirement_slug, "name": requirement_name},
+        "task": _task_payload(task),
+        "deterministic_result": deterministic_result.model_dump(mode="json"),
+        "evidence": evidence,
+    }
+    return (
+        "Grade this Learn to Cloud verification task using only the JSON payload. "
+        "The evidence is the learner's own free-text reflection answers. "
+        "Return a structured grading decision that follows the configured schema.\n\n"
+        f"{json.dumps(payload, sort_keys=True)}"
+    )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -1,11 +1,16 @@
-"""Prepare and apply durable LLM grading for verification jobs."""
+"""Prepare and apply durable LLM grading for verification jobs.
+
+Transitional home of the self-gating grading probe for the phases that have
+not yet moved to a declared engine profile. Migrated phases (Phase 3 onward)
+record their grading requests on the verify result via the engine's
+``llm_rubric_review`` step, so they no longer route through this probe; their
+branches are removed here as they migrate, and the probe is deleted once the
+last graded phase is migrated.
+"""
 
 from __future__ import annotations
 
-import json
-
 from learn_to_cloud_shared.schemas import (
-    FrozenModel,
     HandsOnRequirement,
 )
 from learn_to_cloud_shared.verification.career_reflection import (
@@ -14,15 +19,17 @@ from learn_to_cloud_shared.verification.career_reflection import (
 from learn_to_cloud_shared.verification.deployment_architecture import (
     collect_deployment_architecture_evidence,
 )
-from learn_to_cloud_shared.verification.journal_api import (
-    collect_journal_api_implementation_evidence,
+from learn_to_cloud_shared.verification.grading_requests import (
+    LLMGradingDecisionPayload,
+    LLMGradingRequest,
+    build_repo_rubric_message,
+    build_text_rubric_message,
 )
 from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
 from learn_to_cloud_shared.verification.security_scanning import (
     collect_security_scanning_evidence,
 )
 from learn_to_cloud_shared.verification.tasks import (
-    PHASE3_LLM_TASKS,
     PHASE4_LLM_TASKS,
     PHASE4_REQUIREMENT_SLUG,
     PHASE6_LLM_TASKS,
@@ -37,20 +44,14 @@ from learn_to_cloud_shared.verification_job_executor import (
     VerificationRunResult,
 )
 
-
-class LLMGradingRequest(FrozenModel):
-    """One durable agent grading request."""
-
-    task: VerificationTask
-    message: str
-    thread_id: str
-
-
-class LLMGradingDecisionPayload(FrozenModel):
-    """A structured LLM decision paired with its task definition."""
-
-    task: VerificationTask
-    decision: LLMGradingDecision
+__all__ = [
+    "LLMGradingDecisionPayload",
+    "LLMGradingRequest",
+    "apply_llm_grading_decisions",
+    "collect_llm_grading_requests",
+    "llm_grading_content_filtered_result",
+    "llm_grading_unavailable_result",
+]
 
 
 async def collect_llm_grading_requests(
@@ -75,9 +76,6 @@ async def collect_llm_grading_requests(
 
     if run_result.job.requirement.slug == "security-scanning":
         return await _collect_phase6_requests(run_result, tasks, repo_files)
-
-    if run_result.job.requirement.slug == "journal-api-implementation":
-        return await _collect_phase3_requests(run_result, tasks, repo_files)
 
     return []
 
@@ -207,45 +205,6 @@ async def _collect_phase6_requests(
     return requests
 
 
-async def _collect_phase3_requests(
-    run_result: VerificationRunResult,
-    tasks: list[VerificationTask],
-    repo_files: RepoFiles,
-) -> list[LLMGradingRequest]:
-    if not run_result.validation_result.is_valid:
-        return []
-
-    target = run_result.job.target
-    if target is None or not target.repo:
-        return []
-
-    owner, repo = target.owner, target.repo
-    file_paths = await repo_files.tree(owner, repo)
-    requests: list[LLMGradingRequest] = []
-    for task in tasks:
-        evidence = await collect_journal_api_implementation_evidence(
-            owner,
-            repo,
-            file_paths,
-            task,
-            repo_files=repo_files,
-        )
-        requests.append(
-            LLMGradingRequest(
-                task=task,
-                message=_build_grading_message(
-                    run_result=run_result,
-                    task=task,
-                    owner=owner,
-                    repo=repo,
-                    evidence=evidence.model_dump(mode="json"),
-                ),
-                thread_id=f"{run_result.job.id}-{task.id}",
-            )
-        )
-    return requests
-
-
 async def _collect_phase4_requests(
     run_result: VerificationRunResult,
     tasks: list[VerificationTask],
@@ -322,28 +281,14 @@ def _build_grading_message(
     repo: str,
     evidence: dict[str, object],
 ) -> str:
-    grader = require_llm_rubric_grader(task)
-    payload = {
-        "requirement": {
-            "id": run_result.job.requirement.slug,
-            "name": run_result.job.requirement.name,
-        },
-        "task": {
-            "id": task.id,
-            "name": task.name,
-            "criteria": task.criteria,
-            "rubric_id": grader.rubric_id,
-            "prompt_version": grader.prompt_version,
-            "passing_score": grader.passing_score,
-        },
-        "repository": {"owner": owner, "name": repo},
-        "deterministic_result": run_result.validation_result.model_dump(mode="json"),
-        "evidence": evidence,
-    }
-    return (
-        "Grade this Learn to Cloud verification task using only the JSON payload. "
-        "Return a structured grading decision that follows the configured schema.\n\n"
-        f"{json.dumps(payload, sort_keys=True)}"
+    return build_repo_rubric_message(
+        requirement_slug=run_result.job.requirement.slug,
+        requirement_name=run_result.job.requirement.name,
+        deterministic_result=run_result.validation_result,
+        owner=owner,
+        repo=repo,
+        task=task,
+        evidence=evidence,
     )
 
 
@@ -353,28 +298,12 @@ def _build_text_grading_message(
     task: VerificationTask,
     evidence: dict[str, object],
 ) -> str:
-    grader = require_llm_rubric_grader(task)
-    payload = {
-        "requirement": {
-            "id": run_result.job.requirement.slug,
-            "name": run_result.job.requirement.name,
-        },
-        "task": {
-            "id": task.id,
-            "name": task.name,
-            "criteria": task.criteria,
-            "rubric_id": grader.rubric_id,
-            "prompt_version": grader.prompt_version,
-            "passing_score": grader.passing_score,
-        },
-        "deterministic_result": run_result.validation_result.model_dump(mode="json"),
-        "evidence": evidence,
-    }
-    return (
-        "Grade this Learn to Cloud verification task using only the JSON payload. "
-        "The evidence is the learner's own free-text reflection answers. "
-        "Return a structured grading decision that follows the configured schema.\n\n"
-        f"{json.dumps(payload, sort_keys=True)}"
+    return build_text_rubric_message(
+        requirement_slug=run_result.job.requirement.slug,
+        requirement_name=run_result.job.requirement.name,
+        deterministic_result=run_result.validation_result,
+        task=task,
+        evidence=evidence,
     )
 
 
@@ -408,8 +337,6 @@ def _llm_tasks_for_requirement(
 ) -> list[VerificationTask]:
     if requirement.slug == "security-scanning":
         return PHASE6_LLM_TASKS
-    if requirement.slug == "journal-api-implementation":
-        return PHASE3_LLM_TASKS
     if requirement.slug == PHASE7_REQUIREMENT_SLUG:
         return PHASE7_LLM_TASKS
     if requirement.slug == PHASE4_REQUIREMENT_SLUG:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -52,6 +52,7 @@ from learn_to_cloud_shared.submission_values import (
 from learn_to_cloud_shared.verification.execution import (
     persist_validation_result,
 )
+from learn_to_cloud_shared.verification.grading_requests import LLMGradingRequest
 from learn_to_cloud_shared.verification.tasks.base import EvidenceBundle
 
 tracer = trace.get_tracer(__name__)
@@ -214,11 +215,18 @@ class VerificationRunResult:
     round-tripped between activities but stripped before the terminal DB write
     (see :meth:`without_evidence`) so file contents never reach Postgres.
     Defaults to ``None`` for the legacy path that gathers no evidence.
+
+    ``grading_requests`` is the engine's recorded verdict on whether the
+    profile declares LLM grading: ``None`` means "not a migrated profile, ask
+    the legacy grading probe"; a list (possibly empty) means the profile
+    handled it and the orchestrator should grade exactly those requests. Like
+    ``evidence``, it is transport-only and stripped before persist.
     """
 
     job: PreparedVerificationJob
     validation_result: ValidationResult
     evidence: list[EvidenceBundle] | None = None
+    grading_requests: list[LLMGradingRequest] | None = None
 
     def to_payload(self) -> dict[str, object]:
         """Return a JSON-serializable activity payload."""
@@ -228,6 +236,11 @@ class VerificationRunResult:
             "evidence": (
                 [bundle.model_dump(mode="json") for bundle in self.evidence]
                 if self.evidence is not None
+                else None
+            ),
+            "grading_requests": (
+                [request.model_dump(mode="json") for request in self.grading_requests]
+                if self.grading_requests is not None
                 else None
             ),
         }
@@ -241,19 +254,30 @@ class VerificationRunResult:
             if isinstance(raw_evidence, list)
             else None
         )
+        raw_requests = payload.get("grading_requests")
+        grading_requests = (
+            [LLMGradingRequest.model_validate(request) for request in raw_requests]
+            if isinstance(raw_requests, list)
+            else None
+        )
         return cls(
             job=PreparedVerificationJob.from_payload(_expect_mapping(payload["job"])),
             validation_result=ValidationResult.model_validate(
                 payload["validation_result"]
             ),
             evidence=evidence,
+            grading_requests=grading_requests,
         )
 
     def without_evidence(self) -> VerificationRunResult:
-        """Return a copy with evidence dropped, for the terminal DB write."""
-        if self.evidence is None:
+        """Return a copy with transport-only fields dropped, for the DB write.
+
+        Strips both ``evidence`` (file contents) and ``grading_requests``
+        (which embed evidence in their prompt) so neither reaches Postgres.
+        """
+        if self.evidence is None and self.grading_requests is None:
             return self
-        return replace(self, evidence=None)
+        return replace(self, evidence=None, grading_requests=None)
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -72,6 +72,12 @@ async def synced_requirement(
     persisting submissions need the referenced requirement to exist,
     and ``get_requirement_by_slug`` only returns active rows so the test
     requirement must be alive in the curriculum.
+
+    Uses a still-legacy repo-backed type (security_scanning) so the executor's
+    generic plumbing is exercised through the transitional ``legacy_validate``
+    step, which these tests mock via ``validate_submission``. Migrated profiles
+    (e.g. journal_api_verifier) run declared steps instead and would bypass
+    that mock.
     """
     from learn_to_cloud_shared.testing.requirement_factories import (
         make_requirement,
@@ -89,7 +95,7 @@ async def synced_requirement(
                     CurriculumRequirement.slug,
                     CurriculumRequirement.submission_type,
                 )
-                .where(CurriculumRequirement.submission_type == "journal_api_verifier")
+                .where(CurriculumRequirement.submission_type == "security_scanning")
                 .limit(1)
             )
         ).one()
@@ -194,8 +200,8 @@ async def test_split_verification_primitives_prepare_run_and_persist(
     assert run_result.to_payload()["job"] == preparation.job.to_payload()
     assert run_result.job.target == GitHubTarget(
         owner="executoruser",
-        repo="journal-repo",
-        forked_from="owner/journal-repo",
+        repo="sec-repo",
+        forked_from="owner/sec-repo",
     )
     assert "repository" not in run_result.to_payload()
 
@@ -241,7 +247,7 @@ async def test_execute_verification_job_marks_success_and_links_submission(
     assert payload["code"] == VERIFICATION_SUCCEEDED_CODE
     assert payload["requirement_slug"] == synced_requirement.slug
     assert payload["requirement_name"] == "Verification Executor Test"
-    assert payload["submission_type"] == SubmissionType.JOURNAL_API_VERIFIER.value
+    assert payload["submission_type"] == SubmissionType.SECURITY_SCANNING.value
     assert payload["message"] == "Verification succeeded."
 
     assert await _get_job_link(session_maker, job_id) == result.submission_id

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_run_result_evidence.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_run_result_evidence.py
@@ -68,3 +68,54 @@ class TestVerificationRunResultEvidence:
     def test_without_evidence_is_noop_when_already_none(self) -> None:
         result = _run_result(None)
         assert result.without_evidence() is result
+
+
+def _grading_request():
+    from learn_to_cloud_shared.verification.grading_requests import LLMGradingRequest
+    from learn_to_cloud_shared.verification.tasks.phase3 import (
+        JOURNAL_API_FINAL_RUBRIC_TASK,
+    )
+
+    return LLMGradingRequest(
+        task=JOURNAL_API_FINAL_RUBRIC_TASK,
+        message="grade this",
+        thread_id="job-task",
+    )
+
+
+@pytest.mark.unit
+class TestVerificationRunResultGradingRequests:
+    def test_defaults_to_none(self) -> None:
+        assert _run_result(None).grading_requests is None
+
+    def test_none_grading_requests_round_trips(self) -> None:
+        restored = VerificationRunResult.from_payload(_run_result(None).to_payload())
+        assert restored.grading_requests is None
+
+    def test_grading_requests_round_trip(self) -> None:
+        request = _grading_request()
+        result = VerificationRunResult(
+            job=_run_result(None).job,
+            validation_result=ValidationResult(is_valid=True, message="ok"),
+            grading_requests=[request],
+        )
+        restored = VerificationRunResult.from_payload(result.to_payload())
+        assert restored.grading_requests == [request]
+
+    def test_empty_grading_requests_round_trip(self) -> None:
+        result = VerificationRunResult(
+            job=_run_result(None).job,
+            validation_result=ValidationResult(is_valid=False, message="gate failed"),
+            grading_requests=[],
+        )
+        restored = VerificationRunResult.from_payload(result.to_payload())
+        assert restored.grading_requests == []
+
+    def test_without_evidence_strips_grading_requests(self) -> None:
+        result = VerificationRunResult(
+            job=_run_result(None).job,
+            validation_result=ValidationResult(is_valid=True, message="ok"),
+            grading_requests=[_grading_request()],
+        )
+        stripped = result.without_evidence()
+        assert stripped.grading_requests is None

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -208,3 +208,82 @@ def test_register_check_rejects_duplicates():
 def test_check_for_unknown_raises():
     with pytest.raises(KeyError):
         check_for("does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 journal API profile: CI gate + rubric review + grading requests.
+# ---------------------------------------------------------------------------
+
+
+def _journal_job() -> PreparedVerificationJob:
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        journal_api_verifier_requirement,
+    )
+
+    return PreparedVerificationJob(
+        id=uuid4(),
+        user_id=1,
+        github_username="learner",
+        requirement=journal_api_verifier_requirement(
+            slug="journal-api-implementation",
+            name="Journal API Implementation",
+            required_repo="owner/journal-starter",
+        ),
+        submitted_value="https://github.com/learner/journal-starter",
+    )
+
+
+@pytest.mark.asyncio
+async def test_journal_profile_records_grading_requests_when_ci_passes(monkeypatch):
+    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+    from learn_to_cloud_shared.verification.tasks.phase3 import (
+        JOURNAL_API_FINAL_RUBRIC_TASK,
+        JOURNAL_API_IMPORTANT_PATHS,
+    )
+
+    async def fake_ci(owner, repo, runs=None):
+        return ValidationResult(is_valid=True, message="CI is green")
+
+    monkeypatch.setattr(engine_module, "verify_ci_status", fake_ci)
+    repo_files = InMemoryRepoFiles(
+        {path: f"content of {path}" for path in JOURNAL_API_IMPORTANT_PATHS}
+    )
+
+    result = await run_profile(_journal_job(), repo_files=repo_files)
+
+    assert result.validation_result.is_valid is True
+    assert result.evidence is not None and len(result.evidence) == 1
+    assert result.grading_requests is not None
+    assert len(result.grading_requests) == 1
+    request = result.grading_requests[0]
+    assert request.task.id == JOURNAL_API_FINAL_RUBRIC_TASK.id
+    assert "journal-api-implementation" in request.message
+
+
+@pytest.mark.asyncio
+async def test_journal_profile_skips_grading_when_ci_fails(monkeypatch):
+    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+
+    async def fake_ci(owner, repo, runs=None):
+        return ValidationResult(is_valid=False, message="CI is red")
+
+    monkeypatch.setattr(engine_module, "verify_ci_status", fake_ci)
+
+    result = await run_profile(_journal_job(), repo_files=InMemoryRepoFiles({}))
+
+    assert result.validation_result.is_valid is False
+    assert result.validation_result.message == "CI is red"
+    assert result.grading_requests == []
+    assert result.evidence is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_type_leaves_grading_requests_none(monkeypatch):
+    async def fake_validate(**kwargs):
+        return ValidationResult(is_valid=True, message="legacy ran")
+
+    monkeypatch.setattr(engine_module, "validate_submission", fake_validate)
+
+    result = await run_profile(_job(career_reflection_requirement()))
+
+    assert result.grading_requests is None

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -142,14 +142,6 @@ def test_apply_phase3_llm_decision_appends_feedback_when_passed():
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_collect_phase3_llm_requests_skips_when_ci_failed():
-    requests = await collect_llm_grading_requests(_phase3_run_result(is_valid=False))
-
-    assert requests == []
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit
 async def test_collect_llm_requests_skips_when_target_missing():
     run_result = _run_result()
     without_username = VerificationRunResult(


### PR DESCRIPTION
Part of the #630 declarative verification engine stack. **Base = #641 (PR2). Draft, do not merge.**

## What
Phase 3 (journal API implementation) becomes a real declarative `VerificationProfile` run by the Durable engine: a **CI gate** (`github_ci_passing`) followed by an **LLM rubric review** (`llm_rubric_review`), replacing the legacy dispatcher adapter for this type.

## How
- **New `verification/grading_requests.py`**: `LLMGradingRequest`, `LLMGradingDecisionPayload`, and shared `build_repo_rubric_message` / `build_text_rubric_message`. Imports only schemas + tasks, breaking the `executor <-> llm_grading` cycle so the executor can carry grading requests.
- **`VerificationRunResult.grading_requests` carrier**: round-tripped and stripped before the DB write (like `evidence`). `None` = legacy type, orchestrator asks the probe; a list (possibly empty) = profile handled it, grade exactly these. Empty = migrated profile whose gate failed.
- **`engine.py`**: adds the two checks, a `_PROFILE_REGISTRY` + `register_profile`, and registers the Phase 3 profile. `run_profile` resolves a migrated profile first, gathers exact-path evidence (`JOURNAL_API_IMPORTANT_PATHS`), and records grading requests after aggregation.
- **Orchestrator**: uses recorded grading requests when present; only falls back to `collect_llm_grading_requests` for still-legacy types.
- **`llm_grading.py`**: drops its Phase 3 probe branch (now engine-driven); prompt builders delegate to the shared module.

## Tests
Engine CI-gate pass/fail + grading-request assembly, run-result `grading_requests` round-trip/strip, orchestrator recorded-request path (skips probe), empty-request path (skips grading). Executor plumbing tests retargeted to a still-legacy type (`security_scanning`) since journal API no longer routes through `legacy_validate`. Removed the obsolete phase-3 probe test.

`uv run poe check` green.