### PR TITLE
feat(verification): migrate Phase 6 + Phase 7 to declarative profiles (#630 PR6)

### DIFF
--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -31,9 +31,6 @@ from learn_to_cloud_shared.verification.llm_grading import (
 from learn_to_cloud_shared.verification.llm_grading import (
     apply_llm_grading_decisions as apply_llm_decisions,
 )
-from learn_to_cloud_shared.verification.llm_grading import (
-    collect_llm_grading_requests as collect_llm_requests,
-)
 from learn_to_cloud_shared.verification.engine import run_profile
 from learn_to_cloud_shared.verification_job_executor import (
     PreparedVerificationJob,
@@ -381,24 +378,16 @@ def _llm_grading_step(
 ):
     """Apply LLM rubric grading when the run produced grading requests.
 
-    Migrated profiles record their grading requests on the verify result
+    Every profile records its grading requests on the verify result
     (``grading_requests`` is a list, possibly empty); the orchestrator grades
-    exactly those. Legacy types leave it absent, so we fall back to the
-    transitional grading probe. When no requests result, the run result passes
-    through unchanged.
+    exactly those. Deterministic types record an empty list (or omit the key),
+    so grading is skipped and the run result passes through unchanged.
     """
-    recorded_requests: Sequence[object] | None = None
+    llm_requests: Sequence[object] = []
     if isinstance(run_result, Mapping):
         value = _activity_payload(run_result).get("grading_requests")
         if isinstance(value, list):
-            recorded_requests = value
-    if recorded_requests is None:
-        llm_requests = yield context.call_activity(
-            "collect_llm_grading_requests",
-            run_result,
-        )
-    else:
-        llm_requests = recorded_requests
+            llm_requests = value
     if not llm_requests:
         return run_result
 
@@ -557,19 +546,6 @@ async def execute_requirement_verification(
         result_payload = run_result.to_payload()
         _set_result_span_attributes(result_payload)
         return result_payload
-
-
-@app.activity_trigger(input_name="run_payload")
-async def collect_llm_grading_requests(
-    run_payload,
-    context: func.Context,
-) -> list[dict[str, object]]:
-    """Prepare durable LLM grading requests for the completed verifier output."""
-    with _attached_invocation_context(context):
-        run_result = VerificationRunResult.from_payload(_activity_payload(run_payload))
-        _set_prepared_job_span_attributes(run_result.job)
-        requests = await collect_llm_requests(run_result)
-        return [request.model_dump(mode="json") for request in requests]
 
 
 @app.activity_trigger(input_name="payload")

--- a/apps/verification-functions/tests/test_orchestrations.py
+++ b/apps/verification-functions/tests/test_orchestrations.py
@@ -3,10 +3,9 @@
 The Durable orchestration generator is driven manually here: a fake
 context records each yielded activity call, and the test feeds back the
 activity result. This asserts the exact sequence of activity calls the
-single workflow makes. LLM grading is data-driven -- the workflow calls
-``collect_llm_grading_requests`` for every submission type and only grades
-when that activity returns requests, so deterministic phases pass straight
-through with an empty request list.
+single workflow makes. LLM grading is data-driven -- the verify activity
+records its grading requests on the result, and the workflow grades exactly
+those, so deterministic phases (empty or no requests) pass straight through.
 """
 
 from __future__ import annotations
@@ -121,7 +120,6 @@ def _deterministic_payload() -> dict[str, object]:
 def _make_responder(
     prepared_payload: dict[str, object],
     *,
-    llm_requests: list[object] | None = None,
     recorded_requests: list[object] | None = None,
     config_valid: bool = True,
     fail_activity: str | None = None,
@@ -139,8 +137,6 @@ def _make_responder(
             if recorded_requests is not None:
                 return {"status": "verified", "grading_requests": recorded_requests}
             return {"status": "verified"}
-        if name == "collect_llm_grading_requests":
-            return list(llm_requests or [])
         if name == "ensure_grading_config":
             return {
                 "valid": config_valid,
@@ -170,7 +166,7 @@ class TestCanonicalWorkflow:
         payload = _graded_payload()
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
         responder = _make_responder(
-            payload, llm_requests=[{"task": "a"}, {"task": "b"}]
+            payload, recorded_requests=[{"task": "a"}, {"task": "b"}]
         )
         calls, result = _drive(
             function_app._run_verification_orchestration(ctx), responder
@@ -178,7 +174,6 @@ class TestCanonicalWorkflow:
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
             ("activity_with_retry", "execute_requirement_verification"),
-            ("activity", "collect_llm_grading_requests"),
             ("activity", "ensure_grading_config"),
             ("activity_with_retry", "run_llm_grading"),
             ("activity_with_retry", "run_llm_grading"),
@@ -191,9 +186,9 @@ class TestCanonicalWorkflow:
             "submission_id": 7,
         }
 
-    def test_uses_recorded_grading_requests_and_skips_probe(self) -> None:
-        # A migrated profile records grading requests on the verify result;
-        # the orchestrator grades those directly and skips the legacy probe.
+    def test_uses_recorded_grading_requests(self) -> None:
+        # A profile records grading requests on the verify result; the
+        # orchestrator grades exactly those.
         payload = _graded_payload()
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
         responder = _make_responder(payload, recorded_requests=[{"task": "a"}])
@@ -214,9 +209,9 @@ class TestCanonicalWorkflow:
             "submission_id": 7,
         }
 
-    def test_recorded_empty_requests_skip_grading_and_probe(self) -> None:
-        # A migrated profile whose gate failed records an empty list; the
-        # orchestrator skips grading entirely (no probe, no LLM calls).
+    def test_recorded_empty_requests_skip_grading(self) -> None:
+        # A profile whose gate failed records an empty list; the orchestrator
+        # skips grading entirely (no LLM calls).
         payload = _graded_payload()
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
         responder = _make_responder(payload, recorded_requests=[])
@@ -227,15 +222,15 @@ class TestCanonicalWorkflow:
             ("activity_with_retry", "persist_verification_result"),
         ]
 
-    def test_skips_grading_when_no_requests(self) -> None:
+    def test_skips_grading_when_no_requests_recorded(self) -> None:
+        # A verify result without a grading_requests key skips grading.
         payload = _graded_payload()
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
-        responder = _make_responder(payload, llm_requests=[])
+        responder = _make_responder(payload)
         calls, _ = _drive(function_app._run_verification_orchestration(ctx), responder)
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
             ("activity_with_retry", "execute_requirement_verification"),
-            ("activity", "collect_llm_grading_requests"),
             ("activity_with_retry", "persist_verification_result"),
         ]
 
@@ -243,13 +238,12 @@ class TestCanonicalWorkflow:
         payload = _graded_payload()
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
         responder = _make_responder(
-            payload, llm_requests=[{"task": "a"}], config_valid=False
+            payload, recorded_requests=[{"task": "a"}], config_valid=False
         )
         calls, _ = _drive(function_app._run_verification_orchestration(ctx), responder)
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
             ("activity_with_retry", "execute_requirement_verification"),
-            ("activity", "collect_llm_grading_requests"),
             ("activity", "ensure_grading_config"),
             ("activity", "llm_grading_failed"),
             ("activity_with_retry", "persist_verification_result"),
@@ -260,14 +254,13 @@ class TestCanonicalWorkflow:
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
         responder = _make_responder(
             payload,
-            llm_requests=[{"task": "a"}],
+            recorded_requests=[{"task": "a"}],
             fail_activity="run_llm_grading",
         )
         calls, _ = _drive(function_app._run_verification_orchestration(ctx), responder)
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
             ("activity_with_retry", "execute_requirement_verification"),
-            ("activity", "collect_llm_grading_requests"),
             ("activity", "ensure_grading_config"),
             ("activity_with_retry", "run_llm_grading"),
             ("activity", "llm_grading_failed"),
@@ -290,20 +283,19 @@ class TestCanonicalWorkflow:
 
 class TestDeterministicSubmissionTypes:
     """Deterministic types (e.g. phase 4 deployed_api) run the same single
-    workflow: they call ``collect_llm_grading_requests``, get an empty list,
-    and skip grading -- no separate deterministic orchestrator."""
+    workflow: their profile records an empty grading-request list, so grading
+    is skipped -- no separate deterministic orchestrator."""
 
     def test_passes_through_grading_with_no_requests(self) -> None:
         payload = _deterministic_payload()
         ctx = _FakeOrchestrationContext({"id": "job-1", **payload})
-        responder = _make_responder(payload, llm_requests=[])
+        responder = _make_responder(payload, recorded_requests=[])
         calls, result = _drive(
             function_app._run_verification_orchestration(ctx), responder
         )
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_job"),
             ("activity_with_retry", "execute_requirement_verification"),
-            ("activity", "collect_llm_grading_requests"),
             ("activity_with_retry", "persist_verification_result"),
         ]
         assert result == {

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -31,6 +31,10 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from learn_to_cloud_shared.github_target import GitHubTarget
 from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.schemas import FrozenModel, TaskResult, ValidationResult
+from learn_to_cloud_shared.verification.career_reflection import (
+    collect_career_reflection_evidence,
+    validate_career_reflection,
+)
 from learn_to_cloud_shared.verification.ci_status import verify_ci_status
 from learn_to_cloud_shared.verification.deployed_api import validate_deployed_api
 from learn_to_cloud_shared.verification.deployment_architecture import (
@@ -47,8 +51,13 @@ from learn_to_cloud_shared.verification.evidence import collect_repo_file_eviden
 from learn_to_cloud_shared.verification.grading_requests import (
     LLMGradingRequest,
     build_repo_rubric_message,
+    build_text_rubric_message,
 )
 from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
+from learn_to_cloud_shared.verification.security_scanning import (
+    collect_security_scanning_evidence,
+    validate_security_scanning,
+)
 from learn_to_cloud_shared.verification.tasks.base import (
     EvidenceBundle,
     LLMRubricGraderConfig,
@@ -60,6 +69,12 @@ from learn_to_cloud_shared.verification.tasks.phase3 import (
 )
 from learn_to_cloud_shared.verification.tasks.phase4 import (
     DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK,
+)
+from learn_to_cloud_shared.verification.tasks.phase6 import (
+    SECURITY_SCANNING_RUBRIC_TASK,
+)
+from learn_to_cloud_shared.verification.tasks.phase7 import (
+    CAREER_REFLECTION_RUBRIC_TASK,
 )
 from learn_to_cloud_shared.verification_job_executor import (
     PreparedVerificationJob,
@@ -143,6 +158,46 @@ class DevopsAnalysisCheckParams(FrozenModel):
     check: Literal["devops_analysis_check"] = "devops_analysis_check"
 
 
+class SecurityScanningGateParams(FrozenModel):
+    """Params for the Phase 6 ``security_scanning_gate`` (no config).
+
+    The gate runs the deterministic Dependabot/CodeQL checks against the fork.
+    """
+
+    check: Literal["security_scanning_gate"] = "security_scanning_gate"
+
+
+class SecurityScanningReviewParams(FrozenModel):
+    """Params for the Phase 6 ``security_scanning_review`` rubric step.
+
+    Bundles the fork's security-scanning config files for the LLM rubric
+    grader; carries the rubric ``task``.
+    """
+
+    check: Literal["security_scanning_review"] = "security_scanning_review"
+    task: VerificationTask
+
+
+class CareerReflectionGateParams(FrozenModel):
+    """Params for the Phase 7 ``career_reflection_gate`` (no config).
+
+    The gate only rejects empty submissions; the rubric does the real grading.
+    """
+
+    check: Literal["career_reflection_gate"] = "career_reflection_gate"
+
+
+class CareerReflectionReviewParams(FrozenModel):
+    """Params for the Phase 7 ``career_reflection_review`` text rubric step.
+
+    Bundles the learner's free-text reflection as evidence; carries the rubric
+    ``task``. Text-only, so the grading request uses the no-repo prompt.
+    """
+
+    check: Literal["career_reflection_review"] = "career_reflection_review"
+    task: VerificationTask
+
+
 StepParams = Annotated[
     LegacyValidateParams
     | CIStatusParams
@@ -150,7 +205,11 @@ StepParams = Annotated[
     | DeploymentArchitectureGateParams
     | DeploymentArchitectureReviewParams
     | DeployedApiCheckParams
-    | DevopsAnalysisCheckParams,
+    | DevopsAnalysisCheckParams
+    | SecurityScanningGateParams
+    | SecurityScanningReviewParams
+    | CareerReflectionGateParams
+    | CareerReflectionReviewParams,
     Field(discriminator="check"),
 ]
 
@@ -369,6 +428,91 @@ async def _check_devops_analysis(
     )
 
 
+@register_check("security_scanning_gate")
+async def _check_security_scanning_gate(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Deterministic Phase 6 gate: Dependabot or CodeQL configured on the fork."""
+    target = context.repository
+    if target is None or not target.repo:
+        return StepResult(
+            passed=False,
+            stop_on_fail=True,
+            validation_result=ValidationResult(
+                is_valid=False,
+                message="Requirement configuration error: missing required_repo",
+                username_match=True,
+                repo_exists=False,
+            ),
+        )
+    result = await validate_security_scanning(
+        target.owner, target.repo, context.repo_files
+    )
+    return StepResult(
+        passed=result.is_valid,
+        stop_on_fail=True,
+        validation_result=result,
+    )
+
+
+@register_check("security_scanning_review")
+async def _check_security_scanning_review(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Bundle the fork's security-scanning config files for rubric grading."""
+    assert isinstance(params, SecurityScanningReviewParams)
+    target = context.repository
+    if target is None or not target.repo:
+        return StepResult(passed=True, stop_on_fail=False)
+    repo_files = context.repo_files or default_repo_files()
+    file_paths = await repo_files.tree(target.owner, target.repo)
+    bundle = await collect_security_scanning_evidence(
+        target.owner,
+        target.repo,
+        file_paths,
+        params.task,
+        repo_files=repo_files,
+    )
+    return StepResult(
+        passed=True,
+        stop_on_fail=False,
+        evidence=[bundle],
+        grading_task=params.task,
+    )
+
+
+@register_check("career_reflection_gate")
+async def _check_career_reflection_gate(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Deterministic Phase 7 gate: reject empty reflection submissions."""
+    result = validate_career_reflection(context.submitted_value)
+    return StepResult(
+        passed=result.is_valid,
+        stop_on_fail=True,
+        validation_result=result,
+    )
+
+
+@register_check("career_reflection_review")
+async def _check_career_reflection_review(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Bundle the learner's free-text reflection for text rubric grading."""
+    assert isinstance(params, CareerReflectionReviewParams)
+    bundle = collect_career_reflection_evidence(context.submitted_value, params.task)
+    return StepResult(
+        passed=True,
+        stop_on_fail=False,
+        evidence=[bundle],
+        grading_task=params.task,
+    )
+
+
 @register_check("deployment_architecture_gate")
 async def _check_deployment_architecture_gate(
     context: StepContext,
@@ -545,6 +689,54 @@ _DEVOPS_ANALYSIS_PROFILE = VerificationProfile(
 register_profile(SubmissionType.DEVOPS_ANALYSIS, _DEVOPS_ANALYSIS_PROFILE)
 
 
+_SECURITY_SCANNING_RUBRIC = SECURITY_SCANNING_RUBRIC_TASK.grader
+assert isinstance(_SECURITY_SCANNING_RUBRIC, LLMRubricGraderConfig)
+
+_SECURITY_SCANNING_PROFILE = VerificationProfile(
+    adapter=_profile_steps_adapter,
+    requires_username=True,
+    steps=(
+        Step(
+            check="security_scanning_gate",
+            params=SecurityScanningGateParams(),
+            task_id="security-scanning-gate",
+        ),
+        Step(
+            check="security_scanning_review",
+            params=SecurityScanningReviewParams(task=SECURITY_SCANNING_RUBRIC_TASK),
+            task_id=SECURITY_SCANNING_RUBRIC_TASK.id,
+        ),
+    ),
+    rubric=_SECURITY_SCANNING_RUBRIC,
+)
+
+register_profile(SubmissionType.SECURITY_SCANNING, _SECURITY_SCANNING_PROFILE)
+
+
+_CAREER_REFLECTION_RUBRIC = CAREER_REFLECTION_RUBRIC_TASK.grader
+assert isinstance(_CAREER_REFLECTION_RUBRIC, LLMRubricGraderConfig)
+
+_CAREER_REFLECTION_PROFILE = VerificationProfile(
+    adapter=_profile_steps_adapter,
+    requires_username=False,
+    steps=(
+        Step(
+            check="career_reflection_gate",
+            params=CareerReflectionGateParams(),
+            task_id="career-reflection-gate",
+        ),
+        Step(
+            check="career_reflection_review",
+            params=CareerReflectionReviewParams(task=CAREER_REFLECTION_RUBRIC_TASK),
+            task_id=CAREER_REFLECTION_RUBRIC_TASK.id,
+        ),
+    ),
+    rubric=_CAREER_REFLECTION_RUBRIC,
+)
+
+register_profile(SubmissionType.CAREER_REFLECTION, _CAREER_REFLECTION_PROFILE)
+
+
 def _resolve_descriptor(job: PreparedVerificationJob) -> ValidatorDescriptor | None:
     """Prefer a migrated profile, else the dispatcher's legacy descriptor."""
     profile = profile_for(job.requirement.submission_type)
@@ -595,25 +787,38 @@ def _grading_requests_for(
     Runs after aggregation so the prompt carries the final deterministic
     result. Empty when a gate failed before the rubric step ran, which is how
     a migrated profile signals "no grading needed" to the orchestrator.
+
+    A task whose evidence source is ``submitted_text`` grades free text with no
+    repository (Phase 7); every other task grades repository evidence and is
+    skipped when the job has no GitHub target.
     """
     target = job.target
-    if target is None or not target.repo:
-        return []
     requests: list[LLMGradingRequest] = []
     for result in step_results:
         task = result.grading_task
         if task is None:
             continue
         evidence = result.evidence[0].model_dump(mode="json") if result.evidence else {}
-        message = build_repo_rubric_message(
-            requirement_slug=job.requirement.slug,
-            requirement_name=job.requirement.name,
-            deterministic_result=deterministic_result,
-            owner=target.owner,
-            repo=target.repo,
-            task=task,
-            evidence=evidence,
-        )
+        if task.evidence.source == "submitted_text":
+            message = build_text_rubric_message(
+                requirement_slug=job.requirement.slug,
+                requirement_name=job.requirement.name,
+                deterministic_result=deterministic_result,
+                task=task,
+                evidence=evidence,
+            )
+        else:
+            if target is None or not target.repo:
+                continue
+            message = build_repo_rubric_message(
+                requirement_slug=job.requirement.slug,
+                requirement_name=job.requirement.name,
+                deterministic_result=deterministic_result,
+                owner=target.owner,
+                repo=target.repo,
+                task=task,
+                evidence=evidence,
+            )
         requests.append(
             LLMGradingRequest(
                 task=task,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -1,35 +1,19 @@
-"""Prepare and apply durable LLM grading for verification jobs.
+"""Apply durable LLM grading decisions to verification job results.
 
-Transitional home of the self-gating grading probe for the phases that have
-not yet moved to a declared engine profile. Migrated phases (Phase 3 onward)
-record their grading requests on the verify result via the engine's
-``llm_rubric_review`` step, so they no longer route through this probe; their
-branches are removed here as they migrate, and the probe is deleted once the
-last graded phase is migrated.
+Migrated engine profiles record their grading requests on the verify result
+via the engine's rubric-review steps, so evidence collection and prompt
+assembly live in the engine, not here. This module now only merges the
+grader's decisions back into the run result and formats grader-outage and
+content-filter results.
 """
 
 from __future__ import annotations
 
-from learn_to_cloud_shared.schemas import (
-    HandsOnRequirement,
-)
-from learn_to_cloud_shared.verification.career_reflection import (
-    collect_career_reflection_evidence,
-)
 from learn_to_cloud_shared.verification.grading_requests import (
     LLMGradingDecisionPayload,
     LLMGradingRequest,
-    build_repo_rubric_message,
-    build_text_rubric_message,
-)
-from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
-from learn_to_cloud_shared.verification.security_scanning import (
-    collect_security_scanning_evidence,
 )
 from learn_to_cloud_shared.verification.tasks import (
-    PHASE6_LLM_TASKS,
-    PHASE7_LLM_TASKS,
-    PHASE7_REQUIREMENT_SLUG,
     GradingResult,
     LLMGradingDecision,
     VerificationTask,
@@ -43,33 +27,9 @@ __all__ = [
     "LLMGradingDecisionPayload",
     "LLMGradingRequest",
     "apply_llm_grading_decisions",
-    "collect_llm_grading_requests",
     "llm_grading_content_filtered_result",
     "llm_grading_unavailable_result",
 ]
-
-
-async def collect_llm_grading_requests(
-    run_result: VerificationRunResult,
-    repo_files: RepoFiles | None = None,
-) -> list[LLMGradingRequest]:
-    """Collect evidence and prompts for tasks that require LLM grading."""
-    if not run_result.validation_result.verification_completed:
-        return []
-
-    tasks = _llm_tasks_for_requirement(run_result.job.requirement)
-    if not tasks:
-        return []
-
-    if run_result.job.requirement.slug == PHASE7_REQUIREMENT_SLUG:
-        return _collect_phase7_requests(run_result, tasks)
-
-    repo_files = repo_files or default_repo_files()
-
-    if run_result.job.requirement.slug == "security-scanning":
-        return await _collect_phase6_requests(run_result, tasks, repo_files)
-
-    return []
 
 
 def apply_llm_grading_decisions(
@@ -161,101 +121,6 @@ def llm_grading_content_filtered_result(
     )
 
 
-async def _collect_phase6_requests(
-    run_result: VerificationRunResult,
-    tasks: list[VerificationTask],
-    repo_files: RepoFiles,
-) -> list[LLMGradingRequest]:
-    target = run_result.job.target
-    if target is None or not target.repo:
-        return []
-
-    owner, repo = target.owner, target.repo
-    file_paths = await repo_files.tree(owner, repo)
-    requests: list[LLMGradingRequest] = []
-    for task in tasks:
-        evidence = await collect_security_scanning_evidence(
-            owner,
-            repo,
-            file_paths,
-            task,
-            repo_files=repo_files,
-        )
-        requests.append(
-            LLMGradingRequest(
-                task=task,
-                message=_build_grading_message(
-                    run_result=run_result,
-                    task=task,
-                    owner=owner,
-                    repo=repo,
-                    evidence=evidence.model_dump(mode="json"),
-                ),
-                thread_id=f"{run_result.job.id}-{task.id}",
-            )
-        )
-    return requests
-
-
-def _collect_phase7_requests(
-    run_result: VerificationRunResult,
-    tasks: list[VerificationTask],
-) -> list[LLMGradingRequest]:
-    if not run_result.validation_result.is_valid:
-        return []
-
-    submitted_text = run_result.job.typed_submitted_value.as_text
-    requests: list[LLMGradingRequest] = []
-    for task in tasks:
-        evidence = collect_career_reflection_evidence(submitted_text, task)
-        requests.append(
-            LLMGradingRequest(
-                task=task,
-                message=_build_text_grading_message(
-                    run_result=run_result,
-                    task=task,
-                    evidence=evidence.model_dump(mode="json"),
-                ),
-                thread_id=f"{run_result.job.id}-{task.id}",
-            )
-        )
-    return requests
-
-
-def _build_grading_message(
-    *,
-    run_result: VerificationRunResult,
-    task: VerificationTask,
-    owner: str,
-    repo: str,
-    evidence: dict[str, object],
-) -> str:
-    return build_repo_rubric_message(
-        requirement_slug=run_result.job.requirement.slug,
-        requirement_name=run_result.job.requirement.name,
-        deterministic_result=run_result.validation_result,
-        owner=owner,
-        repo=repo,
-        task=task,
-        evidence=evidence,
-    )
-
-
-def _build_text_grading_message(
-    *,
-    run_result: VerificationRunResult,
-    task: VerificationTask,
-    evidence: dict[str, object],
-) -> str:
-    return build_text_rubric_message(
-        requirement_slug=run_result.job.requirement.slug,
-        requirement_name=run_result.job.requirement.name,
-        deterministic_result=run_result.validation_result,
-        task=task,
-        evidence=evidence,
-    )
-
-
 def _decision_to_grading_result(
     task: VerificationTask,
     decision: LLMGradingDecision,
@@ -279,13 +144,3 @@ def _decision_to_grading_result(
         rubric_version=grader.rubric_id,
         evidence_refs=decision.evidence_refs,
     )
-
-
-def _llm_tasks_for_requirement(
-    requirement: HandsOnRequirement,
-) -> list[VerificationTask]:
-    if requirement.slug == "security-scanning":
-        return PHASE6_LLM_TASKS
-    if requirement.slug == PHASE7_REQUIREMENT_SLUG:
-        return PHASE7_LLM_TASKS
-    return []

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -73,7 +73,7 @@ async def synced_requirement(
     and ``get_requirement_by_slug`` only returns active rows so the test
     requirement must be alive in the curriculum.
 
-    Uses a still-legacy repo-backed type (security_scanning) so the executor's
+    Uses a still-legacy repo-backed type (repo_fork) so the executor's
     generic plumbing is exercised through the transitional ``legacy_validate``
     step, which these tests mock via ``validate_submission``. Migrated profiles
     (e.g. journal_api_verifier) run declared steps instead and would bypass
@@ -95,7 +95,7 @@ async def synced_requirement(
                     CurriculumRequirement.slug,
                     CurriculumRequirement.submission_type,
                 )
-                .where(CurriculumRequirement.submission_type == "security_scanning")
+                .where(CurriculumRequirement.submission_type == "repo_fork")
                 .limit(1)
             )
         ).one()
@@ -200,8 +200,8 @@ async def test_split_verification_primitives_prepare_run_and_persist(
     assert run_result.to_payload()["job"] == preparation.job.to_payload()
     assert run_result.job.target == GitHubTarget(
         owner="executoruser",
-        repo="sec-repo",
-        forked_from="owner/sec-repo",
+        repo="test-repo",
+        forked_from="owner/test-repo",
     )
     assert "repository" not in run_result.to_payload()
 
@@ -247,7 +247,7 @@ async def test_execute_verification_job_marks_success_and_links_submission(
     assert payload["code"] == VERIFICATION_SUCCEEDED_CODE
     assert payload["requirement_slug"] == synced_requirement.slug
     assert payload["requirement_name"] == "Verification Executor Test"
-    assert payload["submission_type"] == SubmissionType.SECURITY_SCANNING.value
+    assert payload["submission_type"] == SubmissionType.REPO_FORK.value
     assert payload["message"] == "Verification succeeded."
 
     assert await _get_job_link(session_maker, job_id) == result.submission_id

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -6,7 +6,6 @@ import pytest
 
 from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
 from learn_to_cloud_shared.testing.requirement_factories import (
-    career_reflection_requirement,
     repo_fork_requirement,
 )
 from learn_to_cloud_shared.verification import engine as engine_module
@@ -66,7 +65,7 @@ async def test_legacy_step_passes_dispatcher_result_through(monkeypatch):
 
     monkeypatch.setattr(engine_module, "validate_submission", fake_validate)
 
-    result = await run_profile(_job(career_reflection_requirement()))
+    result = await run_profile(_job(repo_fork_requirement()))
 
     assert result.validation_result is sentinel
     assert result.evidence is None
@@ -284,7 +283,7 @@ async def test_legacy_type_leaves_grading_requests_none(monkeypatch):
 
     monkeypatch.setattr(engine_module, "validate_submission", fake_validate)
 
-    result = await run_profile(_job(career_reflection_requirement()))
+    result = await run_profile(_job(repo_fork_requirement()))
 
     assert result.grading_requests is None
 
@@ -463,3 +462,112 @@ async def test_devops_profile_fails_when_workflow_fails(monkeypatch):
 
     assert result.validation_result.is_valid is False
     assert result.grading_requests == []
+
+
+# ---------------------------------------------------------------------------
+# Phase 6/7 rubric profiles: security scanning (repo) and career reflection
+# (text-only) both gate then record a grading request.
+# ---------------------------------------------------------------------------
+
+
+def _security_job() -> PreparedVerificationJob:
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        security_scanning_requirement,
+    )
+
+    return PreparedVerificationJob(
+        id=uuid4(),
+        user_id=1,
+        github_username="learner",
+        requirement=security_scanning_requirement(
+            slug="security-scanning",
+            required_repo="owner/sec-repo",
+        ),
+        submitted_value="https://github.com/learner/sec-repo",
+    )
+
+
+def _career_job(text: str) -> PreparedVerificationJob:
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        career_reflection_requirement,
+    )
+
+    return PreparedVerificationJob(
+        id=uuid4(),
+        user_id=1,
+        github_username=None,
+        requirement=career_reflection_requirement(slug="career-reflection"),
+        submitted_value=text,
+    )
+
+
+@pytest.mark.asyncio
+async def test_security_profile_records_grading_request_when_gate_passes(monkeypatch):
+    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+    from learn_to_cloud_shared.verification.tasks.phase6 import (
+        SECURITY_SCANNING_RUBRIC_TASK,
+    )
+
+    async def fake_gate(owner, repo, repo_files=None):
+        return ValidationResult(is_valid=True, message="Dependabot configured")
+
+    monkeypatch.setattr(engine_module, "validate_security_scanning", fake_gate)
+    repo_files = InMemoryRepoFiles(
+        {".github/dependabot.yml": "version: 2\nupdates: []\n"}
+    )
+
+    result = await run_profile(_security_job(), repo_files=repo_files)
+
+    assert result.validation_result.is_valid is True
+    assert result.grading_requests is not None
+    assert len(result.grading_requests) == 1
+    assert result.grading_requests[0].task.id == SECURITY_SCANNING_RUBRIC_TASK.id
+
+
+@pytest.mark.asyncio
+async def test_security_profile_skips_grading_when_gate_fails(monkeypatch):
+    from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+
+    async def fake_gate(owner, repo, repo_files=None):
+        return ValidationResult(is_valid=False, message="No scanning found")
+
+    monkeypatch.setattr(engine_module, "validate_security_scanning", fake_gate)
+
+    result = await run_profile(_security_job(), repo_files=InMemoryRepoFiles({}))
+
+    assert result.validation_result.is_valid is False
+    assert result.grading_requests == []
+    assert result.evidence is None
+
+
+@pytest.mark.asyncio
+async def test_career_profile_records_text_grading_request_when_gate_passes():
+    from learn_to_cloud_shared.verification.tasks.phase7 import (
+        CAREER_REFLECTION_RUBRIC_TASK,
+    )
+
+    text = "A specific, first-person reflection on my target role and projects."
+    result = await run_profile(_career_job(text))
+
+    assert result.validation_result.is_valid is True
+    assert result.grading_requests is not None
+    assert len(result.grading_requests) == 1
+    request = result.grading_requests[0]
+    assert request.task.id == CAREER_REFLECTION_RUBRIC_TASK.id
+    assert request.task.evidence.source == "submitted_text"
+    assert text in request.message
+
+
+@pytest.mark.asyncio
+async def test_career_profile_skips_grading_when_gate_fails(monkeypatch):
+    def fake_gate(text):
+        return ValidationResult(is_valid=False, message="Your reflection was empty.")
+
+    monkeypatch.setattr(engine_module, "validate_career_reflection", fake_gate)
+    text = "A specific, first-person reflection on my target role and projects."
+
+    result = await run_profile(_career_job(text))
+
+    assert result.validation_result.is_valid is False
+    assert result.grading_requests == []
+    assert result.evidence is None

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -11,7 +11,6 @@ from learn_to_cloud_shared.schemas import (
 from learn_to_cloud_shared.verification.llm_grading import (
     LLMGradingDecisionPayload,
     apply_llm_grading_decisions,
-    collect_llm_grading_requests,
     llm_grading_content_filtered_result,
     llm_grading_unavailable_result,
 )
@@ -139,26 +138,6 @@ def test_apply_phase3_llm_decision_appends_feedback_when_passed():
     )
 
 
-@pytest.mark.asyncio
-@pytest.mark.unit
-async def test_collect_llm_requests_skips_when_target_missing():
-    run_result = _run_result()
-    without_username = VerificationRunResult(
-        job=run_result.job.__class__(
-            id=run_result.job.id,
-            user_id=run_result.job.user_id,
-            github_username="",
-            requirement=run_result.job.requirement,
-            submitted_value=run_result.job.submitted_value,
-        ),
-        validation_result=run_result.validation_result,
-    )
-
-    requests = await collect_llm_grading_requests(without_username)
-
-    assert requests == []
-
-
 @pytest.mark.unit
 def test_apply_llm_grading_decisions_fails_when_score_is_below_threshold():
     run_result = _run_result()
@@ -238,27 +217,6 @@ def _phase7_run_result(
             message="Reflection received. Reviewing your answers.",
         ),
     )
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit
-async def test_collect_phase7_requests_uses_submitted_text_as_evidence():
-    text = "Question zero: a specific, first-person reflection answer."
-    requests = await collect_llm_grading_requests(
-        _phase7_run_result(submitted_text=text)
-    )
-
-    assert len(requests) == len(PHASE7_LLM_TASKS)
-    assert text in requests[0].message
-    assert requests[0].task.evidence.source == "submitted_text"
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit
-async def test_collect_phase7_requests_skips_when_deterministic_failed():
-    requests = await collect_llm_grading_requests(_phase7_run_result(is_valid=False))
-
-    assert requests == []
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Part of the #630 declarative verification engine stack (PR6 of 8). Base = #644.

## What
- **Phase 6 (security_scanning)** and **Phase 7 (career_reflection)** now run as declarative engine profiles: a deterministic gate (authoritative `validation_result`, `stop_on_fail`) + a rubric review step that bundles evidence and records the grading task.
- Phase 7's rubric grades **submitted text** with no GitHub target.
- Generalizes `_grading_requests_for`: builds a **text** rubric message when `task.evidence.source == "submitted_text"`, else a repo rubric message. Removes the early `if target is None: return []`.
- **Deletes the transitional LLM grading probe** (`collect_llm_grading_requests` + helpers) and its orchestrator activity/fallback. The orchestrator now grades only the requests recorded by the profile (None/missing/empty = skip). No graded non-profile type remains.

## Tests
- Engine: added phase6/7 gate-pass-records-request and gate-fail-skips tests.
- llm_grading: removed the deleted probe tests, kept apply/result tests.
- Orchestrations: rewritten to use recorded requests, probe branch removed.
- Executor + engine legacy-vehicle tests retargeted to still-legacy types.
- `uv run poe check` green (shared 527 passed/1 skipped; functions 17 passed).

Do not merge; @madebygps reviews manually.