### PR TITLE
feat(phase6): tokenless CodeQL status gate + non-redundant LLM review

### DIFF
--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/capstone.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/capstone.yaml
@@ -99,13 +99,14 @@ learning_steps:
   order: 7
   action: 'Practice:'
   title: Enable security scanning on your repository
-  description: Enable automated security scanning on your GitHub repository to catch vulnerabilities in your code and dependencies.
+  description: Enable automated security scanning on your GitHub repository to catch vulnerabilities in your code and dependencies. Use CodeQL [advanced setup](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/configuring-advanced-setup-for-code-scanning), which commits the workflow to your repo as `.github/workflows/codeql.yml` so it can be verified.
+  url: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/configuring-advanced-setup-for-code-scanning
   checklist:
-  - "**Enable CodeQL advanced setup** — Security tab → Code scanning → CodeQL → Advanced. This commits a workflow to `.github/workflows/codeql.yml`"
-  - "**Target Python** — Set the workflow language to `python` and keep the push, pull_request, and schedule triggers"
-  - "**Enable Actions and run it** — Make sure GitHub Actions is enabled on your fork and the CodeQL workflow runs green on `main`"
-  - "**Enable Dependabot** (recommended) — Settings → Code security and analysis → Enable Dependabot alerts and security updates"
-  - "**Review findings** — Check the Security tab for any alerts and triage critical/high severity ones"
+  - "**Enable CodeQL advanced setup**, following the [advanced setup guide](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/configuring-advanced-setup-for-code-scanning). This commits `.github/workflows/codeql.yml` to your fork"
+  - "**Target Python**: per [customizing your advanced setup](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning), set the workflow language to `python` and keep the push, pull_request, and schedule triggers"
+  - "**Enable Actions and confirm a green run**: make sure Actions is on for your fork (see [managing Actions settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)) so the CodeQL workflow runs on `main`"
+  - "**Enable Dependabot** (recommended): follow [configuring Dependabot alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/configuring-dependabot-alerts) for defense-in-depth"
+  - "**Review findings**: triage any critical or high severity [code scanning alerts](https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/about-code-scanning-alerts)"
   done_when: The CodeQL workflow is committed as `.github/workflows/codeql.yml`, targets Python, and its latest run is green on your `main` branch.
   slug: phase6-capstone-practice-enable-security-scanning-on
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/capstone.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/capstone.yaml
@@ -101,11 +101,12 @@ learning_steps:
   title: Enable security scanning on your repository
   description: Enable automated security scanning on your GitHub repository to catch vulnerabilities in your code and dependencies.
   checklist:
-  - "**Enable Dependabot** — Settings → Code security and analysis → Enable Dependabot alerts and security updates"
-  - "**Enable CodeQL** (optional) — Add a CodeQL analysis workflow in `.github/workflows/`"
-  - "**Review findings** — Check the Security tab for any alerts"
-  - "**Triage** — Fix critical/high severity findings, dismiss false positives with a reason"
-  done_when: Dependabot is enabled, you've reviewed any alerts, and critical findings are addressed.
+  - "**Enable CodeQL advanced setup** — Security tab → Code scanning → CodeQL → Advanced. This commits a workflow to `.github/workflows/codeql.yml`"
+  - "**Target Python** — Set the workflow language to `python` and keep the push, pull_request, and schedule triggers"
+  - "**Enable Actions and run it** — Make sure GitHub Actions is enabled on your fork and the CodeQL workflow runs green on `main`"
+  - "**Enable Dependabot** (recommended) — Settings → Code security and analysis → Enable Dependabot alerts and security updates"
+  - "**Review findings** — Check the Security tab for any alerts and triage critical/high severity ones"
+  done_when: The CodeQL workflow is committed as `.github/workflows/codeql.yml`, targets Python, and its latest run is green on your `main` branch.
   slug: phase6-capstone-practice-enable-security-scanning-on
 
 - uuid: 831a7907-14bc-4a99-b03d-d7dc1fc4d742

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/monitoring-incident-response.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/monitoring-incident-response.yaml
@@ -95,7 +95,7 @@ learning_steps:
   action: 'Practice:'
   title: GitHub Security Scanning
   url: https://docs.github.com/code-security/tutorials
-  description: Enable at least one scanning tool on your journal-starter repository. Dependabot monitors your dependencies for known vulnerabilities — enable it by adding a .github/dependabot.yml file. CodeQL analyzes your code for security issues — enable it via the Security tab or by adding a workflow to .github/workflows/. This is what the phase verification checks.
+  description: 'Enable GitHub CodeQL code scanning on your journal-starter fork. Use **advanced setup** (not default setup): from the Security tab choose CodeQL advanced setup, which commits a workflow to `.github/workflows/codeql.yml`. Set the language to **Python**, keep the push, pull_request, and schedule triggers, and enable GitHub Actions on your fork so the workflow runs. Make sure the latest run is green on `main`. This is what the phase verification checks: it confirms a successful CodeQL run for your most recent commit on `main`. Dependabot (a `.github/dependabot.yml` file) is recommended as defense-in-depth but is not required.'
   slug: phase6-topic4-practice-github-security-scanning
 - uuid: 68bbb198-ba76-47c4-abc5-2d386d377bce
   order: 6

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/requirements/security-scanning.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/requirements/security-scanning.yaml
@@ -3,6 +3,6 @@ uuid: 2f9a6c38-28f5-474b-9578-a71734f112b2
 slug: security-scanning
 submission_type: security_scanning
 name: Enable Security Scanning
