### PR TITLE
feat(verification): migrate deterministic types to declarative profiles (#630 PR5)

### DIFF
--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -32,10 +32,12 @@ from learn_to_cloud_shared.github_target import GitHubTarget
 from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.schemas import FrozenModel, TaskResult, ValidationResult
 from learn_to_cloud_shared.verification.ci_status import verify_ci_status
+from learn_to_cloud_shared.verification.deployed_api import validate_deployed_api
 from learn_to_cloud_shared.verification.deployment_architecture import (
     collect_deployment_architecture_evidence,
     validate_deployment_architecture,
 )
+from learn_to_cloud_shared.verification.devops_analysis import run_devops_workflow
 from learn_to_cloud_shared.verification.dispatcher import (
     ValidatorDescriptor,
     descriptor_for,
@@ -121,12 +123,34 @@ class DeploymentArchitectureReviewParams(FrozenModel):
     task: VerificationTask
 
 
+class DeployedApiCheckParams(FrozenModel):
+    """Params for the deterministic ``deployed_api_check`` (no config).
+
+    The check probes the submitted base URL's health surface; the target URL
+    is the submitted value, so it carries no data.
+    """
+
+    check: Literal["deployed_api_check"] = "deployed_api_check"
+
+
+class DevopsAnalysisCheckParams(FrozenModel):
+    """Params for the deterministic ``devops_analysis_check`` (no config).
+
+    The check runs the Phase 5 DevOps workflow against the fork resolved from
+    the requirement plus the learner's username, so it carries no data.
+    """
+
+    check: Literal["devops_analysis_check"] = "devops_analysis_check"
+
+
 StepParams = Annotated[
     LegacyValidateParams
     | CIStatusParams
     | LLMRubricReviewParams
     | DeploymentArchitectureGateParams
-    | DeploymentArchitectureReviewParams,
+    | DeploymentArchitectureReviewParams
+    | DeployedApiCheckParams
+    | DevopsAnalysisCheckParams,
     Field(discriminator="check"),
 ]
 
@@ -305,6 +329,46 @@ async def _check_llm_rubric_review(
     )
 
 
+@register_check("deployed_api_check")
+async def _check_deployed_api(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Deterministic Phase 4 gate: probe the submitted API base URL."""
+    result = await validate_deployed_api(context.submitted_value)
+    return StepResult(
+        passed=result.is_valid,
+        stop_on_fail=True,
+        validation_result=result,
+    )
+
+
+@register_check("devops_analysis_check")
+async def _check_devops_analysis(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Deterministic Phase 5 gate: run the DevOps workflow on the fork."""
+    target = context.repository
+    if target is None or not target.repo:
+        return StepResult(
+            passed=False,
+            stop_on_fail=True,
+            validation_result=ValidationResult(
+                is_valid=False,
+                message="Requirement configuration error: missing required_repo",
+                username_match=True,
+                repo_exists=False,
+            ),
+        )
+    result = await run_devops_workflow(target.owner, target.repo, context.repo_files)
+    return StepResult(
+        passed=result.is_valid,
+        stop_on_fail=True,
+        validation_result=result,
+    )
+
+
 @register_check("deployment_architecture_gate")
 async def _check_deployment_architecture_gate(
     context: StepContext,
@@ -449,6 +513,36 @@ _DEPLOYMENT_ARCHITECTURE_PROFILE = VerificationProfile(
 register_profile(
     SubmissionType.DEPLOYMENT_ARCHITECTURE, _DEPLOYMENT_ARCHITECTURE_PROFILE
 )
+
+
+_DEPLOYED_API_PROFILE = VerificationProfile(
+    adapter=_profile_steps_adapter,
+    requires_username=False,
+    steps=(
+        Step(
+            check="deployed_api_check",
+            params=DeployedApiCheckParams(),
+            task_id="deployed-api-check",
+        ),
+    ),
+)
+
+register_profile(SubmissionType.DEPLOYED_API, _DEPLOYED_API_PROFILE)
+
+
+_DEVOPS_ANALYSIS_PROFILE = VerificationProfile(
+    adapter=_profile_steps_adapter,
+    requires_username=True,
+    steps=(
+        Step(
+            check="devops_analysis_check",
+            params=DevopsAnalysisCheckParams(),
+            task_id="devops-analysis-check",
+        ),
+    ),
+)
+
+register_profile(SubmissionType.DEVOPS_ANALYSIS, _DEVOPS_ANALYSIS_PROFILE)
 
 
 def _resolve_descriptor(job: PreparedVerificationJob) -> ValidatorDescriptor | None:

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -368,3 +368,98 @@ async def test_deployment_profile_gate_fails_when_deploy_script_missing():
 
     assert result.validation_result.is_valid is False
     assert result.grading_requests == []
+
+
+# ---------------------------------------------------------------------------
+# Phase 4/5 deterministic profiles: deployed API probe and DevOps workflow.
+# ---------------------------------------------------------------------------
+
+
+def _deployed_api_job() -> PreparedVerificationJob:
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        deployed_api_requirement,
+    )
+
+    return PreparedVerificationJob(
+        id=uuid4(),
+        user_id=1,
+        github_username=None,
+        requirement=deployed_api_requirement(slug="deployed-api"),
+        submitted_value="https://api.example.com",
+    )
+
+
+def _devops_job() -> PreparedVerificationJob:
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        devops_analysis_requirement,
+    )
+
+    return PreparedVerificationJob(
+        id=uuid4(),
+        user_id=1,
+        github_username="learner",
+        requirement=devops_analysis_requirement(
+            slug="devops-analysis",
+            required_repo="owner/devops-repo",
+        ),
+        submitted_value="https://github.com/learner/devops-repo",
+    )
+
+
+@pytest.mark.asyncio
+async def test_deployed_api_profile_passes_through_deterministic_result(monkeypatch):
+    async def fake_validate(base_url):
+        assert base_url == "https://api.example.com"
+        return ValidationResult(is_valid=True, message="API is healthy")
+
+    monkeypatch.setattr(engine_module, "validate_deployed_api", fake_validate)
+
+    result = await run_profile(_deployed_api_job())
+
+    assert result.validation_result.is_valid is True
+    assert result.validation_result.message == "API is healthy"
+    assert result.grading_requests == []
+    assert result.evidence is None
+
+
+@pytest.mark.asyncio
+async def test_deployed_api_profile_fails_when_probe_fails(monkeypatch):
+    async def fake_validate(base_url):
+        return ValidationResult(is_valid=False, message="API unreachable")
+
+    monkeypatch.setattr(engine_module, "validate_deployed_api", fake_validate)
+
+    result = await run_profile(_deployed_api_job())
+
+    assert result.validation_result.is_valid is False
+    assert result.grading_requests == []
+
+
+@pytest.mark.asyncio
+async def test_devops_profile_passes_through_deterministic_result(monkeypatch):
+    async def fake_workflow(owner, repo, repo_files=None):
+        assert owner == "learner"
+        assert repo == "devops-repo"
+        return ValidationResult(is_valid=True, message="DevOps checks passed")
+
+    monkeypatch.setattr(engine_module, "run_devops_workflow", fake_workflow)
+
+    result = await run_profile(_devops_job())
+
+    assert result.validation_result.is_valid is True
+    assert result.validation_result.message == "DevOps checks passed"
+    assert result.grading_requests == []
+    assert result.evidence is None
+
+
+@pytest.mark.asyncio
+async def test_devops_profile_fails_when_workflow_fails(monkeypatch):
+    async def fake_workflow(owner, repo, repo_files=None):
+        return ValidationResult(is_valid=False, message="Missing workflow file")
+
+    monkeypatch.setattr(engine_module, "run_devops_workflow", fake_workflow)
+
+    result = await run_profile(_devops_job())
+
+    assert result.validation_result.is_valid is False
+    assert result.grading_requests == []


### PR DESCRIPTION
Part of the #630 declarative verification engine stack. Base = PR4 (#643).

## What
Migrates the two remaining deterministic (non-graded) submission types to declarative profiles:

- **deployed_api**: single `deployed_api_check` step that probes the submitted API base URL via `validate_deployed_api`.
- **devops_analysis**: single `devops_analysis_check` step that runs the Phase 5 DevOps workflow (`run_devops_workflow`) against the fork resolved from the requirement + learner username.

Both profiles are gate-only; they set no `grading_task`, so `run_profile` records an empty `grading_requests` list (migrated, no grading) and the orchestrator skips grading.

## Notes
- No `llm_grading.py` changes: neither type was ever in the grading probe.
- `poe check` green. Engine tests cover pass-through of the deterministic result and failure short-circuit for both types.

Do not merge; @madebygps reviews manually.