### PR TITLE
feat(verification): migrate Phase 0-2 to declarative profiles (#630 PR7)

### DIFF
--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -48,6 +48,10 @@ from learn_to_cloud_shared.verification.dispatcher import (
     validate_submission,
 )
 from learn_to_cloud_shared.verification.evidence import collect_repo_file_evidence
+from learn_to_cloud_shared.verification.github_profile import (
+    validate_profile_readme,
+    validate_repo_fork,
+)
 from learn_to_cloud_shared.verification.grading_requests import (
     LLMGradingRequest,
     build_repo_rubric_message,
@@ -75,6 +79,10 @@ from learn_to_cloud_shared.verification.tasks.phase6 import (
 )
 from learn_to_cloud_shared.verification.tasks.phase7 import (
     CAREER_REFLECTION_RUBRIC_TASK,
+)
+from learn_to_cloud_shared.verification.token_base import (
+    verify_ctf_token,
+    verify_networking_token,
 )
 from learn_to_cloud_shared.verification_job_executor import (
     PreparedVerificationJob,
@@ -198,6 +206,44 @@ class CareerReflectionReviewParams(FrozenModel):
     task: VerificationTask
 
 
+class ProfileReadmeCheckParams(FrozenModel):
+    """Params for the deterministic Phase 0 ``profile_readme_check`` (no config).
+
+    The check confirms the learner's ``<username>/<username>`` profile README
+    repo resolves; the target is built from the username, so it carries no data.
+    """
+
+    check: Literal["profile_readme_check"] = "profile_readme_check"
+
+
+class RepoForkCheckParams(FrozenModel):
+    """Params for the deterministic Phase 1/2 ``repo_fork_check`` (no config).
+
+    The check confirms the learner's repo is a fork of the required upstream;
+    fork identity and upstream come from the target, so it carries no data.
+    """
+
+    check: Literal["repo_fork_check"] = "repo_fork_check"
+
+
+class CtfTokenCheckParams(FrozenModel):
+    """Params for the deterministic Phase 1 ``ctf_token_check`` (no config).
+
+    The check verifies the submitted CTF token against the learner's username.
+    """
+
+    check: Literal["ctf_token_check"] = "ctf_token_check"
+
+
+class NetworkingTokenCheckParams(FrozenModel):
+    """Params for the deterministic Phase 2 ``networking_token_check`` (no config).
+
+    The check verifies the submitted networking token against the username.
+    """
+
+    check: Literal["networking_token_check"] = "networking_token_check"
+
+
 StepParams = Annotated[
     LegacyValidateParams
     | CIStatusParams
@@ -209,7 +255,11 @@ StepParams = Annotated[
     | SecurityScanningGateParams
     | SecurityScanningReviewParams
     | CareerReflectionGateParams
-    | CareerReflectionReviewParams,
+    | CareerReflectionReviewParams
+    | ProfileReadmeCheckParams
+    | RepoForkCheckParams
+    | CtfTokenCheckParams
+    | NetworkingTokenCheckParams,
     Field(discriminator="check"),
 ]
 
@@ -513,6 +563,94 @@ async def _check_career_reflection_review(
     )
 
 
+@register_check("profile_readme_check")
+async def _check_profile_readme(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Deterministic Phase 0 gate: the profile README repo resolves."""
+    target = context.repository
+    if target is None:
+        return StepResult(
+            passed=False,
+            stop_on_fail=True,
+            validation_result=ValidationResult(
+                is_valid=False,
+                message=(
+                    "Requirement configuration error: could not resolve GitHub target"
+                ),
+                username_match=True,
+                repo_exists=False,
+            ),
+        )
+    result = await validate_profile_readme(target)
+    return StepResult(
+        passed=result.is_valid,
+        stop_on_fail=True,
+        validation_result=result,
+    )
+
+
+@register_check("repo_fork_check")
+async def _check_repo_fork(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Deterministic Phase 1/2 gate: the learner's repo forks the upstream."""
+    target = context.repository
+    if target is None:
+        return StepResult(
+            passed=False,
+            stop_on_fail=True,
+            validation_result=ValidationResult(
+                is_valid=False,
+                message=(
+                    "Requirement configuration error: could not resolve GitHub target"
+                ),
+                username_match=True,
+                repo_exists=False,
+            ),
+        )
+    result = await validate_repo_fork(target)
+    return StepResult(
+        passed=result.is_valid,
+        stop_on_fail=True,
+        validation_result=result,
+    )
+
+
+@register_check("ctf_token_check")
+async def _check_ctf_token(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Deterministic Phase 1 gate: verify the submitted CTF token."""
+    result = verify_ctf_token(
+        context.submitted_value, context.job.github_username or ""
+    )
+    return StepResult(
+        passed=result.is_valid,
+        stop_on_fail=True,
+        validation_result=result,
+    )
+
+
+@register_check("networking_token_check")
+async def _check_networking_token(
+    context: StepContext,
+    params: StepParams,
+) -> StepResult:
+    """Deterministic Phase 2 gate: verify the submitted networking token."""
+    result = verify_networking_token(
+        context.submitted_value, context.job.github_username or ""
+    )
+    return StepResult(
+        passed=result.is_valid,
+        stop_on_fail=True,
+        validation_result=result,
+    )
+
+
 @register_check("deployment_architecture_gate")
 async def _check_deployment_architecture_gate(
     context: StepContext,
@@ -737,6 +875,66 @@ _CAREER_REFLECTION_PROFILE = VerificationProfile(
 register_profile(SubmissionType.CAREER_REFLECTION, _CAREER_REFLECTION_PROFILE)
 
 
+_PROFILE_README_PROFILE = VerificationProfile(
+    adapter=_profile_steps_adapter,
+    requires_username=True,
+    steps=(
+        Step(
+            check="profile_readme_check",
+            params=ProfileReadmeCheckParams(),
+            task_id="profile-readme-check",
+        ),
+    ),
+)
+
+register_profile(SubmissionType.PROFILE_README, _PROFILE_README_PROFILE)
+
+
+_REPO_FORK_PROFILE = VerificationProfile(
+    adapter=_profile_steps_adapter,
+    requires_username=True,
+    steps=(
+        Step(
+            check="repo_fork_check",
+            params=RepoForkCheckParams(),
+            task_id="repo-fork-check",
+        ),
+    ),
+)
+
+register_profile(SubmissionType.REPO_FORK, _REPO_FORK_PROFILE)
+
+
+_CTF_TOKEN_PROFILE = VerificationProfile(
+    adapter=_profile_steps_adapter,
+    requires_username=True,
+    steps=(
+        Step(
+            check="ctf_token_check",
+            params=CtfTokenCheckParams(),
+            task_id="ctf-token-check",
+        ),
+    ),
+)
+
+register_profile(SubmissionType.CTF_TOKEN, _CTF_TOKEN_PROFILE)
+
+
+_NETWORKING_TOKEN_PROFILE = VerificationProfile(
+    adapter=_profile_steps_adapter,
+    requires_username=True,
+    steps=(
+        Step(
+            check="networking_token_check",
+            params=NetworkingTokenCheckParams(),
+            task_id="networking-token-check",
+        ),
+    ),
+)
+
+register_profile(SubmissionType.NETWORKING_TOKEN, _NETWORKING_TOKEN_PROFILE)
+
+
 def _resolve_descriptor(job: PreparedVerificationJob) -> ValidatorDescriptor | None:
     """Prefer a migrated profile, else the dispatcher's legacy descriptor."""
     profile = profile_for(job.requirement.submission_type)
@@ -846,6 +1044,24 @@ async def run_profile(
     """
     descriptor = _resolve_descriptor(job)
     steps = _steps_for(descriptor)
+
+    if (
+        descriptor is not None
+        and descriptor.requires_username
+        and not job.github_username
+    ):
+        return VerificationRunResult(
+            job=job,
+            validation_result=ValidationResult(
+                is_valid=False,
+                message="GitHub username is required for this verification",
+                username_match=False,
+            ),
+            evidence=None,
+            grading_requests=[]
+            if isinstance(descriptor, VerificationProfile)
+            else None,
+        )
 
     context = StepContext(
         job=job,

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -73,11 +73,10 @@ async def synced_requirement(
     and ``get_requirement_by_slug`` only returns active rows so the test
     requirement must be alive in the curriculum.
 
-    Uses a still-legacy repo-backed type (repo_fork) so the executor's
-    generic plumbing is exercised through the transitional ``legacy_validate``
-    step, which these tests mock via ``validate_submission``. Migrated profiles
-    (e.g. journal_api_verifier) run declared steps instead and would bypass
-    that mock.
+    Uses repo_fork so the executor's generic prepare/run/persist plumbing is
+    exercised through a gate-only profile. These tests control the outcome by
+    mocking the gate's validator ``validate_repo_fork`` (every submission type
+    now runs a declared profile, so there is no legacy validator to mock).
     """
     from learn_to_cloud_shared.testing.requirement_factories import (
         make_requirement,
@@ -191,7 +190,7 @@ async def test_split_verification_primitives_prepare_run_and_persist(
     assert preparation.job.to_payload()["id"] == str(job_id)
 
     with patch(
-        "learn_to_cloud_shared.verification.engine.validate_submission",
+        "learn_to_cloud_shared.verification.engine.validate_repo_fork",
         validation,
     ):
         run_result = await run_profile(preparation.job)
@@ -228,7 +227,7 @@ async def test_execute_verification_job_marks_success_and_links_submission(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification.engine.validate_submission",
+            "learn_to_cloud_shared.verification.engine.validate_repo_fork",
             validation,
         ),
     ):
@@ -270,7 +269,7 @@ async def test_execute_verification_job_marks_user_validation_failure(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification.engine.validate_submission",
+            "learn_to_cloud_shared.verification.engine.validate_repo_fork",
             validation,
         ),
     ):
@@ -309,7 +308,7 @@ async def test_execute_verification_job_marks_server_error(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification.engine.validate_submission",
+            "learn_to_cloud_shared.verification.engine.validate_repo_fork",
             validation,
         ),
     ):
@@ -347,7 +346,7 @@ async def test_execute_verification_job_truncates_persisted_error_messages(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification.engine.validate_submission",
+            "learn_to_cloud_shared.verification.engine.validate_repo_fork",
             validation,
         ),
     ):
@@ -409,7 +408,7 @@ async def test_execute_verification_job_is_idempotent_for_terminal_jobs(
 
     with (
         patch(
-            "learn_to_cloud_shared.verification.engine.validate_submission",
+            "learn_to_cloud_shared.verification.engine.validate_repo_fork",
             validation,
         ),
     ):

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -64,6 +64,7 @@ async def test_legacy_step_passes_dispatcher_result_through(monkeypatch):
         return sentinel
 
     monkeypatch.setattr(engine_module, "validate_submission", fake_validate)
+    monkeypatch.setattr(engine_module, "profile_for", lambda _t: None)
 
     result = await run_profile(_job(repo_fork_requirement()))
 
@@ -92,6 +93,7 @@ async def test_run_profile_uses_declared_steps(monkeypatch):
         "descriptor_for",
         lambda _t: _profile(_step("test_gate_pass", "gate")),
     )
+    monkeypatch.setattr(engine_module, "profile_for", lambda _t: None)
 
     result = await run_profile(_job())
 
@@ -121,6 +123,7 @@ async def test_failed_gate_short_circuits(monkeypatch):
         "descriptor_for",
         lambda _t: _profile(_step("hard_fail", "a"), _step("never_runs", "b")),
     )
+    monkeypatch.setattr(engine_module, "profile_for", lambda _t: None)
 
     result = await run_profile(_job())
 
@@ -147,6 +150,7 @@ async def test_stop_on_fail_false_continues(monkeypatch):
         "descriptor_for",
         lambda _t: _profile(_step("soft_fail", "a"), _step("after_soft", "b")),
     )
+    monkeypatch.setattr(engine_module, "profile_for", lambda _t: None)
 
     result = await run_profile(_job())
 
@@ -173,6 +177,7 @@ async def test_later_step_sees_prior_evidence(monkeypatch):
         "descriptor_for",
         lambda _t: _profile(_step("emit_evidence", "a"), _step("read_evidence", "b")),
     )
+    monkeypatch.setattr(engine_module, "profile_for", lambda _t: None)
 
     await run_profile(_job())
 
@@ -189,6 +194,7 @@ async def test_unregistered_descriptor_falls_back_to_legacy(monkeypatch):
 
     monkeypatch.setattr(engine_module, "validate_submission", fake_validate)
     monkeypatch.setattr(engine_module, "descriptor_for", lambda _t: None)
+    monkeypatch.setattr(engine_module, "profile_for", lambda _t: None)
 
     result = await run_profile(_job())
 
@@ -282,6 +288,7 @@ async def test_legacy_type_leaves_grading_requests_none(monkeypatch):
         return ValidationResult(is_valid=True, message="legacy ran")
 
     monkeypatch.setattr(engine_module, "validate_submission", fake_validate)
+    monkeypatch.setattr(engine_module, "profile_for", lambda _t: None)
 
     result = await run_profile(_job(repo_fork_requirement()))
 
@@ -571,3 +578,118 @@ async def test_career_profile_skips_grading_when_gate_fails(monkeypatch):
     assert result.validation_result.is_valid is False
     assert result.grading_requests == []
     assert result.evidence is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 0-2 gate-only profiles: profile README, repo fork, CTF and networking
+# tokens. All are deterministic (no grading) and require a GitHub username.
+# ---------------------------------------------------------------------------
+
+
+def _phase02_job(requirement, submitted_value, github_username="learner"):
+    return PreparedVerificationJob(
+        id=uuid4(),
+        user_id=1,
+        github_username=github_username,
+        requirement=requirement,
+        submitted_value=submitted_value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_profile_readme_profile_passes_through_validator(monkeypatch):
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        profile_readme_requirement,
+    )
+
+    sentinel = ValidationResult(is_valid=True, message="Profile README validated")
+
+    async def fake_readme(target, metadata=None):
+        return sentinel
+
+    monkeypatch.setattr(engine_module, "validate_profile_readme", fake_readme)
+
+    job = _phase02_job(
+        profile_readme_requirement(),
+        "https://github.com/learner/learner",
+    )
+    result = await run_profile(job)
+
+    assert result.validation_result is sentinel
+    assert result.grading_requests == []
+    assert result.evidence is None
+
+
+@pytest.mark.asyncio
+async def test_repo_fork_profile_passes_through_validator(monkeypatch):
+    sentinel = ValidationResult(is_valid=True, message="Repository fork validated")
+
+    async def fake_fork(target, metadata=None):
+        return sentinel
+
+    monkeypatch.setattr(engine_module, "validate_repo_fork", fake_fork)
+
+    job = _phase02_job(
+        repo_fork_requirement(),
+        "https://github.com/learner/test-repo",
+    )
+    result = await run_profile(job)
+
+    assert result.validation_result is sentinel
+    assert result.grading_requests == []
+
+
+@pytest.mark.asyncio
+async def test_ctf_token_profile_passes_through_validator(monkeypatch):
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        ctf_token_requirement,
+    )
+
+    captured: dict[str, str] = {}
+
+    def fake_ctf(token, username):
+        captured["token"] = token
+        captured["username"] = username
+        return ValidationResult(is_valid=True, message="CTF token valid")
+
+    monkeypatch.setattr(engine_module, "verify_ctf_token", fake_ctf)
+
+    job = _phase02_job(ctf_token_requirement(), "the-token")
+    result = await run_profile(job)
+
+    assert result.validation_result.is_valid is True
+    assert result.grading_requests == []
+    assert captured == {"token": "the-token", "username": "learner"}
+
+
+@pytest.mark.asyncio
+async def test_networking_token_profile_passes_through_validator(monkeypatch):
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        networking_token_requirement,
+    )
+
+    def fake_net(token, username):
+        return ValidationResult(is_valid=False, message="Networking token invalid")
+
+    monkeypatch.setattr(engine_module, "verify_networking_token", fake_net)
+
+    job = _phase02_job(networking_token_requirement(), "bad-token")
+    result = await run_profile(job)
+
+    assert result.validation_result.is_valid is False
+    assert result.grading_requests == []
+
+
+@pytest.mark.asyncio
+async def test_profile_requiring_username_short_circuits_when_missing():
+    from learn_to_cloud_shared.testing.requirement_factories import (
+        ctf_token_requirement,
+    )
+
+    job = _phase02_job(ctf_token_requirement(), "the-token", github_username=None)
+    result = await run_profile(job)
+
+    assert result.validation_result.is_valid is False
+    assert result.validation_result.username_match is False
+    assert "GitHub username is required" in result.validation_result.message
+    assert result.grading_requests == []