-description: Verify your fork has Dependabot or CodeQL scanning enabled so automated checks can confirm it is configured.
+description: Enable GitHub CodeQL code scanning (advanced setup) for Python on your fork, commit the workflow as .github/workflows/codeql.yml, and make sure it runs green on your main branch. Automated checks confirm the latest CodeQL run passed on your current code. Dependabot is recommended as an extra layer.
 type_config:
   required_repo: learntocloud/journal-starter

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/codeql_status.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/codeql_status.py
@@ -1,0 +1,206 @@
+"""CodeQL status verification service (Phase 6).
+
+Checks whether the learner's fork runs GitHub CodeQL code scanning and that
+it is **green on the current tip of ``main``**. Like Phase 3's CI gate, we
+trust an objective GitHub signal instead of re-grading: a successful run of
+the learner's committed CodeQL workflow on the exact commit at ``main`` HEAD.
+
+Design notes:
+  * **Tokenless.** We use the public workflow-runs endpoint (via the
+    ``WorkflowRuns`` seam) and the public branch endpoint (via ``RepoRef``),
+    both of which answer anonymously, so this gate needs no GitHub token.
+  * **Advanced setup, enforced by the fixed filename.** We look up runs of
+    ``.github/workflows/codeql.yml``. CodeQL *default* setup commits no
+    workflow file and runs under a dynamic workflow, so this lookup 404s for
+    it; only *advanced* setup (a committed ``codeql.yml``) has runs here.
+  * **strict_head.** A green run alone is not enough: a learner could go green
+    once and then break the workflow on a later commit. We require the latest
+    run's ``head_sha`` to equal the current ``main`` HEAD sha, so we verify the
+    code sitting on ``main`` right now.
+  * **Findings are fine.** ``conclusion == "success"`` means the CodeQL
+    workflow completed; CodeQL alerts do not fail the run by default. We verify
+    that scanning works, not that the code is vulnerability-free.
+
+The language (Python) and workflow *quality* are judged by the LLM rubric step
+from the committed ``codeql.yml`` content, not here.
+
+URL validation and ownership checks are handled by the engine gate before this
+module is called. For the workflow-runs seam see ``workflow_runs.py``; for the
+branch-head seam see ``repo_ref.py``.
+"""
+
+from __future__ import annotations
+
+import httpx
+from opentelemetry import trace
+
+from learn_to_cloud_shared.schemas import ValidationResult
+from learn_to_cloud_shared.verification.github_http import (
+    RETRIABLE_EXCEPTIONS,
+    github_error_to_validation_result,
+)
+from learn_to_cloud_shared.verification.repo_ref import RepoRef, default_repo_ref
+from learn_to_cloud_shared.verification.workflow_runs import (
+    WorkflowRuns,
+    default_workflow_runs,
+)
+
+tracer = trace.get_tracer(__name__)
+
+# The committed workflow filename CodeQL advanced setup creates.
+CODEQL_WORKFLOW_FILE = "codeql.yml"
+
+
+async def verify_codeql_status(
+    owner: str,
+    repo: str,
+    runs: WorkflowRuns | None = None,
+    ref: RepoRef | None = None,
+) -> ValidationResult:
+    """Verify CodeQL is green on the current ``main`` HEAD of the learner's fork.
+
+    URL validation and ownership checks are handled by the engine gate before
+    this function is called.
+
+    Args:
+        owner: Repository owner (GitHub username).
+        repo: Repository name.
+        runs: Workflow-runs port (defaults to the production adapter).
+        ref: Branch-head port (defaults to the production adapter).
+
+    Returns:
+        ``ValidationResult`` — valid when the latest ``codeql.yml`` run on
+        ``main`` is ``success`` and its ``head_sha`` equals the current
+        ``main`` HEAD.
+    """
+    runs = runs or default_workflow_runs()
+    ref = ref or default_repo_ref()
+    with tracer.start_as_current_span(
+        "codeql_status_verification",
+        attributes={"github.owner": owner, "github.repo": repo},
+    ) as span:
+        # ── Latest CodeQL workflow run on main ────────────────────────────
+        try:
+            latest_run = await runs.latest_run(owner, repo, CODEQL_WORKFLOW_FILE)
+        except (httpx.HTTPStatusError, *RETRIABLE_EXCEPTIONS) as e:
+            if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
+                span.set_attribute("verification.passed", False)
+                span.set_attribute("verification.reason", "workflow_not_found")
+                return ValidationResult(
+                    is_valid=False,
+                    message=(
+                        f"No CodeQL workflow found in {owner}/{repo}. "
+                        "Enable CodeQL 'advanced setup' and commit the workflow "
+                        "as .github/workflows/codeql.yml, and make sure GitHub "
+                        "Actions is enabled on your fork."
+                    ),
+                )
+            span.record_exception(e)
+            return github_error_to_validation_result(
+                e,
+                event="codeql_status.api_error",
+                context={"owner": owner, "repo": repo},
+            )
+
+        if latest_run is None:
+            span.set_attribute("verification.passed", False)
+            span.set_attribute("verification.reason", "no_runs")
+            return ValidationResult(
+                is_valid=False,
+                message=(
+                    "No CodeQL runs found on the main branch. "
+                    "Push a commit to main (or run the workflow) to trigger "
+                    "CodeQL, then try again."
+                ),
+            )
+
+        status = latest_run.get("status")
+        conclusion = latest_run.get("conclusion")
+        run_head_sha = latest_run.get("head_sha")
+        run_url = latest_run.get("html_url", "")
+        run_number = latest_run.get("run_number", 0)
+
+        span.set_attribute("codeql.status", status or "unknown")
+        span.set_attribute("codeql.conclusion", conclusion or "unknown")
+        span.set_attribute("codeql.run_number", run_number)
+
+        # ── Still running ─────────────────────────────────────────────────
+        if status != "completed":
+            span.set_attribute("verification.passed", False)
+            span.set_attribute("verification.reason", "still_running")
+            return ValidationResult(
+                is_valid=False,
+                message=(
+                    f"CodeQL run #{run_number} is still {status}. "
+                    "Wait for it to finish, then try again."
+                ),
+            )
+
+        # ── Completed but not successful ──────────────────────────────────
+        if conclusion != "success":
+            span.set_attribute("verification.passed", False)
+            span.set_attribute("verification.reason", f"conclusion:{conclusion}")
+            return ValidationResult(
+                is_valid=False,
+                message=(
+                    f"CodeQL run #{run_number} finished with "
+                    f"conclusion '{conclusion}'. "
+                    f"Check the run details at {run_url} "
+                    "to see what went wrong, fix it, and push to main."
+                ),
+            )
+
+        # ── Anchor to the current main HEAD (strict_head) ─────────────────
+        try:
+            head_sha = await ref.head_sha(owner, repo)
+        except (httpx.HTTPStatusError, *RETRIABLE_EXCEPTIONS) as e:
+            if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
+                span.set_attribute("verification.passed", False)
+                span.set_attribute("verification.reason", "branch_not_found")
+                return ValidationResult(
+                    is_valid=False,
+                    message=(
+                        f"Could not find the main branch of {owner}/{repo}. "
+                        "Make sure the repository is public and has a main branch."
+                    ),
+                )
+            span.record_exception(e)
+            return github_error_to_validation_result(
+                e,
+                event="codeql_status.api_error",
+                context={"owner": owner, "repo": repo},
+            )
+
+        if not head_sha:
+            span.set_attribute("verification.passed", False)
+            span.set_attribute("verification.reason", "no_head_sha")
+            return ValidationResult(
+                is_valid=False,
+                message=(
+                    "Could not determine the latest commit on your main branch. "
+                    "Make sure the repository is public and try again."
+                ),
+            )
+
+        if run_head_sha != head_sha:
+            span.set_attribute("verification.passed", False)
+            span.set_attribute("verification.reason", "head_not_scanned")
+            return ValidationResult(
+                is_valid=False,
+                message=(
+                    "CodeQL passed, but not on your latest commit. Your most "
+                    "recent commit on main has not finished scanning yet. "
+                    "CodeQL runs a few minutes after you push; wait for the run "
+                    "on your latest commit, then try again."
+                ),
+            )
+
+        # ── Green on current HEAD ─────────────────────────────────────────
+        span.set_attribute("verification.passed", True)
+        return ValidationResult(
+            is_valid=True,
+            message=(
+                f"CodeQL is passing on main (run #{run_number}) for your latest "
+                "commit. Security scanning is verified!"
+            ),
+        )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -34,6 +34,7 @@ from learn_to_cloud_shared.verification.career_reflection import (
     validate_career_reflection,
 )
 from learn_to_cloud_shared.verification.ci_status import verify_ci_status
