### PR TITLE
feat(verification): migrate Phase 4 deployment architecture to declarative profile (#630 PR4)

### DIFF
--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -32,6 +32,10 @@ from learn_to_cloud_shared.github_target import GitHubTarget
 from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.schemas import FrozenModel, TaskResult, ValidationResult
 from learn_to_cloud_shared.verification.ci_status import verify_ci_status
+from learn_to_cloud_shared.verification.deployment_architecture import (
+    collect_deployment_architecture_evidence,
+    validate_deployment_architecture,
+)
 from learn_to_cloud_shared.verification.dispatcher import (
     ValidatorDescriptor,
     descriptor_for,
@@ -51,6 +55,9 @@ from learn_to_cloud_shared.verification.tasks.base import (
 from learn_to_cloud_shared.verification.tasks.phase3 import (
     JOURNAL_API_FINAL_RUBRIC_TASK,
     JOURNAL_API_IMPORTANT_PATHS,
+)
+from learn_to_cloud_shared.verification.tasks.phase4 import (
+    DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK,
 )
 from learn_to_cloud_shared.verification_job_executor import (
     PreparedVerificationJob,
@@ -93,8 +100,33 @@ class LLMRubricReviewParams(FrozenModel):
     evidence_paths: tuple[str, ...]
 
 
+class DeploymentArchitectureGateParams(FrozenModel):
+    """Params for the Phase 4 ``deployment_architecture_gate`` (no config).
+
+    The gate reads the description length and deploy-script path from the
+    requirement's ``type_config`` at runtime, so it carries no data.
+    """
+
+    check: Literal["deployment_architecture_gate"] = "deployment_architecture_gate"
+
+
+class DeploymentArchitectureReviewParams(FrozenModel):
+    """Params for the Phase 4 ``deployment_architecture_review`` rubric step.
+
+    Bundles the learner's forked ``deploy.sh`` with their architecture
+    description for the LLM rubric grader.
+    """
+
+    check: Literal["deployment_architecture_review"] = "deployment_architecture_review"
+    task: VerificationTask
+
+
 StepParams = Annotated[
-    LegacyValidateParams | CIStatusParams | LLMRubricReviewParams,
+    LegacyValidateParams
+    | CIStatusParams
+    | LLMRubricReviewParams
+    | DeploymentArchitectureGateParams
+    | DeploymentArchitectureReviewParams,
     Field(discriminator="check"),
 ]
 
@@ -273,6 +305,58 @@ async def _check_llm_rubric_review(
     )
 
 
+@register_check("deployment_architecture_gate")
+async def _check_deployment_architecture_gate(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Phase 4 gate: description meets min length and ``deploy.sh`` exists."""
+    result = await validate_deployment_architecture(
+        context.job.requirement,
+        context.submitted_value,
+        context.repository,
+        context.repo_files,
+    )
+    return StepResult(
+        passed=result.is_valid,
+        stop_on_fail=True,
+        validation_result=result,
+    )
+
+
+@register_check("deployment_architecture_review")
+async def _check_deployment_architecture_review(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Bundle the fork's ``deploy.sh`` and the architecture description.
+
+    Like ``llm_rubric_review`` but its evidence is a repo file plus the
+    learner's free-text description, not a set of exact repository paths.
+    """
+    assert isinstance(params, DeploymentArchitectureReviewParams)
+    target = context.repository
+    if target is None or not target.repo:
+        return StepResult(passed=True, stop_on_fail=False)
+    deploy_script_path = getattr(
+        context.job.requirement.type_config, "deploy_script_path", "deploy.sh"
+    )
+    bundle = await collect_deployment_architecture_evidence(
+        target.owner,
+        target.repo,
+        context.submitted_value,
+        params.task,
+        deploy_script_path=deploy_script_path,
+        repo_files=context.repo_files or default_repo_files(),
+    )
+    return StepResult(
+        passed=True,
+        stop_on_fail=False,
+        evidence=[bundle],
+        grading_task=params.task,
+    )
+
+
 _LEGACY_STEP = Step(
     check="legacy_validate",
     params=LegacyValidateParams(),
@@ -337,6 +421,34 @@ _JOURNAL_API_PROFILE = VerificationProfile(
 )
 
 register_profile(SubmissionType.JOURNAL_API_VERIFIER, _JOURNAL_API_PROFILE)
+
+
+_DEPLOYMENT_ARCHITECTURE_RUBRIC = DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK.grader
+assert isinstance(_DEPLOYMENT_ARCHITECTURE_RUBRIC, LLMRubricGraderConfig)
+
+_DEPLOYMENT_ARCHITECTURE_PROFILE = VerificationProfile(
+    adapter=_profile_steps_adapter,
+    requires_username=True,
+    steps=(
+        Step(
+            check="deployment_architecture_gate",
+            params=DeploymentArchitectureGateParams(),
+            task_id="deployment-architecture-gate",
+        ),
+        Step(
+            check="deployment_architecture_review",
+            params=DeploymentArchitectureReviewParams(
+                task=DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK,
+            ),
+            task_id=DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK.id,
+        ),
+    ),
+    rubric=_DEPLOYMENT_ARCHITECTURE_RUBRIC,
+)
+
+register_profile(
+    SubmissionType.DEPLOYMENT_ARCHITECTURE, _DEPLOYMENT_ARCHITECTURE_PROFILE
+)
 
 
 def _resolve_descriptor(job: PreparedVerificationJob) -> ValidatorDescriptor | None:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -16,9 +16,6 @@ from learn_to_cloud_shared.schemas import (
 from learn_to_cloud_shared.verification.career_reflection import (
     collect_career_reflection_evidence,
 )
-from learn_to_cloud_shared.verification.deployment_architecture import (
-    collect_deployment_architecture_evidence,
-)
 from learn_to_cloud_shared.verification.grading_requests import (
     LLMGradingDecisionPayload,
     LLMGradingRequest,
@@ -30,8 +27,6 @@ from learn_to_cloud_shared.verification.security_scanning import (
     collect_security_scanning_evidence,
 )
 from learn_to_cloud_shared.verification.tasks import (
-    PHASE4_LLM_TASKS,
-    PHASE4_REQUIREMENT_SLUG,
     PHASE6_LLM_TASKS,
     PHASE7_LLM_TASKS,
     PHASE7_REQUIREMENT_SLUG,
@@ -70,9 +65,6 @@ async def collect_llm_grading_requests(
         return _collect_phase7_requests(run_result, tasks)
 
     repo_files = repo_files or default_repo_files()
-
-    if run_result.job.requirement.slug == PHASE4_REQUIREMENT_SLUG:
-        return await _collect_phase4_requests(run_result, tasks, repo_files)
 
     if run_result.job.requirement.slug == "security-scanning":
         return await _collect_phase6_requests(run_result, tasks, repo_files)
@@ -205,49 +197,6 @@ async def _collect_phase6_requests(
     return requests
 
 
-async def _collect_phase4_requests(
-    run_result: VerificationRunResult,
-    tasks: list[VerificationTask],
-    repo_files: RepoFiles,
-) -> list[LLMGradingRequest]:
-    if not run_result.validation_result.is_valid:
-        return []
-
-    requirement = run_result.job.requirement
-    target = run_result.job.target
-    if target is None or not target.repo:
-        return []
-
-    description = run_result.job.typed_submitted_value.as_text
-    deploy_script_path = getattr(
-        requirement.type_config, "deploy_script_path", "deploy.sh"
-    )
-    requests: list[LLMGradingRequest] = []
-    for task in tasks:
-        evidence = await collect_deployment_architecture_evidence(
-            target.owner,
-            target.repo,
-            description,
-            task,
-            deploy_script_path=deploy_script_path,
-            repo_files=repo_files,
-        )
-        requests.append(
-            LLMGradingRequest(
-                task=task,
-                message=_build_grading_message(
-                    run_result=run_result,
-                    task=task,
-                    owner=target.owner,
-                    repo=target.repo,
-                    evidence=evidence.model_dump(mode="json"),
-                ),
-                thread_id=f"{run_result.job.id}-{task.id}",
-            )
-        )
-    return requests
-
-
 def _collect_phase7_requests(
     run_result: VerificationRunResult,
     tasks: list[VerificationTask],
@@ -339,6 +288,4 @@ def _llm_tasks_for_requirement(
         return PHASE6_LLM_TASKS
     if requirement.slug == PHASE7_REQUIREMENT_SLUG:
         return PHASE7_LLM_TASKS
-    if requirement.slug == PHASE4_REQUIREMENT_SLUG:
-        return PHASE4_LLM_TASKS
     return []

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -287,3 +287,84 @@ async def test_legacy_type_leaves_grading_requests_none(monkeypatch):
     result = await run_profile(_job(career_reflection_requirement()))
 
     assert result.grading_requests is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 deployment architecture profile: gate + deploy.sh/description rubric.
+# ---------------------------------------------------------------------------
+
+
+def _deployment_job(description: str) -> PreparedVerificationJob:
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        deployment_architecture_requirement,
+    )
+
+    return PreparedVerificationJob(
+        id=uuid4(),
+        user_id=1,
+        github_username="learner",
+        requirement=deployment_architecture_requirement(
+            slug="deployment-architecture",
+            required_repo="owner/journal-starter",
+        ),
+        submitted_value=description,
+    )
+
+
+@pytest.mark.asyncio
+async def test_deployment_profile_bundles_script_and_description():
+    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+    from learn_to_cloud_shared.verification.tasks.phase4 import (
+        DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK,
+    )
+
+    description = (
+        "My two-tier deployment provisions a public API tier and a private "
+        "database tier in an isolated subnet, all created idempotently by "
+        "deploy.sh with restricted inbound rules and TLS termination for the "
+        "API. Traffic flows from the internet to the load balancer, then to "
+        "the API compute, and only the API can reach the private database."
+    )
+    repo_files = InMemoryRepoFiles({"deploy.sh": "#!/bin/bash\naz group create\n"})
+
+    result = await run_profile(_deployment_job(description), repo_files=repo_files)
+
+    assert result.validation_result.is_valid is True
+    assert result.grading_requests is not None
+    assert len(result.grading_requests) == 1
+    request = result.grading_requests[0]
+    assert request.task.id == DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK.id
+    assert "deploy.sh" in request.message
+    assert description in request.message
+
+
+@pytest.mark.asyncio
+async def test_deployment_profile_gate_fails_when_description_too_short():
+    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+
+    repo_files = InMemoryRepoFiles({"deploy.sh": "#!/bin/bash\n"})
+
+    result = await run_profile(_deployment_job("too short"), repo_files=repo_files)
+
+    assert result.validation_result.is_valid is False
+    assert result.grading_requests == []
+    assert result.evidence is None
+
+
+@pytest.mark.asyncio
+async def test_deployment_profile_gate_fails_when_deploy_script_missing():
+    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+
+    description = (
+        "My two-tier deployment provisions a public API tier and a private "
+        "database tier in an isolated subnet, all created idempotently by a "
+        "script with restricted inbound rules and TLS termination for the "
+        "API. Traffic flows from the internet to the load balancer, then to "
+        "the API compute, and only the API can reach the private database."
+    )
+    repo_files = InMemoryRepoFiles({"README.md": "no script here"})
+
+    result = await run_profile(_deployment_job(description), repo_files=repo_files)
+
+    assert result.validation_result.is_valid is False
+    assert result.grading_requests == []

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -17,7 +17,6 @@ from learn_to_cloud_shared.verification.llm_grading import (
 )
 from learn_to_cloud_shared.verification.tasks import (
     PHASE3_LLM_TASKS,
-    PHASE4_LLM_TASKS,
     PHASE6_LLM_TASKS,
     PHASE7_LLM_TASKS,
     LLMGradingDecision,
@@ -211,84 +210,6 @@ def test_llm_grading_content_filtered_result_asks_learner_to_rephrase():
     assert updated.validation_result.verification_completed is False
     assert "content safety filter" in updated.validation_result.message
     assert "rewrite your answers" in updated.validation_result.message
-
-
-def _phase4_run_result(
-    is_valid: bool = True,
-    github_username: str = "learner",
-    description: str = (
-        "My two-tier deployment: a public API tier and a private database tier "
-        "in an isolated subnet, provisioned idempotently by deploy.sh."
-    ),
-) -> VerificationRunResult:
-    from learn_to_cloud_shared.testing.requirement_factories import (
-        deployment_architecture_requirement,
-    )
-
-    requirement = deployment_architecture_requirement(
-        slug="deployment-architecture",
-        required_repo="learntocloud/journal-starter",
-    )
-    return VerificationRunResult(
-        job=PreparedVerificationJob(
-            id=uuid4(),
-            user_id=1,
-            github_username=github_username,
-            requirement=requirement,
-            submitted_value=description,
-        ),
-        validation_result=ValidationResult(
-            is_valid=is_valid,
-            message="Description received and deploy script found.",
-        ),
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit
-async def test_collect_phase4_requests_bundles_script_and_description():
-    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
-
-    description = (
-        "My two-tier deployment provisions a public API and a private database."
-    )
-    run_result = _phase4_run_result(description=description)
-    repo_files = InMemoryRepoFiles({"deploy.sh": "#!/bin/bash\naz group create\n"})
-
-    requests = await collect_llm_grading_requests(run_result, repo_files=repo_files)
-
-    assert len(requests) == len(PHASE4_LLM_TASKS)
-    assert "deploy.sh" in requests[0].message
-    assert description in requests[0].message
-    assert requests[0].task.evidence.source == "repo_files"
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit
-async def test_collect_phase4_requests_skips_when_gate_failed():
-    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
-
-    repo_files = InMemoryRepoFiles({"deploy.sh": "#!/bin/bash\n"})
-
-    requests = await collect_llm_grading_requests(
-        _phase4_run_result(is_valid=False), repo_files=repo_files
-    )
-
-    assert requests == []
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit
-async def test_collect_phase4_requests_skips_when_username_missing():
-    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
-
-    repo_files = InMemoryRepoFiles({"deploy.sh": "#!/bin/bash\n"})
-
-    requests = await collect_llm_grading_requests(
-        _phase4_run_result(github_username=""), repo_files=repo_files
-    )
-
-    assert requests == []
 
 
 def _phase7_run_result(


### PR DESCRIPTION
Part of the #630 declarative verification engine stack. Base = PR3 (#642).

## What
Migrates the Phase 4 deployment-architecture submission type to a declarative profile:

- **Gate step** (`deployment_architecture_gate`): deterministic check via `validate_deployment_architecture` (description >= min_answer_length and `deploy.sh` present in the repo tree). `stop_on_fail=True`, authoritative validation_result.
- **Review step** (`deployment_architecture_review`): bundles `deploy.sh` + the learner's free-text description into a single evidence bundle via `collect_deployment_architecture_evidence`, sets the rubric grading task. Never a gate.

Removes the Phase 4 branch (`_collect_phase4_requests`) from the transitional grading probe now that the profile records its own grading requests.

## Notes
- Phase 4 has no CI gate; profile mirrors Phase 3's two-step (gate + rubric) shape.
- `deploy_script_path` is read at runtime from `requirement.type_config`, keeping params declarative.
- `poe check` green. Engine tests cover: happy path bundles script+description, gate fails on short description, gate fails on missing deploy.sh.

Do not merge; @madebygps reviews manually.