### PR DESCRIPTION
Part of the #630 declarative verification engine stack (PR7 of 8). Base = #645.

## What
- **Phase 0-2** types (`profile_readme`, `repo_fork`, `ctf_token`, `networking_token`) now run as **gate-only engine profiles** instead of the transitional `legacy_validate` step. Each is one deterministic gate whose `ValidationResult` is authoritative (`stop_on_fail`); none records grading requests.
- Adds a **username guard to `run_profile`**: a profile that `requires_username` short-circuits with "GitHub username is required" before running steps, mirroring the dispatcher's guard (and giving repo-backed profiles a clean guard instead of a missing-target config error).
- **Every real submission type now resolves to a profile.** The `legacy_validate` fallback remains only for unregistered types and is deleted in PR8.

## Tests
- Added gate-passthrough tests for all four new profiles + a username-guard test.
- Retargeted the executor tests to mock the `repo_fork` gate validator (`validate_repo_fork`) since no legacy vehicle is left.
- Isolated the generic-machinery / legacy-fallback engine tests via `profile_for` so they no longer depend on a real type being legacy.
- `uv run poe check` green.

Note: the API already routes every type through Durable Functions (transport half #632-#636), so no 0-2 endpoint rewiring was needed.

Do not merge; @madebygps reviews manually.