+from learn_to_cloud_shared.verification.codeql_status import verify_codeql_status
 from learn_to_cloud_shared.verification.deployed_api import validate_deployed_api
 from learn_to_cloud_shared.verification.deployment_architecture import (
     collect_deployment_architecture_evidence,
@@ -53,7 +54,6 @@ from learn_to_cloud_shared.verification.grading_requests import (
 from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
 from learn_to_cloud_shared.verification.security_scanning import (
     collect_security_scanning_evidence,
-    validate_security_scanning,
 )
 from learn_to_cloud_shared.verification.tasks.base import (
     EvidenceBundle,
@@ -153,13 +153,15 @@ class DevopsAnalysisCheckParams(FrozenModel):
     check: Literal["devops_analysis_check"] = "devops_analysis_check"
 
 
-class SecurityScanningGateParams(FrozenModel):
-    """Params for the Phase 6 ``security_scanning_gate`` (no config).
+class CodeQLStatusParams(FrozenModel):
+    """Params for the Phase 6 ``codeql_status`` gate (no config).
 
-    The gate runs the deterministic Dependabot/CodeQL checks against the fork.
+    The gate verifies the fork's CodeQL workflow ran green on the current
+    ``main`` HEAD; the target is resolved from the requirement plus username,
+    so it carries no data.
     """
 
-    check: Literal["security_scanning_gate"] = "security_scanning_gate"
+    check: Literal["codeql_status"] = "codeql_status"
 
 
 class SecurityScanningReviewParams(FrozenModel):
@@ -238,7 +240,7 @@ StepParams = Annotated[
     | DeploymentArchitectureReviewParams
     | DeployedApiCheckParams
     | DevopsAnalysisCheckParams
-    | SecurityScanningGateParams
+    | CodeQLStatusParams
     | SecurityScanningReviewParams
     | CareerReflectionGateParams
     | CareerReflectionReviewParams
@@ -442,12 +444,12 @@ async def _check_devops_analysis(
     )
 
 
-@register_check("security_scanning_gate")
-async def _check_security_scanning_gate(
+@register_check("codeql_status")
+async def _check_codeql_status(
     context: StepContext,
     params: StepParams,
 ) -> StepResult:
-    """Deterministic Phase 6 gate: Dependabot or CodeQL configured on the fork."""
+    """Deterministic Phase 6 gate: CodeQL green on the fork's current main HEAD."""
     target = context.repository
     if target is None or not target.repo:
         return StepResult(
@@ -460,9 +462,7 @@ async def _check_security_scanning_gate(
                 repo_exists=False,
             ),
         )
-    result = await validate_security_scanning(
-        target.owner, target.repo, context.repo_files
-    )
+    result = await verify_codeql_status(target.owner, target.repo)
     return StepResult(
         passed=result.is_valid,
         stop_on_fail=True,
@@ -481,11 +481,9 @@ async def _check_security_scanning_review(
     if target is None or not target.repo:
         return StepResult(passed=True, stop_on_fail=False)
     repo_files = context.repo_files or default_repo_files()
-    file_paths = await repo_files.tree(target.owner, target.repo)
     bundle = await collect_security_scanning_evidence(
         target.owner,
         target.repo,
-        file_paths,
         params.task,
         repo_files=repo_files,
     )
@@ -777,9 +775,9 @@ _SECURITY_SCANNING_PROFILE = VerificationProfile(
     requires_username=True,
     steps=(
         Step(
-            check="security_scanning_gate",
-            params=SecurityScanningGateParams(),
-            task_id="security-scanning-gate",
+            check="codeql_status",
+            params=CodeQLStatusParams(),
+            task_id="codeql-status-gate",
         ),
         Step(
             check="security_scanning_review",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_ref.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_ref.py
@@ -1,0 +1,80 @@
+"""The RepoRef seam: read a repository branch's current HEAD commit sha.
+
+The Phase 6 CodeQL gate anchors to the *current* tip of ``main``: it only
+passes when the latest CodeQL run's ``head_sha`` matches the branch HEAD. That
+requires one small question of GitHub: "what commit is at the tip of this
+branch right now?" This interface captures exactly that.
+
+Two adapters justify the seam: :class:`GitHubApiRepoRef` talks to live GitHub
+in production, :class:`InMemoryRepoRef` answers from in-memory data in tests.
+``verify_codeql_status`` accepts an optional ``RepoRef`` and falls back to
+:func:`default_repo_ref` when none is supplied.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from learn_to_cloud_shared.verification.github_http import github_api_get
+
+
+@runtime_checkable
+class RepoRef(Protocol):
+    """Read access to a repository branch's HEAD commit sha.
+
+    ``head_sha`` returns the branch tip's commit sha, or ``None`` when the
+    branch payload carries no sha. It raises ``httpx.HTTPStatusError`` (for
+    example a 404 when the repository or branch is missing) and the retriable
+    :class:`GitHubServerError`; callers already handle these.
+    """
+
+    async def head_sha(
+        self, owner: str, repo: str, branch: str = "main"
+    ) -> str | None: ...
+
+
+class GitHubApiRepoRef:
+    """Production adapter backed by the GitHub HTTP API."""
+
+    async def head_sha(self, owner: str, repo: str, branch: str = "main") -> str | None:
+        """Return the branch HEAD commit sha, or ``None`` when absent."""
+        url = f"https://api.github.com/repos/{owner}/{repo}/branches/{branch}"
+        response = await github_api_get(url)
+        data: dict[str, Any] = response.json()
+        commit = data.get("commit")
+        if isinstance(commit, dict):
+            sha = commit.get("sha")
+            if isinstance(sha, str):
+                return sha
+        return None
+
+
+class InMemoryRepoRef:
+    """Test adapter answering from in-memory data.
+
+    ``sha`` is returned by ``head_sha`` (``None`` models a branch payload with
+    no sha). Set ``error`` to make ``head_sha`` raise (for example an
+    ``httpx.HTTPStatusError`` for a missing repository).
+    """
+
+    def __init__(
+        self,
+        sha: str | None = None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self._sha = sha
+        self._error = error
+
+    async def head_sha(self, owner: str, repo: str, branch: str = "main") -> str | None:
+        if self._error is not None:
+            raise self._error
+        return self._sha
+
+
+_DEFAULT_REPO_REF = GitHubApiRepoRef()
+
+
+def default_repo_ref() -> RepoRef:
+    """Return the shared production adapter used when no port is injected."""
+    return _DEFAULT_REPO_REF

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/security_scanning.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/security_scanning.py
@@ -1,40 +1,22 @@
-"""Security scanning verification service.
+"""Security scanning evidence collection (Phase 6).
 
-This module provides Phase 6 verification: checking that learners have enabled
-security scanning (Dependabot and/or CodeQL) on their GitHub repository.
+Phase 6 verification is split into two steps (see ``engine.py``):
 
-Approach:
-  1. Parse and validate the submitted GitHub URL
-  2. Verify the repo owner matches the learner's GitHub username
-  3. Fetch the repo file tree via GitHub API
-  4. Check for Dependabot config and/or CodeQL workflow files
-  5. If workflow files exist, fetch them to confirm CodeQL action usage
-  6. Return per-check pass/fail results
+  * a deterministic gate (``codeql_status``) that proves CodeQL ran green on
+    the current ``main`` HEAD, and
+  * an LLM rubric review that grades the committed workflow's *quality* and
+    confirms it targets Python.
 
-Verification is purely file-based.
+This module supplies the evidence for the review step: it fetches the fixed
+CodeQL workflow file plus any Dependabot config from the default branch. The
+old file-presence verdict logic is gone; the gate is the source of truth for
+"did scanning run and pass".
 """
 
 from __future__ import annotations
 
-import asyncio
-
-import httpx
-import yaml
-from opentelemetry import trace
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential_jitter,
-)
-
-from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
-from learn_to_cloud_shared.verification.errors import VerificationError
 from learn_to_cloud_shared.verification.evidence import (
     collect_repo_file_evidence,
-)
-from learn_to_cloud_shared.verification.github_http import (
-    RETRIABLE_EXCEPTIONS,
 )
 from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
 from learn_to_cloud_shared.verification.tasks.base import (
@@ -42,288 +24,29 @@ from learn_to_cloud_shared.verification.tasks.base import (
     VerificationTask,
 )
 from learn_to_cloud_shared.verification.tasks.phase6 import (
-    CODEQL_ACTION_PATTERN,
-    CODEQL_TASK,
+    CODEQL_WORKFLOW_PATH,
     DEPENDABOT_CONFIG_PATHS,
-    DEPENDABOT_TASK,
     SECURITY_SCANNING_RUBRIC_TASK,
 )
 
-
-class SecurityVerificationError(VerificationError):
-    """Raised when Phase 6 security scanning verification fails."""
-
-
-async def _check_dependabot(
-    repo_files: RepoFiles, owner: str, repo: str, file_paths: list[str]
-) -> TaskResult:
-    """Check for a valid Dependabot configuration file in the repo tree.
-
-    Verifies both file existence and content: the file must contain
-    a ``version`` key and at least one ``updates`` entry.
-    """
-    found = [p for p in file_paths if p in DEPENDABOT_CONFIG_PATHS]
-
-    if not found:
-        return TaskResult(
-            task_name=DEPENDABOT_TASK.name,
-            passed=False,
-            feedback=(
-                "No Dependabot config found. Add a .github/dependabot.yml file "
-                "to enable automated dependency updates."
-            ),
-        )
-
-    content = await _fetch_workflow_content(repo_files, owner, repo, found[0])
-    if not content:
-        return TaskResult(
-            task_name=DEPENDABOT_TASK.name,
-            passed=False,
-            feedback=(
-                f"Found {found[0]} but could not read its content. "
-                "Make sure the repository is public."
-            ),
-        )
-
-    try:
-        parsed = yaml.safe_load(content)
-    except yaml.YAMLError:
-        parsed = None
-
-    has_version = isinstance(parsed, dict) and "version" in parsed
-    updates = parsed.get("updates") if isinstance(parsed, dict) else None
-    has_updates = isinstance(updates, list) and len(updates) > 0
-
-    if has_version and has_updates:
-        return TaskResult(
-            task_name=DEPENDABOT_TASK.name,
-            passed=True,
-            feedback=f"Found valid Dependabot config: {found[0]}",
-        )
-
-    missing = []
-    if not has_version:
-        missing.append("version")
-    if not has_updates:
-        missing.append("updates")
-
-    return TaskResult(
-        task_name=DEPENDABOT_TASK.name,
-        passed=False,
-        feedback=(
-            f"Found {found[0]} but it is missing required keys: "
-            f"{', '.join(missing)}. A valid Dependabot config needs a "
-            "'version' key and at least one 'updates' entry."
-        ),
-    )
-
-
-def _find_codeql_workflow_candidates(file_paths: list[str]) -> list[str]:
-    """Find workflow files that may contain CodeQL configuration.
-
-    Returns workflow paths that either:
-    - Have 'codeql' in the filename
-    - Are any .yml/.yaml file in .github/workflows/ (to check content)
-    """
-    codeql_by_name: list[str] = []
-    other_workflows: list[str] = []
-
-    for path in file_paths:
-        if not path.startswith(".github/workflows/"):
-            continue
-        if not (path.endswith((".yml", ".yaml"))):
-            continue
-
-        filename = path.rsplit("/", 1)[-1].lower()
-        if "codeql" in filename:
-            codeql_by_name.append(path)
-        else:
-            other_workflows.append(path)
-
-    # Prioritise files with codeql in name, then check others
-    return codeql_by_name + other_workflows
-
-
-async def _fetch_workflow_content(
-    repo_files: RepoFiles, owner: str, repo: str, path: str
-) -> str | None:
-    """Fetch a single workflow file's raw content from GitHub."""
-    return await repo_files.file(owner, repo, path)
-
-
-async def _check_codeql(
-    repo_files: RepoFiles, owner: str, repo: str, file_paths: list[str]
-) -> TaskResult:
-    """Check for CodeQL workflow in the repository.
-
-    First checks filenames for 'codeql', then fetches workflow content
-    to look for the github/codeql-action action reference.
-    """
-    candidates = _find_codeql_workflow_candidates(file_paths)
-
-    if not candidates:
-        return TaskResult(
-            task_name=CODEQL_TASK.name,
-            passed=False,
-            feedback=(
-                "No CodeQL workflow found. Add a CodeQL analysis workflow "
-                "in .github/workflows/ using the github/codeql-action action."
-            ),
-        )
-
-    # Check files with 'codeql' in the name first — they're most likely matches
-    codeql_named = [c for c in candidates if "codeql" in c.rsplit("/", 1)[-1].lower()]
-    if codeql_named:
-        # Fetch to confirm it actually uses the CodeQL action
-        content = await _fetch_workflow_content(
-            repo_files, owner, repo, codeql_named[0]
-        )
-        if content and CODEQL_ACTION_PATTERN in content:
-            return TaskResult(
-                task_name=CODEQL_TASK.name,
-                passed=True,
-                feedback=f"Found CodeQL workflow: {codeql_named[0]}",
-            )
-
-    # Check remaining workflow files for CodeQL action usage
-    to_check = [c for c in candidates if c not in codeql_named][
-        : CODEQL_TASK.evidence.max_files
-    ]
-
-    fetch_tasks = [
-        _fetch_workflow_content(repo_files, owner, repo, path) for path in to_check
-    ]
-    results = await asyncio.gather(*fetch_tasks, return_exceptions=True)
-
-    for path, result in zip(to_check, results, strict=True):
-        if isinstance(result, BaseException) or result is None:
-            continue
-        if CODEQL_ACTION_PATTERN in result:
-            return TaskResult(
-                task_name=CODEQL_TASK.name,
-                passed=True,
-                feedback=f"Found CodeQL action in workflow: {path}",
-            )
-
-    return TaskResult(
-        task_name=CODEQL_TASK.name,
-        passed=False,
-        feedback=(
-            "No workflow using github/codeql-action found. Add a CodeQL "
-            "analysis workflow to enable code scanning."
-        ),
-    )
+# Fixed paths graded by the rubric: the committed CodeQL workflow plus optional
+# Dependabot config. Missing files are skipped by ``collect_repo_file_evidence``.
+SECURITY_SCANNING_EVIDENCE_PATHS = [CODEQL_WORKFLOW_PATH, *DEPENDABOT_CONFIG_PATHS]
 
 
 async def collect_security_scanning_evidence(
     owner: str,
     repo: str,
-    file_paths: list[str],
     task: VerificationTask = SECURITY_SCANNING_RUBRIC_TASK,
     repo_files: RepoFiles | None = None,
 ) -> EvidenceBundle:
-    """Collect bounded Phase 6 repository evidence for rubric grading."""
-    repo_files = repo_files or default_repo_files()
-    codeql_candidates = set(_find_codeql_workflow_candidates(file_paths))
-    candidate_paths = [
-        path
-        for path in file_paths
-        if path in DEPENDABOT_CONFIG_PATHS or path in codeql_candidates
-    ]
-    unique_paths = list(dict.fromkeys(candidate_paths))[: task.evidence.max_files]
-    return await collect_repo_file_evidence(repo_files, owner, repo, unique_paths, task)
+    """Collect bounded Phase 6 repository evidence for rubric grading.
 
-
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_exponential_jitter(initial=0.5, max=10),
-    retry=retry_if_exception_type(RETRIABLE_EXCEPTIONS),
-    reraise=True,
-)
-async def _verify_security_scanning(
-    repo_files: RepoFiles, owner: str, repo: str, file_paths: list[str]
-) -> ValidationResult:
-    """Internal: run security scanning checks with retry."""
-    dependabot_result = await _check_dependabot(repo_files, owner, repo, file_paths)
-    codeql_result = await _check_codeql(repo_files, owner, repo, file_paths)
-
-    task_results = [dependabot_result, codeql_result]
-    any_passed = dependabot_result.passed or codeql_result.passed
-    all_passed = dependabot_result.passed and codeql_result.passed
-
-    passed_count = sum(1 for t in task_results if t.passed)
-
-    span = trace.get_current_span()
-    span.set_attribute("security.dependabot", dependabot_result.passed)
-    span.set_attribute("security.codeql", codeql_result.passed)
-    span.set_attribute("security.passed_count", passed_count)
-
-    if all_passed:
-        message = (
-            "Both Dependabot and CodeQL scanning are configured. "
-            "Your repository has comprehensive security scanning enabled."
-        )
-    elif any_passed:
-        passed_name = (
-            dependabot_result.task_name
-            if dependabot_result.passed
-            else codeql_result.task_name
-        )
-        message = (
-            f"{passed_name} is configured. Security scanning verified! "
-            "Consider enabling the other scanner for more comprehensive coverage."
-        )
-    else:
-        message = (
-            "No security scanning found. Enable Dependabot "
-            "(.github/dependabot.yml) or CodeQL (.github/workflows/) "
-            "on your repository and try again."
-        )
-
-    return ValidationResult(
-        is_valid=any_passed,
-        message=message,
-        task_results=task_results,
-    )
-
-
-async def validate_security_scanning(
-    owner: str,
-    repo: str,
-    repo_files: RepoFiles | None = None,
-) -> ValidationResult:
-    """Verify a learner's GitHub repo has security scanning enabled.
-
-    URL validation and ownership checks are handled by the engine gate
-    before this function is called.
-
-    Flow:
-      1. Fetch the repo file tree
-      2. Check for Dependabot config and/or CodeQL workflows
-      3. Return per-check results (pass if at least one is found)
-
-    Args:
-        owner: Repository owner (GitHub username).
-        repo: Repository name.
-        repo_files: Read access to the repository; defaults to live GitHub.
-
-    Returns:
-        ValidationResult with is_valid=True if at least one security feature
-        is found, and detailed task_results for feedback.
+    Fetches the fixed CodeQL workflow (``.github/workflows/codeql.yml``) and
+    any Dependabot config from the default branch. Files that do not exist are
+    skipped, so a repo without Dependabot simply yields the workflow alone.
     """
     repo_files = repo_files or default_repo_files()
-    try:
-        all_files = await repo_files.tree(owner, repo)
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            return ValidationResult(
-                is_valid=False,
-                message=(
-                    f"Repository '{owner}/{repo}' not found. "
-                    "Make sure the repository is public."
-                ),
-                username_match=True,
-            )
-        raise
-
-    return await _verify_security_scanning(repo_files, owner, repo, all_files)
+    return await collect_repo_file_evidence(
+        repo_files, owner, repo, SECURITY_SCANNING_EVIDENCE_PATHS, task
+    )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/__init__.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/__init__.py
@@ -33,7 +33,6 @@ from learn_to_cloud_shared.verification.tasks.phase5 import (
 from learn_to_cloud_shared.verification.tasks.phase6 import (
     PHASE6_LLM_TASKS,
     PHASE6_REQUIREMENT_SLUG,
-    PHASE6_TASKS,
     SECURITY_SCANNING_RUBRIC_TASK,
 )
 from learn_to_cloud_shared.verification.tasks.phase7 import (
@@ -65,7 +64,6 @@ __all__ = [
     "PHASE5_TASKS",
     "PHASE6_REQUIREMENT_SLUG",
     "PHASE6_LLM_TASKS",
-    "PHASE6_TASKS",
     "CAREER_REFLECTION_RUBRIC_TASK",
     "PHASE7_REQUIREMENT_SLUG",
     "PHASE7_LLM_TASKS",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase6.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase6.py
@@ -1,58 +1,22 @@
-"""Phase 6 task definitions: security scanning verification."""
+"""Phase 6 task definitions: security scanning verification.
+
+The deterministic gate (``codeql_status``) proves CodeQL ran green on the
+current ``main`` HEAD. The LLM rubric below does *not* re-check that a scan
+ran; it grades the committed workflow's **quality** and confirms it targets
+**Python**, so it stays non-redundant with the gate.
+"""
 
 from __future__ import annotations
 
 from learn_to_cloud_shared.verification.tasks.base import (
     EvidencePolicy,
-    FilePresenceGraderConfig,
     LLMRubricGraderConfig,
     VerificationTask,
 )
 
 PHASE6_REQUIREMENT_SLUG = "security-scanning"
-CODEQL_ACTION_PATTERN = "github/codeql-action"
+CODEQL_WORKFLOW_PATH = ".github/workflows/codeql.yml"
 DEPENDABOT_CONFIG_PATHS = (".github/dependabot.yml", ".github/dependabot.yaml")
-
-DEPENDABOT_TASK = VerificationTask(
-    id="dependabot",
-    phase_id=6,
-    requirement_slug=PHASE6_REQUIREMENT_SLUG,
-    name="Dependabot Configuration",
-    criteria=[
-        "MUST include a .github/dependabot.yml or .github/dependabot.yaml file",
-        "MUST include a version key",
-        "MUST include at least one updates entry",
-    ],
-    evidence=EvidencePolicy(
-        source="repo_files",
-        path_patterns=list(DEPENDABOT_CONFIG_PATHS),
-        max_files=1,
-    ),
-    grader=FilePresenceGraderConfig(
-        required_any=list(DEPENDABOT_CONFIG_PATHS),
-        content_indicators=["version", "updates"],
-    ),
-)
-
-CODEQL_TASK = VerificationTask(
-    id="codeql",
-    phase_id=6,
-    requirement_slug=PHASE6_REQUIREMENT_SLUG,
-    name="CodeQL Scanning",
-    criteria=[
-        "MUST include a GitHub Actions workflow for CodeQL",
-        "MUST use the github/codeql-action action",
-    ],
-    evidence=EvidencePolicy(
-        source="repo_files",
-        path_patterns=[".github/workflows/"],
-        max_files=5,
-    ),
-    grader=FilePresenceGraderConfig(
-        required_any=[".github/workflows/"],
-        content_indicators=[CODEQL_ACTION_PATTERN],
-    ),
-)
 
 SECURITY_SCANNING_RUBRIC_TASK = VerificationTask(
     id="security-scanning-rubric",
@@ -60,27 +24,43 @@ SECURITY_SCANNING_RUBRIC_TASK = VerificationTask(
     requirement_slug=PHASE6_REQUIREMENT_SLUG,
     name="Security Scanning Rubric Review",
     criteria=[
-        "MUST show valid Dependabot configuration or CodeQL scanning evidence",
-        "Dependabot evidence MUST include a version key and at least one updates entry",
-        "CodeQL evidence MUST include a workflow using github/codeql-action",
         (
-            "MUST grade only the repository evidence and deterministic task "
-            "results provided"
+            "The CodeQL workflow MUST analyze Python: its languages / "
+            "build-mode configuration must include python"
+        ),
+        (
+            "The workflow SHOULD run on sensible triggers: push and "
+            "pull_request to the default branch, plus a scheduled run"
+        ),
+        (
+            "SHOULD use a deliberate query suite (for example "
+            "security-extended) rather than relying only on defaults"
+        ),
+        (
+            "SHOULD pin the github/codeql-action steps to a version "
+            "(a tag or SHA), not float on an implicit latest"
+        ),
+        (
+            "Dependabot configuration (version key and at least one updates "
+            "entry) is a bonus for defense-in-depth, not required"
+        ),
+        (
+            "MUST grade only the repository evidence provided and MUST NOT "
+            "re-judge whether a scan ran or passed (a separate gate proves that)"
         ),
     ],
     evidence=EvidencePolicy(
         source="repo_files",
-        path_patterns=[*DEPENDABOT_CONFIG_PATHS, ".github/workflows/"],
-        max_files=6,
+        path_patterns=[CODEQL_WORKFLOW_PATH, *DEPENDABOT_CONFIG_PATHS],
+        max_files=3,
         max_total_bytes=75 * 1024,
     ),
     grader=LLMRubricGraderConfig(
-        rubric_id="phase6-security-scanning-v1",
-        prompt_version="2026-05-08",
+        rubric_id="phase6-security-scanning-v2",
+        prompt_version="2026-07-13",
         passing_score=0.75,
         model="gpt-5-mini",
     ),
 )
 
-PHASE6_TASKS = [DEPENDABOT_TASK, CODEQL_TASK]
 PHASE6_LLM_TASKS = [SECURITY_SCANNING_RUBRIC_TASK]

--- a/packages/learn-to-cloud-shared/tests/services/test_security_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_security_verification_service.py
@@ -1,21 +1,23 @@
-"""Tests for security_verification_service (Phase 6).
+"""Tests for Phase 6 security-scanning evidence collection.
 
-Covers:
-- 404 / not-public repo handling
-- Dependabot and CodeQL detection
+The deterministic verdict now lives in the ``codeql_status`` gate (see
+``test_codeql_status.py``). This module only covers the evidence bundle the
+LLM rubric grades: it gathers the committed CodeQL workflow plus any
+Dependabot config from fixed paths, tolerating missing files.
 
-Evidence is supplied through the ``RepoFiles`` seam with an in-memory
-adapter, so these tests exercise the grading rules without the network.
-
-URL validation and ownership checks are exercised by the engine gate tests.
+Evidence is supplied through the ``RepoFiles`` seam with an in-memory adapter,
+so these tests run without the network.
 """
 
-import httpx
 import pytest
 
 from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
 from learn_to_cloud_shared.verification.security_scanning import (
-    validate_security_scanning,
+    collect_security_scanning_evidence,
+)
+from learn_to_cloud_shared.verification.tasks.phase6 import (
+    CODEQL_WORKFLOW_PATH,
+    SECURITY_SCANNING_RUBRIC_TASK,
 )
 
 _TEST_OWNER = "testuser"
@@ -28,66 +30,36 @@ _CODEQL_WORKFLOW = (
 )
 
 
-# ---------------------------------------------------------------------------
-# 404 / not-public repo
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.unit
-class TestValidateSecurityScanning404:
-    """Repo-not-found handling."""
+class TestCollectSecurityScanningEvidence:
+    """Evidence collection over the fixed Phase 6 paths."""
 
-    @pytest.mark.asyncio
-    async def test_404_returns_not_found(self):
-        mock_response = httpx.Response(
-            status_code=404, request=httpx.Request("GET", "https://api.github.com")
-        )
+    async def test_collects_codeql_and_dependabot(self):
         repo_files = InMemoryRepoFiles(
-            tree_error=httpx.HTTPStatusError(
-                "Not Found", request=mock_response.request, response=mock_response
-            )
+            {
+                CODEQL_WORKFLOW_PATH: _CODEQL_WORKFLOW,
+                ".github/dependabot.yml": _VALID_DEPENDABOT,
+            }
         )
-        result = await validate_security_scanning(
+        bundle = await collect_security_scanning_evidence(
             _TEST_OWNER, _TEST_REPO, repo_files=repo_files
         )
-        assert result.is_valid is False
-        assert "not found" in result.message.lower()
-        assert result.username_match is True
+        paths = {item.path for item in bundle.items}
+        assert CODEQL_WORKFLOW_PATH in paths
+        assert ".github/dependabot.yml" in paths
+        assert bundle.task_id == SECURITY_SCANNING_RUBRIC_TASK.id
 
-
-# ---------------------------------------------------------------------------
-# Dependabot and CodeQL detection
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestValidateSecurityScanningDetection:
-    """Detection of security scanning configuration."""
-
-    @pytest.mark.asyncio
-    async def test_dependabot_only_passes(self):
-        repo_files = InMemoryRepoFiles({".github/dependabot.yml": _VALID_DEPENDABOT})
-        result = await validate_security_scanning(
+    async def test_missing_dependabot_is_skipped(self):
+        repo_files = InMemoryRepoFiles({CODEQL_WORKFLOW_PATH: _CODEQL_WORKFLOW})
+        bundle = await collect_security_scanning_evidence(
             _TEST_OWNER, _TEST_REPO, repo_files=repo_files
         )
-        assert result.is_valid is True
+        paths = {item.path for item in bundle.items}
+        assert paths == {CODEQL_WORKFLOW_PATH}
 
-    @pytest.mark.asyncio
-    async def test_codeql_only_passes(self):
-        repo_files = InMemoryRepoFiles(
-            {".github/workflows/codeql.yml": _CODEQL_WORKFLOW}
-        )
-        result = await validate_security_scanning(
-            _TEST_OWNER, _TEST_REPO, repo_files=repo_files
-        )
-        assert result.is_valid is True
-
-    @pytest.mark.asyncio
-    async def test_no_scanning_fails(self):
+    async def test_empty_repo_yields_no_items(self):
         repo_files = InMemoryRepoFiles({"README.md": "# project\n"})
-        result = await validate_security_scanning(
+        bundle = await collect_security_scanning_evidence(
             _TEST_OWNER, _TEST_REPO, repo_files=repo_files
         )
-        assert result.is_valid is False
-        assert result.task_results is not None
-        assert all(not t.passed for t in result.task_results)
+        assert bundle.items == []

--- a/packages/learn-to-cloud-shared/tests/verification/test_codeql_status.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_codeql_status.py
@@ -1,0 +1,147 @@
+"""Tests for CodeQL status verification service (Phase 6).
+
+Tests cover:
+- CodeQL workflow not found (404 → advanced-setup message)
+- No runs on main
+- Run still in progress
+- Run succeeded on current HEAD (pass)
+- Run succeeded but at an older commit (stale HEAD → fail, wait & retry)
+- Run failed
+- Successful run with open findings still passes
+- Branch head lookup 404 / API errors
+
+URL validation and ownership checks are exercised by the engine gate tests.
+
+These tests inject :class:`InMemoryWorkflowRuns` and :class:`InMemoryRepoRef`
+adapters instead of patching internals, so they exercise the real
+``verify_codeql_status`` logic through the seams.
+"""
+
+import httpx
+import pytest
+
+from learn_to_cloud_shared.verification.codeql_status import verify_codeql_status
+from learn_to_cloud_shared.verification.errors import GitHubServerError
+from learn_to_cloud_shared.verification.repo_ref import InMemoryRepoRef
+from learn_to_cloud_shared.verification.workflow_runs import InMemoryWorkflowRuns
+
+_TEST_OWNER = "testuser"
+_TEST_REPO = "journal-starter"
+_HEAD = "abc123def456"
+
+
+def _run(**overrides):
+    run = {
+        "status": "completed",
+        "conclusion": "success",
+        "head_sha": _HEAD,
+        "run_number": 10,
+        "html_url": "https://github.com/testuser/journal-starter/actions/runs/789",
+    }
+    run.update(overrides)
+    return run
+
+
+def _http_error(status: int) -> httpx.HTTPStatusError:
+    response = httpx.Response(status, request=httpx.Request("GET", "https://test"))
+    return httpx.HTTPStatusError("err", request=response.request, response=response)
+
+
+@pytest.mark.unit
+class TestCodeQLStatusCheck:
+    """Tests for the CodeQL workflow-run + HEAD-anchoring gate."""
+
+    async def test_workflow_not_found_returns_advanced_setup_message(self):
+        runs = InMemoryWorkflowRuns(error=_http_error(404))
+        result = await verify_codeql_status(
+            _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(_HEAD)
+        )
+        assert not result.is_valid
+        assert "advanced setup" in result.message.lower()
+        assert "codeql.yml" in result.message
+
+    async def test_no_runs_on_main(self):
+        runs = InMemoryWorkflowRuns(run=None)
+        result = await verify_codeql_status(
+            _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(_HEAD)
+        )
+        assert not result.is_valid
+        assert "No CodeQL runs" in result.message
+
+    async def test_run_in_progress(self):
+        runs = InMemoryWorkflowRuns(_run(status="in_progress", conclusion=None))
+        result = await verify_codeql_status(
+            _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(_HEAD)
+        )
+        assert not result.is_valid
+        assert "still" in result.message
+
+    async def test_run_succeeded_on_current_head_passes(self):
+        runs = InMemoryWorkflowRuns(_run())
+        result = await verify_codeql_status(
+            _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(_HEAD)
+        )
+        assert result.is_valid
+        assert "#10" in result.message
+
+    async def test_successful_run_with_findings_still_passes(self):
+        # CodeQL alerts do not fail the run; conclusion success is what matters.
+        runs = InMemoryWorkflowRuns(_run(conclusion="success"))
+        result = await verify_codeql_status(
+            _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(_HEAD)
+        )
+        assert result.is_valid
+
+    async def test_green_but_stale_head_is_rejected(self):
+        runs = InMemoryWorkflowRuns(_run(head_sha="oldsha000"))
+        result = await verify_codeql_status(
+            _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(_HEAD)
+        )
+        assert not result.is_valid
+        assert "latest commit" in result.message.lower()
+
+    async def test_run_failed(self):
+        run_url = "https://github.com/testuser/journal-starter/actions/runs/999"
+        runs = InMemoryWorkflowRuns(
+            _run(conclusion="failure", run_number=7, html_url=run_url)
+        )
+        result = await verify_codeql_status(
+            _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(_HEAD)
+        )
+        assert not result.is_valid
+        assert "failure" in result.message
+        assert run_url in result.message
+
+    async def test_branch_not_found(self):
+        runs = InMemoryWorkflowRuns(_run())
+        ref = InMemoryRepoRef(error=_http_error(404))
+        result = await verify_codeql_status(_TEST_OWNER, _TEST_REPO, runs, ref)
+        assert not result.is_valid
+        assert "main branch" in result.message
+
+    async def test_missing_head_sha(self):
+        runs = InMemoryWorkflowRuns(_run())
+        result = await verify_codeql_status(
+            _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(None)
+        )
+        assert not result.is_valid
+
+
+@pytest.mark.unit
+class TestCodeQLStatusErrorHandling:
+    """Tests for GitHub API error handling."""
+
+    async def test_runs_server_error(self):
+        runs = InMemoryWorkflowRuns(error=GitHubServerError("GitHub returned 500"))
+        result = await verify_codeql_status(
+            _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(_HEAD)
+        )
+        assert not result.is_valid
+        assert result.verification_completed is False
+
+    async def test_ref_transient_failure(self):
+        runs = InMemoryWorkflowRuns(_run())
+        ref = InMemoryRepoRef(error=httpx.ConnectError("connection refused"))
+        result = await verify_codeql_status(_TEST_OWNER, _TEST_REPO, runs, ref)
+        assert not result.is_valid
+        assert result.verification_completed is False

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -463,12 +463,12 @@ async def test_security_profile_records_grading_request_when_gate_passes(monkeyp
         SECURITY_SCANNING_RUBRIC_TASK,
     )
 
-    async def fake_gate(owner, repo, repo_files=None):
-        return ValidationResult(is_valid=True, message="Dependabot configured")
+    async def fake_gate(owner, repo):
+        return ValidationResult(is_valid=True, message="CodeQL green on main")
 
-    monkeypatch.setattr(engine_module, "validate_security_scanning", fake_gate)
+    monkeypatch.setattr(engine_module, "verify_codeql_status", fake_gate)
     repo_files = InMemoryRepoFiles(
-        {".github/dependabot.yml": "version: 2\nupdates: []\n"}
+        {".github/workflows/codeql.yml": "name: CodeQL\non: [push]\n"}
     )
 
     result = await run_profile(_security_job(), repo_files=repo_files)
@@ -483,10 +483,10 @@ async def test_security_profile_records_grading_request_when_gate_passes(monkeyp
 async def test_security_profile_skips_grading_when_gate_fails(monkeypatch):
     from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
 
-    async def fake_gate(owner, repo, repo_files=None):
-        return ValidationResult(is_valid=False, message="No scanning found")
+    async def fake_gate(owner, repo):
+        return ValidationResult(is_valid=False, message="No CodeQL runs found")
 
-    monkeypatch.setattr(engine_module, "validate_security_scanning", fake_gate)
+    monkeypatch.setattr(engine_module, "verify_codeql_status", fake_gate)
 
     result = await run_profile(_security_job(), repo_files=InMemoryRepoFiles({}))
 
@@ -656,3 +656,28 @@ def test_every_submission_type_has_a_registered_profile():
     missing = [t for t in SubmissionType if profile_for(t) is None]
 
     assert missing == [], f"submission types without a profile: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Every registered profile step must round-trip through the StepParams
+# discriminated union and reference a registered check. This fails in CI (not
+# only in the Functions host) if a new check is added without a StepParams
+# union arm, e.g. the Phase 6 ``codeql_status`` gate.
+# ---------------------------------------------------------------------------
+
+
+def test_every_registered_profile_step_is_valid():
+    from learn_to_cloud_shared.verification.engine import (
+        _CHECK_REGISTRY,
+        _PROFILE_REGISTRY,
+    )
+
+    for submission_type, profile in _PROFILE_REGISTRY.items():
+        for step in profile.steps:
+            assert step.check in _CHECK_REGISTRY, (
+                f"{submission_type}: step check '{step.check}' is not registered"
+            )
+            # Re-validating the dumped step forces the discriminated union to
+            # resolve the params type; a missing union arm raises here.
+            rebuilt = Step.model_validate(step.model_dump())
+            assert rebuilt.params.check == step.check

--- a/packages/learn-to-cloud-shared/tests/verification/test_task_definitions.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_task_definitions.py
@@ -10,14 +10,14 @@ from learn_to_cloud_shared.verification.tasks import (
     PHASE3_LLM_TASKS,
     PHASE5_TASKS,
     PHASE6_LLM_TASKS,
-    PHASE6_TASKS,
     PHASE7_LLM_TASKS,
 )
 from learn_to_cloud_shared.verification.tasks.base import (
+    EvidencePolicy,
     FilePresenceGraderConfig,
     IndicatorGraderConfig,
     LLMRubricGraderConfig,
-    require_file_presence_grader,
+    VerificationTask,
     require_indicator_grader,
     require_llm_rubric_grader,
 )
@@ -32,16 +32,13 @@ from learn_to_cloud_shared.verification.tasks.phase7 import PHASE7_REQUIREMENT_S
 @pytest.mark.unit
 def test_phase_task_ids_are_stable_and_unique():
     """Task identifiers are stable API/telemetry keys."""
-    tasks = [*PHASE5_TASKS, *PHASE6_TASKS]
-    ids = [task.id for task in tasks]
+    ids = [task.id for task in PHASE5_TASKS]
 
     assert ids == [
         "dockerfile",
         "cicd-pipeline",
         "terraform-iac",
         "kubernetes-manifests",
-        "dependabot",
-        "codeql",
     ]
     assert len(ids) == len(set(ids))
 
@@ -55,16 +52,6 @@ def test_phase5_tasks_use_indicator_graders():
         assert task.evidence.path_patterns
         assert task.evidence.required_files
         assert isinstance(require_indicator_grader(task), IndicatorGraderConfig)
-
-
-@pytest.mark.unit
-def test_phase6_tasks_use_file_presence_graders():
-    for task in PHASE6_TASKS:
-        assert task.phase_id == 6
-        assert task.requirement_slug == PHASE6_REQUIREMENT_SLUG
-        assert task.evidence.source == "repo_files"
-        assert task.evidence.path_patterns
-        assert isinstance(require_file_presence_grader(task), FilePresenceGraderConfig)
 
 
 @pytest.mark.unit
@@ -88,6 +75,7 @@ def test_phase6_llm_tasks_use_rubric_graders():
     assert task.phase_id == 6
     assert task.requirement_slug == PHASE6_REQUIREMENT_SLUG
     assert task.evidence.source == "repo_files"
+    assert ".github/workflows/codeql.yml" in task.evidence.path_patterns
     assert isinstance(require_llm_rubric_grader(task), LLMRubricGraderConfig)
 
 
@@ -126,7 +114,22 @@ def test_indicator_grader_returns_normalized_result():
 
 @pytest.mark.unit
 def test_file_presence_grader_returns_normalized_result():
-    task = PHASE6_TASKS[0]
+    task = VerificationTask(
+        id="dependabot",
+        phase_id=6,
+        requirement_slug=PHASE6_REQUIREMENT_SLUG,
+        name="Dependabot Configuration",
+        criteria=["MUST include a .github/dependabot.yml file"],
+        evidence=EvidencePolicy(
+            source="repo_files",
+            path_patterns=[".github/dependabot.yml"],
+            max_files=1,
+        ),
+        grader=FilePresenceGraderConfig(
+            required_any=[".github/dependabot.yml"],
+            content_indicators=["version", "updates"],
+        ),
+    )
 
     result = grade_file_presence_task(
         task,


### PR DESCRIPTION
Closes #629.

## Problem
Phase 6 (`security_scanning`) ran a **file-presence** deterministic check (Dependabot OR CodeQL file exists) and then an LLM rubric that re-judged the *same* presence evidence. The LLM added no independent signal, unlike Phase 3/4 where the gate proves an objective fact and the LLM judges something subjective.

## Change (mirrors Phase 3)
A meaningful deterministic **gate** + a non-redundant LLM **review**.

**Gate (new, tokenless): CodeQL ran green on the current `main` HEAD.**
- Reuses the `WorkflowRuns` seam to fetch the latest `.github/workflows/codeql.yml` run on `main`.
- New tiny `RepoRef` seam fetches the branch tip; the gate requires `run.head_sha == main HEAD` (**strict_head**), so a learner can't go green once then break the workflow later and stay verified.
- Uses only **public** GitHub endpoints, so it needs **no token** (same as Phase 3).
- The fixed filename `codeql.yml` inherently requires **advanced setup** (default setup 404s at this endpoint) and points Python-first learners at the right convention.
- A green run passes **even with open findings**: we verify the scanner runs, not that the code is vuln-free.

**Review (retargeted): grade workflow quality + confirm Python.**
The LLM now grades languages/build-mode (Python), triggers, query suite, action pinning, and Dependabot as defense-in-depth, and explicitly must not re-judge "did a scan run" (the gate proves that).

## What's in here
- New `verification/repo_ref.py` (RepoRef seam) and `verification/codeql_status.py` (`verify_codeql_status`, modeled on `ci_status.py`).
- `engine.py`: add `codeql_status` check + `CodeQLStatusParams` union arm; remove `security_scanning_gate` / `SecurityScanningGateParams` and the file-presence verdict path; drop the `repo_files.tree()` call from the review step.
- `security_scanning.py`: reduced to `collect_security_scanning_evidence` over fixed paths (`codeql.yml` + Dependabot), tolerating missing files.
- `tasks/phase6.py`: rewrite rubric criteria (quality + Python), bump `rubric_id` to `phase6-security-scanning-v2`; remove `PHASE6_TASKS`/`DEPENDABOT_TASK`/`CODEQL_TASK`.
- Content: `security-scanning.yaml`, `capstone.yaml`, `monitoring-incident-response.yaml` now require CodeQL advanced setup **for Python**, committed as `codeql.yml`, green on `main`, Actions enabled; Dependabot recommended.
- Tests: new `test_codeql_status.py` (pass / stale-HEAD-rejected / still-running / failed / no-runs / 404 / API-error / findings-still-pass); import-time profile-build test so a missing union arm fails in CI; updated engine / task-definition / security-service tests.

## Validation
- `uv run poe check` green (ruff lint + format, ty, shared + API tests).
- **Dogfood** against `madebygps/journal-starter` (no CodeQL implemented): gate returns a clean, actionable fail (`is_valid=False`, `verification_completed=True`): "No CodeQL workflow found ... Enable CodeQL 'advanced setup' and commit .github/workflows/codeql.yml ...". The system works; the learner just hasn't done the task.

## Notes
Single PR: only the wiring -> status function is a real code dependency and content ships atomically with the behavioural flip, so there's no deploy gap. #625 (Phase 5) and #648 (engine cleanup) are separate follow-ups.