### PR TITLE
Build deterministic curriculum artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,6 +187,34 @@ jobs:
             exit 1
           fi
 
+      - name: Verify generated curriculum.json artifact is up to date
+        working-directory: packages/learn-to-cloud-shared
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          artifact_path=src/learn_to_cloud_shared/content/curriculum.json
+          repo_artifact_path=packages/learn-to-cloud-shared/$artifact_path
+          prior_sha="${PR_BASE_SHA:-${PUSH_BEFORE_SHA:-}}"
+          previous_artifact_args=()
+
+          # workflow_dispatch and a branch's first push have no meaningful
+          # prior SHA (before-SHA is all zeros) -- skip the version check.
+          if [ -n "$prior_sha" ] && [ "$prior_sha" != "0000000000000000000000000000000000000000" ]; then
+            previous_artifact="$RUNNER_TEMP/previous-curriculum.json"
+            if git show "${prior_sha}:${repo_artifact_path}" > "$previous_artifact" 2>/dev/null; then
+              previous_artifact_args=(--previous-artifact "$previous_artifact")
+            fi
+          fi
+
+          uv run python scripts/compile_curriculum.py "${previous_artifact_args[@]}"
+          if ! git diff --exit-code "$artifact_path"; then
+            echo "::error::curriculum.json drifted from the authored YAML." >&2
+            echo "Run 'cd packages/learn-to-cloud-shared && uv run python scripts/compile_curriculum.py' and commit the result." >&2
+            exit 1
+          fi
+
       - name: Verify single migration head (no branches)
         working-directory: api
         run: |

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
+from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
 from learn_to_cloud_shared.core.azure_auth import close_credential
 from learn_to_cloud_shared.core.config import get_web_settings
 from learn_to_cloud_shared.core.database import (
@@ -117,6 +118,20 @@ async def lifespan(app: fastapi.FastAPI):
     app.state.session_maker = create_session_maker(app.state.engine)
     # Parsing migration scripts is cheap once, not on every /ready poll.
     app.state.alembic_code_head = get_code_alembic_head()
+
+    # Fail fast (unlike the alembic head above, a bad/missing curriculum
+    # artifact is not tolerated) so a broken deploy never starts serving.
+    app.state.curriculum_catalog = get_curriculum_catalog()
+    logger.info(
+        "init.curriculum_loaded",
+        extra={
+            "curriculum_version": app.state.curriculum_catalog.curriculum_version,
+            "artifact_schema_version": (
+                app.state.curriculum_catalog.artifact_schema_version
+            ),
+            "content_hash": app.state.curriculum_catalog.content_hash,
+        },
+    )
 
     app.state.init_done = False
     app.state.init_error = None

--- a/api/src/learn_to_cloud/routes/health_routes.py
+++ b/api/src/learn_to_cloud/routes/health_routes.py
@@ -7,6 +7,7 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import PlainTextResponse
+from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
 from learn_to_cloud_shared.core.database import check_db_connection
 from learn_to_cloud_shared.schemas import HealthResponse
 from sqlalchemy import text
@@ -48,8 +49,20 @@ async def _get_db_alembic_head(engine: AsyncEngine) -> str | None:
 
 @router.get("/health", summary="Health check")
 async def health() -> HealthResponse:
-    """Health check endpoint."""
-    return HealthResponse(status="healthy", service="learn-to-cloud-api")
+    """Health check endpoint.
+
+    Includes the compiled curriculum artifact's identity (schema
+    version, authored version, content hash) -- loaded once per process
+    and guaranteed present because startup fails fast if it can't load.
+    """
+    catalog = get_curriculum_catalog()
+    return HealthResponse(
+        status="healthy",
+        service="learn-to-cloud-api",
+        curriculum_version=catalog.curriculum_version,
+        artifact_schema_version=catalog.artifact_schema_version,
+        content_hash=catalog.content_hash,
+    )
 
 
 @router.get(
@@ -115,7 +128,14 @@ async def ready(request: Request) -> HealthResponse:
                     extra={"db_head": db_head, "code_head": code_head},
                 )
 
-    return HealthResponse(status="ready", service="learn-to-cloud-api")
+    catalog = get_curriculum_catalog()
+    return HealthResponse(
+        status="ready",
+        service="learn-to-cloud-api",
+        curriculum_version=catalog.curriculum_version,
+        artifact_schema_version=catalog.artifact_schema_version,
+        content_hash=catalog.content_hash,
+    )
 
 
 @router.get("/robots.txt", response_class=PlainTextResponse, include_in_schema=False)

--- a/api/tests/routes/test_health_routes.py
+++ b/api/tests/routes/test_health_routes.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
+from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
 
 from learn_to_cloud.routes.health_routes import health, ready
 
@@ -17,6 +18,16 @@ class TestHealthEndpoint:
         result = await health()
         assert result.status == "healthy"
         assert result.service == "learn-to-cloud-api"
+
+    async def test_health_exposes_curriculum_artifact_identity(self):
+        """Health response includes the loaded artifact's identity fields."""
+        catalog = get_curriculum_catalog()
+
+        result = await health()
+
+        assert result.curriculum_version == catalog.curriculum_version
+        assert result.artifact_schema_version == catalog.artifact_schema_version
+        assert result.content_hash == catalog.content_hash
 
 
 @pytest.mark.unit
@@ -42,6 +53,24 @@ class TestReadyEndpoint:
             request.app.state.engine,
             request.app.state.settings.database,
         )
+
+    async def test_ready_exposes_curriculum_artifact_identity(self):
+        """Ready response includes the loaded artifact's identity fields."""
+        catalog = get_curriculum_catalog()
+        request = MagicMock()
+        request.app.state.init_error = None
+        request.app.state.init_done = True
+        request.app.state.alembic_code_head = None
+
+        with patch(
+            "learn_to_cloud.routes.health_routes.check_db_connection",
+            autospec=True,
+        ):
+            result = await ready(request)
+
+        assert result.curriculum_version == catalog.curriculum_version
+        assert result.artifact_schema_version == catalog.artifact_schema_version
+        assert result.content_hash == catalog.content_hash
 
     async def test_ready_returns_503_when_init_error(self):
         """Ready returns 503 when init_error is set."""

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -1,0 +1,79 @@
+"""Unit tests for the FastAPI app's startup lifespan.
+
+Covers the curriculum artifact fail-fast contract: a missing/corrupted
+packaged artifact must abort application startup (not merely mark
+``/ready`` unhealthy), and a successful load must be recorded on
+``app.state`` and logged for telemetry.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from learn_to_cloud_shared.content_catalog import CurriculumCatalogError
+
+from learn_to_cloud.main import lifespan
+
+pytestmark = pytest.mark.unit
+
+
+def _fake_catalog(
+    *, curriculum_version: int = 7, artifact_schema_version: int = 1
+) -> MagicMock:
+    catalog = MagicMock()
+    catalog.curriculum_version = curriculum_version
+    catalog.artifact_schema_version = artifact_schema_version
+    catalog.content_hash = "deadbeef"
+    return catalog
+
+
+@pytest.fixture
+def fake_app() -> FastAPI:
+    return FastAPI()
+
+
+@pytest.fixture(autouse=True)
+def _patch_startup_dependencies(test_settings):
+    """Patch every I/O dependency lifespan touches, except the curriculum catalog."""
+    with (
+        patch("learn_to_cloud.main.get_web_settings", return_value=test_settings),
+        patch("learn_to_cloud.main.create_engine", return_value=MagicMock()),
+        patch("learn_to_cloud.main.create_session_maker", return_value=MagicMock()),
+        patch("learn_to_cloud.main.get_code_alembic_head", return_value="head123"),
+        patch("learn_to_cloud.main.init_oauth"),
+        patch("learn_to_cloud.main.init_db", new=AsyncMock()),
+        patch("learn_to_cloud.main.close_github_client", new=AsyncMock()),
+        patch("learn_to_cloud.main.dispose_engine", new=AsyncMock()),
+    ):
+        yield
+
+
+@pytest.mark.asyncio
+class TestLifespanCurriculumFailFast:
+    async def test_catalog_load_failure_aborts_startup(self, fake_app: FastAPI):
+        """A broken/missing artifact must prevent the app from starting."""
+        with (
+            patch(
+                "learn_to_cloud.main.get_curriculum_catalog",
+                side_effect=CurriculumCatalogError("artifact missing"),
+            ),
+            pytest.raises(CurriculumCatalogError, match="artifact missing"),
+        ):
+            async with lifespan(fake_app):
+                pytest.fail("lifespan must not yield when the catalog fails to load")
+
+    async def test_successful_load_is_recorded_and_logged(
+        self, fake_app: FastAPI, caplog: pytest.LogCaptureFixture
+    ):
+        catalog = _fake_catalog(curriculum_version=3)
+
+        with (
+            patch("learn_to_cloud.main.get_curriculum_catalog", return_value=catalog),
+            caplog.at_level("INFO"),
+        ):
+            async with lifespan(fake_app):
+                assert fake_app.state.curriculum_catalog is catalog
+
+        assert "init.curriculum_loaded" in caplog.text

--- a/build-out-notes.md
+++ b/build-out-notes.md
@@ -1,0 +1,3 @@
+# Build-out Notes
+
+No deviations from the approved plan.

--- a/packages/learn-to-cloud-shared/pyproject.toml
+++ b/packages/learn-to-cloud-shared/pyproject.toml
@@ -9,6 +9,11 @@ include-package-data = false
 where = ["src"]
 include = ["learn_to_cloud_shared*"]
 
+[tool.setuptools.package-data]
+# Only the compiled artifact ships in the wheel -- authored YAML under
+# content/phases/ stays source-only (see content_yaml_loader.py).
+learn_to_cloud_shared = ["content/curriculum.json"]
+
 [project]
 name = "learn-to-cloud-shared"
 version = "0.1.0"

--- a/packages/learn-to-cloud-shared/scripts/compile_curriculum.py
+++ b/packages/learn-to-cloud-shared/scripts/compile_curriculum.py
@@ -1,0 +1,52 @@
+"""Compile the authored curriculum YAML into the canonical curriculum.json artifact.
+
+Runs the strict deterministic compiler in ``content_compiler.py`` and
+writes ``curriculum.json`` next to ``phases/`` and ``schemas/`` under
+``content/``. That file is committed to the repo and packaged as
+``learn-to-cloud-shared`` wheel data (see ``pyproject.toml``).
+
+Run from the package root::
+
+    cd packages/learn-to-cloud-shared && uv run python scripts/compile_curriculum.py
+
+Pass ``--previous-artifact PATH`` to also enforce the curriculum_version
+policy (must not decrease; may repeat only if content is unchanged)
+against a prior artifact. CI does this against the artifact committed
+at the PR base / pre-push SHA (see .github/workflows/deploy.yml) and
+also diffs the result against the committed copy to catch drift.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from learn_to_cloud_shared.content_compiler import (
+    ContentCompileError,
+    compile_and_write,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--previous-artifact",
+        type=Path,
+        default=None,
+        help="Prior curriculum.json to check the curriculum_version policy against.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        path = compile_and_write(previous_artifact_path=args.previous_artifact)
+    except ContentCompileError as exc:
+        print(f"Curriculum compile failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Curriculum compiled: OK -> {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
@@ -1,0 +1,7269 @@
+{
+  "artifact_schema_version": 1,
+  "content_hash": "d358192a7e540fcb95288f7a847c6c3db2e2ea3de108d957315a9d160a57e750",
+  "curriculum_version": 1,
+  "phases": [
+    {
+      "capstone": null,
+      "description": "This phase is designed for complete beginners who are starting from zero and want to build toward cloud engineering. You will learn the core ideas behind Linux, networking, programming, cloud computing, and DevOps in a beginner-friendly sequence. A strong foundation here will make every later phase easier to understand and apply in real projects.",
+      "hands_on_verification": {
+        "requirement_slugs": [
+          "profile-readme"
+        ],
+        "requirements": [
+          {
+            "description": "On github.com, create a new repository named exactly after your username. GitHub turns it into your profile README automatically, and you will use this same account to submit verification work in every phase.",
+            "name": "Create Your GitHub Profile README",
+            "slug": "profile-readme",
+            "submission_type": "profile_readme",
+            "type_config": {},
+            "uuid": "96327def-780b-4209-8ef1-b0d85b34357f"
+          }
+        ]
+      },
+      "name": "Starting from Zero",
+      "objectives": [],
+      "order": 0,
+      "short_description": "Build your beginner-friendly IT foundation across Linux, networking, programming, cloud computing, and DevOps.",
+      "slug": "phase0",
+      "topic_slugs": [
+        "prepare-to-learn",
+        "linux",
+        "networking",
+        "programming",
+        "cloud-computing",
+        "devops",
+        "cloud-engineer"
+      ],
+      "topics": [
+        {
+          "description": "Before you learn anything technical, you need to set yourself up for success. That means committing to one path, eliminating distractions, and learning how to actually learn. Most people restart their journey every time they watch a new roadmap video \u2014 this topic exists so you don't become one of them.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Commit to a single learning path and stop consuming surface-level roadmap content.",
+              "uuid": "5b2e06d9-55df-4384-ae83-0f98e1bbd57c"
+            },
+            {
+              "order": 2,
+              "text": "Remove digital distractions from your phone and browser that fragment your focus.",
+              "uuid": "6eaf4290-f527-4b85-9ef7-39405c300006"
+            },
+            {
+              "order": 3,
+              "text": "Understand how learning actually works and build a structured study routine.",
+              "uuid": "aec2606d-e81c-4afc-a628-e1a4b847587c"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Dr. K explains why self-help content crosses from helpful to harmful \u2014 why watching another roadmap or motivational video feels productive but actually replaces doing the work. Commit to this learning resource until you finish it and stop. Every time you watch a roadmap video, you are restarting your journey. Stop doing that.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase0-topic0-watch-why-you-should-stop",
+              "tips": [],
+              "title": "Why You Should Stop Watching YouTube (HealthyGamerGG)",
+              "url": "https://www.youtube.com/watch?v=XEb89CQJPO4",
+              "uuid": "755e00f3-e90f-4752-b3ec-7bffcf067a7d"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Your phone is a massive distraction machine. Read this post and follow the advice outlined there to remove all distractions from your phone \u2014 which apps to delete, how to configure notifications so only calls and calendar alerts make sound, disabling tap-to-wake and raise-to-wake, and keeping your home screen distraction-free.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase0-topic0-read-my-weekly-screen-time",
+              "tips": [],
+              "title": "My Weekly Screen Time Average is 41 Minutes",
+              "url": "https://substack.com/@madebygps/p-181593856",
+              "uuid": "e4e257d2-f376-45af-9041-1bbb72026197"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Now that you've eliminated distractions from your phone, do the same on your laptop. Install the SocialFocus browser extension (or similar) to hide social media feeds. This removes the temptation to scroll YouTube, Twitter, or LinkedIn when you sit down to study. You can toggle it off when you need to, but the default should be distraction-free.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase0-topic0-practice-install-a-feed-blocker",
+              "tips": [],
+              "title": "Install a Feed Blocker on Your Browser",
+              "url": "https://chromewebstore.google.com/detail/socialfocus-%E2%80%94-hide-feeds/abocjojdmemdpiffeadpdnicnlhcndcg",
+              "uuid": "e67dbaa9-13fc-4a35-8184-8ef46010d06a"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Engineering professor Barbara Oakley shares techniques from her online course \u2014 one of the largest in the world \u2014 on how your brain actually acquires new skills. Learn how to use focused and diffuse modes of thinking, and why short daily practice beats long cramming sessions.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase0-topic0-watch-learning-how-to-learn",
+              "tips": [],
+              "title": "Learning How to Learn (Barbara Oakley, TEDx)",
+              "url": "https://www.youtube.com/watch?v=O96fE1E-rf8",
+              "uuid": "57e8f00d-1c4e-4275-8291-3821ecb950ca"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "See the exact study routine that was followed for 6 months while learning cloud engineering \u2014 how to structure sessions, stay consistent, and avoid burnout. Use this as a template to build your own study schedule before moving on to the next topic.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase0-topic0-watch-6-months-following-this",
+              "tips": [],
+              "title": "6 Months Following This Study Routine TRANSFORMED My Cloud Career",
+              "url": "https://www.youtube.com/watch?v=88hnhRmpPZs",
+              "uuid": "b967e042-7164-400c-b8a3-2aca864da0eb"
+            }
+          ],
+          "name": "Prepare to Learn",
+          "order": 1,
+          "slug": "prepare-to-learn",
+          "uuid": "053f8cec-000a-4332-b2a2-9db7f18f3711"
+        },
+        {
+          "description": "Linux is the backbone of all cloud environments. Understanding what it is and why it matters is essential for cloud engineering.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Understand the history and importance of Linux.",
+              "uuid": "5ad3a05b-9291-46f6-b8e4-f34608c12426"
+            },
+            {
+              "order": 2,
+              "text": "Get hands-on with the most basic Linux commands.",
+              "uuid": "23ca265d-7fa3-4359-9fd8-999e2f296f02"
+            },
+            {
+              "order": 3,
+              "text": "Understand what the most popular Linux distros are.",
+              "uuid": "02f8f94b-8088-45ee-9655-838245c65f41"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Watch this documentary for the history, ecosystem, and culture behind Linux so you understand why it became the foundation of modern cloud infrastructure.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase0-topic1-watch-linux-documentary-the-story",
+              "tips": [],
+              "title": "Linux Documentary (The Story of Linux)",
+              "url": "https://www.youtube.com/watch?v=zPt_e9Cdk08",
+              "uuid": "90cba226-9b47-483e-abe9-06265b378f45"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Learn the basics of Bash and the command line so you can understand how Linux terminal commands work.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase0-topic1-practice-bash-scripting-and-command",
+              "tips": [],
+              "title": "Bash Scripting and Command Line for Beginners",
+              "url": "https://www.freecodecamp.org/news/bash-scripting-tutorial-linux-shell-script-and-command-line-for-beginners/",
+              "uuid": "65563a74-3a18-4dfa-b312-ee07661b6756"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Get a quick overview of common Linux distributions and how they differ.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase0-topic1-watch-every-linux-distro-explained",
+              "tips": [],
+              "title": "Every LINUX DISTRO Explained in 4 minutes",
+              "url": "https://youtu.be/VKNMI6cYOFk?si=zudsWVGRxBCpRlyA",
+              "uuid": "68abc922-ed80-424f-b6ff-e0a76b925f1c"
+            }
+          ],
+          "name": "What is Linux",
+          "order": 2,
+          "slug": "linux",
+          "uuid": "9974bac3-6879-4373-80bc-044693360a06"
+        },
+        {
+          "description": "Computer networking is how data moves across the internet and within cloud environments. Understanding the basics is crucial.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Describe how data moves between devices across local and internet networks.",
+              "uuid": "57d1440e-c044-48d6-8fe3-c2aca4f63d24"
+            },
+            {
+              "order": 2,
+              "text": "Explain the role of IP addresses and DNS in finding and reaching services.",
+              "uuid": "ee77bb6b-1b27-4e58-b825-df98b0bf603e"
+            },
+            {
+              "order": 3,
+              "text": "Relate networking fundamentals to cloud deployment and troubleshooting tasks.",
+              "uuid": "361aaabc-aaa6-498f-b85b-ba8eca32c36c"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how data moves across networks and why networking knowledge is essential for cloud engineering.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase0-topic2-watch-what-is-networking",
+              "tips": [],
+              "title": "What is Networking",
+              "url": "https://youtu.be/3QhU9jd03a0",
+              "uuid": "fe527e98-2928-4f23-aa80-8e8de313e712"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand IP addresses\u2014the unique identifiers that allow devices to communicate.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase0-topic2-read-what-is-an-ip",
+              "tips": [],
+              "title": "What is an IP Address?",
+              "url": "https://www.cloudflare.com/learning/dns/glossary/what-is-my-ip-address/",
+              "uuid": "6278022e-d20c-441e-a8cc-4f3cf4cc63d8"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how DNS translates domain names into IP addresses\u2014the phonebook of the internet.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase0-topic2-read-what-is-dns",
+              "tips": [],
+              "title": "What is DNS?",
+              "url": "https://www.cloudflare.com/learning/dns/what-is-dns/",
+              "uuid": "50b8f642-3657-468a-a437-35559e7a7eb7"
+            }
+          ],
+          "name": "What is Computer Networking",
+          "order": 3,
+          "slug": "networking",
+          "uuid": "98926657-c293-4b61-b361-a9ac71f4af82"
+        },
+        {
+          "description": "Computer programming enables you to automate tasks and manage cloud resources efficiently. Understanding the basics will help you throughout your cloud journey.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Understand what computer programming is and why it matters for cloud and DevOps automation.",
+              "uuid": "1d541314-ba5d-4800-8075-d4799bd839a4"
+            },
+            {
+              "order": 2,
+              "text": "Install Python and complete beginner Day 1 exercises to set up your coding environment.",
+              "uuid": "dbdb6def-c2e0-468e-9988-0df16b9fc7d0"
+            },
+            {
+              "order": 3,
+              "text": "Build confidence reading API-style JSON data with a simple Python script.",
+              "uuid": "2c7b8ec9-a388-48b1-83ab-42f5cfcbd6db"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Learn core computer programming concepts including what a program, programmer, and programming language are, types of languages (machine, assembly, middle, and high level), and how compilation vs interpretation works.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase0-topic3-watch-what-is-computer-programming",
+              "tips": [],
+              "title": "What is Computer Programming",
+              "url": "https://youtu.be/ifo76VyrBYo",
+              "uuid": "b4e89f70-5216-44ff-ac4c-36706bd206b6"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Install Python on your computer, then complete Day 1 of this beginner track to set up your environment and run your first Python exercises.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase0-topic3-practice-install-python-and-complete",
+              "tips": [],
+              "title": "Install Python and Complete Day 1",
+              "url": "https://7daysofpython.com/days/day1/",
+              "uuid": "05fa7e46-8d09-4845-8ef6-843e16d9700f"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": "sample = {\n  \"service\": \"journal-api\",\n  \"status\": \"healthy\",\n  \"region\": \"eastus\",\n  \"requests_last_hour\": 128,\n}\n\nfor key, value in sample.items():\n    print(f\"{key}: {value}\")\n",
+              "description": "Run this small script to practice reading JSON data like you'll do when working with APIs in later phases.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase0-topic3-practice-parse-json-with-a",
+              "tips": [],
+              "title": "Parse JSON with a Simple Python Script",
+              "url": null,
+              "uuid": "01e74e45-2267-472e-9a83-506834097d9e"
+            }
+          ],
+          "name": "What is Computer Programming",
+          "order": 4,
+          "slug": "programming",
+          "uuid": "6fb1f072-0530-47c5-96e0-f429aa3ed611"
+        },
+        {
+          "description": "Cloud computing is the foundation of modern infrastructure. Learn about IaaS, PaaS, SaaS, and different service models.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Define cloud computing and differentiate IaaS, PaaS, and SaaS models.",
+              "uuid": "6affa270-c865-4e23-bcc1-3ff2e1b0a86c"
+            },
+            {
+              "order": 2,
+              "text": "Identify AWS, Azure, and GCP as major cloud providers and understand their shared fundamentals.",
+              "uuid": "472b4880-c6ab-45ed-8c3b-3beeff1abba6"
+            },
+            {
+              "order": 3,
+              "text": "Choose a primary cloud provider while keeping concepts transferable across platforms.",
+              "uuid": "b1e5cccb-6d87-4c32-832d-53f6a3d42772"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Learn about IaaS, PaaS, SaaS and the different service models that make up cloud computing.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase0-topic4-watch-what-is-cloud-computing",
+              "tips": [],
+              "title": "What is Cloud Computing",
+              "url": "https://youtu.be/eZLcyTxi8ZI",
+              "uuid": "896b6f45-9273-46c6-8459-fadad67c2857"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Dive deeper into the three main cloud service models and when to use each.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase0-topic4-read-iaas-vs-paas-vs",
+              "tips": [],
+              "title": "IaaS vs PaaS vs SaaS",
+              "url": "https://azure.microsoft.com/resources/cloud-computing-dictionary/types-of-cloud-computing",
+              "uuid": "3bc1c215-a8ca-410f-8c73-caa5299aa07a"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Select one cloud provider and stick with it throughout the entire curriculum\u2014do not switch, because changing providers mid-way wastes time. Research job listings in your local area for roles like \"sysadmin,\" \"helpdesk,\" \"cloud engineer,\" and \"devops,\" then pick the cloud provider that appears most often.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase0-topic4-practice-choose-one-cloud-and",
+              "tips": [],
+              "title": "Choose One Cloud and Stick With It",
+              "url": null,
+              "uuid": "f0548620-51e7-4196-a912-1d077e7fb4ce"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Use your cloud picker decision from the previous step, then create an account in your chosen provider.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Sign in or create your Azure account in the Azure portal.",
+                  "provider": "azure",
+                  "title": "Create an Azure account",
+                  "url": "https://portal.azure.com"
+                },
+                {
+                  "description": "Sign in or create your AWS account in the AWS Management Console.",
+                  "provider": "aws",
+                  "title": "Create an AWS account",
+                  "url": "https://console.aws.amazon.com"
+                },
+                {
+                  "description": "Sign in or create your Google Cloud account in the Google Cloud console.",
+                  "provider": "gcp",
+                  "title": "Create a Google Cloud account",
+                  "url": "https://console.cloud.google.com"
+                }
+              ],
+              "order": 4,
+              "slug": "phase0-topic4-practice-create-your-cloud-account",
+              "tips": [],
+              "title": "Create Your Cloud Account",
+              "url": null,
+              "uuid": "c2386ab8-0997-40e1-9996-ccd7391a96be"
+            }
+          ],
+          "name": "What is Cloud Computing",
+          "order": 5,
+          "slug": "cloud-computing",
+          "uuid": "04cc6d93-f344-4228-9911-ce190354d4e0"
+        },
+        {
+          "description": "DevOps combines development and operations practices to improve software delivery. It's a key methodology in cloud engineering.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Understand what DevOps is and why it improves software delivery and reliability.",
+              "uuid": "2a8a6633-5b79-44c7-8f2d-c630c9665466"
+            },
+            {
+              "order": 2,
+              "text": "Identify core DevOps building blocks including version control, IaC, CI/CD, observability, containers, and Kubernetes.",
+              "uuid": "e877812b-b03f-472a-a017-f2b646de5447"
+            },
+            {
+              "order": 3,
+              "text": "Explain how these practices and tools fit together in modern cloud engineering workflows.",
+              "uuid": "fe1c1c58-f4ad-43f6-9d70-95a5805a4c8b"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Get a practical introduction to DevOps and how it connects software development, operations, and automation.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase0-topic5-watch-what-is-devops",
+              "tips": [],
+              "title": "What is DevOps",
+              "url": "https://youtu.be/UbtB4sMaaNM?si=8uH2Gr76QSrvCmAY",
+              "uuid": "86e38156-218e-487d-977b-e1a5088f81df"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn version control fundamentals with Git and how to track changes safely when collaborating on code.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase0-topic5-read-what-is-version-control",
+              "tips": [],
+              "title": "What is Version Control?",
+              "url": "https://github.blog/developer-skills/programming-languages-and-frameworks/what-is-git-our-beginners-guide-to-version-control/",
+              "uuid": "8b041688-0028-46c0-8a4b-8115eaad767a"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand how infrastructure is defined with code for consistency, repeatability, and automation.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase0-topic5-read-what-is-infrastructure-as",
+              "tips": [],
+              "title": "What is Infrastructure as Code (IaC)?",
+              "url": "https://www.hashicorp.com/resources/what-is-infrastructure-as-code",
+              "uuid": "441e0cfb-beba-45ca-80c8-0926231dbd95"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how continuous integration and continuous delivery automate build, test, and release workflows.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase0-topic5-read-what-is-cicd",
+              "tips": [],
+              "title": "What is CI/CD?",
+              "url": "https://www.redhat.com/topics/devops/what-is-ci-cd",
+              "uuid": "2afaa557-89d4-4367-a100-b924e58b436a"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand how logs, metrics, and traces help you monitor and troubleshoot systems in production.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase0-topic5-read-what-is-observability",
+              "tips": [],
+              "title": "What is Observability?",
+              "url": "https://www.ibm.com/think/topics/observability",
+              "uuid": "b02db398-de6d-40fc-bef9-1d9d81b2ef6c"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how containers package applications and dependencies so software runs consistently across environments.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase0-topic5-read-what-are-containers",
+              "tips": [],
+              "title": "What are Containers?",
+              "url": "https://www.docker.com/resources/what-container/",
+              "uuid": "999343bd-9a92-4344-92f0-c1bccd3c5bd8"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand Kubernetes as a container orchestration platform for deployment, scaling, and management.",
+              "done_when": null,
+              "options": [],
+              "order": 7,
+              "slug": "phase0-topic5-read-what-is-kubernetes",
+              "tips": [],
+              "title": "What is Kubernetes?",
+              "url": "https://kubernetes.io/docs/concepts/overview/",
+              "uuid": "b30afc5b-1176-45ef-b049-3cf64d5fbb71"
+            }
+          ],
+          "name": "What is DevOps",
+          "order": 6,
+          "slug": "devops",
+          "uuid": "54461c96-70f9-4ef4-8d68-8a93941c904e"
+        },
+        {
+          "description": "Learn about the cloud engineer role, what they do day-to-day, and whether it's the right fit for you.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain what cloud engineers do and the types of problems they solve.",
+              "uuid": "0dcf3b3d-f52e-49f6-a205-19a5f1b693cf"
+            },
+            {
+              "order": 2,
+              "text": "Identify foundational skills and habits needed to grow in cloud engineering.",
+              "uuid": "c3f08af7-dfd4-4e38-94a2-11e408a2535d"
+            },
+            {
+              "order": 3,
+              "text": "Reflect on personal fit and readiness for continuous learning in this career path.",
+              "uuid": "5244de99-b6f8-4ffa-adaf-fcae2a60f0ff"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "A cloud engineer designs, builds, and maintains the infrastructure that runs applications in the cloud. Day-to-day, that can include provisioning servers and databases, writing infrastructure-as-code, setting up CI/CD pipelines, monitoring system health, managing costs, and responding to incidents. They work across teams \u2014 with developers to deploy code reliably, with security to lock down access, and with leadership to choose the right services for the job. The role blends system administration, networking, automation, and software development. No two days look the same, and the tooling evolves constantly, so curiosity and a willingness to learn are just as important as any specific technology.\n",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase0-topic6-read-what-does-a-cloud",
+              "tips": [],
+              "title": "What Does a Cloud Engineer Do?",
+              "url": null,
+              "uuid": "ebe8caca-1a08-4369-91bf-99319d270832"
+            },
+            {
+              "action": "reflect",
+              "checklist": [],
+              "code": null,
+              "description": "Cloud engineering requires continuous learning and problem-solving. Consider: Do you enjoy figuring out how things work? Are you comfortable with change? Can you commit to learning new technologies regularly?",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase0-topic6-reflect-is-this-for-me",
+              "tips": [],
+              "title": "Is this for me?",
+              "url": null,
+              "uuid": "d9d12552-e9af-4f22-ae41-9b77c455fc0a"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Follow the creator of Learn to Cloud on GitHub to stay connected with the community.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase0-topic6-practice-follow-made-by-gps",
+              "tips": [],
+              "title": "Follow Made by GPS on GitHub",
+              "url": "https://github.com/madebygps",
+              "uuid": "666c5db3-ada0-4aa6-b47b-f45df1af7fcd"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Keep up to date with video tutorials and updates on the guide.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase0-topic6-practice-subscribe-youtube",
+              "tips": [],
+              "title": "Subscribe to youtube.com/@madebygps",
+              "url": "https://www.youtube.com/@madebygps",
+              "uuid": "76c727e9-100a-498d-8871-2a13335d527d"
+            }
+          ],
+          "name": "What is a Cloud Engineer",
+          "order": 7,
+          "slug": "cloud-engineer",
+          "uuid": "42af2089-5118-4fe2-a223-a0a83a314d6d"
+        }
+      ],
+      "uuid": "be385f44-1086-4b97-bfbb-b652540ad228"
+    },
+    {
+      "capstone": null,
+      "description": "Phase 1 gets you hands-on immediately with Linux and Bash through a Capture The Flag (CTF) lab. You\u2019ll build the foundation needed to access and complete the lab by setting up your environment, learning core command-line workflows, and practicing the tools you\u2019ll use throughout the rest of the curriculum.",
+      "hands_on_verification": {
+        "requirement_slugs": [
+          "linux-ctfs-fork",
+          "linux-ctfs-token"
+        ],
+        "requirements": [
+          {
+            "description": "Fork learntocloud/linux-ctfs to your account so your challenge work is tied to your profile.",
+            "name": "Fork the Linux CTFs Repository",
+            "slug": "linux-ctfs-fork",
+            "submission_type": "repo_fork",
+            "type_config": {
+              "required_repo": "learntocloud/linux-ctfs"
+            },
+            "uuid": "44c3bbb6-d6c3-466d-8d55-c1fec757ace7"
+          },
+          {
+            "description": "Finish all 18 Linux CTF challenges and submit the final completion token to verify completion.",
+            "name": "Submit the Linux CTF Completion Token",
+            "slug": "linux-ctfs-token",
+            "submission_type": "ctf_token",
+            "type_config": {
+              "placeholder": "Paste your CTF completion token here"
+            },
+            "uuid": "ec20af63-2ea2-418f-ac14-2c2ae3d06ca7"
+          }
+        ]
+      },
+      "name": "Linux and Bash",
+      "objectives": [],
+      "order": 1,
+      "short_description": "Build practical Linux and Bash skills with Git, cloud CLI, SSH, and Infrastructure as Code fundamentals through hands-on CTF lab work.",
+      "slug": "phase1",
+      "topic_slugs": [
+        "developer-setup",
+        "cloud-cli",
+        "iac",
+        "ssh",
+        "cli-basics",
+        "ctf-lab"
+      ],
+      "topics": [
+        {
+          "description": "Set up your local development environment and foundational GitHub workflow so you can move through the rest of Phase 1 smoothly.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Star the Learn to Cloud app repository and use the community discussions page for support.",
+              "uuid": "61c7c482-54a9-4d3b-90fe-937a8be8ce5e"
+            },
+            {
+              "order": 2,
+              "text": "Install VS Code and practice core terminal commands on your operating system.",
+              "uuid": "17c49b72-c555-46ea-8708-1af21f87a424"
+            },
+            {
+              "order": 3,
+              "text": "Update your profile README locally and push changes using a local-to-remote Git workflow.",
+              "uuid": "37069f97-e291-4273-ac57-64c319654725"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Open the repository and click Star so you can keep up with updates.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase1-topic1-practice-star-the-learn-to",
+              "tips": [],
+              "title": "Star the Learn to Cloud App repository",
+              "url": "https://github.com/learntocloud/learn-to-cloud-app",
+              "uuid": "6e5bfcf7-e17c-416e-9681-f6d717d338e5"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "We use VS Code for all programming and labs in this course.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase1-topic1-practice-install-vs-code",
+              "tips": [],
+              "title": "Install VS Code",
+              "url": "https://code.visualstudio.com/",
+              "uuid": "ed86669d-9137-4e97-95d3-2c83cf795b91"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "You were introduced to terminal basics in Phase 0. In this step, open your local terminal and practice core commands (for example pwd, ls, cd, mkdir, and cat) using the path for your operating system.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Install WSL if needed, open your Linux shell, and practice basic terminal commands there.",
+                  "provider": "windows",
+                  "title": "Windows terminal (WSL)",
+                  "url": "https://learn.microsoft.com/windows/wsl/install"
+                },
+                {
+                  "description": "Open your built-in terminal and use it to practice the core commands listed in this step.",
+                  "provider": "linux",
+                  "title": "Linux terminal",
+                  "url": "https://documentation.ubuntu.com/desktop/en/latest/tutorial/the-linux-command-line-for-beginners/"
+                },
+                {
+                  "description": "Use the built-in Terminal app and practice basic command-line workflow.",
+                  "provider": "macos",
+                  "title": "macOS terminal",
+                  "url": "https://support.apple.com/guide/terminal/welcome/mac"
+                }
+              ],
+              "order": 3,
+              "slug": "phase1-topic1-practice-practice-terminal-usage-on",
+              "tips": [],
+              "title": "Practice terminal usage on your operating system",
+              "url": null,
+              "uuid": "6b267155-1732-4ee9-a625-30f344dbb2ce"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Every GitHub account includes free usage of GitHub Copilot, so you do not need a paid plan to start. Enable Copilot and use it as a learning assistant while working through Learn to Cloud.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase1-topic1-read-set-up-github-copilot",
+              "tips": [],
+              "title": "Set up GitHub Copilot",
+              "url": "https://code.visualstudio.com/blogs/2024/12/18/free-github-copilot",
+              "uuid": "6aac64fd-2d9d-4088-948c-386b9088e19d"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Learn Markdown basics so you can write clean documentation in READMEs, issues, and project notes.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase1-topic1-practice-communicate-using-markdown",
+              "tips": [],
+              "title": "Communicate using markdown",
+              "url": "https://learn.microsoft.com/training/modules/communicate-using-markdown/",
+              "uuid": "5ba1f017-4242-4b65-b817-bd4a4a72b1d8"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "In Phase 0 you created your profile README repository on GitHub. Open it and review the README that powers your profile before you start editing it locally.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase1-topic1-practice-adding-a-profile-readme",
+              "tips": [],
+              "title": "Review your profile README repository",
+              "url": "https://docs.github.com/account-and-profile/how-tos/profile-customization/managing-your-profile-readme",
+              "uuid": "21e322f4-9fae-4609-af79-13fb33f828a0"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Clone your README repo to your local machine. Use VS Code to edit it and push changes back to GitHub from the terminal. Don't feel like you have to make a very fancy README\u2014write a brief description on who you are and add links to your socials.",
+              "done_when": null,
+              "options": [],
+              "order": 7,
+              "slug": "phase1-topic1-practice-practice-git-workflow",
+              "tips": [],
+              "title": "Practice Git workflow",
+              "url": null,
+              "uuid": "4a41c7e9-a0aa-4ab4-b47d-8760d92c6ffc"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Open the Learn to Cloud discussions page and bookmark it. If you ever have questions while working through the curriculum, this is the primary place to ask, share progress, and get support.",
+              "done_when": null,
+              "options": [],
+              "order": 8,
+              "slug": "phase1-topic1-practice-join-the-learn-to",
+              "tips": [],
+              "title": "Join the Learn to Cloud community",
+              "url": "https://github.com/learntocloud/learn-to-cloud-app/discussions",
+              "uuid": "e2b87158-c3d4-4aae-b6ee-b38d48fce103"
+            }
+          ],
+          "name": "Developer Setup",
+          "order": 1,
+          "slug": "developer-setup",
+          "uuid": "7617e76a-d657-43e1-9615-a47b065c8833"
+        },
+        {
+          "description": "Learn to interact with cloud platforms through the command line. The CLI is essential for automation and scripting.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Install the CLI for your chosen cloud provider and verify it works locally.",
+              "uuid": "948decfc-494b-44e6-a266-713af819abd0"
+            },
+            {
+              "order": 2,
+              "text": "Configure authentication securely for command-line access to cloud resources.",
+              "uuid": "7754d73f-9b3b-46e8-be44-f3e1c668ba16"
+            },
+            {
+              "order": 3,
+              "text": "Build baseline CLI fluency needed for upcoming labs and automation tasks.",
+              "uuid": "19cad967-2d96-486d-bc1d-9c71da5008e4"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Choose and install the CLI for your preferred cloud platform:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Follow the official guide to install the Azure CLI on your system.",
+                  "provider": "azure",
+                  "title": "Install the Azure CLI",
+                  "url": "https://learn.microsoft.com/cli/azure/install-azure-cli"
+                },
+                {
+                  "description": "Follow the official guide to install the AWS CLI on your system.",
+                  "provider": "aws",
+                  "title": "Install the AWS CLI",
+                  "url": "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+                },
+                {
+                  "description": "Follow the official guide to install the gcloud CLI on your system.",
+                  "provider": "gcp",
+                  "title": "Install the Google Cloud CLI",
+                  "url": "https://docs.cloud.google.com/sdk/docs/install-sdk"
+                }
+              ],
+              "order": 1,
+              "slug": "phase1-topic2-practice-install-your-cloud-providers",
+              "tips": [],
+              "title": "Install your cloud provider's CLI",
+              "url": null,
+              "uuid": "583da302-6fac-450c-a881-5ecf6e9fcb91"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Run a simple command to verify your CLI is working correctly:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Run this command in your terminal:\n```bash az --version ```",
+                  "provider": "azure",
+                  "title": "Verify Azure CLI",
+                  "url": "https://learn.microsoft.com/cli/azure/reference-index?view=azure-cli-latest#az-version"
+                },
+                {
+                  "description": "Run this command in your terminal:\n```bash aws --version ```",
+                  "provider": "aws",
+                  "title": "Verify AWS CLI",
+                  "url": "https://docs.aws.amazon.com/cli/latest/reference/#global-options"
+                },
+                {
+                  "description": "Run this command in your terminal:\n```bash gcloud --version ```",
+                  "provider": "gcp",
+                  "title": "Verify Google Cloud CLI",
+                  "url": "https://docs.cloud.google.com/sdk/gcloud/reference/version"
+                }
+              ],
+              "order": 2,
+              "slug": "phase1-topic2-practice-test-your-cli-installation",
+              "tips": [],
+              "title": "Test your CLI installation",
+              "url": null,
+              "uuid": "3a9e7fe9-4ba8-4ea3-b9e3-af8ba62a3e7f"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Set up your credentials to authenticate with your cloud provider:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Run this command in your terminal:\n```bash az login ```",
+                  "provider": "azure",
+                  "title": "Authenticate Azure CLI",
+                  "url": "https://learn.microsoft.com/cli/azure/authenticate-azure-cli"
+                },
+                {
+                  "description": "Run this command in your terminal:\n```bash aws configure ```",
+                  "provider": "aws",
+                  "title": "Authenticate AWS CLI",
+                  "url": "https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html"
+                },
+                {
+                  "description": "Run this command in your terminal:\n```bash gcloud auth login ```",
+                  "provider": "gcp",
+                  "title": "Authenticate Google Cloud CLI",
+                  "url": "https://docs.cloud.google.com/sdk/docs/authorizing"
+                }
+              ],
+              "order": 3,
+              "slug": "phase1-topic2-practice-configure-authentication",
+              "tips": [],
+              "title": "Configure authentication",
+              "url": null,
+              "uuid": "6c8ee969-af99-4bdc-b75d-989c751aa71c"
+            }
+          ],
+          "name": "Cloud CLI",
+          "order": 2,
+          "slug": "cloud-cli",
+          "uuid": "6b9b665a-fc4c-4037-8d74-12cc6741711f"
+        },
+        {
+          "description": "We will spend a lot more time on Infrastructure as Code and other DevOps practices later as all of our labs use them. For now, you need to familiarize yourself with a few Terraform concepts.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Describe Infrastructure as Code principles and why IaC improves consistency.",
+              "uuid": "df842b16-a929-49f7-9a1c-82f506208b91"
+            },
+            {
+              "order": 2,
+              "text": "Understand the purpose of key Terraform commands used in real workflows.",
+              "uuid": "3670ae48-bed3-4213-95b7-b97655ff790a"
+            },
+            {
+              "order": 3,
+              "text": "Install Terraform and prepare your environment for hands-on infrastructure work.",
+              "uuid": "0bdc2207-d784-47be-855a-74ad03e81058"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn the fundamentals of Infrastructure as Code and why it's important.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase1-topic3-read-what-is-iac",
+              "tips": [],
+              "title": "What is IaC",
+              "url": "https://www.hashicorp.com/resources/what-is-infrastructure-as-code",
+              "uuid": "9b6bb9e2-dfe0-4de8-adfb-117e4ff3ecc4"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": null,
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase1-topic3-read-what-is-infrastructure-as",
+              "tips": [],
+              "title": "What is Infrastructure as Code with Terraform?",
+              "url": "https://developer.hashicorp.com/terraform/intro",
+              "uuid": "ecaf51a3-166a-4584-b843-aa46549cbf66"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn what terraform init does and why it's the first command you run.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase1-topic3-read-terraform-init",
+              "tips": [],
+              "title": "Terraform init",
+              "url": "https://developer.hashicorp.com/terraform/cli/commands/init",
+              "uuid": "1219cbf7-2205-4e4a-b727-7d549f6a7854"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how terraform apply creates and updates infrastructure.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase1-topic3-read-terraform-apply",
+              "tips": [],
+              "title": "Terraform apply",
+              "url": "https://developer.hashicorp.com/terraform/cli/commands/apply",
+              "uuid": "34aeb3ff-88e1-4f82-8810-a3084ac76899"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": "I'm studying cloud engineering and recently learned about Infrastructure as Code. I will provide you an explanation about it and please ask me any questions if my explanation is not clear. I want to make sure I really understand this concept so please do not correct me, simply ask questions until I get the explanation right. Here is my explanation: IaC is...",
+              "description": "Remember: The goal is for AI to challenge your understanding, not give you the answer. Use this prompt to verify you understand IaC concepts:",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase1-topic3-read-test-your-understanding-with",
+              "tips": [],
+              "title": "Test your understanding with an AI assistant",
+              "url": null,
+              "uuid": "8566b08e-2db1-4358-bf50-52de49ca0133"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Windows users: Make sure you're installing Terraform inside Ubuntu via WSL.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase1-topic3-practice-install-terraform",
+              "tips": [],
+              "title": "Install Terraform",
+              "url": "https://developer.hashicorp.com/terraform/install",
+              "uuid": "7b9f42b2-796a-412c-b522-94e88770517e"
+            }
+          ],
+          "name": "Infrastructure as Code",
+          "order": 3,
+          "slug": "iac",
+          "uuid": "492f5805-7709-4cff-b9fb-baa4a93f4504"
+        },
+        {
+          "description": "Now you need to learn how to access a virtual machine via SSH. This is a fundamental skill for working with cloud servers.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain why SSH is used for secure remote administration of cloud systems.",
+              "uuid": "24581de1-a22b-47b5-9983-28aea80c3aac"
+            },
+            {
+              "order": 2,
+              "text": "Connect to a virtual machine using your provider\u2019s recommended SSH workflow.",
+              "uuid": "1dfbd841-95c9-4882-90c9-3d94b20a7214"
+            },
+            {
+              "order": 3,
+              "text": "Build confidence with remote access steps required for future labs and deployments.",
+              "uuid": "52261710-7e7b-4b41-bf02-c6c64dec17fe"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn what SSH is and why it's used for secure remote access.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase1-topic4-read-what-is-ssh",
+              "tips": [],
+              "title": "What is SSH",
+              "url": "https://www.cloudflare.com/learning/access-management/what-is-ssh/",
+              "uuid": "9279efbf-63ea-41c6-8281-cffdbf39acfb"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Follow your cloud provider's guide to connect to a VM via SSH:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Learn to connect and develop on Azure VMs remotely.",
+                  "provider": "azure",
+                  "title": "Develop on a remote machine",
+                  "url": "https://learn.microsoft.com/training/modules/develop-on-remote-machine/"
+                },
+                {
+                  "description": "AWS guide to connecting to EC2 instances via SSH.",
+                  "provider": "aws",
+                  "title": "Connect to your Linux instance",
+                  "url": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-linux-inst-ssh.html"
+                },
+                {
+                  "description": "GCP documentation for SSH access to Compute Engine instances.",
+                  "provider": "gcp",
+                  "title": "SSH into a VM",
+                  "url": "https://docs.cloud.google.com/compute/docs/connect/standard-ssh"
+                }
+              ],
+              "order": 2,
+              "slug": "phase1-topic4-practice-practice-connecting-to-a",
+              "tips": [],
+              "title": "Practice connecting to a VM",
+              "url": null,
+              "uuid": "452d2dab-33ba-4c57-959f-c52156e53003"
+            }
+          ],
+          "name": "SSH",
+          "order": 4,
+          "slug": "ssh",
+          "uuid": "4cb6ee56-8266-45a3-a379-e7b5a6b4832c"
+        },
+        {
+          "description": "The Linux command line is your gateway to cloud infrastructure. Work through Linux Basics for Hackers chapter by chapter to prepare for the CTF challenges.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Use essential Linux commands to navigate, inspect, and manage files efficiently.",
+              "uuid": "896e503c-ea2e-4064-970a-fde0427ba214"
+            },
+            {
+              "order": 2,
+              "text": "Apply permissions, process management, and package operations in practical scenarios.",
+              "uuid": "f0f630d7-9e2c-4213-b73f-88c89ffc9c1e"
+            },
+            {
+              "order": 3,
+              "text": "Build command-line fluency needed to troubleshoot and solve CTF lab challenges.",
+              "uuid": "5a2229c0-46c8-4c5e-be3e-274471bea0a2"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "explore",
+              "checklist": [],
+              "code": null,
+              "description": "Purchase or borrow Linux Basics for Hackers by OccupyTheWeb. We'll work through chapters 1-9, which cover everything you need for the CTF challenges.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase1-topic5-explore-linux-basics-for-hackers",
+              "tips": [],
+              "title": "Linux Basics for Hackers, 2nd Edition",
+              "url": "https://nostarch.com/linux-basics-hackers-2nd-edition",
+              "uuid": "9fd9c5bf-900e-49d7-a656-2fb1807a608d"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn essential navigation commands: pwd, cd, ls, whoami, and getting help with man pages. Understand the Linux filesystem hierarchy.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase1-topic5-read-getting-started-with-the",
+              "tips": [],
+              "title": "Getting Started with the Basics",
+              "url": "https://nostarch.com/linux-basics-hackers-2nd-edition",
+              "uuid": "d6a26f73-06d8-41ee-913b-95895db89e9f"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn to view and manipulate text files using cat, head, tail, grep, and sed. Master pipes and redirects for chaining commands.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase1-topic5-read-text-manipulation",
+              "tips": [],
+              "title": "Text Manipulation",
+              "url": "https://nostarch.com/linux-basics-hackers-2nd-edition",
+              "uuid": "17135a43-1765-46ab-9e94-df925a287ef8"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn network analysis commands: ifconfig/ip, iwconfig, dig, and DNS configuration. Essential for cloud engineering.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase1-topic5-read-analyzing-and-managing-networks",
+              "tips": [],
+              "title": "Analyzing and Managing Networks",
+              "url": "https://nostarch.com/linux-basics-hackers-2nd-edition",
+              "uuid": "64492642-4c84-4830-ac37-293a3263bc37"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn package management with apt: searching, installing, updating, and removing software.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase1-topic5-read-adding-and-removing-software",
+              "tips": [],
+              "title": "Adding and Removing Software",
+              "url": "https://nostarch.com/linux-basics-hackers-2nd-edition",
+              "uuid": "2f641f23-9cd0-41f1-bb7f-ada2e9f46e5c"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Master Linux permissions: understanding rwx, chmod, chown, and special permissions. Critical for security.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase1-topic5-read-controlling-file-and-directory",
+              "tips": [],
+              "title": "Controlling File and Directory Permissions",
+              "url": "https://nostarch.com/linux-basics-hackers-2nd-edition",
+              "uuid": "0909b550-2e76-4785-848c-5db60c93b5a9"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn to view and manage processes with ps, top, kill, and nice. Essential for troubleshooting.",
+              "done_when": null,
+              "options": [],
+              "order": 7,
+              "slug": "phase1-topic5-read-process-management",
+              "tips": [],
+              "title": "Process Management",
+              "url": "https://nostarch.com/linux-basics-hackers-2nd-edition",
+              "uuid": "221ce82f-c783-45d8-b0a8-5f9614a19f5f"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand environment variables like PATH, HOME, and how to configure them in .bashrc.",
+              "done_when": null,
+              "options": [],
+              "order": 8,
+              "slug": "phase1-topic5-read-managing-user-environment-variables",
+              "tips": [],
+              "title": "Managing User Environment Variables",
+              "url": "https://nostarch.com/linux-basics-hackers-2nd-edition",
+              "uuid": "c70f8b39-10c0-460a-a8df-acbcd408660e"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Introduction to bash scripting: variables, conditionals, loops. Free sample chapter available!",
+              "done_when": null,
+              "options": [],
+              "order": 9,
+              "slug": "phase1-topic5-read-bash-scripting",
+              "tips": [],
+              "title": "Bash Scripting",
+              "url": "https://nostarch.com/download/LinuxBasicsforHackers2e_chapter8.pdf",
+              "uuid": "a345d102-ed18-45d1-9ed9-c7ef0c26e3ae"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn to work with compressed files using tar, gzip, bzip2. Used constantly for logs and backups.",
+              "done_when": null,
+              "options": [],
+              "order": 10,
+              "slug": "phase1-topic5-read-compressing-and-archiving",
+              "tips": [],
+              "title": "Compressing and Archiving",
+              "url": "https://nostarch.com/linux-basics-hackers-2nd-edition",
+              "uuid": "b696262e-137e-415a-af9d-c2e72cf5df1e"
+            }
+          ],
+          "name": "CLI Basics",
+          "order": 5,
+          "slug": "cli-basics",
+          "uuid": "53ee5ca9-8003-4e86-b2e5-efbea7349f97"
+        },
+        {
+          "description": "Time to put your Linux skills to the test! Complete 18 progressive Capture The Flag challenges covering file navigation, permissions, networking, and more. The curriculum may not have covered everything you need \u2014 that's intentional. Researching what you don't know is part of the job.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Deploy and configure the Linux CTF lab environment successfully.",
+              "uuid": "9a98bb7e-ab14-4591-9321-011958ca7d1d"
+            },
+            {
+              "order": 2,
+              "text": "Complete the progressive Linux CTF challenges using command-line problem solving.",
+              "uuid": "78e39df3-a143-4ad2-ba5c-078902a45d4d"
+            },
+            {
+              "order": 3,
+              "text": "Demonstrate practical Linux troubleshooting, permissions, and networking skills.",
+              "uuid": "6f5e9b0d-7140-41b2-adc4-dba34d9e5cd6"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "The repository README has everything you need: setup instructions for AWS/Azure/GCP, challenge descriptions, and tips. Follow the instructions there to deploy and complete the challenges.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase1-topic6-practice-linux-ctfs-repository",
+              "tips": [],
+              "title": "Linux CTFs Repository",
+              "url": "https://github.com/learntocloud/linux-ctfs",
+              "uuid": "09fdb96c-4084-40ae-9900-0896ff778d00"
+            },
+            {
+              "action": "reflect",
+              "checklist": [],
+              "code": null,
+              "description": "When you've completed the CTF challenges, share your experience on LinkedIn or the Learn to Cloud community to celebrate your progress and help others.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase1-topic6-reflect-share-your-progress",
+              "tips": [],
+              "title": "Share Your Progress",
+              "url": null,
+              "uuid": "d99e13fa-cc35-472b-8dcc-c106cb4bf4b5"
+            }
+          ],
+          "name": "Capstone: Linux CTF Lab",
+          "order": 6,
+          "slug": "ctf-lab",
+          "uuid": "3fa502ac-3a8e-4878-9f82-516785b4bcbc"
+        }
+      ],
+      "uuid": "2cc27dfe-e922-4e98-89bb-c0555af94472"
+    },
+    {
+      "capstone": null,
+      "description": "Welcome to Phase 2! This phase covers the core networking concepts you need before diving into cloud infrastructure. Understanding how networks work\u2014IP addressing, routing, DNS, and common protocols\u2014is essential for cloud engineering. You'll learn to troubleshoot connectivity issues and build a mental model of how data flows across networks.",
+      "hands_on_verification": {
+        "requirement_slugs": [
+          "networking-lab-fork",
+          "networking-lab-token"
+        ],
+        "requirements": [
+          {
+            "description": "Fork learntocloud/networking-lab so you can complete and track the lab in your own account.",
+            "name": "Fork the Networking Lab Repository",
+            "slug": "networking-lab-fork",
+            "submission_type": "repo_fork",
+            "type_config": {
+              "required_repo": "learntocloud/networking-lab"
+            },
+            "uuid": "1e8d79f3-9936-4fd4-ab46-ddd1a7eea65f"
+          },
+          {
+            "description": "Finish all four networking challenges and submit the completion token shown at the end.",
+            "name": "Submit the Networking Lab Completion Token",
+            "slug": "networking-lab-token",
+            "submission_type": "networking_token",
+            "type_config": {
+              "placeholder": "Paste your Networking Lab completion token here"
+            },
+            "uuid": "c359bc2e-3215-4841-ab9b-e51be59ed3ff"
+          }
+        ]
+      },
+      "name": "Networking Fundamentals",
+      "objectives": [],
+      "order": 2,
+      "short_description": "Learn core networking: IP/subnetting, routing, DNS, HTTP, ports, and troubleshooting. Build the foundation for cloud networking.",
+      "slug": "phase2",
+      "topic_slugs": [
+        "fundamentals",
+        "protocols",
+        "http",
+        "troubleshooting-lab"
+      ],
+      "topics": [
+        {
+          "description": "Master the building blocks of networking: IP addresses, subnets, routing, and DNS. These concepts are the foundation for everything in cloud infrastructure.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain core networking concepts including IP addressing, subnetting, routing, and DNS.",
+              "uuid": "0b2eb39d-a3d1-4a59-82a4-8d394d32d187"
+            },
+            {
+              "order": 2,
+              "text": "Use foundational networking commands to inspect connectivity and resolve common issues.",
+              "uuid": "fa016709-ee7e-40d1-ab81-cb6d1b5bcc63"
+            },
+            {
+              "order": 3,
+              "text": "Build a strong networking baseline for cloud architecture and troubleshooting tasks.",
+              "uuid": "e9d47b99-c820-43ee-8f1d-04024f39bccf"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Understand IPv4 addresses, octets, and how binary relates to IP addressing. Know the difference between public and private IP ranges (10.x.x.x, 172.16-31.x.x, 192.168.x.x).",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase2-topic1-watch-ip-addresses-explained",
+              "tips": [],
+              "title": "IP Addresses Explained",
+              "url": "https://www.youtube.com/watch?v=LIzTo6e4FgY",
+              "uuid": "0fbd4542-8da2-488d-a761-2599fb9e4738"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Learn CIDR notation (/24, /16, etc.), subnet masks, and how to calculate network ranges. Practice subnetting until it becomes second nature.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase2-topic1-watch-subnetting-made-simple",
+              "tips": [],
+              "title": "Subnetting Made Simple",
+              "url": "https://www.youtube.com/watch?v=ecCuyq-Wprc",
+              "uuid": "49671d40-1c31-4f1a-9198-3f51758068f4"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Use this interactive tool to practice subnetting. Aim to answer subnet questions quickly and accurately before moving on.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase2-topic1-practice-subnet-practice-tool",
+              "tips": [],
+              "title": "Subnet Practice Tool",
+              "url": "https://subnetipv4.com/",
+              "uuid": "b7a4fb19-990b-432a-9f64-b5896adc3f5f"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Understand how packets travel between networks: routing tables, default gateways, and how routers make forwarding decisions.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase2-topic1-watch-how-routing-works",
+              "tips": [],
+              "title": "How Routing Works",
+              "url": "https://www.youtube.com/watch?v=AkxqkoxErRk",
+              "uuid": "7cd02ab6-1870-4bcc-b1b9-558fc35f1083"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how NAT allows private IP addresses to communicate with the internet. Understand SNAT, DNAT, and port forwarding.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase2-topic1-watch-network-address-translation",
+              "tips": [],
+              "title": "Network Address Translation",
+              "url": "https://www.youtube.com/watch?v=FTUV0t6JaDA",
+              "uuid": "5732aaf0-381b-457f-8802-490254440663"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Understand how DNS resolves domain names: recursive resolvers, root servers, authoritative servers, and common record types (A, AAAA, CNAME, MX, TXT).",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase2-topic1-watch-dns-explained",
+              "tips": [],
+              "title": "DNS Explained",
+              "url": "https://www.youtube.com/watch?v=27r4Bzuj5NQ",
+              "uuid": "cd334f9c-8d99-4f29-91fc-f78efaec2a3d"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": "dig google.com\ndig +trace google.com\nnslookup -type=MX gmail.com",
+              "description": "Practice using dig and nslookup to query DNS records. Try: dig google.com, dig +trace google.com, nslookup -type=MX gmail.com",
+              "done_when": null,
+              "options": [],
+              "order": 7,
+              "slug": "phase2-topic1-practice-using-dig-and-nslookup",
+              "tips": [],
+              "title": "Using dig and nslookup",
+              "url": null,
+              "uuid": "654c1893-4e57-42dd-805c-35202941be9a"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": "ping google.com\ntraceroute google.com\ntracert google.com",
+              "description": "Use ping to test host reachability and measure round-trip latency, and traceroute (tracert on Windows) to trace the path packets take to a destination. Try ping google.com, traceroute google.com, and ping between VMs to verify connectivity.",
+              "done_when": null,
+              "options": [],
+              "order": 8,
+              "slug": "phase2-topic1-practice-testing-network-connectivity",
+              "tips": [],
+              "title": "Testing Network Connectivity",
+              "url": null,
+              "uuid": "d6512a19-16ae-4af2-ac83-77d0f3883b52"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Comprehensive recap of networking concepts (including extra topics) to consolidate your understanding after completing steps 1-8.",
+              "done_when": null,
+              "options": [],
+              "order": 9,
+              "slug": "phase2-topic1-watch-networking-fundamentals-recap-optional",
+              "tips": [],
+              "title": "Networking Fundamentals Recap (Optional)",
+              "url": "https://www.youtube.com/watch?v=IPvYjXCsTg8",
+              "uuid": "61a306c6-c890-44ab-b881-5c8e148b6609"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "See how the networking concepts you just learned (subnets, route tables, gateways, NAT) map to a real cloud environment. This prepares you for the capstone lab where you'll troubleshoot a broken cloud network.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "End-to-end walkthrough of setting up a VPC with public and private subnets, route tables, and gateways in AWS.",
+                  "provider": "aws",
+                  "title": "AWS Networking Basics For Programmers",
+                  "url": "https://www.youtube.com/watch?v=2doSoMN2xvI"
+                },
+                {
+                  "description": "Build a VNet with subnets, NSGs, and route tables in Azure.",
+                  "provider": "azure",
+                  "title": "Azure Virtual Network Tutorial",
+                  "url": "https://www.youtube.com/watch?v=9DuTWSvsLXM"
+                },
+                {
+                  "description": "Set up a VPC with subnets, firewall rules, and routing in Google Cloud.",
+                  "provider": "gcp",
+                  "title": "GCP VPC Networking Fundamentals",
+                  "url": "https://www.youtube.com/watch?v=XLaFU1t9pM8"
+                }
+              ],
+              "order": 10,
+              "slug": "phase2-topic1-watch-cloud-vpc-walkthrough",
+              "tips": [],
+              "title": "Cloud VPC Walkthrough",
+              "url": null,
+              "uuid": "1e6b156c-ae9d-4cb9-bac8-ca187c9eaa54"
+            }
+          ],
+          "name": "Networking Fundamentals",
+          "order": 1,
+          "slug": "fundamentals",
+          "uuid": "fdcf8dbd-a1fa-49a1-b4d0-e76486d92558"
+        },
+        {
+          "description": "Learn how applications communicate over networks through ports and protocols. Understand TCP vs UDP, common port numbers, and how firewalls control traffic flow.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Differentiate TCP and UDP behavior and identify appropriate use cases.",
+              "uuid": "c9fb08ef-462a-4f82-bf9e-104533ffa493"
+            },
+            {
+              "order": 2,
+              "text": "Identify common ports and explain how firewall rules control network traffic.",
+              "uuid": "416553fa-5204-4696-90b4-0f9efe73fba4"
+            },
+            {
+              "order": 3,
+              "text": "Analyze active connections and listening services with practical host-level tools.",
+              "uuid": "381d9dcf-49be-4137-bc1d-7fa14a41648d"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Understand the difference between TCP (connection-oriented, reliable) and UDP (connectionless, fast). Know when to use each protocol.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase2-topic2-watch-tcp-and-udp-explained",
+              "tips": [],
+              "title": "TCP and UDP Explained",
+              "url": "https://www.youtube.com/watch?v=uwoD5YsGACg",
+              "uuid": "a65b223b-f2f2-4b17-a73b-f537ef714f96"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Understand SYN, SYN-ACK, ACK and how TCP connections are established. This knowledge is crucial for troubleshooting connection issues.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase2-topic2-watch-tcp-three-way-handshake",
+              "tips": [],
+              "title": "TCP Three-Way Handshake",
+              "url": "https://www.youtube.com/watch?v=xMtP5ZB3wSk",
+              "uuid": "14b373f4-f7f0-4006-804e-20a10f0892d4"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Every service you run uses a port. Some services have well-known, commonly used ports\u2014read this overview to understand the most important ones.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase2-topic2-read-common-port-numbers",
+              "tips": [],
+              "title": "Common Port Numbers",
+              "url": "https://www.cloudflare.com/learning/network-layer/what-is-a-computer-port/",
+              "uuid": "35a8eb0f-3406-49d5-89a7-49cb32cbc70c"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Understand how firewalls filter traffic based on IP, port, and protocol. Learn about stateful vs stateless firewalls.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase2-topic2-watch-how-firewalls-work",
+              "tips": [],
+              "title": "How Firewalls Work",
+              "url": "https://www.youtube.com/watch?v=kDEX1HXybrU",
+              "uuid": "574ee75d-60a2-4085-ba29-d3ff9d6ba813"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Understand how load balancers distribute traffic across multiple servers: health checks, round-robin vs least-connections, and Layer 4 vs Layer 7 balancing. Load balancers are essential for high availability and scaling.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase2-topic2-watch-how-load-balancers-work",
+              "tips": [],
+              "title": "How Load Balancers Work",
+              "url": "https://www.youtube.com/watch?v=sCR3SAVdyCc",
+              "uuid": "6ca28aaa-c88c-4989-95f3-2e8b063715b6"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Preview how cloud providers implement firewalls as security groups. Understand inbound vs outbound rules and the concept of least privilege.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Virtual firewall rules for EC2 instances in a VPC",
+                  "provider": "aws",
+                  "title": "AWS Security Groups",
+                  "url": "https://docs.aws.amazon.com/vpc/latest/userguide/default-security-group.html"
+                },
+                {
+                  "description": "Filter network traffic with inbound and outbound security rules",
+                  "provider": "azure",
+                  "title": "Azure Network Security Groups",
+                  "url": "https://learn.microsoft.com/azure/virtual-network/network-security-groups-overview"
+                },
+                {
+                  "description": "Ingress and egress firewall rules for VPC networks",
+                  "provider": "gcp",
+                  "title": "GCP VPC Firewall Rules",
+                  "url": "https://docs.cloud.google.com/firewall/docs/firewalls"
+                }
+              ],
+              "order": 6,
+              "slug": "phase2-topic2-read-cloud-security-groups",
+              "tips": [],
+              "title": "Cloud Security Groups",
+              "url": null,
+              "uuid": "9613348d-847f-4c27-aa21-53229c98c74e"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": "# Primary (modern)\nss -lntup\nsudo ss -lntup\n\n# Optional (process-oriented view)\nlsof -i -P -n | grep LISTEN\nsudo lsof -i -P -n | grep LISTEN\n\n# Fallback (older systems)\nnetstat -tulpn\nsudo netstat -tulpn",
+              "description": "Use ss -lntup as your primary command to see listening ports and owning processes. If you're on Windows, run these commands inside WSL. Use netstat only as a fallback on older systems. You may need sudo to see process names/PIDs for services owned by other users.",
+              "done_when": null,
+              "options": [],
+              "order": 7,
+              "slug": "phase2-topic2-practice-view-active-connections",
+              "tips": [],
+              "title": "View Active Connections",
+              "url": null,
+              "uuid": "5ea4e8b8-c405-44ec-b0d6-f01b43a0ab73"
+            }
+          ],
+          "name": "Ports and Protocols",
+          "order": 2,
+          "slug": "protocols",
+          "uuid": "90328c27-63fd-4eec-b187-fb7109a4225c"
+        },
+        {
+          "description": "Understand how the web works: HTTP requests and responses, headers, status codes, and TLS/HTTPS. Essential knowledge for working with APIs and web services.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain HTTP request/response structure including methods, headers, and status codes.",
+              "uuid": "48df55a2-6cec-4433-b46c-81243ec33d70"
+            },
+            {
+              "order": 2,
+              "text": "Describe TLS/HTTPS fundamentals and why encrypted web traffic matters.",
+              "uuid": "e4af0f61-0d60-4d8b-8afb-3a406295a5ef"
+            },
+            {
+              "order": 3,
+              "text": "Use curl and browser tooling to inspect and debug real web traffic.",
+              "uuid": "25197e4b-c7d8-4904-bc4e-5bbbcd714425"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Understand the HTTP request/response cycle: methods (GET, POST, PUT, DELETE), headers, body, and how clients communicate with servers.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase2-topic3-watch-how-http-works",
+              "tips": [],
+              "title": "How HTTP Works",
+              "url": "https://www.youtube.com/watch?v=iYM2zFP3Zn0",
+              "uuid": "72fd8d7a-a71e-486c-9c52-1ac357c15549"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand the status code categories: 2xx (success), 3xx (redirect), 4xx (client error), and 5xx (server error). Focus on recognizing patterns and meanings, not memorizing long code lists.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase2-topic3-read-status-code-categories",
+              "tips": [],
+              "title": "Status Code Categories",
+              "url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Status",
+              "uuid": "c49d4a1c-4fc6-4e0b-af99-a75d24b66b8d"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand common headers: Content-Type, Authorization, Accept, Cache-Control, User-Agent. Know how headers control request/response behavior.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase2-topic3-read-common-http-headers",
+              "tips": [],
+              "title": "Common HTTP Headers",
+              "url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers",
+              "uuid": "b5bb4136-ee37-4049-bcba-07ba927eca58"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Understand how TLS encrypts HTTP traffic: certificates, certificate authorities, the TLS handshake, and why HTTPS matters for security.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase2-topic3-watch-tlsssl-explained",
+              "tips": [],
+              "title": "TLS/SSL Explained",
+              "url": "https://www.youtube.com/watch?v=j9QmMEWmcfo",
+              "uuid": "fc294a7f-7c16-4b7b-b945-2506d5faca14"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": "curl -v https://httpbin.org/get\ncurl -I https://httpbin.org/get\ncurl -X POST -d \"name=test\" https://httpbin.org/post\ncurl https://httpbin.org/status/404\ncurl -H \"X-Demo: l2c\" https://httpbin.org/headers",
+              "description": "Practice curl with safe, public test endpoints. Use verbose output, inspect headers-only responses, and send test payloads. Do not send real secrets or personal data in these requests.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase2-topic3-practice-curl-for-http-testing",
+              "tips": [],
+              "title": "curl for HTTP Testing",
+              "url": null,
+              "uuid": "65339025-d672-4899-881a-b4228d8dba04"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Use browser DevTools Network tab to inspect HTTP traffic. Observe request/response headers, timing, and payload data on your favorite websites.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase2-topic3-practice-inspect-network-traffic",
+              "tips": [],
+              "title": "Inspect Network Traffic",
+              "url": "https://developer.chrome.com/docs/devtools/network",
+              "uuid": "6b8cf08a-f1e0-49ba-b9e5-fc0f3ea894d4"
+            }
+          ],
+          "name": "HTTP and Web Basics",
+          "order": 3,
+          "slug": "http",
+          "uuid": "6fca74ee-f1f1-40cd-a948-ec83ec5efa3e"
+        },
+        {
+          "description": "Put your networking knowledge to the test! Diagnose and fix connectivity issues in a broken environment using the tools you've learned. The curriculum may not have covered everything you need \u2014 that's intentional. Researching what you don't know is part of the job.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Diagnose broken network behavior using structured troubleshooting methods.",
+              "uuid": "fcd0e23f-53c2-4d44-b180-df1f6e5547e6"
+            },
+            {
+              "order": 2,
+              "text": "Apply targeted fixes for DNS, routing, firewall, and service connectivity issues.",
+              "uuid": "23947eca-ba5c-4523-b112-cac85c3bebff"
+            },
+            {
+              "order": 3,
+              "text": "Validate restored connectivity and communicate the troubleshooting process clearly.",
+              "uuid": "c2c6646c-e8e5-4b7e-9a13-f9b599e1cdd9"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "The repository README has everything you need: setup instructions, lab scenarios, and troubleshooting exercises. Follow the instructions there to complete the lab.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase2-topic4-practice-networking-lab-repository",
+              "tips": [],
+              "title": "Networking Lab Repository",
+              "url": "https://github.com/learntocloud/networking-lab",
+              "uuid": "b3d0dea2-8e88-40f5-86ad-654b96a257b0"
+            },
+            {
+              "action": "reflect",
+              "checklist": [],
+              "code": null,
+              "description": "When you've completed the networking lab, share your experience on LinkedIn or the Learn to Cloud community to celebrate your progress and help others.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase2-topic4-reflect-share-your-progress",
+              "tips": [],
+              "title": "Share Your Progress",
+              "url": null,
+              "uuid": "17b368e6-eb5d-493e-ac11-e489b0ebd609"
+            }
+          ],
+          "name": "Capstone: Network Troubleshooting Lab",
+          "order": 4,
+          "slug": "troubleshooting-lab",
+          "uuid": "4a4cc769-c479-48c4-a852-3c01b19b6d88"
+        }
+      ],
+      "uuid": "9a45b1ee-ff89-4b59-9708-6c7c6229e8bb"
+    },
+    {
+      "capstone": null,
+      "description": "Welcome to Phase 3! This phase is all about programming with Python and building real applications. Programming is a fundamental skill for cloud engineering, enabling you to create, manage, and optimize cloud resources efficiently. You'll build a working API with database integration\u2014the foundation for everything that follows.",
+      "hands_on_verification": {
+        "requirement_slugs": [
+          "journal-api-implementation"
+        ],
+        "requirements": [
+          {
+            "description": "Submit your Journal API fork URL after your implementation is on main. The verifier checks that CI passes, then runs an LLM rubric review of the final code for API completeness, Python quality, validation, logging, AI analysis, cloud CLI setup, and secret safety.",
+            "name": "Verify Journal API Implementation",
+            "slug": "journal-api-implementation",
+            "submission_type": "journal_api_verifier",
+            "type_config": {
+              "required_repo": "learntocloud/journal-starter"
+            },
+            "uuid": "d6201101-8873-447a-957a-0e5773627618"
+          }
+        ]
+      },
+      "name": "Programming Fundamentals",
+      "objectives": [],
+      "order": 3,
+      "short_description": "Learn Python programming, FastAPI, and databases. Build a real-world Journal API project.",
+      "slug": "phase3",
+      "topic_slugs": [
+        "python",
+        "fastapi",
+        "databases",
+        "genai-apis",
+        "build-the-app"
+      ],
+      "topics": [
+        {
+          "description": "Python is the most popular programming language in cloud engineering. Work through Python Crash Course chapter by chapter to build a solid foundation.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Build fluency with Python syntax, data structures, control flow, and functions.",
+              "uuid": "6a322426-8484-44da-ba72-4cc8221237c2"
+            },
+            {
+              "order": 2,
+              "text": "Apply foundational practices like testing, file handling, and error management.",
+              "uuid": "aab53dcf-7336-4f64-8920-a5ade2f3a311"
+            },
+            {
+              "order": 3,
+              "text": "Prepare for API development by applying Python fundamentals to structured data, modular code, and problem solving.",
+              "uuid": "124e13ca-2dd5-469c-bfcc-d9a163bedc79"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "explore",
+              "checklist": [],
+              "code": null,
+              "description": "Purchase or borrow Python Crash Course by Eric Matthes. We'll work through Part I (chapters 1-11), which covers all the Python fundamentals you need.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase3-topic1-explore-python-crash-course-3rd",
+              "tips": [],
+              "title": "Python Crash Course, 3rd Edition",
+              "url": "https://nostarch.com/python-crash-course-3rd-edition",
+              "uuid": "b1054be1-5fec-4cb1-8c25-d0805bdea97d"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Set up your Python environment, install VS Code, and write your first 'Hello World' program.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase3-topic1-read-getting-started",
+              "tips": [],
+              "title": "Getting Started",
+              "url": "https://nostarch.com/python-crash-course-3rd-edition",
+              "uuid": "c698f775-6b6c-4950-9881-3b35d2f9a8a7"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn about variables, strings, integers, and floats. Free sample chapter available!",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase3-topic1-read-variables-and-simple-data",
+              "tips": [],
+              "title": "Variables and Simple Data Types",
+              "url": "https://nostarch.com/download/PCC3e_ch2sample_8.17.22.pdf",
+              "uuid": "9dc7bb31-e492-473f-af3f-09d61ddf7a72"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Create lists, access elements by index, and use methods like append, insert, and remove.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase3-topic1-read-introducing-lists",
+              "tips": [],
+              "title": "Introducing Lists",
+              "url": "https://nostarch.com/python-crash-course-3rd-edition",
+              "uuid": "0c2edc3d-653a-4a73-a2f7-c048a2334a93"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Master for loops, list comprehensions, slicing, and tuples.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase3-topic1-read-working-with-lists",
+              "tips": [],
+              "title": "Working with Lists",
+              "url": "https://nostarch.com/python-crash-course-3rd-edition",
+              "uuid": "876c93bb-0942-4b59-9c5c-235f57744a0d"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn conditional logic: if, elif, else, and boolean expressions.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase3-topic1-read-if-statements",
+              "tips": [],
+              "title": "if Statements",
+              "url": "https://nostarch.com/python-crash-course-3rd-edition",
+              "uuid": "bca8bdce-dace-48e1-af2b-0261ec7efbbb"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand key-value pairs\u2014essential for working with JSON and APIs.",
+              "done_when": null,
+              "options": [],
+              "order": 7,
+              "slug": "phase3-topic1-read-dictionaries",
+              "tips": [],
+              "title": "Dictionaries",
+              "url": "https://nostarch.com/python-crash-course-3rd-edition",
+              "uuid": "f89b6ddc-8226-4cac-b614-761f2409db5c"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Accept user input and control program flow with while loops.",
+              "done_when": null,
+              "options": [],
+              "order": 8,
+              "slug": "phase3-topic1-read-user-input-and-while",
+              "tips": [],
+              "title": "User Input and while Loops",
+              "url": "https://nostarch.com/python-crash-course-3rd-edition",
+              "uuid": "474aa570-8735-4d07-a802-b237063f03a9"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Define functions, pass arguments, and return values. The building blocks of clean code.",
+              "done_when": null,
+              "options": [],
+              "order": 9,
+              "slug": "phase3-topic1-read-functions",
+              "tips": [],
+              "title": "Functions",
+              "url": "https://nostarch.com/python-crash-course-3rd-edition",
+              "uuid": "d01cf2b6-efee-4b71-99aa-e1f6017d3ad8"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Introduction to object-oriented programming: classes, instances, attributes, and methods.",
+              "done_when": null,
+              "options": [],
+              "order": 10,
+              "slug": "phase3-topic1-read-classes",
+              "tips": [],
+              "title": "Classes",
+              "url": "https://nostarch.com/python-crash-course-3rd-edition",
+              "uuid": "65b384d4-d052-4200-b9ea-a4d890db8cc4"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Read and write files, handle errors gracefully with try/except.",
+              "done_when": null,
+              "options": [],
+              "order": 11,
+              "slug": "phase3-topic1-read-files-and-exceptions",
+              "tips": [],
+              "title": "Files and Exceptions",
+              "url": "https://nostarch.com/python-crash-course-3rd-edition",
+              "uuid": "e7f4a842-4ec9-4d62-9ac5-941ed6623008"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Write tests with pytest\u2014a professional skill that catches bugs early.",
+              "done_when": null,
+              "options": [],
+              "order": 12,
+              "slug": "phase3-topic1-read-testing-your-code",
+              "tips": [],
+              "title": "Testing Your Code",
+              "url": "https://nostarch.com/python-crash-course-3rd-edition",
+              "uuid": "b1eec6d3-c3ff-4a5d-a8e6-de114c8b7e63"
+            }
+          ],
+          "name": "Python Basics",
+          "order": 1,
+          "slug": "python",
+          "uuid": "e4c55c80-e6f1-4a09-ba10-0ab7868464e5"
+        },
+        {
+          "description": "FastAPI is a modern, fast (high-performance) web framework for building APIs with Python 3.6+ based on standard Python type hints. It is the framework we use to build the L2C Journal application and what you will use as well.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Implement and test FastAPI endpoints with path parameters, /docs workflows, and clear HTTP method semantics.",
+              "uuid": "f3b3edbc-165a-47d6-a56a-3550722cfe43"
+            },
+            {
+              "order": 2,
+              "text": "Apply Pydantic models and HTTPException handling to enforce request validation and required 404 behaviors.",
+              "uuid": "5ea08cde-2f38-44a8-8e6b-f428f36a5c42"
+            },
+            {
+              "order": 3,
+              "text": "Build async-ready endpoint patterns for I/O-bound workflows such as database and external API calls.",
+              "uuid": "7d62bfbd-b6ad-423e-b48d-a77ef95dd21d"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Complete the first-steps tutorial end to end in code. This gives you the minimum FastAPI workflow needed to run endpoints and use /docs for the capstone.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase3-topic2-practice-fastapi-first-steps",
+              "tips": [],
+              "title": "FastAPI First Steps",
+              "url": "https://fastapi.tiangolo.com/tutorial/first-steps/",
+              "uuid": "c0f8dad9-5ddd-401d-af86-4face816553e"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Focus on path parameter patterns for routes like /entries/{entry_id} used by GET single entry, DELETE single entry, and analyze entry endpoints.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase3-topic2-read-path-parameters",
+              "tips": [],
+              "title": "Path Parameters",
+              "url": "https://fastapi.tiangolo.com/tutorial/path-params/",
+              "uuid": "151fedf8-6559-4dd0-81b3-ac2c791be9f3"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn request validation and schema modeling to handle journal entry payloads and consistent API responses.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase3-topic2-read-request-body-and-pydantic",
+              "tips": [],
+              "title": "Request Body and Pydantic Models",
+              "url": "https://fastapi.tiangolo.com/tutorial/body/",
+              "uuid": "b41ea03b-6d0b-41ca-87e8-29e9f4e6550e"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Use HTTPException correctly for not found and validation scenarios, especially 404 behavior required in the capstone tasks.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase3-topic2-read-handling-errors",
+              "tips": [],
+              "title": "Handling Errors",
+              "url": "https://fastapi.tiangolo.com/tutorial/handling-errors/",
+              "uuid": "26115328-3790-4c05-a23d-9f9757213ffb"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand when to use async def vs def for your endpoints. The Journal API uses async endpoints for database and LLM operations, so understanding this pattern is important.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase3-topic2-read-async-and-await-in",
+              "tips": [],
+              "title": "Async and Await in FastAPI",
+              "url": "https://fastapi.tiangolo.com/async/",
+              "uuid": "a13ffd9b-2bd0-4640-96e5-4c39b17ea7d9"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn reliable process patterns for running FastAPI in production \u2014 workers, restarts, and service management with Uvicorn.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase3-topic2-read-uvicorn-process-management",
+              "tips": [],
+              "title": "Uvicorn Process Management",
+              "url": "https://uvicorn.dev/deployment/",
+              "uuid": "d944c570-4877-488d-8310-822841b615c2"
+            }
+          ],
+          "name": "FastAPI",
+          "order": 2,
+          "slug": "fastapi",
+          "uuid": "7595b77a-a400-4aa3-9ea6-a559afaa1517"
+        },
+        {
+          "description": "We will be using a PostgreSQL database to store our application data. You'll learn SQL fundamentals, run PostgreSQL locally using Docker, and connect to it from Python.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Apply SQL fundamentals for querying and mutating relational data.",
+              "uuid": "bd7c4812-65f2-4b0c-83cb-0bcd1e492f15"
+            },
+            {
+              "order": 2,
+              "text": "Run and configure PostgreSQL locally for development workflows.",
+              "uuid": "a8f11146-2998-44ba-8292-33a3129c68cb"
+            },
+            {
+              "order": 3,
+              "text": "Implement database access patterns in Python with SQLAlchemy.",
+              "uuid": "986ba0ff-1219-4ed2-bcac-00e1f400e448"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Learn SQL fundamentals that directly support the capstone. Focus on SELECT, INSERT, UPDATE, DELETE, WHERE, ORDER BY, and basic joins.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase3-topic3-watch-postgresql-tutorial-for-beginners",
+              "tips": [],
+              "title": "PostgreSQL Tutorial for Beginners",
+              "url": "https://www.youtube.com/watch?v=SpfIwlAYaKk",
+              "uuid": "869435d0-543e-4977-bffb-e23e0502f99f"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how to run PostgreSQL in a Docker container. This is the easiest way to get a database running locally without installing PostgreSQL on your system.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase3-topic3-practice-postgresql-in-docker",
+              "tips": [],
+              "title": "PostgreSQL in Docker",
+              "url": "https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/",
+              "uuid": "23f18616-4070-4f9c-9aa4-0290f9ac6f0a"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Install the PostgreSQL extension in VS Code so you can connect to your local database, inspect tables, and run queries while building the capstone. For a guided walkthrough, watch https://www.youtube.com/watch?v=d_wpn8wW2sw.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase3-topic3-practice-install-vs-code-postgresql",
+              "tips": [],
+              "title": "Install VS Code PostgreSQL Extension",
+              "url": "https://www.youtube.com/watch?v=d_wpn8wW2sw",
+              "uuid": "bb805ff1-45b7-469e-8ce9-8b9ee9a00698"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how to connect to PostgreSQL from Python using SQLAlchemy, the most popular Python ORM. This is the same library used in the capstone project.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase3-topic3-practice-sqlalchemy-tutorial",
+              "tips": [],
+              "title": "SQLAlchemy Tutorial",
+              "url": "https://docs.sqlalchemy.org/en/20/tutorial/index.html",
+              "uuid": "a6b42622-8f13-4696-a0ba-75111f6d0b4a"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Create a local PostgreSQL database, verify connection from the app, and run simple CRUD queries against the journal entry table shape used in the capstone.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase3-topic3-practice-capstone-db-workflow-check",
+              "tips": [],
+              "title": "Capstone DB Workflow Check",
+              "url": null,
+              "uuid": "dbe66489-45ce-49a1-b32b-1ef688545250"
+            }
+          ],
+          "name": "Databases",
+          "order": 3,
+          "slug": "databases",
+          "uuid": "cb7a1da6-95af-429e-8717-5cb0b9751f81"
+        },
+        {
+          "description": "Generative AI and Large Language Models (LLMs) are transforming how we build applications. In this topic, you'll learn how to integrate LLM APIs into your Python applications using GitHub Models. This topic is intentionally focused on coding fundamentals before moving to cloud AI platform operations in Phase 4.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Understand core LLM API patterns including messages, parameters, and structured outputs.",
+              "uuid": "3a23023a-af15-4252-8ec8-bbf11f317b51"
+            },
+            {
+              "order": 2,
+              "text": "Set up provider credentials and run the required OpenAI Chat Completions Python examples successfully.",
+              "uuid": "6cf52985-3c09-4695-92ff-111500551b5f"
+            },
+            {
+              "order": 3,
+              "text": "Run and validate GitHub Models-backed chat completion workflows you can adapt to your Journal API use case.",
+              "uuid": "33f17190-b658-40a0-b2aa-99474e1d84bb"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "A strong intro session on LLM fundamentals, model options, the OpenAI Python SDK, streaming, chat history, prompt engineering, and async app patterns. Watch this first, then move to the hands-on demos.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase3-topic4-watch-python-ai-large-language",
+              "tips": [],
+              "title": "Python + AI: Large Language Models",
+              "url": "https://www.youtube.com/live/X967IsYvhTM?si=qDi7Rcu8fN1UE5iE",
+              "uuid": "bf840bef-8dad-4734-bbed-349753bc33b1"
+            },
+            {
+              "action": "explore",
+              "checklist": [],
+              "code": null,
+              "description": "This GitHub repository contains several examples that show how to use the OpenAI Python SDK to build Generative AI Python applications. For this curriculum, focus on the OpenAI Chat Completions examples.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase3-topic4-explore-star-the-python-openai",
+              "tips": [],
+              "title": "Star the Python OpenAI Demos Repository",
+              "url": "https://github.com/Azure-Samples/python-openai-demos?tab=readme-ov-file#openai-chat-completions",
+              "uuid": "8ee8e568-47e9-4012-94a0-1eac47bb4891"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Fork the repository to your GitHub account so you can run and experiment with the examples in your own environment.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase3-topic4-practice-fork-the-repository",
+              "tips": [],
+              "title": "Fork the Repository",
+              "url": "https://github.com/Azure-Samples/python-openai-demos",
+              "uuid": "8ec7d5e6-e9d6-4221-9c7e-d002b17ef652"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Follow the repository instructions to prepare your local or Codespaces environment before running any examples.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase3-topic4-read-set-up-the-python",
+              "tips": [],
+              "title": "Set Up the Python Environment",
+              "url": "https://github.com/Azure-Samples/python-openai-demos?tab=readme-ov-file#setting-up-the-python-environment",
+              "uuid": "d79f9515-404e-45cd-bad0-13229e37bd2b"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Configure your environment for GitHub Models as documented in the repository so the examples run successfully.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase3-topic4-read-configure-github-models-environment",
+              "tips": [],
+              "title": "Configure GitHub Models Environment Variables",
+              "url": "https://github.com/Azure-Samples/python-openai-demos?tab=readme-ov-file#using-github-models",
+              "uuid": "4e4b6e66-ddea-4c46-b34d-dc864ce66349"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Run chat.py and confirm you can get a successful completion response.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase3-topic4-practice-run-chatpy",
+              "tips": [],
+              "title": "Run chat.py",
+              "url": "https://github.com/Azure-Samples/python-openai-demos?tab=readme-ov-file#openai-chat-completions",
+              "uuid": "febec971-664f-4b5c-b771-0ab428c18437"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Run chat_stream.py and verify streaming output works in your terminal.",
+              "done_when": null,
+              "options": [],
+              "order": 7,
+              "slug": "phase3-topic4-practice-run-chatstreampy",
+              "tips": [],
+              "title": "Run chat_stream.py",
+              "url": "https://github.com/Azure-Samples/python-openai-demos?tab=readme-ov-file#openai-chat-completions",
+              "uuid": "04e042da-abfd-47da-aff7-1e0893faa3ba"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Run chat_history.py to practice multi-turn conversations with message history.",
+              "done_when": null,
+              "options": [],
+              "order": 8,
+              "slug": "phase3-topic4-practice-run-chathistorypy",
+              "tips": [],
+              "title": "Run chat_history.py",
+              "url": "https://github.com/Azure-Samples/python-openai-demos?tab=readme-ov-file#openai-chat-completions",
+              "uuid": "bc2818bd-edcb-4d75-95ee-9122b4cd4c45"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Run chat_history_stream.py to combine multi-turn history with streaming. You can explore additional repository examples after completing these required ones.",
+              "done_when": null,
+              "options": [],
+              "order": 9,
+              "slug": "phase3-topic4-practice-run-chathistorystreampy",
+              "tips": [],
+              "title": "Run chat_history_stream.py",
+              "url": "https://github.com/Azure-Samples/python-openai-demos?tab=readme-ov-file#openai-chat-completions",
+              "uuid": "3efafaef-86ed-4556-b4d2-6f9519b90712"
+            }
+          ],
+          "name": "Generative AI APIs",
+          "order": 4,
+          "slug": "genai-apis",
+          "uuid": "1d920a98-5f15-4312-8fd1-39a32338b42f"
+        },
+        {
+          "description": "Time to put everything together! In this capstone project, you'll build a working Learning Journal API that combines Python, FastAPI, databases, and LLM integration. This project synthesizes all Phase 3 skills into a complete application.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Integrate FastAPI routing, request/response models, PostgreSQL data access, and LLM analysis into one working API.",
+              "uuid": "a52a062c-bc9b-4140-8948-aabe16deef8c"
+            },
+            {
+              "order": 2,
+              "text": "Implement required capstone behaviors end to end, including path-parameter routes, correct 404 handling, and async-ready service flows.",
+              "uuid": "09fdd5e6-070c-4f25-8556-d76b0933764d"
+            },
+            {
+              "order": 3,
+              "text": "Follow a professional development workflow using feature branches, pull requests, and test-driven development for each task.",
+              "uuid": "bee07dd7-b40c-49cb-973b-b6f4da245636"
+            },
+            {
+              "order": 4,
+              "text": "Validate required API behaviors, publish your implementation on GitHub, and present it as a cloud engineering project artifact.",
+              "uuid": "856aacbe-63c9-4cf1-8096-da33a19b2a03"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. Important: Follow the development workflow \u2014 create a feature branch for each task, run the tests, then open a Pull Request to merge into main. You'll need to submit each merged PR link for verification.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase3-topic5-practice-journal-starter-repository",
+              "tips": [],
+              "title": "Journal Starter Repository",
+              "url": "https://github.com/learntocloud/journal-starter",
+              "uuid": "29ca368b-cd6e-4145-bb59-c395775b45b5"
+            },
+            {
+              "action": "reflect",
+              "checklist": [],
+              "code": null,
+              "description": "When you've completed the capstone, push your work to GitHub! This becomes part of your portfolio. Consider sharing it on LinkedIn or with the Learn to Cloud community to get feedback and celebrate your progress.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase3-topic5-reflect-share-your-progress",
+              "tips": [],
+              "title": "Share Your Progress",
+              "url": null,
+              "uuid": "0f5b41ca-70f1-43f3-a1d2-f6396f00f1c3"
+            }
+          ],
+          "name": "Capstone: Learning Journal API",
+          "order": 5,
+          "slug": "build-the-app",
+          "uuid": "e8852e92-83a5-4e92-92f1-a450324278f3"
+        }
+      ],
+      "uuid": "5edbc820-fe9c-4b17-bdb1-91991f0fe9f6"
+    },
+    {
+      "capstone": null,
+      "description": "This phase focuses on cloud platform fundamentals - the core concepts and skills you need to work effectively with cloud services. You'll learn everything from virtual machines and networking to security and application deployment. Through hands-on practice and real-world projects, you'll build the practical experience needed to work with cloud platforms professionally.",
+      "hands_on_verification": {
+        "requirement_slugs": [
+          "deployed-journal-api",
+          "deployment-architecture"
+        ],
+        "requirements": [
+          {
+            "description": "Submit your HTTPS API base URL so the verifier can run POST/GET challenge-response checks on /entries and validate the response format.",
+            "name": "Deploy a Public Journal API",
+            "slug": "deployed-journal-api",
+            "submission_type": "deployed_api",
+            "type_config": {
+              "placeholder": "https://your-api.example.com"
+            },
+            "uuid": "cd4dfc97-5081-4361-a345-a3690c86f1e6"
+          },
+          {
+            "description": "Write an idempotent deploy.sh at the root of your journal-starter fork, then describe your deployment architecture in your own words. An automated reviewer reads your deploy.sh and your description and checks that they match, so describe what you actually built, not what the guide suggested.",
+            "name": "Explain Your Deployment Architecture",
+            "slug": "deployment-architecture",
+            "submission_type": "deployment_architecture",
+            "type_config": {
+              "deploy_script_path": "deploy.sh",
+              "min_answer_length": 300,
+              "prompt": "Describe the architecture your deploy.sh provisions. Cover your network layout (public and private subnets), how the API and database VMs are placed, the firewall or security rules that keep the database private, and how traffic flows from the internet to your API and down to the database. Be specific about what your script actually does.",
+              "required_repo": "learntocloud/journal-starter"
+            },
+            "uuid": "e156741f-9226-45ff-8129-704d1e23eeec"
+          }
+        ]
+      },
+      "name": "Cloud Platform Fundamentals",
+      "objectives": [],
+      "order": 4,
+      "short_description": "Deploy on AWS, Azure, or GCP: virtual machines, cloud networking, IAM security, databases, and application hosting.",
+      "slug": "phase4",
+      "topic_slugs": [
+        "vms-compute",
+        "billing-cost-management",
+        "security-iam",
+        "cloud-networking",
+        "secure-remote-access",
+        "database-deployment",
+        "monitoring-foundations-for-apps-and-vms",
+        "cloud-ai-services",
+        "capstone"
+      ],
+      "topics": [
+        {
+          "description": "Virtualization and compute services are fundamental to cloud engineering, enabling scalable and flexible infrastructure. In this topic, you will focus on deploying virtual machines on various cloud providers (such as AWS, Azure, and GCP).",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain virtualization and cloud compute fundamentals across AWS, Azure, and GCP.",
+              "uuid": "8485c9ca-5d6b-409a-8528-6964c9d7ec37"
+            },
+            {
+              "order": 2,
+              "text": "Select appropriate VM sizes or instance types based on workload, performance, and cost constraints.",
+              "uuid": "81ea5bd1-7c3d-4daa-a32c-b11d79e4df3a"
+            },
+            {
+              "order": 3,
+              "text": "Deploy and verify a working cloud virtual machine in your chosen cloud provider.",
+              "uuid": "45f4c56e-8f9f-40fb-a728-f56df40485eb"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn the fundamentals of cloud compute - the on-demand delivery of computing power that forms the foundation of cloud infrastructure.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase4-topic1-read-what-are-compute-services",
+              "tips": [],
+              "title": "What are Compute Services?",
+              "url": "https://aws.amazon.com/what-is/compute/",
+              "uuid": "9d3cc492-c400-488e-8d6c-fb922081f9c3"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand how virtualization technology enables running multiple virtual machines on a single physical server, enabling cloud scalability.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase4-topic1-read-understanding-virtualization",
+              "tips": [],
+              "title": "Understanding Virtualization",
+              "url": "https://aws.amazon.com/what-is/virtualization/",
+              "uuid": "d587e404-5f25-4ee0-a410-1ffa16d3f5b1"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Compare VM sizing and instance-family guidance across major providers to choose the right CPU, memory, and storage profile for your workload.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Review Azure VM size families and guidance for selecting the right SKU.",
+                  "provider": "azure",
+                  "title": "Sizes for Virtual Machines in Azure",
+                  "url": "https://learn.microsoft.com/azure/virtual-machines/sizes/overview"
+                },
+                {
+                  "description": "Compare EC2 instance families and choose the right type for your workload.",
+                  "provider": "aws",
+                  "title": "Amazon EC2 Instance Types",
+                  "url": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html"
+                },
+                {
+                  "description": "Learn how Google Cloud machine families map to common workload requirements.",
+                  "provider": "gcp",
+                  "title": "Machine Families Resource and Comparison Guide",
+                  "url": "https://docs.cloud.google.com/compute/docs/machine-resource"
+                }
+              ],
+              "order": 3,
+              "slug": "phase4-topic1-read-compare-vm-sizing-guidance",
+              "tips": [],
+              "title": "Compare VM sizing guidance by cloud provider",
+              "url": null,
+              "uuid": "c56ed215-c0d5-47af-841f-bcc9c2382d60"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Choose your cloud platform and follow the official guide to deploy your first virtual machine:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Create and manage virtual machines in Azure",
+                  "provider": "azure",
+                  "title": "Azure Virtual Machines Documentation",
+                  "url": "https://learn.microsoft.com/azure/virtual-machines/linux/quick-create-cli"
+                },
+                {
+                  "description": "Launch your first Linux instance on AWS Elastic Compute Cloud",
+                  "provider": "aws",
+                  "title": "Get Started with Amazon EC2",
+                  "url": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html"
+                },
+                {
+                  "description": "Get started with Google Compute Engine",
+                  "provider": "gcp",
+                  "title": "Create Your First VM on GCP",
+                  "url": "https://cloud.google.com/products/compute#create-your-first-vm"
+                }
+              ],
+              "order": 4,
+              "slug": "phase4-topic1-practice-deploy-a-vm-on",
+              "tips": [],
+              "title": "Deploy a VM on your cloud provider",
+              "url": null,
+              "uuid": "9d3fd137-7819-4c6b-80e9-44956912dc42"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Delete the virtual machine you created and any associated resources (disks, public IPs, security groups). Check your cloud console to confirm nothing is still running. Leaving resources active will incur charges.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase4-topic1-practice-clean-up-your-cloud",
+              "tips": [],
+              "title": "Clean up your cloud resources",
+              "url": null,
+              "uuid": "44bb3ac3-c295-41e7-807a-22797f7a28e9"
+            }
+          ],
+          "name": "Virtual Machines & Compute Services",
+          "order": 1,
+          "slug": "vms-compute",
+          "uuid": "dc870ba9-0c1a-4174-9beb-e3bd917608a1"
+        },
+        {
+          "description": "Cloud services are billed based on consumption. Every VM, database, and API call has a cost. In this topic, you'll learn to monitor spending, set up cost alerts, and estimate expenses before deploying infrastructure. These skills prevent surprise bills and teach you to make cost-aware architecture decisions.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain cloud pricing mechanics and billing drivers for common resource types.",
+              "uuid": "b26382c1-d1cb-4c66-88dc-c8317b7fe7bb"
+            },
+            {
+              "order": 2,
+              "text": "Configure budgets and alerts to reduce cost overruns and surprise spend.",
+              "uuid": "c356df1b-722a-44fc-af2f-cff6990a63e7"
+            },
+            {
+              "order": 3,
+              "text": "Estimate deployment costs and apply cost-aware decision making before provisioning.",
+              "uuid": "073bacc1-913a-4bd2-9b5d-1b26d4d291b7"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand pay-as-you-go pricing, common billing dimensions, and core cost drivers for compute, storage, and network resources.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Learn foundational Azure pricing and cost management concepts.",
+                  "provider": "azure",
+                  "title": "Plan and Manage Costs for Azure",
+                  "url": "https://learn.microsoft.com/azure/cost-management-billing/understand/plan-manage-costs"
+                },
+                {
+                  "description": "Understand billing concepts, pricing dimensions, and account charges in AWS.",
+                  "provider": "aws",
+                  "title": "AWS Cloud Financial Management Basics",
+                  "url": "https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/"
+                },
+                {
+                  "description": "Review how billing accounts, projects, and charges work in Google Cloud.",
+                  "provider": "gcp",
+                  "title": "Cloud Billing Concepts",
+                  "url": "https://docs.cloud.google.com/billing/docs/concepts"
+                }
+              ],
+              "order": 1,
+              "slug": "phase4-topic7-read-learn-cloud-pricing-and",
+              "tips": [],
+              "title": "Learn cloud pricing and billing fundamentals by provider",
+              "url": null,
+              "uuid": "a827b497-9ea5-42c3-8078-aa0b872ab646"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Learn the billing and cost management tools for your cloud provider:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Complete overview of Azure billing and cost management",
+                  "provider": "azure",
+                  "title": "Azure Cost Management + Billing",
+                  "url": "https://learn.microsoft.com/azure/cost-management-billing/cost-management-billing-overview"
+                },
+                {
+                  "description": "Understanding your AWS bills and managing costs",
+                  "provider": "aws",
+                  "title": "AWS Billing and Cost Management",
+                  "url": "https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/"
+                },
+                {
+                  "description": "How to manage billing in Google Cloud",
+                  "provider": "gcp",
+                  "title": "GCP Cloud Billing",
+                  "url": "https://docs.cloud.google.com/billing/docs/how-to"
+                }
+              ],
+              "order": 2,
+              "slug": "phase4-topic7-practice-cost-management-overview",
+              "tips": [],
+              "title": "Cost Management Overview",
+              "url": null,
+              "uuid": "ee765ac7-7c31-4e31-b6af-37b87971a1d5"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Get notified before you overspend! Configure alerts at thresholds like 50%, 80%, 100% of your budget.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Tutorial for creating budgets and alerts in Azure",
+                  "provider": "azure",
+                  "title": "Create Azure Budgets",
+                  "url": "https://learn.microsoft.com/azure/cost-management-billing/costs/tutorial-acm-create-budgets"
+                },
+                {
+                  "description": "Setting up AWS Budget alerts",
+                  "provider": "aws",
+                  "title": "Create AWS Budgets",
+                  "url": "https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-create.html"
+                },
+                {
+                  "description": "Configuring budget alerts in Google Cloud",
+                  "provider": "gcp",
+                  "title": "Create GCP Budget Alerts",
+                  "url": "https://docs.cloud.google.com/billing/docs/how-to/budgets"
+                }
+              ],
+              "order": 3,
+              "slug": "phase4-topic7-practice-set-up-budget-alerts",
+              "tips": [],
+              "title": "Set Up Budget Alerts",
+              "url": null,
+              "uuid": "b2c9d077-315c-4c28-980d-25925d7c61e2"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Estimate costs BEFORE you deploy. Each cloud provider has a calculator:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Estimate costs for Azure services before deploying",
+                  "provider": "azure",
+                  "title": "Azure Pricing Calculator",
+                  "url": "https://azure.microsoft.com/pricing/calculator/"
+                },
+                {
+                  "description": "Estimate costs for AWS services before deploying",
+                  "provider": "aws",
+                  "title": "AWS Pricing Calculator",
+                  "url": "https://calculator.aws/#/"
+                },
+                {
+                  "description": "Estimate costs for Google Cloud services before deploying",
+                  "provider": "gcp",
+                  "title": "GCP Pricing Calculator",
+                  "url": "https://cloud.google.com/products/calculator"
+                }
+              ],
+              "order": 4,
+              "slug": "phase4-topic7-practice-use-pricing-calculators",
+              "tips": [],
+              "title": "Use Pricing Calculators",
+              "url": null,
+              "uuid": "a14c93c6-af99-4ad3-ad8f-885ac83c648e"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Review cost-optimization best practices from your cloud provider's architecture framework. Focus on right-sizing, eliminating idle resources, and reducing avoidable data-transfer/storage costs.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Use Azure's cost-optimization checklist to improve cloud spend efficiency.",
+                  "provider": "azure",
+                  "title": "Azure Well-Architected Cost Optimization Checklist",
+                  "url": "https://learn.microsoft.com/azure/well-architected/cost-optimization/checklist"
+                },
+                {
+                  "description": "Apply AWS cost-optimization design principles and workload review practices.",
+                  "provider": "aws",
+                  "title": "AWS Well-Architected Cost Optimization Pillar",
+                  "url": "https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html"
+                },
+                {
+                  "description": "Follow GCP cost-optimization recommendations for architecture and operations.",
+                  "provider": "gcp",
+                  "title": "Google Cloud Architecture Framework: Cost Optimization",
+                  "url": "https://docs.cloud.google.com/architecture/framework/cost-optimization"
+                }
+              ],
+              "order": 5,
+              "slug": "phase4-topic7-read-review-cost-optimization-frameworks-by",
+              "tips": [],
+              "title": "Review cost-optimization frameworks by provider",
+              "url": null,
+              "uuid": "7ce6fc4b-cd77-4709-be7e-9bb01f220426"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Open your cloud provider's billing dashboard and review your current month's charges. Identify which resources are costing the most.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase4-topic7-practice-review-your-current-months",
+              "tips": [],
+              "title": "Review your current month's charges",
+              "url": null,
+              "uuid": "a9ac36a5-e8e4-4231-9c6e-8a4b45bc6967"
+            }
+          ],
+          "name": "Cloud Billing & Cost Management",
+          "order": 2,
+          "slug": "billing-cost-management",
+          "uuid": "39af4f01-5c09-4e1e-8eba-07822628c5b0"
+        },
+        {
+          "description": "This section focuses on identity and access management (IAM) to control permissions and protect cloud resources through users, roles, policies, and the principle of least privilege.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain IAM primitives including users, groups, roles, and policy-based access.",
+              "uuid": "0051b6a9-b335-412d-a23e-29abc035e967"
+            },
+            {
+              "order": 2,
+              "text": "Apply least-privilege access principles for safer day-to-day operations.",
+              "uuid": "ed3f5b2e-2cde-42e1-b950-203aafcd3270"
+            },
+            {
+              "order": 3,
+              "text": "Explain how managed identities and service accounts allow workloads to authenticate without long-lived credentials.",
+              "uuid": "4154913a-cccc-4cfd-a5c1-d95935c6d594"
+            },
+            {
+              "order": 4,
+              "text": "Describe the importance of MFA enforcement and secure credential management.",
+              "uuid": "189690ba-1467-40d9-8afc-f27c300fcf84"
+            },
+            {
+              "order": 5,
+              "text": "Create and scope IAM roles and policies through hands-on practice.",
+              "uuid": "ed34908d-f0de-47af-9bf4-763afa0bea21"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Identity and Access Management (IAM) is how you control who can do what in your cloud environment. Master these core concepts: Users, Groups, Roles, and Policies.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Understand role-based access control concepts in Azure",
+                  "provider": "azure",
+                  "title": "Azure RBAC Overview",
+                  "url": "https://learn.microsoft.com/azure/role-based-access-control/overview"
+                },
+                {
+                  "description": "Official AWS guide to IAM users, groups, policies, and roles",
+                  "provider": "aws",
+                  "title": "Getting Started with AWS IAM",
+                  "url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html"
+                },
+                {
+                  "description": "Understanding Identity and Access Management in Google Cloud",
+                  "provider": "gcp",
+                  "title": "GCP IAM Overview",
+                  "url": "https://docs.cloud.google.com/iam/docs/overview"
+                }
+              ],
+              "order": 1,
+              "slug": "phase4-topic2-read-learn-iam-concepts-across",
+              "tips": [],
+              "title": "Learn IAM concepts across cloud providers",
+              "url": null,
+              "uuid": "41cc723c-6ce1-4860-a15a-0de33b2eefe2"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand role-based access control and the principle of least privilege \u2014 granting only the minimum permissions needed for a task.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Apply least-privilege and identity security best practices in Azure",
+                  "provider": "azure",
+                  "title": "Secure access to resources with Azure identity and access management best practices",
+                  "url": "https://learn.microsoft.com/azure/security/fundamentals/identity-management-best-practices"
+                },
+                {
+                  "description": "Apply IAM best practices, including least privilege and short-term credentials",
+                  "provider": "aws",
+                  "title": "AWS IAM Best Practices",
+                  "url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html"
+                },
+                {
+                  "description": "Review IAM security best practices and least-privilege guidance in GCP",
+                  "provider": "gcp",
+                  "title": "Secure IAM in Google Cloud",
+                  "url": "https://docs.cloud.google.com/iam/docs/using-iam-securely"
+                }
+              ],
+              "order": 2,
+              "slug": "phase4-topic2-read-learn-least-privilege-iam-practices",
+              "tips": [],
+              "title": "Learn least-privilege IAM practices by provider",
+              "url": null,
+              "uuid": "b3d0791b-a219-4904-ad2f-1d3eee9ab2a8"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "In production, workloads (VMs, containers, functions) need their own identity to access other cloud services. Managed identities and service accounts eliminate the need for storing secrets or rotating access keys manually.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Learn how Azure resources authenticate to services without credentials in code",
+                  "provider": "azure",
+                  "title": "Azure Managed Identities",
+                  "url": "https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview"
+                },
+                {
+                  "description": "Understand how EC2 instances and Lambda functions assume IAM roles",
+                  "provider": "aws",
+                  "title": "IAM Roles for AWS Services",
+                  "url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_services.html"
+                },
+                {
+                  "description": "Learn how GCP workloads use service accounts for authentication",
+                  "provider": "gcp",
+                  "title": "GCP Service Accounts",
+                  "url": "https://docs.cloud.google.com/iam/docs/service-account-overview"
+                }
+              ],
+              "order": 3,
+              "slug": "phase4-topic2-read-understand-managed-identities",
+              "tips": [],
+              "title": "Understand managed identities and service accounts",
+              "url": null,
+              "uuid": "8d2f5eff-e699-4065-bef0-ae164fa3a3c9"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Multi-factor authentication (MFA) adds a critical second layer of protection. Understand why MFA should be enforced for all human users and why long-lived access keys should be avoided.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Learn how Azure enforces multi-factor authentication for user accounts",
+                  "provider": "azure",
+                  "title": "Azure MFA Setup and Enforcement",
+                  "url": "https://learn.microsoft.com/entra/identity/authentication/concept-mfa-howitworks"
+                },
+                {
+                  "description": "Configure MFA for IAM users and understand credential best practices",
+                  "provider": "aws",
+                  "title": "Enable MFA in AWS",
+                  "url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html"
+                },
+                {
+                  "description": "Enforce MFA across Google Cloud user accounts",
+                  "provider": "gcp",
+                  "title": "GCP 2-Step Verification",
+                  "url": "https://docs.cloud.google.com/identity/docs/overview"
+                }
+              ],
+              "order": 4,
+              "slug": "phase4-topic2-read-learn-mfa-credential-hygiene",
+              "tips": [],
+              "title": "Learn MFA and credential hygiene by provider",
+              "url": null,
+              "uuid": "c34d57df-b86b-4cbb-a763-085c511a13cc"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Create a storage bucket or container (S3, Azure Blob Storage, or GCS). Upload a test file using your admin account. Then create a new IAM role or user with a policy that grants ONLY read access to that storage service. Sign in or assume that restricted role and verify: (1) you can list and download the file, (2) you CANNOT upload or delete files.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase4-topic2-practice-create-scoped-iam-role",
+              "tips": [],
+              "title": "Create a read-only storage role and test its limits",
+              "url": null,
+              "uuid": "cfe6c01b-e0fa-4840-98de-dc790a41095e"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Delete the storage bucket, test files, and IAM role or user you created. Check your cloud console to confirm all resources are removed.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase4-topic2-practice-clean-up-your-cloud",
+              "tips": [],
+              "title": "Clean up your cloud resources",
+              "url": null,
+              "uuid": "df127f82-93f4-4ee8-966c-5508fd7b70cf"
+            }
+          ],
+          "name": "Security & Identity Management",
+          "order": 3,
+          "slug": "security-iam",
+          "uuid": "2ca41505-7759-4ac6-bed1-e046488e00ef"
+        },
+        {
+          "description": "This topic focuses on cloud networking concepts essential for secure deployments, building on Phase 2 networking fundamentals. You'll learn VPC/VNet architecture, subnet segmentation, security groups, and routing \u2014 then validate your understanding by deploying and testing resources in a real cloud network.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Describe VPC/VNet architecture, CIDR planning, and subnet segmentation.",
+              "uuid": "ae5453c4-5f75-41e8-b2d5-230506f8ea07"
+            },
+            {
+              "order": 2,
+              "text": "Explain security group and firewall principles used to control network traffic.",
+              "uuid": "8d52131a-53da-48a7-8c5a-c85d5b370229"
+            },
+            {
+              "order": 3,
+              "text": "Configure routing components such as gateways, NAT, and route tables correctly.",
+              "uuid": "01232608-54bc-41b8-9c19-012b024c096e"
+            },
+            {
+              "order": 4,
+              "text": "Validate secure network behavior through practical deployment and connectivity testing.",
+              "uuid": "5ebda0e3-9bf3-4df9-aafd-acf011419a95"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "A VPC is your private network in the cloud - an isolated section where you can launch resources with full control over IP addressing, subnets, and routing.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Azure Virtual Network fundamentals",
+                  "provider": "azure",
+                  "title": "Azure Virtual Network Overview",
+                  "url": "https://learn.microsoft.com/azure/virtual-network/virtual-networks-overview"
+                },
+                {
+                  "description": "Amazon Virtual Private Cloud documentation",
+                  "provider": "aws",
+                  "title": "What is Amazon VPC?",
+                  "url": "https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html"
+                },
+                {
+                  "description": "Google Cloud VPC documentation",
+                  "provider": "gcp",
+                  "title": "GCP Virtual Private Cloud",
+                  "url": "https://docs.cloud.google.com/vpc/docs/overview"
+                }
+              ],
+              "order": 1,
+              "slug": "phase4-topic3-read-understand-virtual-private-cloud",
+              "tips": [],
+              "title": "Understand Virtual Private Cloud (VPC/VNet)",
+              "url": null,
+              "uuid": "53e1643d-7acd-4a23-b096-aa774adf4d82"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Security groups act as virtual firewalls for your cloud resources, controlling inbound and outbound traffic.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Overview of Network Security Groups in Azure",
+                  "provider": "azure",
+                  "title": "Azure Network Security Groups",
+                  "url": "https://learn.microsoft.com/azure/virtual-network/network-security-groups-overview"
+                },
+                {
+                  "description": "Official documentation for controlling inbound and outbound traffic",
+                  "provider": "aws",
+                  "title": "AWS Security Groups",
+                  "url": "https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html"
+                },
+                {
+                  "description": "Understanding firewall rules in Google Cloud",
+                  "provider": "gcp",
+                  "title": "GCP Firewall Rules",
+                  "url": "https://docs.cloud.google.com/firewall/docs/firewalls"
+                }
+              ],
+              "order": 2,
+              "slug": "phase4-topic3-read-understand-security-groups-firewall",
+              "tips": [],
+              "title": "Understand Security Groups & Firewall Rules",
+              "url": null,
+              "uuid": "26bacf49-3e5e-421d-90ec-78f6391ab57e"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand public vs. private subnets and CIDR block notation. This is fundamental to designing secure cloud architectures.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Plan address spaces and subnet segmentation for Azure virtual networks.",
+                  "provider": "azure",
+                  "title": "Azure VNet Planning and Design",
+                  "url": "https://learn.microsoft.com/azure/virtual-network/virtual-network-vnet-plan-design-arm"
+                },
+                {
+                  "description": "Learn how CIDR ranges and subnetting are designed in AWS VPC.",
+                  "provider": "aws",
+                  "title": "AWS VPC CIDR Blocks and Subnetting",
+                  "url": "https://docs.aws.amazon.com/vpc/latest/userguide/vpc-cidr-blocks.html"
+                },
+                {
+                  "description": "Understand subnet ranges and IP design in Google Cloud VPC.",
+                  "provider": "gcp",
+                  "title": "GCP VPC Networks and Subnets",
+                  "url": "https://docs.cloud.google.com/vpc/docs/vpc"
+                }
+              ],
+              "order": 3,
+              "slug": "phase4-topic3-read-learn-cidr-and-subnet",
+              "tips": [],
+              "title": "Learn CIDR and subnet design by provider",
+              "url": null,
+              "uuid": "8c0ed360-124a-40c9-96d3-5dd329a4a038"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand how public-facing network components enable internet connectivity for resources in public subnets.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Learn how internet-routable connectivity is provided to Azure resources.",
+                  "provider": "azure",
+                  "title": "Azure Public IP Addresses",
+                  "url": "https://learn.microsoft.com/azure/virtual-network/ip-services/public-ip-addresses"
+                },
+                {
+                  "description": "Learn how Internet Gateways provide VPC internet connectivity.",
+                  "provider": "aws",
+                  "title": "Internet Gateways",
+                  "url": "https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html"
+                },
+                {
+                  "description": "Understand how public IP addresses provide external access in GCP.",
+                  "provider": "gcp",
+                  "title": "GCP External IP Addresses",
+                  "url": "https://docs.cloud.google.com/compute/docs/ip-addresses"
+                }
+              ],
+              "order": 4,
+              "slug": "phase4-topic3-read-understand-internet-connectivity-components",
+              "tips": [],
+              "title": "Understand internet connectivity components by provider",
+              "url": null,
+              "uuid": "d6297150-72ba-447b-b9b6-d9fb3f16dd64"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "NAT services allow private subnet resources to access the internet for updates and package downloads without direct inbound exposure.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Learn outbound internet connectivity for private Azure subnets.",
+                  "provider": "azure",
+                  "title": "Azure NAT Gateway Overview",
+                  "url": "https://learn.microsoft.com/azure/nat-gateway/nat-overview"
+                },
+                {
+                  "description": "Learn how AWS NAT Gateways provide outbound access from private subnets.",
+                  "provider": "aws",
+                  "title": "NAT Gateway Basics (AWS)",
+                  "url": "https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateway-basics.html"
+                },
+                {
+                  "description": "Configure private Google Cloud workloads to reach the internet via NAT.",
+                  "provider": "gcp",
+                  "title": "Cloud NAT Overview",
+                  "url": "https://docs.cloud.google.com/nat/docs/overview"
+                }
+              ],
+              "order": 5,
+              "slug": "phase4-topic3-read-compare-nat-patterns-across",
+              "tips": [],
+              "title": "Compare NAT patterns across cloud providers",
+              "url": null,
+              "uuid": "9490f99b-6efb-452e-8836-731cf2201d94"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Use provider-native diagnostics to validate effective routes and security policy decisions. Focus on proving why traffic is allowed or denied, not re-learning networking basics.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Validate NSG decisions for allowed and denied VM traffic flows.",
+                  "provider": "azure",
+                  "title": "Azure Network Watcher - IP Flow Verify",
+                  "url": "https://learn.microsoft.com/azure/network-watcher/ip-flow-verify-overview"
+                },
+                {
+                  "description": "Analyze network path reachability across route tables, gateways, and security controls.",
+                  "provider": "aws",
+                  "title": "AWS Reachability Analyzer",
+                  "url": "https://docs.aws.amazon.com/vpc/latest/reachability/what-is-reachability-analyzer.html"
+                },
+                {
+                  "description": "Run path analysis to verify routing and firewall behavior for target endpoints.",
+                  "provider": "gcp",
+                  "title": "GCP Connectivity Tests Overview",
+                  "url": "https://docs.cloud.google.com/network-intelligence-center/docs/connectivity-tests/concepts/overview"
+                }
+              ],
+              "order": 6,
+              "slug": "phase4-topic3-read-validate-routing-and-security",
+              "tips": [],
+              "title": "Validate routing and security decisions by provider",
+              "url": null,
+              "uuid": "378183a3-37a3-4a99-aee6-586060c2d27b"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Your database should accept connections only from your API server \u2014 not from the public internet. Use private endpoints or private IP connectivity to eliminate the public network path to your database entirely.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Deploy RDS in a private subnet and restrict access with security group rules allowing port 5432 only from your API server",
+                  "provider": "aws",
+                  "title": "RDS in a Private Subnet",
+                  "url": "https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html"
+                },
+                {
+                  "description": "Eliminate public network access to your Azure database with Private Endpoint",
+                  "provider": "azure",
+                  "title": "Azure Private Endpoint Overview",
+                  "url": "https://learn.microsoft.com/azure/private-link/private-endpoint-overview"
+                },
+                {
+                  "description": "Connect to Cloud SQL over private IP with no public internet exposure",
+                  "provider": "gcp",
+                  "title": "Cloud SQL Private IP",
+                  "url": "https://docs.cloud.google.com/sql/docs/postgres/private-ip"
+                }
+              ],
+              "order": 7,
+              "slug": "phase4-topic3-read-restrict-database-access",
+              "tips": [],
+              "title": "Restrict database access to your API server only",
+              "url": null,
+              "uuid": "aff9e130-cccb-4dc4-afa6-17361f6f4f11"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Load balancers distribute traffic across multiple targets and enable high availability. Understand the difference between Layer 4 (network) and Layer 7 (application) load balancers, health checks, and target groups in your cloud provider.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Layer 7 load balancing with path-based routing, health checks, and target groups.",
+                  "provider": "aws",
+                  "title": "Application Load Balancer (ALB)",
+                  "url": "https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html"
+                },
+                {
+                  "description": "Layer 4 load balancing with health probes, backend pools, and load balancing rules.",
+                  "provider": "azure",
+                  "title": "Azure Load Balancer Overview",
+                  "url": "https://learn.microsoft.com/azure/load-balancer/load-balancer-overview"
+                },
+                {
+                  "description": "Global and regional load balancing with HTTP(S), TCP/UDP, and internal options.",
+                  "provider": "gcp",
+                  "title": "Cloud Load Balancing Overview",
+                  "url": "https://docs.cloud.google.com/load-balancing/docs/load-balancing-overview"
+                }
+              ],
+              "order": 8,
+              "slug": "phase4-topic3-read-cloud-load-balancers",
+              "tips": [],
+              "title": "Cloud Load Balancers",
+              "url": null,
+              "uuid": "8942ce4b-d77d-4fde-9940-618817454bea"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Use your cloud CLI to inspect networking resources. Practice listing VPCs, subnets, security groups, and route tables. Learn to filter output and parse JSON \u2014 these skills are essential for the Phase 2 networking lab and real-world troubleshooting.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Inspect VPCs, subnets, and security groups from the command line. Use --query and --output table to filter results, or pipe to jq for JSON parsing.",
+                  "provider": "aws",
+                  "title": "AWS CLI Networking Commands",
+                  "url": "https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpcs.html"
+                },
+                {
+                  "description": "Inspect VNets, subnets, and NSGs from the command line. Use --query with JMESPath and --output table to shape output.",
+                  "provider": "azure",
+                  "title": "Azure CLI Networking Commands",
+                  "url": "https://learn.microsoft.com/cli/azure/network/vnet"
+                },
+                {
+                  "description": "Inspect VPCs, subnets, and firewall rules from the command line. Use --format and --filter flags to shape output, or pipe to jq.",
+                  "provider": "gcp",
+                  "title": "GCP CLI Networking Commands",
+                  "url": "https://cloud.google.com/sdk/gcloud/reference/compute/networks"
+                }
+              ],
+              "order": 9,
+              "slug": "phase4-topic3-practice-explore-cloud-networking-cli",
+              "tips": [],
+              "title": "Explore Cloud Networking via CLI",
+              "url": null,
+              "uuid": "cb2747b5-c258-4a06-8010-ce59db026109"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Create a VPC or VNet on your cloud provider with a custom CIDR block.",
+              "done_when": null,
+              "options": [],
+              "order": 10,
+              "slug": "phase4-topic3-practice-set-up-a-cloud",
+              "tips": [],
+              "title": "Set up a cloud network (VPC/VNet)",
+              "url": null,
+              "uuid": "0f26efe0-8522-4ab1-b490-4983a0794eb4"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Create two subnets inside your VPC \u2014 one public (with a route to the internet gateway) and one private (no direct internet access).",
+              "done_when": null,
+              "options": [],
+              "order": 11,
+              "slug": "phase4-topic3-practice-create-a-public-and",
+              "tips": [],
+              "title": "Create a public and a private subnet",
+              "url": null,
+              "uuid": "4410640a-0605-4463-abc6-283ff91d8d5f"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Associate subnets with appropriate route tables and set up security groups for each subnet.",
+              "done_when": null,
+              "options": [],
+              "order": 12,
+              "slug": "phase4-topic3-practice-configure-routing-and-security",
+              "tips": [],
+              "title": "Configure routing and security groups",
+              "url": null,
+              "uuid": "bfc78160-ddef-4a7c-a413-922298da9fdb"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Deploy a VM in the public subnet and another in the private subnet. Verify the public VM is accessible from the internet and the private VM is not.",
+              "done_when": null,
+              "options": [],
+              "order": 13,
+              "slug": "phase4-topic3-practice-deploy-vms-in-each",
+              "tips": [],
+              "title": "Deploy VMs in each subnet and verify access",
+              "url": null,
+              "uuid": "062f4256-fb79-4d87-a114-60ca34f92c0d"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Delete all resources you created in this topic \u2014 VMs, VPC/VNet, subnets, route tables, internet gateways, NAT gateways, and security groups. Check your cloud console to confirm nothing is still running. Leaving resources active will incur charges.",
+              "done_when": null,
+              "options": [],
+              "order": 14,
+              "slug": "phase4-topic3-practice-clean-up-your-cloud",
+              "tips": [],
+              "title": "Clean up your cloud resources",
+              "url": null,
+              "uuid": "ca268dba-b19f-4c48-a31a-827c9ac6d4fa"
+            }
+          ],
+          "name": "Cloud Networking Fundamentals",
+          "order": 4,
+          "slug": "cloud-networking",
+          "uuid": "822291f9-041c-4846-8db0-90d58ca414f0"
+        },
+        {
+          "description": "In the previous topic, you learned about cloud networking fundamentals, including VPCs, subnets, and traffic flow. Now, the focus is on understanding secure remote access mechanisms that protect cloud resources from unauthorized access.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain modern session-based remote access patterns and their security benefits.",
+              "uuid": "a17d5793-3363-421b-bd5d-8cbb21d7e650"
+            },
+            {
+              "order": 2,
+              "text": "Configure secure VM access using provider-native tooling without exposing unnecessary ports.",
+              "uuid": "c8784558-4c15-4539-87ee-ab948a429835"
+            },
+            {
+              "order": 3,
+              "text": "Review and interpret remote access audit logs for accountability and compliance.",
+              "uuid": "0f7443a1-f13b-4bfd-b7c2-8d0238cbd823"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Modern cloud security recommends session-based access over direct SSH/RDP connections. These services provide audit logging, don't require opening SSH ports, and integrate with your cloud IAM.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Secure RDP/SSH connectivity to your VMs directly in the Azure portal",
+                  "provider": "azure",
+                  "title": "Azure Bastion",
+                  "url": "https://learn.microsoft.com/azure/bastion/"
+                },
+                {
+                  "description": "Connect to your instances without SSH keys or open ports",
+                  "provider": "aws",
+                  "title": "AWS Systems Manager Session Manager",
+                  "url": "https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html"
+                },
+                {
+                  "description": "Official guide to using IAP for secure access to GCP resources",
+                  "provider": "gcp",
+                  "title": "GCP Identity-Aware Proxy",
+                  "url": "https://docs.cloud.google.com/iap/docs/concepts-overview"
+                }
+              ],
+              "order": 1,
+              "slug": "phase4-topic4-read-understand-session-based-access-management",
+              "tips": [],
+              "title": "Understand Session-Based Access Management",
+              "url": null,
+              "uuid": "4c55a93a-3b9b-49eb-b9c5-bd6205cad013"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand how to connect to VMs with provider-native session-based access, without exposing SSH/RDP to the public internet.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Use Azure Bastion to securely connect to VMs from the Azure portal.",
+                  "provider": "azure",
+                  "title": "Connect to a VM using Azure Bastion",
+                  "url": "https://learn.microsoft.com/azure/bastion/quickstart-host-portal"
+                },
+                {
+                  "description": "Connect to EC2 without open inbound ports using AWS Systems Manager.",
+                  "provider": "aws",
+                  "title": "Connect to EC2 Using Session Manager",
+                  "url": "https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/"
+                },
+                {
+                  "description": "Access VMs securely through Identity-Aware Proxy instead of direct external SSH exposure.",
+                  "provider": "gcp",
+                  "title": "Connect to Linux VMs using IAP",
+                  "url": "https://docs.cloud.google.com/compute/docs/connect/ssh-using-iap"
+                }
+              ],
+              "order": 2,
+              "slug": "phase4-topic4-read-compare-secure-vm-access",
+              "tips": [],
+              "title": "Compare secure VM access workflows by provider",
+              "url": null,
+              "uuid": "5e8b2962-52c7-43c6-a9ca-a7f3e9890261"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Deploy a VM on your cloud provider and set up session-based access using AWS SSM, Azure Bastion, or GCP IAP. Connect to the VM without using traditional SSH.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase4-topic4-practice-deploy-a-vm-and-configure",
+              "tips": [],
+              "title": "Deploy a VM and configure session-based access",
+              "url": null,
+              "uuid": "a1667f65-7186-440e-9d94-2b263c941a14"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "After connecting via session-based access, review the audit logs generated by your session. Understand what information is captured for security and compliance.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase4-topic4-practice-review-the-audit-logs",
+              "tips": [],
+              "title": "Review the audit logs from your session",
+              "url": null,
+              "uuid": "53d265ca-9724-4497-844f-acf6bd422915"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Delete the VM and any associated bastion or session manager resources you created. Check your cloud console to confirm nothing is still running. Leaving resources active will incur charges.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase4-topic4-practice-clean-up-your-cloud",
+              "tips": [],
+              "title": "Clean up your cloud resources",
+              "url": null,
+              "uuid": "ec6b2d97-caba-4199-8dc8-7b0f6721348f"
+            }
+          ],
+          "name": "Secure Remote Access",
+          "order": 5,
+          "slug": "secure-remote-access",
+          "uuid": "515137fb-3308-4131-a925-f8b149e3f587"
+        },
+        {
+          "description": "Learn to deploy and configure PostgreSQL databases in the cloud. This topic covers the fundamentals of relational database deployment, including architecture, installation, and secure remote access configuration. It builds on Phase 3 database fundamentals and focuses on cloud-specific deployment and network hardening.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Understand PostgreSQL deployment fundamentals in cloud environments.",
+              "uuid": "43076020-3783-4f18-8a59-c87d723e49e0"
+            },
+            {
+              "order": 2,
+              "text": "Configure database access controls for private, least-exposed connectivity.",
+              "uuid": "4a336d46-8248-4430-ac39-dd9e03588fc8"
+            },
+            {
+              "order": 3,
+              "text": "Validate secure application-to-database connectivity in a realistic deployment pattern.",
+              "uuid": "5c303b3f-b97c-4adb-be3f-e573aca6ac66"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Review your provider's PostgreSQL options (managed services vs self-hosted on VMs) and choose the model you'll use for this topic.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Review PostgreSQL offerings on Azure and decide between managed and VM-hosted patterns.",
+                  "provider": "azure",
+                  "title": "Azure PostgreSQL Deployment Options Overview",
+                  "url": "https://learn.microsoft.com/azure/postgresql/configure-maintain/overview-postgres-choose-server-options"
+                },
+                {
+                  "description": "Compare PostgreSQL options on AWS including managed and self-managed approaches.",
+                  "provider": "aws",
+                  "title": "AWS PostgreSQL Deployment Options Overview",
+                  "url": "https://aws.amazon.com/rds/postgresql/"
+                },
+                {
+                  "description": "Understand PostgreSQL options on Google Cloud and choose the right deployment path.",
+                  "provider": "gcp",
+                  "title": "Google Cloud PostgreSQL Deployment Options Overview",
+                  "url": "https://docs.cloud.google.com/sql/docs/postgres/introduction"
+                }
+              ],
+              "order": 1,
+              "slug": "phase4-topic5-read-compare-postgresql-deployment-options",
+              "tips": [],
+              "title": "Compare PostgreSQL deployment options by provider",
+              "url": null,
+              "uuid": "6444cced-1a5f-45e5-bb80-6836b34e41a7"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Before deploying PostgreSQL in the cloud, learn how to install it on a Linux VM. This covers adding the official PostgreSQL repository, installing the server package, starting the service, and performing initial setup like creating a database and setting a password.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Step-by-step guide to installing and configuring PostgreSQL on a Linux VM in Azure.",
+                  "provider": "azure",
+                  "title": "Install PostgreSQL on an Azure Linux VM",
+                  "url": "https://learn.microsoft.com/previous-versions/azure/virtual-machines/linux/postgresql-install"
+                },
+                {
+                  "description": "Official PostgreSQL installation instructions for Ubuntu, Debian, RHEL, and other Linux distributions.",
+                  "provider": "aws",
+                  "title": "PostgreSQL Linux Downloads (Official)",
+                  "url": "https://www.postgresql.org/download/linux/"
+                },
+                {
+                  "description": "Official PostgreSQL installation instructions for Ubuntu, Debian, RHEL, and other Linux distributions.",
+                  "provider": "gcp",
+                  "title": "PostgreSQL Linux Downloads (Official)",
+                  "url": "https://www.postgresql.org/download/linux/"
+                }
+              ],
+              "order": 2,
+              "slug": "phase4-topic5-read-install-postgresql-on-linux",
+              "tips": [],
+              "title": "Learn how to install PostgreSQL on Linux",
+              "url": null,
+              "uuid": "3caf398c-5af1-4f52-ab12-af9efe430220"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Deploy a VM in a private subnet on your cloud provider and install PostgreSQL. Use provider networking guidance plus the PostgreSQL Linux packages docs to complete the setup.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Build a VNet/subnet-secured VM pattern you can adapt for a private PostgreSQL host.",
+                  "provider": "azure",
+                  "title": "Azure Network Security Tutorial (subnet + NSG)",
+                  "url": "https://learn.microsoft.com/azure/virtual-network/tutorial-filter-network-traffic"
+                },
+                {
+                  "description": "Follow the AWS reference architecture for private-subnet workloads before installing PostgreSQL.",
+                  "provider": "aws",
+                  "title": "Amazon VPC with Public and Private Subnets",
+                  "url": "https://docs.aws.amazon.com/vpc/latest/userguide/vpc-example-private-subnets-nat.html"
+                },
+                {
+                  "description": "Launch a VM in your chosen subnet and use no external IP for private-only database hosting.",
+                  "provider": "gcp",
+                  "title": "Create an Instance in a Specific Subnet",
+                  "url": "https://docs.cloud.google.com/compute/docs/instances/create-vm-specific-subnet"
+                }
+              ],
+              "order": 3,
+              "slug": "phase4-topic5-practice-deploy-a-vm-in",
+              "tips": [],
+              "title": "Deploy a VM in a private subnet and install PostgreSQL",
+              "url": null,
+              "uuid": "05687ff1-b259-4ad8-ac72-9ea73f821a63"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Even though your database VM sits in a private subnet, network controls alone aren't enough. A misconfigured NSG/security-group rule, a compromised peer workload, or a future subnet expansion could expose the database to unintended clients. pg_hba.conf is PostgreSQL's own host-based authentication layer. Edit pg_hba.conf to allow connections only from your API server's IP range and require strong authentication. Then create database users with least-privilege permissions for your application.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase4-topic5-practice-configure-pghbaconf-for-secure",
+              "tips": [],
+              "title": "Configure pg_hba.conf for secure remote access",
+              "url": "https://www.postgresql.org/docs/current/auth-pg-hba-conf.html",
+              "uuid": "59dbd8d7-026f-4385-9744-1e669ca28b0e"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Your database VM has no public IP, so you can't SSH in directly \u2014 you need a way to reach it securely. Use your provider's approach to connect to the database VM, then run psql to verify PostgreSQL is running and your pg_hba.conf rules work. Next, launch a second VM in a different subnet (simulating an application server), connect to it the same way, and test that it can reach the database with psql over the private network. Finally, confirm the database is NOT reachable from the public internet \u2014 try connecting from your local machine directly and verify it times out or is refused.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "A managed PaaS bastion host \u2014 provides browser-based SSH/RDP through the Azure portal. No agent needed on the VM.",
+                  "provider": "azure",
+                  "title": "Connect to a Private VM via Azure Bastion",
+                  "url": "https://learn.microsoft.com/azure/bastion/bastion-connect-vm-ssh-linux"
+                },
+                {
+                  "description": "Agent-based access through the AWS control plane \u2014 requires the SSM agent on the instance. No bastion host, no open inbound ports. Also supports port forwarding and session logging.",
+                  "provider": "aws",
+                  "title": "Connect to a Private Instance via Session Manager",
+                  "url": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-with-systems-manager-session-manager.html"
+                },
+                {
+                  "description": "An identity-aware tunnel proxy \u2014 creates an encrypted tunnel from your machine authenticated via IAM, then you use your own SSH client through it. No agent required.",
+                  "provider": "gcp",
+                  "title": "Connect to a Private VM via IAP TCP Forwarding",
+                  "url": "https://docs.cloud.google.com/iap/docs/using-tcp-forwarding"
+                }
+              ],
+              "order": 5,
+              "slug": "phase4-topic5-practice-verify-database-connectivity-and",
+              "tips": [],
+              "title": "Verify database connectivity and security",
+              "url": null,
+              "uuid": "690ffd69-c16f-481b-b8ac-933572437133"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Delete all resources you created \u2014 VMs, PostgreSQL installations, Bastion/SSM/IAP configurations, VPC/VNet, subnets, and security groups. Check your cloud console to confirm nothing is still running. Leaving resources active will incur charges.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase4-topic5-practice-clean-up-your-cloud",
+              "tips": [],
+              "title": "Clean up your cloud resources",
+              "url": null,
+              "uuid": "4b2a2cd1-84f5-4851-b7fc-1fd89d591add"
+            }
+          ],
+          "name": "Database Deployment & Configuration",
+          "order": 6,
+          "slug": "database-deployment",
+          "uuid": "8ae1dfb6-626c-424c-b57d-b86a82eafb30"
+        },
+        {
+          "description": "This topic focuses on monitoring cloud-hosted applications. You'll learn provider monitoring fundamentals, how application logs are collected and queried, and how infrastructure and application metrics give you runtime visibility.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Understand core monitoring services across Azure, AWS, and GCP for app and VM visibility.",
+              "uuid": "9440f45d-67d5-4d3a-b0f3-23b31e415f89"
+            },
+            {
+              "order": 2,
+              "text": "Understand where application logs come from and how to query them during incident response.",
+              "uuid": "f3aad083-8f5f-42e9-8d76-f733e904e85f"
+            },
+            {
+              "order": 3,
+              "text": "Understand how infrastructure and application metrics are collected and used for runtime visibility.",
+              "uuid": "7a1500b3-5ae9-4df8-9761-37166dde49cc"
+            },
+            {
+              "order": 4,
+              "text": "Configure a VM to emit logs and metrics, then query the data in your provider's console.",
+              "uuid": "535a72c7-c580-4759-8bf1-884cf6dac142"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Start with your cloud provider's monitoring platform and understand how logs, metrics, traces, and alerts are organized:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Learn Azure Monitor fundamentals for application and VM observability.",
+                  "provider": "azure",
+                  "title": "What is Azure Monitor?",
+                  "url": "https://learn.microsoft.com/azure/azure-monitor/fundamentals/overview"
+                },
+                {
+                  "description": "Learn CloudWatch fundamentals for metrics, logs, alarms, and dashboards.",
+                  "provider": "aws",
+                  "title": "What is Amazon CloudWatch?",
+                  "url": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html"
+                },
+                {
+                  "description": "Learn Google Cloud Monitoring fundamentals for infrastructure and services.",
+                  "provider": "gcp",
+                  "title": "Cloud Monitoring Overview",
+                  "url": "https://docs.cloud.google.com/monitoring/docs/monitoring-overview"
+                }
+              ],
+              "order": 1,
+              "slug": "phase4-topic6-read-learn-your-providers-monitoring",
+              "tips": [],
+              "title": "Learn your provider's monitoring fundamentals",
+              "url": null,
+              "uuid": "d30e3be8-f18f-487b-9e33-cea2b8f15abb"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn where application logs come from in your provider and how to query them during incident response.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Understand log ingestion and querying with Log Analytics.",
+                  "provider": "azure",
+                  "title": "Azure Monitor Logs Overview",
+                  "url": "https://learn.microsoft.com/azure/azure-monitor/logs/data-platform-logs"
+                },
+                {
+                  "description": "Understand log groups, streams, and search workflows.",
+                  "provider": "aws",
+                  "title": "CloudWatch Logs User Guide",
+                  "url": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html"
+                },
+                {
+                  "description": "Understand structured logs and query workflows in Cloud Logging.",
+                  "provider": "gcp",
+                  "title": "Cloud Logging Overview",
+                  "url": "https://docs.cloud.google.com/logging/docs/overview"
+                }
+              ],
+              "order": 2,
+              "slug": "phase4-topic6-read-understand-logs",
+              "tips": [],
+              "title": "Understand logs",
+              "url": null,
+              "uuid": "dde46b10-97bc-4812-bf2e-035d3d261315"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how infrastructure and application metrics are collected and how to use them for dashboards, alerts, and capacity planning.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Understand platform and custom metrics collection and analysis.",
+                  "provider": "azure",
+                  "title": "Azure Monitor Metrics Overview",
+                  "url": "https://learn.microsoft.com/azure/azure-monitor/metrics/data-platform-metrics"
+                },
+                {
+                  "description": "Understand metric namespaces, dimensions, and alarm workflows.",
+                  "provider": "aws",
+                  "title": "Using Amazon CloudWatch Metrics",
+                  "url": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/working_with_metrics.html"
+                },
+                {
+                  "description": "Understand built-in and custom metrics in Google Cloud Monitoring.",
+                  "provider": "gcp",
+                  "title": "Cloud Monitoring Metrics Overview",
+                  "url": "https://docs.cloud.google.com/monitoring/docs/monitoring-overview"
+                }
+              ],
+              "order": 3,
+              "slug": "phase4-topic6-read-understand-metrics",
+              "tips": [],
+              "title": "Understand metrics",
+              "url": null,
+              "uuid": "7e385e9a-b597-4762-8446-45a16eb57acd"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Deploy a VM on your cloud provider and install your provider's monitoring agent so the VM emits logs and metrics to your monitoring platform.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Install the Azure Monitor Agent and configure a data collection rule to send VM logs and metrics to a Log Analytics workspace.",
+                  "provider": "azure",
+                  "title": "Install the Azure Monitor Agent on a VM",
+                  "url": "https://learn.microsoft.com/azure/azure-monitor/agents/azure-monitor-agent-manage"
+                },
+                {
+                  "description": "Install and configure the CloudWatch Agent to send system metrics and logs from your EC2 instance to CloudWatch.",
+                  "provider": "aws",
+                  "title": "Install the CloudWatch Agent on an EC2 Instance",
+                  "url": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/install-CloudWatch-Agent-on-EC2-Instance.html"
+                },
+                {
+                  "description": "Install the Ops Agent to collect logs and metrics from your Compute Engine VM and send them to Cloud Monitoring and Cloud Logging.",
+                  "provider": "gcp",
+                  "title": "Install the Ops Agent on a Compute Engine VM",
+                  "url": "https://docs.cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/installation"
+                }
+              ],
+              "order": 4,
+              "slug": "phase4-topic6-practice-configure-vm-monitoring",
+              "tips": [],
+              "title": "Configure a VM to emit logs and metrics",
+              "url": null,
+              "uuid": "12aa5b66-0391-47e0-8e7a-29538ad740b8"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Now that your VM is emitting data, open your provider's log query tool and find all SSH login attempts on your VM from the last hour. You SSH'd in to install the agent, so you should see at least your own session. This is the same workflow you'd use during a real security investigation.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Open your Log Analytics workspace and write a query to find SSH login events from the last hour.",
+                  "provider": "azure",
+                  "title": "Log Analytics Tutorial: Run a KQL Query",
+                  "url": "https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-tutorial"
+                },
+                {
+                  "description": "Open Logs Insights, select your VM's log group, and write a query to find SSH login events from the last hour.",
+                  "provider": "aws",
+                  "title": "CloudWatch Logs Insights: Run a Sample Query",
+                  "url": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_AnalyzeLogData_RunSampleQuery.html"
+                },
+                {
+                  "description": "Open Logs Explorer and write a query to find SSH login events on your VM from the last hour.",
+                  "provider": "gcp",
+                  "title": "Logs Explorer: Query Your Logs",
+                  "url": "https://docs.cloud.google.com/logging/docs/view/logs-explorer-interface"
+                }
+              ],
+              "order": 5,
+              "slug": "phase4-topic6-practice-query-vm-logs",
+              "tips": [],
+              "title": "Query your VM's logs for SSH login events",
+              "url": null,
+              "uuid": "e6cd4b85-f809-44d2-a437-ab525295f9ea"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Delete the VM, monitoring agent configuration, and any associated resources (disks, public IPs, security groups, Log Analytics workspace or log groups). Check your cloud console to confirm nothing is still running. Leaving resources active will incur charges.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase4-topic6-practice-clean-up-your-cloud",
+              "tips": [],
+              "title": "Clean up your cloud resources",
+              "url": null,
+              "uuid": "bf28478b-d877-44c5-b436-a5fcf7fae96a"
+            }
+          ],
+          "name": "Monitoring Foundations for Apps and VMs",
+          "order": 7,
+          "slug": "monitoring-foundations-for-apps-and-vms",
+          "uuid": "282db8e5-b3a0-47f5-bb37-ffcd63e92ae7"
+        },
+        {
+          "description": "Cloud providers offer comprehensive AI service platforms. In this topic, you'll take the same LLM workflow you built in Phase 3 and run it on a cloud AI platform. You'll learn model options, deployment strategies, safety controls, and operational features needed for production use.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Map your Phase 3 GitHub Models workflow to your cloud AI platform's model catalog and deployment options.",
+              "uuid": "94fb0b7b-880c-4e19-a592-cbc30fdd993f"
+            },
+            {
+              "order": 2,
+              "text": "Evaluate safety and guardrail features for responsible AI application design.",
+              "uuid": "c3eece64-dce6-4fcd-978c-bb7c3d0e0a79"
+            },
+            {
+              "order": 3,
+              "text": "Select and deploy an appropriate cloud-hosted model for your capstone use case.",
+              "uuid": "abde4fdd-af46-4e6a-afc9-a805cb0d10dc"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Each major cloud provider offers an AI platform for deploying and managing models. Learn about your chosen platform:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Microsoft's unified platform for building, deploying, and managing AI models",
+                  "provider": "azure",
+                  "title": "Microsoft Foundry",
+                  "url": "https://learn.microsoft.com/azure/foundry/what-is-foundry"
+                },
+                {
+                  "description": "Amazon's fully managed service for building generative AI applications",
+                  "provider": "aws",
+                  "title": "AWS Bedrock",
+                  "url": "https://docs.aws.amazon.com/bedrock/latest/userguide/what-is-bedrock.html"
+                },
+                {
+                  "description": "Google's unified AI platform for building and deploying ML models",
+                  "provider": "gcp",
+                  "title": "GCP Vertex AI",
+                  "url": "https://docs.cloud.google.com/vertex-ai/docs/start/introduction-unified-platform"
+                }
+              ],
+              "order": 1,
+              "slug": "phase4-topic8-read-platform-overview",
+              "tips": [],
+              "title": "Platform Overview",
+              "url": null,
+              "uuid": "0244b5d1-5de4-4efb-92e6-b0a8e7478121"
+            },
+            {
+              "action": "explore",
+              "checklist": [],
+              "code": null,
+              "description": "Each platform offers different models with varying capabilities, speeds, and costs:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Browse models available in Microsoft Foundry including OpenAI, Meta, and Mistral models",
+                  "provider": "azure",
+                  "title": "Microsoft Foundry Models",
+                  "url": "https://learn.microsoft.com/azure/foundry-classic/concepts/foundry-models-overview"
+                },
+                {
+                  "description": "Explore foundation models available in Amazon Bedrock",
+                  "provider": "aws",
+                  "title": "AWS Bedrock Models",
+                  "url": "https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html"
+                },
+                {
+                  "description": "Discover models available in Google's Vertex AI Model Garden",
+                  "provider": "gcp",
+                  "title": "GCP Model Garden",
+                  "url": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models"
+                }
+              ],
+              "order": 2,
+              "slug": "phase4-topic8-explore-explore-available-models",
+              "tips": [],
+              "title": "Explore Available Models",
+              "url": null,
+              "uuid": "3a242df7-68b2-4d5b-b472-c4611669256d"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how to deploy models in production:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Understand model deployment options in Microsoft Foundry",
+                  "provider": "azure",
+                  "title": "Microsoft Foundry Deployments",
+                  "url": "https://learn.microsoft.com/azure/foundry-classic/concepts/deployments-overview"
+                },
+                {
+                  "description": "Deploy and manage models with Amazon Bedrock",
+                  "provider": "aws",
+                  "title": "AWS Bedrock Deployment",
+                  "url": "https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-marketplace-deploy-a-model.html"
+                },
+                {
+                  "description": "Deploy models to endpoints in Vertex AI",
+                  "provider": "gcp",
+                  "title": "GCP Deployment",
+                  "url": "https://docs.cloud.google.com/vertex-ai/docs/general/deployment"
+                }
+              ],
+              "order": 3,
+              "slug": "phase4-topic8-read-understand-deployment-options",
+              "tips": [],
+              "title": "Understand Deployment Options",
+              "url": null,
+              "uuid": "d70e1caf-d6be-4c1b-9d9f-fc1e6f544b67"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Learn about content filtering and safety features to ensure responsible AI use:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Configure content filtering and safety guardrails in Microsoft Foundry",
+                  "provider": "azure",
+                  "title": "Microsoft Foundry Guardrails",
+                  "url": "https://learn.microsoft.com/azure/foundry/guardrails/guardrails-overview"
+                },
+                {
+                  "description": "Set up guardrails for responsible AI use in Amazon Bedrock",
+                  "provider": "aws",
+                  "title": "AWS Bedrock Guardrails",
+                  "url": "https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html"
+                },
+                {
+                  "description": "Understand safety features and content filtering in Vertex AI",
+                  "provider": "gcp",
+                  "title": "GCP Safety Overview",
+                  "url": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/safety-overview"
+                }
+              ],
+              "order": 4,
+              "slug": "phase4-topic8-practice-safety-guardrails",
+              "tips": [],
+              "title": "Safety & Guardrails",
+              "url": null,
+              "uuid": "f09e2ffb-b85f-46b3-a705-96846f73d321"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Use your cloud AI playground to compare at least 2 models using your Phase 3 sentiment-analysis prompt set, then choose the model for your Journal API based on quality, speed, cost, reliability, and safety:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Experiment with models in the Microsoft Foundry playground",
+                  "provider": "azure",
+                  "title": "Microsoft Foundry Playgrounds",
+                  "url": "https://learn.microsoft.com/azure/foundry/concepts/concept-playgrounds"
+                },
+                {
+                  "description": "Test and compare models in the Amazon Bedrock playground",
+                  "provider": "aws",
+                  "title": "AWS Bedrock Playgrounds",
+                  "url": "https://docs.aws.amazon.com/bedrock/latest/userguide/playgrounds.html"
+                },
+                {
+                  "description": "Try models directly in Google's Model Garden",
+                  "provider": "gcp",
+                  "title": "GCP Model Garden",
+                  "url": "https://cloud.google.com/model-garden"
+                }
+              ],
+              "order": 5,
+              "slug": "phase4-topic8-practice-compare-and-choose-a",
+              "tips": [],
+              "title": "Compare and choose a cloud model in the playground",
+              "url": null,
+              "uuid": "393a8393-f60d-4fe2-b376-dcf4adc4e77d"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Delete the model deployment and any associated resources on your cloud AI platform. Check your cloud console to confirm nothing is still running. AI model deployments can incur significant per-hour charges.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase4-topic8-practice-clean-up-your-cloud",
+              "tips": [],
+              "title": "Clean up your cloud resources",
+              "url": null,
+              "uuid": "f7762570-e727-4082-b91e-189352787192"
+            }
+          ],
+          "name": "Cloud AI Service Platforms",
+          "order": 8,
+          "slug": "cloud-ai-services",
+          "uuid": "7ca1401a-0e78-4fcb-8665-aeba544555d1"
+        },
+        {
+          "description": "Deploy the Journal API you built in Phase 3 to a secure 2-tier cloud architecture. This capstone challenges you to research, design, and implement a production-ready environment with proper networking and security, using the database and deployment preparation work you completed in earlier Phase 4 topics. You must have all Phase 3 endpoints implemented (GET single entry, DELETE single entry, and AI analysis) before starting. The curriculum may not have covered everything you need \u2014 that's intentional. Researching what you don't know is part of the job.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Design a secure two-tier cloud architecture for API and database workloads.",
+              "uuid": "a8283b86-24bb-4e2e-8a20-7679cd19741a"
+            },
+            {
+              "order": 2,
+              "text": "Implement networking, compute, and database components to run the Journal API end to end.",
+              "uuid": "6654c03c-ccbf-4983-9147-3130f07ee90e"
+            },
+            {
+              "order": 3,
+              "text": "Deploy and integrate a cloud-hosted AI model with your application.",
+              "uuid": "f3263740-4646-4160-9cb7-e5d07445ce2c"
+            },
+            {
+              "order": 4,
+              "text": "Validate deployment success criteria including HTTPS, connectivity controls, and functional API behavior.",
+              "uuid": "0f9954fd-42d1-4a8a-99e1-9ee7b8f1a8d4"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "explore",
+              "checklist": [
+                "A virtual network with a CIDR range (e.g., `10.0.0.0/16`)",
+                "A **public subnet** for the API (e.g., `10.0.1.0/24`)",
+                "A **private subnet** for the database (e.g., `10.0.2.0/24`)",
+                "Firewall rules for each subnet, including **SSH (22)** for management access \u2014 not just application ports",
+                "The traffic flow: Internet \u2192 port 443 (reverse proxy) \u2192 port 8000 (your application) \u2192 port 5432 (database)",
+                "How you will manage the private VM (e.g., SSH through the public VM as a jump box, since the database VM has no public IP)"
+              ],
+              "code": null,
+              "description": "Use your **Database Deployment & Configuration** topic work as input. Sketch your infrastructure on paper or a diagram before touching the cloud console.",
+              "done_when": "You have a diagram showing public subnet (API), private subnet (database), CIDR ranges, firewall rules including SSH access, and the port chain from internet to database.",
+              "options": [],
+              "order": 1,
+              "slug": "phase4-topic9-explore-design-your-2-tier-architecture",
+              "tips": [
+                {
+                  "text": "If your cloud platform requires approval for AI model access (e.g., Azure OpenAI, AWS Bedrock), request it now \u2014 approval can take days and will block Step 6.",
+                  "type": "tip"
+                },
+                {
+                  "text": "On some cloud platforms, subnets are not inherently \"public\" or \"private\" \u2014 visibility depends on whether a VM has a public IP and what the firewall rules allow.",
+                  "type": "note"
+                }
+              ],
+              "title": "Design your 2-tier architecture",
+              "url": null,
+              "uuid": "0bb54815-026c-4012-96c6-c4511e8870c3"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Public subnet** \u2014 allow inbound SSH (22), HTTP (80), and HTTPS (443) from the internet",
+                "**Private subnet** \u2014 allow inbound PostgreSQL (5432) and SSH (22) **only from the public subnet's CIDR range**. Deny all other inbound from the internet",
+                "Associate each security group with its respective subnet",
+                "Verify outbound internet access is allowed for both subnets (needed for package installation \u2014 most platforms allow this by default)"
+              ],
+              "code": null,
+              "description": "Create a virtual network with at least two subnets \u2014 one public (API) and one private (database). Create security groups or firewall rules for each.",
+              "done_when": "Both subnets exist, security groups are associated with them, and your firewall rules match the design from Step 1.",
+              "options": [],
+              "order": 2,
+              "slug": "phase4-topic9-practice-create-your-virtual-network",
+              "tips": [],
+              "title": "Create your virtual network with public and private subnets",
+              "url": null,
+              "uuid": "c35ea082-b623-475d-94ff-32a71fa9e519"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Provision the VM** \u2014 Create in the private subnet with a **temporary public IP** and a temporary SSH firewall rule (needed for initial setup)",
+                "**Install PostgreSQL**",
+                "**Create the database** and a dedicated user",
+                "**Run the schema** \u2014 Execute `database_setup.sql` from your repository to create the `entries` table and indexes",
+                "**Grant permissions** \u2014 If you ran the schema as the `postgres` superuser, your app user won't have access without explicit `GRANT` statements on the schema and tables",
+                "**Configure remote access** \u2014 Modify `postgresql.conf` (set `listen_addresses`) and `pg_hba.conf` (allow your API subnet)",
+                "**Restart PostgreSQL**",
+                "**Save connection details** \u2014 Private IP, username, password, and database name for building `DATABASE_URL` in the next step"
+              ],
+              "code": null,
+              "description": "Deploy a VM in the private subnet, install PostgreSQL, create the `career_journal` database with a dedicated user, and run your schema migration.",
+              "done_when": "You can connect to PostgreSQL from the API subnet via private IP, your dedicated user can read and write the `entries` table, and the database is **not** reachable from the internet.",
+              "options": [],
+              "order": 3,
+              "slug": "phase4-topic9-practice-deploy-the-database-in",
+              "tips": [
+                {
+                  "text": "The DB VM needs outbound internet to install packages \u2014 use a temporary public IP (remove after) or a managed NAT service. If your VM has \u22641 GiB RAM, configure swap space (2 GiB recommended) or PostgreSQL may be killed by the OOM handler.",
+                  "type": "tip"
+                }
+              ],
+              "title": "Deploy the database in the private subnet",
+              "url": null,
+              "uuid": "91dd5f9e-365f-445f-a113-fca4abbfe0c0"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Provision the VM** \u2014 Create in the public subnet with a public IP",
+                "**Clone your repo** onto the VM",
+                "**Install `uv`** \u2014 `curl -LsSf https://astral.sh/uv/install.sh | sh`, then `uv sync`",
+                "**Configure the database connection** \u2014 Create `.env` with `DATABASE_URL=postgresql://youruser:yourpassword@db-private-ip:5432/career_journal`",
+                "**Run as a background service** (e.g., systemd) \u2014 set `PYTHONPATH` to your project dir, include `uv` in `PATH`, entry point: `uv run uvicorn api.main:app --host 0.0.0.0 --port 8000`. Do **not** use `--reload` in production",
+                "**Smoke test** \u2014 `curl http://localhost:8000/entries`"
+              ],
+              "code": null,
+              "description": "Deploy a VM in the public subnet, install the Journal API, and connect it to the database using the DB VM's **private IP address**.",
+              "done_when": "All CRUD operations work from the VM \u2014 `POST /entries`, `GET /entries`, `GET /entries/{id}`, `PATCH /entries/{id}`, and `DELETE /entries/{id}`.",
+              "options": [],
+              "order": 4,
+              "slug": "phase4-topic9-practice-deploy-the-api-server",
+              "tips": [
+                {
+                  "text": "The Journal API requires Python 3.11+. Ubuntu 24.04 LTS ships Python 3.12 \u2014 older images may need a separate install. If your VM has \u22641 GiB RAM, configure swap space (2 GiB recommended).",
+                  "type": "tip"
+                }
+              ],
+              "title": "Deploy the API server and connect to the database",
+              "url": null,
+              "uuid": "4c1da717-a539-446a-81bc-deb7aec0e05a"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Domain name** \u2014 Create an A record pointing to your VM's public IP. Use a registrar, free DNS service, or your cloud platform's DNS features",
+                "**Reverse proxy** \u2014 Install **Nginx** or **Caddy**. Configure to forward requests to `http://127.0.0.1:8000`",
+                "**TLS certificate** \u2014 Use **Let's Encrypt** with **Certbot** (Nginx) or Caddy's built-in auto-TLS"
+              ],
+              "code": null,
+              "description": "Set up a **domain name** pointing to your VM's public IP, obtain a **TLS certificate**, and configure a **reverse proxy** to terminate TLS and forward traffic to `localhost:8000`.",
+              "done_when": "`curl -v https://yourdomain/entries` returns valid JSON with a trusted certificate, a 200 status code, and no redirects.",
+              "options": [],
+              "order": 5,
+              "slug": "phase4-topic9-practice-expose-your-api-over-https",
+              "tips": [
+                {
+                  "text": "The automated verifier does **not** follow HTTP redirects. Ensure `GET /entries` on your HTTPS URL returns a direct `200 OK`, not a `3xx` redirect. Watch for trailing-slash behavior \u2014 FastAPI redirects `/entries/` to `/entries` with a 307. Use `/entries` (no trailing slash).",
+                  "type": "warning"
+                }
+              ],
+              "title": "Expose your API over HTTPS",
+              "url": null,
+              "uuid": "27462a4a-7f2d-47f2-b910-2eb9d030deba"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Option A \u2014 OpenAI-compatible endpoint:** Update `OPENAI_BASE_URL`, `OPENAI_API_KEY`, and `OPENAI_MODEL` in `.env`",
+                "**Option B \u2014 Provider-specific SDK:** Modify the client creation in `llm_service.py` to use your provider's client class. Check your provider's docs for integration",
+                "**Redeploy** \u2014 Push changes to the VM and restart your service"
+              ],
+              "code": null,
+              "description": "Deploy or provision access to an LLM on your cloud platform. Your Journal API's AI integration lives in `api/services/llm_service.py` and uses the `openai` Python package.",
+              "done_when": "`curl -X POST https://yourdomain/entries/{id}/analyze` returns sentiment, summary, and topics from your cloud-hosted model.",
+              "options": [],
+              "order": 6,
+              "slug": "phase4-topic9-practice-deploy-and-switch-your",
+              "tips": [],
+              "title": "Deploy and switch your Journal API to cloud AI",
+              "url": null,
+              "uuid": "023ae8e4-f00e-4c6b-af08-93055c275aeb"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Submit your HTTPS base URL (e.g., `https://your-api.example.com`). The verifier POSTs a challenge entry to `/entries`, confirms it appears in `GET /entries`, then deletes it.",
+              "done_when": "The verifier shows \"Deployed API verified!\"",
+              "options": [],
+              "order": 7,
+              "slug": "phase4-topic9-practice-verify-and-submit-your",
+              "tips": [
+                {
+                  "text": "Your API's response format must match the data schema defined in the journal-starter README. Your API must respond within 15 seconds.",
+                  "type": "tip"
+                }
+              ],
+              "title": "Verify and submit your deployment",
+              "url": null,
+              "uuid": "a6ab032c-fe77-4d31-987f-564f6248ede6"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Network** \u2014 create your virtual network, public subnet, and private subnet with their CIDR ranges",
+                "**Firewall rules** \u2014 recreate the inbound and outbound rules for each subnet, keeping the database private",
+                "**Compute** \u2014 provision the API VM (public) and database VM (private) and install their dependencies",
+                "**App and database** \u2014 install and start the Journal API, install PostgreSQL, create the database, and run your schema",
+                "**Idempotency** \u2014 guard steps so re-running does not error on resources that already exist (check-before-create, or `|| true` where appropriate)"
+              ],
+              "code": null,
+              "description": "Write a `deploy.sh` at the **root** of your journal-starter fork that provisions your deployment end to end. Idempotent means running it again on a clean environment reproduces the same architecture without manual steps.",
+              "done_when": "A `deploy.sh` exists at your repository root and clearly shows a secure two-tier design: a public API tier, a private database tier that is not reachable from the internet, and the networking and firewall rules that enforce it.",
+              "options": [],
+              "order": 8,
+              "slug": "phase4-topic9-practice-capture-your-deployment-as-deploy-sh",
+              "tips": [
+                {
+                  "text": "Your deploy.sh does not need to run untouched on every cloud; it should honestly document what you built. The reviewer compares it against your written description, so keep them consistent.",
+                  "type": "tip"
+                },
+                {
+                  "text": "Your journal-starter fork must be **public** so the reviewer can read your `deploy.sh`. A private fork fails with a \"repository not found\" error.",
+                  "type": "warning"
+                }
+              ],
+              "title": "Capture your deployment as an idempotent deploy.sh",
+              "url": null,
+              "uuid": "8560edaf-a754-485a-93bc-42b20d6b18f6"
+            },
+            {
+              "action": "reflect",
+              "checklist": [
+                "Explain your network layout, including public and private subnets and their CIDR ranges",
+                "Describe how the API and database VMs are placed and how the database stays private",
+                "Walk through the traffic flow from the internet to the API and down to the database",
+                "Make sure everything you claim is actually done by your `deploy.sh`",
+                "Write at least a few paragraphs (roughly 300 characters minimum); a one or two sentence summary is rejected as too short"
+              ],
+              "code": null,
+              "description": "In the app, write a description of the architecture your `deploy.sh` provisions, then submit it. An automated reviewer reads both your `deploy.sh` and your description and checks that they align and that your design is a secure two-tier deployment.",
+              "done_when": "The reviewer confirms your description aligns with your deploy.sh.",
+              "options": [],
+              "order": 9,
+              "slug": "phase4-topic9-reflect-describe-and-submit-your-architecture",
+              "tips": [
+                {
+                  "text": "The reviewer fails the check if your description claims resources or controls that your `deploy.sh` does not create. Describe what you built, not the ideal design.",
+                  "type": "warning"
+                }
+              ],
+              "title": "Describe and submit your architecture",
+              "url": null,
+              "uuid": "db9a4aa7-4a04-42c5-a661-c54b091ed157"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "VMs, disks, and public IPs",
+                "Virtual networks, subnets, and security groups",
+                "AI resources and deployments",
+                "Temporary public IP and SSH rule from the database VM"
+              ],
+              "code": null,
+              "description": "Delete all cloud resources you provisioned. Check your cloud console to confirm nothing is still running or incurring charges.",
+              "done_when": null,
+              "options": [],
+              "order": 10,
+              "slug": "phase4-topic9-practice-clean-up-your-cloud",
+              "tips": [
+                {
+                  "text": "If your cloud platform supports resource groups or tagging, use them \u2014 deleting a single group or filtering by tag makes cleanup straightforward.",
+                  "type": "tip"
+                }
+              ],
+              "title": "Clean up your cloud resources",
+              "url": null,
+              "uuid": "6dd5149a-494d-4f19-a401-fe7a1a71c75c"
+            },
+            {
+              "action": "reflect",
+              "checklist": [],
+              "code": null,
+              "description": "Push your work to GitHub and write a brief technical writeup covering your architecture decisions, what networking and security controls you implemented, and what you'd do differently. Share it on LinkedIn or with the Learn to Cloud community to get feedback and celebrate your progress.",
+              "done_when": null,
+              "options": [],
+              "order": 11,
+              "slug": "phase4-topic9-reflect-share-your-progress",
+              "tips": [],
+              "title": "Share your progress",
+              "url": null,
+              "uuid": "ab084238-bf88-487e-9aa9-45c257463179"
+            }
+          ],
+          "name": "Capstone: Cloud Deployment",
+          "order": 9,
+          "slug": "capstone",
+          "uuid": "ddd726e7-818e-4672-b33a-579718b1a8f3"
+        }
+      ],
+      "uuid": "0308493d-4c94-4ea9-b643-6a7f534bacda"
+    },
+    {
+      "capstone": null,
+      "description": "This phase covers DevOps fundamentals - the practices and tools that enable teams to deliver software faster and more reliably. You'll learn containerization, CI/CD pipelines, Infrastructure as Code, container orchestration, and how to instrument your application with OpenTelemetry for cloud-native monitoring.",
+      "hands_on_verification": {
+        "requirement_slugs": [
+          "devops-implementation"
+        ],
+        "requirements": [
+          {
+            "description": "Submit your journal-starter fork after finishing the DevOps capstone so automated checks can validate your implementation.",
+            "name": "Complete the DevOps Capstone",
+            "slug": "devops-implementation",
+            "submission_type": "devops_analysis",
+            "type_config": {
+              "required_repo": "learntocloud/journal-starter"
+            },
+            "uuid": "623a87ae-156f-42da-a83c-09241d523e00"
+          }
+        ]
+      },
+      "name": "DevOps Fundamentals",
+      "objectives": [],
+      "order": 5,
+      "short_description": "Master Docker containers, Kubernetes orchestration, CI/CD pipelines, Terraform IaC, and OpenTelemetry observability with your cloud provider.",
+      "slug": "phase5",
+      "topic_slugs": [
+        "containers",
+        "cicd",
+        "infrastructure-as-code",
+        "container-orchestration",
+        "monitoring-observability",
+        "ai-tooling-mcp",
+        "capstone"
+      ],
+      "topics": [
+        {
+          "description": "Containerization is a modern approach to deploying and managing applications across various environments. It allows you to package software, tools, and their dependencies into lightweight, portable units called containers. Key benefits include consistency across environments, efficient resource utilization, simplified deployment, and isolation between applications.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain containerization benefits and differences from traditional virtualization.",
+              "uuid": "73870957-eb0f-4062-83eb-780854c74e20"
+            },
+            {
+              "order": 2,
+              "text": "Build container images and distribute them through registry workflows.",
+              "uuid": "19c66e8f-1105-46e1-bb14-791a1d9ef6e0"
+            },
+            {
+              "order": 3,
+              "text": "Apply container practices directly to your Journal API project lifecycle.",
+              "uuid": "b4535664-bd6a-4753-9ddc-843bd4fc54a9"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how containers package applications with their dependencies for consistent deployment.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase5-topic1-read-what-is-containerization",
+              "tips": [],
+              "title": "What is Containerization?",
+              "url": "https://github.com/resources/articles/containerization",
+              "uuid": "1ab0f304-8648-4ce0-8338-a936bdd4c69a"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand the key differences between containers and virtual machines.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase5-topic1-read-containerization-vs-virtualization",
+              "tips": [],
+              "title": "Containerization vs Virtualization",
+              "url": "https://kodekloud.com/blog/virtualization-vs-containerization/",
+              "uuid": "bc4f427e-7570-4e70-ad88-ad34982a001f"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Comprehensive video introduction to Docker and containerization.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase5-topic1-watch-what-is-docker",
+              "tips": [],
+              "title": "What is Docker?",
+              "url": "https://youtu.be/3c-iBn73dDE",
+              "uuid": "9e4f8ffd-e67c-40c2-a18f-d1e48316d376"
+            },
+            {
+              "action": "explore",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how container registries store and distribute Docker images.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase5-topic1-explore-what-is-a-container",
+              "tips": [],
+              "title": "What is a Container Registry?",
+              "url": "https://docs.docker.com/get-started/docker-concepts/the-basics/what-is-a-registry/",
+              "uuid": "8b29c044-7f74-49fa-b7a7-0a4bfd682424"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": "FROM python:3.11-slim\n\nWORKDIR /app\n\nCOPY requirements.txt .\nRUN pip install --no-cache-dir -r requirements.txt\n\nCOPY . .\n\nEXPOSE 8000\n\nCMD [\"uvicorn\", \"main:app\", \"--host\", \"0.0.0.0\", \"--port\", \"8000\"]",
+              "description": "Write a Dockerfile for your Journal API. Use the sample below as a reference:",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase5-topic1-practice-write-a-dockerfile-for",
+              "tips": [],
+              "title": "Write a Dockerfile for your Journal API",
+              "url": null,
+              "uuid": "38475b32-430f-417c-8a80-5093d1b15969"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Build the Docker image from your Dockerfile and run it locally. Test that your Journal API works correctly inside the container.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase5-topic1-practice-build-and-run-your",
+              "tips": [],
+              "title": "Build and run your container locally",
+              "url": null,
+              "uuid": "626b6cfe-1133-49c7-acc9-70042f5415e8"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Tag your image and push it to a container registry. Follow the guide for your cloud provider:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Push images to Azure Container Registry",
+                  "provider": "azure",
+                  "title": "Azure Container Registry",
+                  "url": "https://learn.microsoft.com/training/modules/deploy-use-azure-container-registry/"
+                },
+                {
+                  "description": "Push images to Amazon Elastic Container Registry",
+                  "provider": "aws",
+                  "title": "AWS ECR",
+                  "url": "https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html"
+                },
+                {
+                  "description": "Push images to Google Container Registry",
+                  "provider": "gcp",
+                  "title": "Google Container Registry",
+                  "url": "https://www.youtube.com/watch?v=D1_FC6pGutQ"
+                }
+              ],
+              "order": 7,
+              "slug": "phase5-topic1-practice-push-your-image-to",
+              "tips": [],
+              "title": "Push your image to a container registry",
+              "url": null,
+              "uuid": "bc8cb897-feb7-4b62-9501-addac708c334"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Reference for common Docker issues and solutions.",
+              "done_when": null,
+              "options": [],
+              "order": 8,
+              "slug": "phase5-topic1-read-docker-troubleshooting",
+              "tips": [],
+              "title": "Docker Troubleshooting",
+              "url": "https://docs.docker.com/engine/daemon/troubleshoot/",
+              "uuid": "61d5fb18-5389-4b6e-a564-179df9d4da8c"
+            },
+            {
+              "action": "note",
+              "checklist": [],
+              "code": null,
+              "description": "Don't delete the container image you pushed to your registry \u2014 you'll need it for the DevOps capstone project. Registry storage for a single image is minimal cost.",
+              "done_when": null,
+              "options": [],
+              "order": 9,
+              "slug": "phase5-topic1-note-keep-your-container-image",
+              "tips": [],
+              "title": "Keep your container image for the capstone",
+              "url": null,
+              "uuid": "ff97145c-d0be-48ba-9403-c7eb1e613d91"
+            }
+          ],
+          "name": "Containerization",
+          "order": 1,
+          "slug": "containers",
+          "uuid": "fc28fe36-e319-44f2-a3aa-d8bbb1621db5"
+        },
+        {
+          "description": "One challenge you'll face after containerizing your application is the need to manually rebuild and push for every code change. CI/CD pipelines automate this entire process - building, testing, and deploying your application every time changes are made, ensuring a smooth and reliable development workflow.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain CI/CD stages and the value of automated build, test, and release workflows.",
+              "uuid": "d5114bfd-0b48-4185-836b-3a77ff605527"
+            },
+            {
+              "order": 2,
+              "text": "Create and iterate pipeline definitions for repeatable application delivery.",
+              "uuid": "60c07495-b5ed-4d72-bdb0-83462efec496"
+            },
+            {
+              "order": 3,
+              "text": "Diagnose and fix workflow failures to maintain a reliable deployment path.",
+              "uuid": "b212b9c6-b857-44ee-9ab5-299ccbe8e71d"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn the fundamentals of continuous integration and continuous deployment, and how CI, continuous delivery, and continuous deployment differ.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase5-topic2-read-understand-cicd",
+              "tips": [],
+              "title": "Understand CI/CD",
+              "url": "https://www.jetbrains.com/teamcity/ci-cd-guide/continuous-integration-vs-delivery-vs-deployment/",
+              "uuid": "5259a6d6-6336-420b-a14b-449868928256"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand how GitHub Actions works \u2014 workflows, triggers, jobs, and steps \u2014 so you can automate your build and deploy pipeline.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase5-topic2-read-learn-about-github-actions",
+              "tips": [],
+              "title": "Learn about GitHub Actions",
+              "url": "https://docs.github.com/actions/get-started/understand-github-actions",
+              "uuid": "8a2ab5be-dbef-4557-8fb1-576a712277b2"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": "name: CI\n\non:\n  push:\n    branches: [main]\n\njobs:\n  build-and-test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      \n      - name: Set up Python\n        uses: actions/setup-python@v5\n        with:\n          python-version: '3.11'\n      \n      - name: Install dependencies\n        run: pip install -r requirements.txt\n      \n      - name: Run tests\n        run: pytest",
+              "description": "Create a workflow file in .github/workflows/ that automatically builds your application and runs tests on every push to the main branch. Here's a starter template:",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase5-topic2-practice-create-a-github-actions",
+              "tips": [],
+              "title": "Create a GitHub Actions workflow that builds and tests your app",
+              "url": null,
+              "uuid": "c4826180-0c6a-4927-b530-2408d494451e"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": "name: Build and Push\n\non:\n  push:\n    branches: [main]\n\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      \n      - name: Build Docker image\n        run: docker build -t myapp:${{ github.sha }} .\n      \n      - name: Login to Registry\n        run: echo ${{ secrets.REGISTRY_PASSWORD }} | docker login -u ${{ secrets.REGISTRY_USER }} --password-stdin\n      \n      - name: Push image\n        run: docker push myapp:${{ github.sha }}",
+              "description": "Extend your workflow to build a Docker image and push it to a container registry on successful builds. Use this as a reference:",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase5-topic2-practice-add-docker-image-build",
+              "tips": [],
+              "title": "Add Docker image build and push to your workflow",
+              "url": null,
+              "uuid": "59da8a18-206b-42d0-9e59-636a8ae46515"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Push a commit and verify that your workflow runs successfully in the GitHub Actions tab. Fix any issues until you have a green build.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase5-topic2-practice-verify-a-successful-workflow",
+              "tips": [],
+              "title": "Verify a successful workflow run",
+              "url": null,
+              "uuid": "ccc8eee2-a5ee-480c-8efe-4eb8c3c7dadd"
+            }
+          ],
+          "name": "CI/CD Pipelines",
+          "order": 2,
+          "slug": "cicd",
+          "uuid": "622714e9-a0d9-40a3-9345-433128e039ef"
+        },
+        {
+          "description": "Infrastructure as Code (IaC) is a key DevOps practice that allows you to manage and provision infrastructure using code, rather than manual processes like using the console. In this phase, you'll build on Phase 1 fundamentals and execute a complete Terraform workflow for real cloud provisioning.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain how IaC improves reliability, repeatability, and change control in DevOps workflows.",
+              "uuid": "ec4d1b2c-5e6e-428c-9628-f3ec1fc248f7"
+            },
+            {
+              "order": 2,
+              "text": "Execute end-to-end Terraform workflows from initialization through teardown.",
+              "uuid": "cf832a84-8572-4968-a86e-9fca6cd2cd20"
+            },
+            {
+              "order": 3,
+              "text": "Provision and manage cloud resources safely using provider-specific declarative configuration.",
+              "uuid": "6152f442-6023-4583-999b-4847b80ff6d7"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Choose one cloud tutorial and follow the full workflow:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Video walkthrough of Terraform with Azure",
+                  "provider": "azure",
+                  "title": "Azure Terraform Example",
+                  "url": "https://youtu.be/HdMB2YCtVr4"
+                },
+                {
+                  "description": "Video walkthrough of Terraform with AWS",
+                  "provider": "aws",
+                  "title": "AWS Terraform Example",
+                  "url": "https://youtu.be/P4A62b1dkJE"
+                },
+                {
+                  "description": "Video walkthrough of Terraform with GCP",
+                  "provider": "gcp",
+                  "title": "GCP Terraform Example",
+                  "url": "https://youtu.be/VCayKl82Lt8"
+                }
+              ],
+              "order": 1,
+              "slug": "phase5-topic3-watch-watch-a-cloud-specific-terraform",
+              "tips": [],
+              "title": "Watch a cloud-specific Terraform tutorial",
+              "url": null,
+              "uuid": "a161c925-c3cc-4e30-9e90-1ef07d8a8d45"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Use the provider docs for your selected cloud to confirm resource arguments and defaults:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Terraform provider for Microsoft Azure",
+                  "provider": "azure",
+                  "title": "Azure Provider",
+                  "url": "https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs"
+                },
+                {
+                  "description": "Terraform provider for Amazon Web Services",
+                  "provider": "aws",
+                  "title": "AWS Provider",
+                  "url": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs"
+                },
+                {
+                  "description": "Terraform provider for Google Cloud Platform",
+                  "provider": "gcp",
+                  "title": "GCP Provider",
+                  "url": "https://registry.terraform.io/providers/hashicorp/google/latest/docs"
+                }
+              ],
+              "order": 2,
+              "slug": "phase5-topic3-practice-cloud-specific-providers",
+              "tips": [],
+              "title": "Cloud-Specific Providers",
+              "url": null,
+              "uuid": "a10a0883-e424-4d95-ac8e-b03ebb09ca15"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Write a Terraform configuration file that creates a virtual machine on your cloud provider with a security group allowing SSH access.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase5-topic3-practice-write-a-terraform-config",
+              "tips": [],
+              "title": "Write a Terraform config to create a VM",
+              "url": null,
+              "uuid": "eba35467-ab26-4906-82d9-1385cd4a96e5"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Initialize Terraform with `terraform init`, preview your changes with `terraform plan`, then create the resources with `terraform apply`. Verify the resources exist in your cloud console.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase5-topic3-practice-run-terraform-init-plan",
+              "tips": [],
+              "title": "Run terraform init, plan, and apply",
+              "url": null,
+              "uuid": "e7475372-2f50-4c24-a9d3-0d40fdccaf3a"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Run `terraform destroy` to remove all resources you created, and verify cleanup in your cloud console.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase5-topic3-practice-clean-up-with-terraform",
+              "tips": [],
+              "title": "Clean up with terraform destroy",
+              "url": null,
+              "uuid": "6eee2650-6a06-41b2-9b9d-7e5789c2924d"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn about module organization, state management, and variable patterns.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase5-topic3-read-terraform-best-practices",
+              "tips": [],
+              "title": "Terraform Best Practices",
+              "url": "https://www.terraform-best-practices.com/",
+              "uuid": "d8573f28-0fb2-47cf-87cc-0a5b56392582"
+            }
+          ],
+          "name": "Infrastructure as Code (IaC)",
+          "order": 3,
+          "slug": "infrastructure-as-code",
+          "uuid": "3965a6b1-f216-47a8-a4f4-66e93d16a5ea"
+        },
+        {
+          "description": "As applications grow in complexity, managing containers manually becomes challenging. Kubernetes (K8s) is an open-source container orchestration platform that automates the deployment, scaling, and management of containerized applications. It's widely used in modern cloud-native environments to ensure applications are highly available, scalable, and resilient.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Understand Kubernetes architecture and key workload/resource abstractions.",
+              "uuid": "3d5e623c-ba40-420d-8c56-6cc8036a546f"
+            },
+            {
+              "order": 2,
+              "text": "Deploy and expose applications using Kubernetes manifests and core commands.",
+              "uuid": "9ef9a5d7-1a01-4e55-ac50-da721c53af12"
+            },
+            {
+              "order": 3,
+              "text": "Evaluate local and managed Kubernetes options for real deployment scenarios.",
+              "uuid": "963dac44-26ee-4c83-a889-1de462b70735"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand what Kubernetes is and why it was created \u2014 automated deployment, self-healing, load balancing, and declarative configuration.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase5-topic4-read-kubernetes-overview",
+              "tips": [],
+              "title": "Kubernetes Overview",
+              "url": "https://kubernetes.io/docs/concepts/overview/",
+              "uuid": "8e7e6fa0-0f31-4ffc-9366-af4b2f6c2e40"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand the building blocks \u2014 clusters, nodes, pods, services, deployments, ConfigMaps, and Secrets.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase5-topic4-read-kubernetes-components",
+              "tips": [],
+              "title": "Kubernetes Components",
+              "url": "https://kubernetes.io/docs/concepts/overview/components/",
+              "uuid": "689b3c72-692f-4290-ad8c-4eeaf632b8fa"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Install Minikube or Kind on your local machine to run a local Kubernetes cluster for development. Verify your cluster is running with `kubectl cluster-info`.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase5-topic4-practice-local-setup",
+              "tips": [],
+              "title": "Set up a local Kubernetes cluster",
+              "url": "https://minikube.sigs.k8s.io/docs/start/",
+              "uuid": "6591585d-4ecf-49e1-84bb-fe311e06eba1"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": "# View cluster information\nkubectl cluster-info\n\n# List all nodes in the cluster\nkubectl get nodes\n\n# Deploy an application\nkubectl apply -f deployment.yaml\n\n# View running pods\nkubectl get pods\n\n# View logs of a pod\nkubectl logs <pod-name>\n\n# Delete a resource\nkubectl delete -f deployment.yaml",
+              "description": "Now that you have a cluster running, familiarize yourself with these essential kubectl commands:",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase5-topic4-read-essential-kubectl-commands",
+              "tips": [],
+              "title": "Essential kubectl commands",
+              "url": null,
+              "uuid": "bccb88cc-23e7-4d65-84ff-419a5a185f3f"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: journal-api\nspec:\n  replicas: 2\n  selector:\n    matchLabels:\n      app: journal-api\n  template:\n    metadata:\n      labels:\n        app: journal-api\n    spec:\n      containers:\n      - name: journal-api\n        image: your-registry/journal-api:latest\n        ports:\n        - containerPort: 8000",
+              "description": "Create a Kubernetes deployment YAML file for your Journal API and apply it with `kubectl apply -f deployment.yaml`. Verify pods are running with `kubectl get pods`. Use this sample as a starting point:",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase5-topic4-practice-deploy-journal-api-locally",
+              "tips": [],
+              "title": "Deploy your Journal API locally",
+              "url": null,
+              "uuid": "26fad149-93f0-4fff-a52c-5ae003385c11"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Expose your deployment with `kubectl expose deployment journal-api --type=NodePort --port=8000` and access the application in your browser using the NodePort.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase5-topic4-practice-expose-your-deployment-and",
+              "tips": [],
+              "title": "Expose your deployment and access it in a browser",
+              "url": null,
+              "uuid": "41021035-3d16-4394-80a0-121c3acac5b2"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Most cloud providers offer managed Kubernetes services that handle control plane management for you:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Azure Kubernetes Service \u2014 managed Kubernetes on Azure",
+                  "provider": "azure",
+                  "title": "Azure AKS",
+                  "url": "https://learn.microsoft.com/azure/aks/"
+                },
+                {
+                  "description": "Amazon Elastic Kubernetes Service \u2014 managed Kubernetes on AWS",
+                  "provider": "aws",
+                  "title": "AWS EKS",
+                  "url": "https://aws.amazon.com/eks/"
+                },
+                {
+                  "description": "Google Kubernetes Engine \u2014 managed Kubernetes on GCP",
+                  "provider": "gcp",
+                  "title": "Google GKE",
+                  "url": "https://docs.cloud.google.com/kubernetes-engine/docs/concepts/kubernetes-engine-overview"
+                }
+              ],
+              "order": 7,
+              "slug": "phase5-topic4-read-managed-kubernetes-services",
+              "tips": [],
+              "title": "Managed Kubernetes Services",
+              "url": null,
+              "uuid": "7155d4da-4dab-41c0-82a2-3459ad0a9460"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Follow the quickstart for your cloud provider to provision a managed Kubernetes cluster and deploy your Journal API to it:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Provision and validate an AKS cluster from the command line.",
+                  "provider": "azure",
+                  "title": "Quickstart - Deploy an AKS cluster",
+                  "url": "https://learn.microsoft.com/azure/aks/learn/quick-kubernetes-deploy-cli"
+                },
+                {
+                  "description": "Launch your first Amazon EKS cluster and verify node health.",
+                  "provider": "aws",
+                  "title": "Create an EKS cluster - getting started",
+                  "url": "https://docs.aws.amazon.com/eks/latest/userguide/getting-started-console.html"
+                },
+                {
+                  "description": "Create and validate a Google Kubernetes Engine cluster quickly.",
+                  "provider": "gcp",
+                  "title": "Deploy a GKE cluster",
+                  "url": "https://docs.cloud.google.com/kubernetes-engine/docs/learn/cymbal-books/lp1/containerize"
+                }
+              ],
+              "order": 8,
+              "slug": "phase5-topic4-practice-deploy-to-managed-k8s",
+              "tips": [],
+              "title": "Deploy to a managed Kubernetes cluster",
+              "url": null,
+              "uuid": "e747c63a-bf85-4b91-b4be-855f35042ce6"
+            },
+            {
+              "action": "note",
+              "checklist": [],
+              "code": null,
+              "description": "You'll reuse your managed Kubernetes cluster in the DevOps capstone project. Managed clusters do incur ongoing costs, so be mindful \u2014 but you'll need it for the capstone steps ahead.",
+              "done_when": null,
+              "options": [],
+              "order": 9,
+              "slug": "phase5-topic4-note-keep-cluster-for-capstone",
+              "tips": [],
+              "title": "Keep your cluster for the capstone",
+              "url": null,
+              "uuid": "2821b5d4-601e-4831-975b-19d9204e474e"
+            }
+          ],
+          "name": "Container Orchestration - Kubernetes",
+          "order": 4,
+          "slug": "container-orchestration",
+          "uuid": "74cb89f5-c79a-4939-94dd-6b28d32801f2"
+        },
+        {
+          "description": "Monitoring and observability are essential DevOps practices that help you understand the health, performance, and reliability of your applications and infrastructure. In this topic, you'll instrument your application with OpenTelemetry, verify telemetry locally with Aspire Dashboard, and export logs, traces, and metrics to your cloud provider's monitoring platform.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Differentiate monitoring and observability and explain the three pillars (logs, traces, metrics).",
+              "uuid": "25f4f0a3-9407-4159-8983-99ac72fa91de"
+            },
+            {
+              "order": 2,
+              "text": "Explain what OpenTelemetry is and why vendor-neutral instrumentation matters.",
+              "uuid": "22208e90-14b4-4dd3-b40d-9eca857c23f5"
+            },
+            {
+              "order": 3,
+              "text": "Instrument a Python/FastAPI application with the OpenTelemetry SDK to produce logs, traces, and metrics.",
+              "uuid": "d92428eb-720a-4464-bad6-1cfe179fc2a7"
+            },
+            {
+              "order": 4,
+              "text": "Verify telemetry locally with an OTLP-compatible tool such as Aspire Dashboard before sending it to the cloud.",
+              "uuid": "4ab4a8bc-c12a-45f0-b689-ab809714884a"
+            },
+            {
+              "order": 5,
+              "text": "Export OpenTelemetry signals to a cloud monitoring platform and query them.",
+              "uuid": "28667c2b-fbd4-42b5-a31c-00b2a8d74e81"
+            },
+            {
+              "order": 6,
+              "text": "Build a useful dashboard and alert from application telemetry.",
+              "uuid": "4c55eaa2-f985-44af-9f6c-a73aa178fe6b"
+            },
+            {
+              "order": 7,
+              "text": "Recognize where Prometheus and Grafana fit as common open-source observability alternatives.",
+              "uuid": "ca50fda2-0114-45b8-94f5-819ce3dfa7da"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Optional refresher from Phase 4. If you've already completed the monitoring foundations topic, skim this quickly to reconnect with your provider's core monitoring services.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Learn Azure's monitoring architecture, signals, and core capabilities.",
+                  "provider": "azure",
+                  "title": "Azure Monitor Overview",
+                  "url": "https://learn.microsoft.com/azure/azure-monitor/fundamentals/overview"
+                },
+                {
+                  "description": "Review AWS monitoring fundamentals for metrics, logs, alarms, and dashboards.",
+                  "provider": "aws",
+                  "title": "Amazon CloudWatch Overview",
+                  "url": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html"
+                },
+                {
+                  "description": "Understand how Cloud Monitoring collects and visualizes service telemetry.",
+                  "provider": "gcp",
+                  "title": "Google Cloud Monitoring Overview",
+                  "url": "https://docs.cloud.google.com/monitoring/docs/monitoring-overview"
+                }
+              ],
+              "order": 1,
+              "slug": "phase5-topic5-read-prerequisite-refresher-provider-monitoring",
+              "tips": [],
+              "title": "Prerequisite refresher: provider monitoring basics (optional)",
+              "url": null,
+              "uuid": "9778ac75-c4f4-45a2-bdf1-ad573b1c534e"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand the difference between monitoring and observability in DevOps.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase5-topic5-read-monitoring-vs-observability",
+              "tips": [],
+              "title": "Monitoring vs Observability",
+              "url": "https://www.ibm.com/think/topics/observability-vs-monitoring",
+              "uuid": "03d129e2-06e2-4bcb-9abc-0aee9662933c"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn the three pillars of observability \u2014 metrics, logs, and traces \u2014 and how dashboards and alerts are built from these telemetry signals.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase5-topic5-read-observability-patterns-microsoft-learn",
+              "tips": [],
+              "title": "Observability Patterns (Microsoft Learn)",
+              "url": "https://learn.microsoft.com/dotnet/architecture/cloud-native/observability-patterns",
+              "uuid": "f1f3d332-062f-4569-9656-ffdfd7f508aa"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand OpenTelemetry (OTel) \u2014 the vendor-neutral, open-source observability framework. Learn why it matters and how it provides a single set of APIs and SDKs for emitting logs, traces, and metrics from any application.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase5-topic5-read-what-is-opentelemetry",
+              "tips": [],
+              "title": "What is OpenTelemetry?",
+              "url": "https://opentelemetry.io/docs/what-is-opentelemetry/",
+              "uuid": "8bf22d48-b4ac-4fd8-85ee-bbfcff518b80"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Understand the three telemetry signals OpenTelemetry standardizes: traces (request flow across services), metrics (numeric measurements over time), and logs (timestamped event records). In Phase 3 you added basic logging \u2014 now you'll connect all three signals into a unified observability pipeline.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase5-topic5-read-opentelemetry-signals",
+              "tips": [],
+              "title": "OpenTelemetry Concepts: Signals",
+              "url": "https://opentelemetry.io/docs/concepts/signals/",
+              "uuid": "9b9a6d47-51ec-4259-a65f-d77069664892"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Review the official OpenTelemetry Python documentation. Understand how to install the SDK, configure providers and exporters, and auto-instrument popular frameworks.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase5-topic5-read-opentelemetry-python-sdk",
+              "tips": [],
+              "title": "OpenTelemetry Python SDK",
+              "url": "https://opentelemetry.io/docs/languages/python/",
+              "uuid": "24ac8a65-ad9d-457e-8098-716ab2673efe"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how Aspire Dashboard can run locally as a standalone OpenTelemetry dashboard so you can inspect logs, traces, and metrics before wiring your app to a cloud backend.",
+              "done_when": null,
+              "options": [],
+              "order": 7,
+              "slug": "phase5-topic5-read-aspire-dashboard",
+              "tips": [],
+              "title": "Aspire Dashboard",
+              "url": "https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/overview",
+              "uuid": "314986af-5e2b-421b-867b-9b805d60896e"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "Install packages: `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-instrumentation-fastapi`",
+                "Configure a `TracerProvider` with a `Resource` that identifies your service name",
+                "Configure a `MeterProvider` for custom metrics",
+                "Call `FastAPIInstrumentor.instrument_app(app)` to auto-instrument routes",
+                "Add at least one custom span (e.g., around a database call) using `tracer.start_as_current_span()`",
+                "Add at least one custom metric (e.g., a counter for journal entries created)",
+                "Connect your Python logger to the OTel log pipeline so structured logs are correlated with traces"
+              ],
+              "code": null,
+              "description": "Add OpenTelemetry instrumentation to your Journal API. Install the core packages and the FastAPI auto-instrumentation library, then configure tracing, metrics, and log correlation. You should be able to see traces for incoming HTTP requests and custom spans for key operations.",
+              "done_when": null,
+              "options": [],
+              "order": 8,
+              "slug": "phase5-topic5-practice-instrument-fastapi-with-otel",
+              "tips": [],
+              "title": "Instrument Your FastAPI App with OpenTelemetry",
+              "url": "https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/fastapi/fastapi.html",
+              "uuid": "4f00d06f-6fd2-4fc8-9dee-f6cb1d1fbc15"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "Run the standalone dashboard: `docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard mcr.microsoft.com/dotnet/aspire-dashboard:latest`",
+                "Set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` for your local app",
+                "Start the Journal API and send requests to several routes, including at least one route that returns an error",
+                "Open `http://localhost:18888` and confirm requests appear as traces",
+                "Confirm logs include trace context and that your custom metric appears in the dashboard"
+              ],
+              "code": null,
+              "description": "Run Aspire Dashboard locally, point your Journal API at its OTLP endpoint, and confirm your instrumentation works before sending telemetry to your cloud provider.",
+              "done_when": null,
+              "options": [],
+              "order": 9,
+              "slug": "phase5-topic5-practice-verify-telemetry-aspire-dashboard",
+              "tips": [],
+              "title": "Verify Telemetry Locally with Aspire Dashboard",
+              "url": null,
+              "uuid": "5fab9ffe-c081-4b75-8a90-7986edfa59e9"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Connect your OpenTelemetry pipeline to your cloud provider's monitoring backend so logs, traces, and metrics are visible in the cloud console. Follow the guide for your provider:",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Install `azure-monitor-opentelemetry` and configure it with your Application Insights connection string. Traces, metrics, and logs will appear in the Azure portal under Application Insights.",
+                  "provider": "azure",
+                  "title": "Azure Monitor OpenTelemetry (Python)",
+                  "url": "https://learn.microsoft.com/azure/azure-monitor/app/opentelemetry-enable?tabs=python"
+                },
+                {
+                  "description": "Use the AWS Distro for OpenTelemetry (ADOT) to export traces to AWS X-Ray and metrics to CloudWatch. Install the `opentelemetry-exporter-otlp` package and configure the ADOT Collector as your OTLP endpoint.",
+                  "provider": "aws",
+                  "title": "AWS Distro for OpenTelemetry (Python)",
+                  "url": "https://aws-otel.github.io/docs/getting-started/x-ray"
+                },
+                {
+                  "description": "Install `opentelemetry-exporter-gcp-trace` and `opentelemetry-exporter-gcp-monitoring` to export traces to Cloud Trace and metrics to Cloud Monitoring.",
+                  "provider": "gcp",
+                  "title": "Google Cloud OpenTelemetry (Python)",
+                  "url": "https://cloud.google.com/trace/docs/setup/python-ot"
+                }
+              ],
+              "order": 10,
+              "slug": "phase5-topic5-practice-export-telemetry-cloud-provider",
+              "tips": [],
+              "title": "Export Telemetry to Your Cloud Provider",
+              "url": null,
+              "uuid": "1b44c659-927a-4bce-ad0d-06088f5d44b4"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "Confirm traces are visible (Azure: Application Insights \u2192 Transaction search, AWS: X-Ray \u2192 Traces, GCP: Cloud Trace \u2192 Trace list)",
+                "Confirm metrics are visible (Azure: Application Insights \u2192 Metrics, AWS: CloudWatch \u2192 Metrics, GCP: Cloud Monitoring \u2192 Metrics Explorer)",
+                "Confirm logs are correlated with trace IDs (Azure: Application Insights \u2192 Logs, AWS: CloudWatch Logs, GCP: Cloud Logging)"
+              ],
+              "code": null,
+              "description": "After instrumenting your app and configuring the exporter, send a few requests to your Journal API and verify the telemetry appears in your cloud console:",
+              "done_when": null,
+              "options": [],
+              "order": 11,
+              "slug": "phase5-topic5-practice-verify-telemetry-cloud-console",
+              "tips": [],
+              "title": "Verify Telemetry in Your Cloud Console",
+              "url": null,
+              "uuid": "18ae6ef5-4958-4bc9-92c9-3c978f5fe767"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "Find failed requests from the last hour",
+                "Show request count by route or endpoint",
+                "Show slow requests or p95 request duration",
+                "Find recent exceptions",
+                "Correlate one log entry with the trace/request that produced it"
+              ],
+              "code": null,
+              "description": "Use your provider's query tool to investigate real application behavior. For Azure, write KQL in Log Analytics or Application Insights Logs. For AWS, use CloudWatch Logs Insights. For GCP, use Logs Explorer and Metrics Explorer.",
+              "done_when": null,
+              "options": [],
+              "order": 12,
+              "slug": "phase5-topic5-practice-query-telemetry",
+              "tips": [],
+              "title": "Query Your Telemetry",
+              "url": null,
+              "uuid": "87962710-a649-4f86-b576-5a17c32157a5"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "Add request count",
+                "Add error count or error rate",
+                "Add average or p95 latency",
+                "Add recent exceptions or failed requests",
+                "Create one alert for repeated 5xx responses, high latency, or another user-impacting symptom"
+              ],
+              "code": null,
+              "description": "Create a small production-style dashboard and one actionable alert from your telemetry. Keep it simple and focused on signals an on-call engineer would actually use.",
+              "done_when": null,
+              "options": [],
+              "order": 13,
+              "slug": "phase5-topic5-practice-build-dashboard-alert",
+              "tips": [],
+              "title": "Build a Dashboard and Alert",
+              "url": null,
+              "uuid": "f726e27e-64c7-4c69-a633-b38817f7eec4"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Trigger or find a small issue in your telemetry and write a short note explaining what happened, how you detected it, which query or dashboard helped, and what alert would catch it next time.",
+              "done_when": null,
+              "options": [],
+              "order": 14,
+              "slug": "phase5-topic5-practice-write-incident-note",
+              "tips": [],
+              "title": "Write a Short Incident Note",
+              "url": null,
+              "uuid": "c7d2f35c-ab16-4118-b18b-ac0c7d171d1a"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how Prometheus and Grafana fit into open-source and self-hosted observability stacks. Prometheus collects and queries metrics; Grafana visualizes data from Prometheus, cloud monitoring platforms, and many other backends.",
+              "done_when": null,
+              "options": [],
+              "order": 15,
+              "slug": "phase5-topic5-read-prometheus-grafana",
+              "tips": [],
+              "title": "Prometheus and Grafana as Optional Alternatives",
+              "url": "https://grafana.com/docs/grafana/latest/fundamentals/getting-started/first-dashboards/get-started-grafana-prometheus/",
+              "uuid": "0d18c18e-1d6f-4e0d-898e-ae7bba9b9bb9"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Optional advanced practice for learners interested in Kubernetes, SRE, or platform engineering roles. Expose Prometheus-compatible metrics from your app, run Prometheus and Grafana locally, and recreate the same request, error, and latency dashboard you built in your cloud provider.",
+              "done_when": null,
+              "options": [],
+              "order": 16,
+              "slug": "phase5-topic5-read-prometheus-grafana-documentation",
+              "tips": [],
+              "title": "Optional: Recreate Your Dashboard with Prometheus and Grafana",
+              "url": "https://prometheus.io/docs/",
+              "uuid": "0c42eb14-c41b-46b5-8fd0-ae9eb132ad2a"
+            }
+          ],
+          "name": "Monitoring & Observability",
+          "order": 5,
+          "slug": "monitoring-observability",
+          "uuid": "14b8435a-4fba-433f-a38e-f80d9124277f"
+        },
+        {
+          "description": "Modern DevOps workflows increasingly integrate AI-powered tools. The Model Context Protocol (MCP) provides a standard way for AI assistants to interact with external services through containerized servers. In this topic, you'll learn what MCP is, set up MCP servers in VS Code, and use GitHub Copilot to query your CI/CD pipelines and cloud telemetry.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Explain the Model Context Protocol and how it connects AI assistants to external tools.",
+              "uuid": "b5570b5b-f2ad-4e38-9291-3656cc8bac0e"
+            },
+            {
+              "order": 2,
+              "text": "Set up and configure MCP servers in VS Code for use with GitHub Copilot.",
+              "uuid": "0cb0549f-323c-456e-971a-36130f4fb9c3"
+            },
+            {
+              "order": 3,
+              "text": "Use GitHub Copilot with MCP to query CI/CD workflows and cloud telemetry data.",
+              "uuid": "d7330d07-3302-4d3c-9ec8-8879e60fb907"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn how the Model Context Protocol enables AI assistants to interact with external services through a standardized interface.",
+              "done_when": null,
+              "options": [],
+              "order": 1,
+              "slug": "phase5-topic7-read-what-is-mcp-model",
+              "tips": [],
+              "title": "What is MCP (Model Context Protocol)?",
+              "url": "https://modelcontextprotocol.io/docs/getting-started/intro",
+              "uuid": "2ce3e3da-fcf0-47f7-919d-af08f235d630"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn what agent mode is, how it works autonomously to complete multi-step tasks, and why it matters for modern development workflows.",
+              "done_when": null,
+              "options": [],
+              "order": 2,
+              "slug": "phase5-topic7-read-copilot-agent-mode-mcp",
+              "tips": [],
+              "title": "GitHub Copilot Agent Mode",
+              "url": "https://github.blog/ai-and-ml/github-copilot/agent-mode-101-all-about-github-copilots-powerful-mode/",
+              "uuid": "f45d1c18-b642-4abb-b66a-d8bac5e1a757"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Follow the setup instructions to add the GitHub MCP server to your VS Code configuration. Create a GitHub Personal Access Token, configure the server in your .vscode/mcp.json, and verify the server starts successfully.",
+              "done_when": null,
+              "options": [],
+              "order": 3,
+              "slug": "phase5-topic7-practice-install-github-mcp",
+              "tips": [],
+              "title": "Install the GitHub MCP Server in VS Code",
+              "url": "https://github.com/github/github-mcp-server",
+              "uuid": "7dc679db-2d2a-4aee-ada2-190dc778ac04"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Open GitHub Copilot in agent mode and ask it to review your latest GitHub Actions workflow run. For example, try prompts like \"Review my latest workflow run and summarize any failures\" or \"What's the status of my most recent CI pipeline?\" Confirm that Copilot uses the GitHub MCP server tools to fetch and analyze the results.",
+              "done_when": null,
+              "options": [],
+              "order": 4,
+              "slug": "phase5-topic7-practice-query-cicd-github-mcp",
+              "tips": [],
+              "title": "Query Your CI/CD with GitHub MCP",
+              "url": null,
+              "uuid": "dcd6fc7e-4e76-4881-b9f4-7a625296b130"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Read about your cloud provider's MCP server and how it lets GitHub Copilot query monitoring data, inspect resources, and troubleshoot deployments.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "The Azure MCP server exposes tools for querying App Insights, managing resources, checking deployments, and running KQL queries \u2014 all from GitHub Copilot.",
+                  "provider": "azure",
+                  "title": "Azure MCP Server",
+                  "url": "https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/README.md"
+                },
+                {
+                  "description": "AWS Labs MCP servers for CloudWatch logs, CDK infrastructure, and AWS documentation \u2014 enabling GitHub Copilot to query and manage AWS resources.",
+                  "provider": "aws",
+                  "title": "AWS MCP Servers",
+                  "url": "https://github.com/awslabs/mcp"
+                },
+                {
+                  "description": "Google Cloud MCP servers for querying Cloud Monitoring, managing GCP resources, and interacting with Google Cloud services through GitHub Copilot.",
+                  "provider": "gcp",
+                  "title": "Google Cloud MCP Servers",
+                  "url": "https://github.com/google/mcp"
+                }
+              ],
+              "order": 5,
+              "slug": "phase5-topic7-read-cloud-provider-mcp-servers",
+              "tips": [],
+              "title": "Cloud Provider MCP Servers",
+              "url": null,
+              "uuid": "6cd6819c-ebf8-4a0a-b98e-25f8fe5a4b3e"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Install and configure your cloud provider's MCP server in VS Code, then use GitHub Copilot to query the monitoring data from the resources you deployed earlier in this phase.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Install the Azure MCP server, authenticate with your Azure account, and ask Copilot to query App Insights for recent errors, list your resource groups, or run a KQL query against your deployed application.",
+                  "provider": "azure",
+                  "title": "Azure MCP \u2014 Query App Insights",
+                  "url": "https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/README.md"
+                },
+                {
+                  "description": "Install the AWS MCP servers, authenticate with your AWS credentials, and ask Copilot to query CloudWatch for recent log events, errors, or metrics from your deployed application.",
+                  "provider": "aws",
+                  "title": "AWS MCP \u2014 Query CloudWatch",
+                  "url": "https://github.com/awslabs/mcp"
+                },
+                {
+                  "description": "Install the Google Cloud MCP servers, authenticate with your GCP account, and ask Copilot to query Cloud Monitoring for metrics, logs, or errors from your deployed application.",
+                  "provider": "gcp",
+                  "title": "GCP MCP \u2014 Query Cloud Monitoring",
+                  "url": "https://github.com/google/mcp"
+                }
+              ],
+              "order": 6,
+              "slug": "phase5-topic7-practice-query-cloud-telemetry",
+              "tips": [],
+              "title": "Query Cloud Telemetry with MCP",
+              "url": null,
+              "uuid": "9cbc5168-233e-4de9-a616-2d81c883dea3"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Learn what Agent Skills are \u2014 reusable folders of instructions and scripts that Copilot loads on demand to perform specialized tasks. Understand the SKILL.md format, directory structure, and how progressive disclosure keeps context efficient.",
+              "done_when": null,
+              "options": [],
+              "order": 7,
+              "slug": "phase5-topic7-read-agent-skills",
+              "tips": [],
+              "title": "Agent Skills in VS Code",
+              "url": "https://code.visualstudio.com/docs/copilot/customization/agent-skills",
+              "uuid": "d450d05d-32b8-4faf-95fc-8ce5a53bff95"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Create an Agent Skill at `.github/skills/preflight-check/SKILL.md` that validates your capstone project is submission-ready. The skill should instruct Copilot to run bash commands that check for required files, verify the Docker build, run terraform validate, and confirm Kubernetes manifests are valid YAML. Then trigger it by asking Copilot to run the preflight check and fix any issues it finds.",
+              "done_when": null,
+              "options": [],
+              "order": 8,
+              "slug": "phase5-topic7-practice-create-preflight-skill",
+              "tips": [],
+              "title": "Create a Capstone Preflight Check Skill",
+              "url": null,
+              "uuid": "bb0a8c86-664e-44ca-96ef-174a8282162d"
+            }
+          ],
+          "name": "AI Tooling & MCP",
+          "order": 6,
+          "slug": "ai-tooling-mcp",
+          "uuid": "9ed2b936-3240-4986-9b4b-aa67178ad3dd"
+        },
+        {
+          "description": "Now that you've learned the fundamentals of DevOps, it's time to apply these practices to the Journal API app you built in Phase 3 and deployed in Phase 4. In this capstone, you'll containerize the app, automate its deployment, manage infrastructure as code, set up monitoring, and orchestrate containers with Kubernetes\u2014demonstrating your end-to-end DevOps skills. The curriculum may not have covered everything you need \u2014 that's intentional. Researching what you don't know is part of the job.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Integrate containerization, CI/CD, IaC, and orchestration into one delivery workflow.",
+              "uuid": "a8da24c4-65e0-45a6-88c3-f6ea7c851706"
+            },
+            {
+              "order": 2,
+              "text": "Implement required DevOps project artifacts and deployment components correctly.",
+              "uuid": "a1c2cce3-b77b-428c-b308-4c76f93e06be"
+            },
+            {
+              "order": 3,
+              "text": "Document and communicate technical decisions and outcomes as portfolio-ready work.",
+              "uuid": "f08ad590-a714-4327-b22c-4ab4cf99c5b0"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "build",
+              "checklist": [
+                "Use `python:3.12-slim` as the base image (matches the dev container's Python version)",
+                "Install `uv` (not pip) and run `uv sync` to install dependencies",
+                "Commit `uv.lock` to your repo for reproducible builds",
+                "Set `PYTHONPATH` to your app directory so imports resolve correctly",
+                "Expose port 8000",
+                "Use `uvicorn api.main:app --host 0.0.0.0 --port 8000` as the entry point",
+                "Create `.dockerignore` to exclude `.git/`, `tests/`, `.devcontainer/`"
+              ],
+              "code": null,
+              "description": "Write a `Dockerfile` at the root of your repository that packages your Journal API into a container image. Also create a `.dockerignore` to exclude non-production files.",
+              "done_when": "`docker build` succeeds and `docker run` starts the API listening on port 8000.",
+              "options": [],
+              "order": 1,
+              "slug": "phase5-topic6-build-containerize-the-application",
+              "tips": [
+                {
+                  "text": "Docker is not available inside the dev container by default. To build locally, run `docker build` on your host machine. Alternatively, use `az acr build --registry <name> --image journal-api:latest .` to build remotely in Azure Container Registry without needing local Docker.",
+                  "type": "note"
+                }
+              ],
+              "title": "Containerize the Application",
+              "url": null,
+              "uuid": "e44b670a-c53c-4e31-8a6a-23fdc0729c6d"
+            },
+            {
+              "action": "build",
+              "checklist": [
+                "**Container registry** \u2014 e.g., Azure Container Registry",
+                "**Managed Kubernetes cluster** \u2014 e.g., AKS",
+                "**Managed PostgreSQL 15 database** \u2014 e.g., Azure Database for PostgreSQL Flexible Server",
+                "**IAM/role bindings** \u2014 so your K8s cluster can pull images from the registry",
+                "**`main.tf`** \u2014 core resource definitions",
+                "**`variables.tf`** \u2014 input variable declarations",
+                "**`providers.tf`** \u2014 cloud provider and Terraform version config",
+                "**`outputs.tf`** \u2014 export registry URL, DB connection string, kubeconfig",
+                "**`terraform.tfvars`** \u2014 your variable values (add to `.gitignore`)",
+                "**Run `database_setup.sql`** against your PostgreSQL instance after provisioning"
+              ],
+              "code": null,
+              "description": "Create Terraform configuration files in an `infra/` directory to provision your cloud infrastructure.",
+              "done_when": "`terraform apply` completes, all resources exist, and you can connect to the database.",
+              "options": [],
+              "order": 2,
+              "slug": "phase5-topic6-build-infrastructure-as-code",
+              "tips": [
+                {
+                  "text": "Azure PostgreSQL requires `?sslmode=require` appended to your `DATABASE_URL`. The local dev format without SSL will not work in the cloud.",
+                  "type": "note"
+                },
+                {
+                  "text": "If Terraform fails with `LocationIsOfferRestricted` for PostgreSQL, try a different Azure region (e.g., `centralus`, `westus2`).",
+                  "type": "tip"
+                }
+              ],
+              "title": "Infrastructure as Code",
+              "url": null,
+              "uuid": "340708fb-f0f4-438f-9058-e0c88dce33f4"
+            },
+            {
+              "action": "build",
+              "checklist": [
+                "**Test job** \u2014 Run linting and tests with a PostgreSQL 15 service container, run `database_setup.sql` before pytest, install `uv` using `astral-sh/setup-uv`",
+                "**Build & Push job** \u2014 Build the Docker image and push to your container registry, tagged with commit SHA and `latest`",
+                "**Deploy job** \u2014 Connect to your K8s cluster, `sed`-substitute the image placeholder, apply manifests from `k8s/`",
+                "**`AZURE_CREDENTIALS` secret** \u2014 output of `az ad sp create-for-rbac --sdk-auth`",
+                "**`ACR_LOGIN_SERVER` secret** \u2014 your ACR login server URL",
+                "**`ACR_USERNAME` secret** \u2014 ACR username",
+                "**`ACR_PASSWORD` secret** \u2014 ACR password",
+                "**`AZURE_RESOURCE_GROUP` secret** \u2014 your resource group name",
+                "**`AKS_CLUSTER_NAME` secret** \u2014 your AKS cluster name"
+              ],
+              "code": null,
+              "description": "Apply the GitHub Actions workflow you built in the CI/CD Pipelines topic. It should trigger on every push to `main` with at least three jobs.",
+              "done_when": "Pushing to `main` triggers the workflow, all three jobs pass, and your image is pushed to the registry.",
+              "options": [],
+              "order": 3,
+              "slug": "phase5-topic6-build-cicd-pipeline",
+              "tips": [],
+              "title": "CI/CD Pipeline",
+              "url": null,
+              "uuid": "a995972d-217d-487a-b9cf-4818ca9bd64e"
+            },
+            {
+              "action": "build",
+              "checklist": [
+                "**`deployment.yaml`** \u2014 use `IMAGE_PLACEHOLDER` as the image reference (CI/CD substitutes with real tag)",
+                "**Environment from Secret** \u2014 reference `journal-api-secrets` via `envFrom` for `DATABASE_URL`, `OPENAI_API_KEY`, etc.",
+                "**Health probes** \u2014 configure liveness and readiness probes pointing to `/health` on port 8000",
+                "**`secrets.yaml.example`** \u2014 show required keys (never commit real values)",
+                "**`service.yaml`** \u2014 create a `LoadBalancer` or `NodePort` service routing port 80 \u2192 container port 8000"
+              ],
+              "code": null,
+              "description": "Write Kubernetes manifests in a `k8s/` directory to deploy and expose your containerized application. First, add a `GET /health` endpoint to `api/main.py` that returns `{\"status\": \"healthy\"}`.",
+              "done_when": "`kubectl get pods` shows your app running, and `curl http://<EXTERNAL-IP>/health` returns `{\"status\": \"healthy\"}`.",
+              "options": [],
+              "order": 4,
+              "slug": "phase5-topic6-build-container-orchestration",
+              "tips": [
+                {
+                  "text": "When creating your `DATABASE_URL` secret for the cloud database, remember to append `?sslmode=require` to the connection string.",
+                  "type": "note"
+                }
+              ],
+              "title": "Container Orchestration",
+              "url": null,
+              "uuid": "cddc7d25-1801-4d27-86a8-ba8317bbab8f"
+            },
+            {
+              "action": "build",
+              "checklist": [
+                "Install OpenTelemetry packages: `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-instrumentation-fastapi`",
+                "Configure a `TracerProvider` and `MeterProvider` with a `Resource` identifying your service",
+                "Call `FastAPIInstrumentor.instrument_app(app)` to auto-instrument HTTP requests",
+                "Add at least one custom span (e.g., around a database or LLM call) and one custom metric (e.g., entries created counter)",
+                "Verify telemetry locally with an OTLP-compatible tool such as Aspire Dashboard before sending it to the cloud",
+                "Install your provider's OTel exporter (`azure-monitor-opentelemetry`, `opentelemetry-exporter-otlp` for AWS/ADOT, or `opentelemetry-exporter-gcp-trace`/`opentelemetry-exporter-gcp-monitoring`)",
+                "Configure the exporter so traces, metrics, and logs are sent to your cloud console (Azure Application Insights, AWS X-Ray + CloudWatch, or GCP Cloud Trace + Cloud Monitoring)",
+                "Query your telemetry in your provider's tool (Azure KQL, CloudWatch Logs Insights, or GCP Logs Explorer)",
+                "Build a small dashboard with request count, error rate, latency, and recent exceptions",
+                "Create one alert for repeated 5xx responses, high latency, or another user-impacting symptom",
+                "Optional advanced: recreate the same dashboard with Prometheus and Grafana"
+              ],
+              "code": null,
+              "description": "Instrument your Journal API with OpenTelemetry so that logs, traces, and metrics are exported to your cloud provider's monitoring platform. This builds on the basic logging you added in Phase 3 by connecting all three telemetry signals into a unified, cloud-native observability pipeline. This step is not auto-verified but is essential for production readiness.",
+              "done_when": "Traces, metrics, and logs from your Journal API are visible in your cloud provider's monitoring console, and you have a basic dashboard and alert.",
+              "options": [],
+              "order": 5,
+              "slug": "phase5-topic6-build-monitoring-observability",
+              "tips": [],
+              "title": "Monitoring & Observability",
+              "url": null,
+              "uuid": "c77ee2ee-9913-49b5-8e46-e9258129e06e"
+            },
+            {
+              "action": "build",
+              "checklist": [],
+              "code": null,
+              "description": "Document your setup and deployment process so others can understand and reproduce your work. This step is not auto-verified but strengthens your portfolio.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase5-topic6-build-documentation",
+              "tips": [],
+              "title": "Documentation",
+              "url": null,
+              "uuid": "3b4da54e-8bc3-4ff9-945a-85dd2d234d44"
+            },
+            {
+              "action": "build",
+              "checklist": [],
+              "code": "your-journal-starter/\n  \u251c\u2500\u2500 Dockerfile              # Step 1: Container definition\n  \u251c\u2500\u2500 .dockerignore            # Step 1: Exclude non-production files from build\n  \u251c\u2500\u2500 .github/\n  \u2502   \u2514\u2500\u2500 workflows/          # Step 3: CI/CD pipeline configs\n  \u2502       \u2514\u2500\u2500 *.yml\n  \u251c\u2500\u2500 infra/                   # Step 2: Terraform IaC configs\n  \u2502   \u251c\u2500\u2500 main.tf\n  \u2502   \u251c\u2500\u2500 variables.tf\n  \u2502   \u251c\u2500\u2500 outputs.tf\n  \u2502   \u2514\u2500\u2500 providers.tf\n  \u251c\u2500\u2500 k8s/                     # Step 4: Kubernetes manifests\n  \u2502   \u251c\u2500\u2500 deployment.yaml\n  \u2502   \u251c\u2500\u2500 service.yaml\n  \u2502   \u2514\u2500\u2500 secrets.yaml.example # Example secrets (never commit real values)\n  \u251c\u2500\u2500 api/                     # Your FastAPI app code\n  \u2514\u2500\u2500 README.md                # Step 6: Documentation",
+              "description": "Your repository must include these directories and files for auto-verification. Steps 1\u20134 are verified automatically when you submit your repo URL.",
+              "done_when": null,
+              "options": [],
+              "order": 7,
+              "slug": "phase5-topic6-build-required-project-structure",
+              "tips": [],
+              "title": "Required Project Structure",
+              "url": null,
+              "uuid": "e080abdc-bf94-4e6b-a78e-33294ef28595"
+            },
+            {
+              "action": "reflect",
+              "checklist": [],
+              "code": null,
+              "description": "When you've completed the capstone, push your work to GitHub! This becomes part of your portfolio. Consider sharing it on LinkedIn or with the Learn to Cloud community to get feedback and celebrate your progress.",
+              "done_when": null,
+              "options": [],
+              "order": 8,
+              "slug": "phase5-topic6-reflect-share-your-progress",
+              "tips": [],
+              "title": "Share Your Progress",
+              "url": null,
+              "uuid": "c43d5d38-c50f-40eb-af1b-c77cb41c4be2"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "Kubernetes clusters",
+                "Container registries",
+                "Terraform-provisioned infrastructure (`terraform destroy`)",
+                "Any other billable resources"
+              ],
+              "code": null,
+              "description": "After you have submitted your repo for hands-on verification and received a passing result, delete all cloud resources.",
+              "done_when": null,
+              "options": [],
+              "order": 9,
+              "slug": "phase5-topic6-practice-clean-up-your-cloud",
+              "tips": [
+                {
+                  "text": "Check your cloud console to confirm nothing is still running.",
+                  "type": "tip"
+                }
+              ],
+              "title": "Clean up your cloud resources",
+              "url": null,
+              "uuid": "8136ecc2-60e2-4909-89ac-cb4d3592725e"
+            }
+          ],
+          "name": "Capstone: DevOps Project",
+          "order": 7,
+          "slug": "capstone",
+          "uuid": "bcef3efa-8416-4ac8-a99e-eef16cd88e2a"
+        }
+      ],
+      "uuid": "9f4fb0fa-407b-4fe5-9020-dc9c6b44f9e0"
+    },
+    {
+      "capstone": null,
+      "description": "You've built your Journal API, deployed it to the cloud, and set up CI/CD pipelines. Now it's time to lock it down. Security isn't a separate thing you bolt on at the end\u2014it's something every cloud engineer needs to think about from day one. In this phase, we'll walk you through the key security practices that keep real production apps safe. By the end, your Journal API will be hardened and production-ready.",
+      "hands_on_verification": {
+        "requirement_slugs": [
+          "security-scanning"
+        ],
+        "requirements": [
+          {
+            "description": "Enable GitHub CodeQL code scanning (advanced setup) for Python on your fork, commit the workflow as .github/workflows/codeql.yml, and make sure it runs green on your main branch. Automated checks confirm the latest CodeQL run passed on your current code. Dependabot is recommended as an extra layer.",
+            "name": "Enable Security Scanning",
+            "slug": "security-scanning",
+            "submission_type": "security_scanning",
+            "type_config": {
+              "required_repo": "learntocloud/journal-starter"
+            },
+            "uuid": "2f9a6c38-28f5-474b-9578-a71734f112b2"
+          }
+        ]
+      },
+      "name": "Securing Your Cloud Applications",
+      "objectives": [],
+      "order": 6,
+      "short_description": "Secure your Journal API with IAM, secrets management, network controls, monitoring, and incident response. Make it production-ready.",
+      "slug": "phase6",
+      "topic_slugs": [
+        "iam-secrets",
+        "network-security",
+        "monitoring-incident-response",
+        "capstone"
+      ],
+      "topics": [
+        {
+          "description": "Control who can access your cloud resources and keep your credentials safe. You'll set up service accounts with least-privilege permissions and move secrets out of your code into a cloud secrets manager.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Apply IAM fundamentals to separate human and service identities safely.",
+              "uuid": "0ad94eb8-b048-41cc-a389-42fb388f211d"
+            },
+            {
+              "order": 2,
+              "text": "Implement least-privilege access controls for applications and automation paths.",
+              "uuid": "35cebc72-a449-4334-996c-f6ae47772b57"
+            },
+            {
+              "order": 3,
+              "text": "Move and manage sensitive credentials through provider-native secrets services.",
+              "uuid": "4850c103-bb23-4392-ab04-bf2c281a27db"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Refresh core IAM concepts briefly, then focus on how they apply to service identities and production workloads in this phase.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Role-based access control in Azure",
+                  "provider": "azure",
+                  "title": "Azure RBAC Overview",
+                  "url": "https://learn.microsoft.com/azure/role-based-access-control/overview"
+                },
+                {
+                  "description": "AWS IAM users, groups, policies, and roles",
+                  "provider": "aws",
+                  "title": "Getting Started with AWS IAM",
+                  "url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/getting-started.html"
+                },
+                {
+                  "description": "Identity and Access Management in Google Cloud",
+                  "provider": "gcp",
+                  "title": "GCP IAM Overview",
+                  "url": "https://docs.cloud.google.com/iam/docs/overview"
+                }
+              ],
+              "order": 1,
+              "slug": "phase6-topic1-read-iam-refresher-for-application",
+              "tips": [],
+              "title": "IAM Refresher (for application security)",
+              "url": null,
+              "uuid": "ca8db46e-1af9-45f0-a238-d1537e902586"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Give users and services only the minimum permissions they need. If credentials get compromised, least privilege limits the blast radius.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Apply IAM best practices in Azure",
+                  "provider": "azure",
+                  "title": "Secure access to resources with Azure identity and access management best practices",
+                  "url": "https://learn.microsoft.com/azure/security/fundamentals/identity-management-best-practices"
+                },
+                {
+                  "description": "Apply IAM best practices in AWS",
+                  "provider": "aws",
+                  "title": "AWS IAM Best Practices",
+                  "url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html"
+                },
+                {
+                  "description": "Apply IAM best practices in GCP",
+                  "provider": "gcp",
+                  "title": "Secure IAM in Google Cloud",
+                  "url": "https://docs.cloud.google.com/iam/docs/using-iam-securely"
+                }
+              ],
+              "order": 2,
+              "slug": "phase6-topic1-read-iam-best-practices-by",
+              "tips": [],
+              "title": "IAM best practices by provider",
+              "url": null,
+              "uuid": "6734d968-9e82-4d9f-8a07-fa1c2cbf0db3"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "User accounts are for people. Service accounts are for applications \u2014 your API, your CI/CD pipeline. Your Journal API should never run with your personal credentials.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "How AWS uses roles as service identities instead of long-lived credentials",
+                  "provider": "aws",
+                  "title": "AWS IAM Roles",
+                  "url": "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html"
+                },
+                {
+                  "description": "Automatically managed identities for Azure services \u2014 no credentials in code",
+                  "provider": "azure",
+                  "title": "Azure Managed Identities",
+                  "url": "https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview"
+                },
+                {
+                  "description": "Non-human identities for applications running on Google Cloud",
+                  "provider": "gcp",
+                  "title": "GCP Service Accounts",
+                  "url": "https://docs.cloud.google.com/iam/docs/service-account-overview"
+                }
+              ],
+              "order": 3,
+              "slug": "phase6-topic1-read-learn-the-difference-between",
+              "tips": [],
+              "title": "Learn the difference between service accounts and user accounts",
+              "url": null,
+              "uuid": "2f939601-1915-4d5c-9a37-7b4253c5dd08"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Your .env file works for local dev, but in production use a secrets manager to store database passwords, API keys, and other credentials outside your code.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Store and manage secrets in Azure",
+                  "provider": "azure",
+                  "title": "Azure Key Vault",
+                  "url": "https://learn.microsoft.com/azure/key-vault/general/overview"
+                },
+                {
+                  "description": "Store and rotate secrets in AWS",
+                  "provider": "aws",
+                  "title": "AWS Secrets Manager",
+                  "url": "https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html"
+                },
+                {
+                  "description": "Store and access secrets in GCP",
+                  "provider": "gcp",
+                  "title": "Google Secret Manager",
+                  "url": "https://docs.cloud.google.com/secret-manager/docs/overview"
+                }
+              ],
+              "order": 4,
+              "slug": "phase6-topic1-read-explore-your-cloud-providers",
+              "tips": [],
+              "title": "Explore your cloud provider's secrets manager",
+              "url": null,
+              "uuid": "e7b69bf6-f32f-4829-afe2-070ab1cd5bb9"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Pick the workshop for your cloud provider and work through it.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Assign roles in Azure using PowerShell",
+                  "provider": "azure",
+                  "title": "Azure RBAC Tutorial",
+                  "url": "https://learn.microsoft.com/azure/role-based-access-control/tutorial-role-assignments-user-powershell"
+                },
+                {
+                  "description": "Hands-on AWS IAM exercises",
+                  "provider": "aws",
+                  "title": "AWS IAM Workshop",
+                  "url": "https://catalog.workshops.aws/general-immersionday/basic-modules/30-iam"
+                },
+                {
+                  "description": "Get started with IAM in Google Cloud",
+                  "provider": "gcp",
+                  "title": "GCP IAM Quickstart",
+                  "url": "https://docs.cloud.google.com/iam/docs/grant-role-console"
+                }
+              ],
+              "order": 5,
+              "slug": "phase6-topic1-practice-complete-an-iam-hands-on",
+              "tips": [],
+              "title": "Complete an IAM hands-on workshop",
+              "url": null,
+              "uuid": "9f5c17f1-56d4-428d-b943-383533f56bc4"
+            },
+            {
+              "action": "review",
+              "checklist": [],
+              "code": null,
+              "description": "Confirm your Phase 4 cloud resources are available and documented so you can apply security hardening to real infrastructure.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase6-topic1-review-verify-cloud-platform-baseline",
+              "tips": [],
+              "title": "Verify Cloud Platform baseline",
+              "url": null,
+              "uuid": "ae1bc54b-581e-4848-a315-135f753166f4"
+            },
+            {
+              "action": "review",
+              "checklist": [],
+              "code": null,
+              "description": "Confirm your Phase 5 CI/CD and deployment workflow is working so security checks can be integrated into your existing pipeline.",
+              "done_when": null,
+              "options": [],
+              "order": 7,
+              "slug": "phase6-topic1-review-verify-devops-pipeline-baseline",
+              "tips": [],
+              "title": "Verify DevOps pipeline baseline",
+              "url": null,
+              "uuid": "873fa868-321e-48e9-862a-ba043c08ba43"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Verify you can access your Journal API repository, deployed environment, and cloud account admin controls needed for IAM and secrets configuration.",
+              "done_when": null,
+              "options": [],
+              "order": 8,
+              "slug": "phase6-topic1-practice-confirm-application-and-admin",
+              "tips": [],
+              "title": "Confirm application and admin access",
+              "url": null,
+              "uuid": "fa115425-67a3-4160-a7d0-27247ecccb01"
+            }
+          ],
+          "name": "IAM & Secrets Management",
+          "order": 1,
+          "slug": "iam-secrets",
+          "uuid": "b57eae17-5a02-4369-b651-53e225991902"
+        },
+        {
+          "description": "Harden your Journal API's network against external threats. You'll add WAF and DDoS protection to the API tier and enable flow logs \u2014 the controls that separate a hardened production environment from an exposed one.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Apply WAF and DDoS protection controls to the API tier.",
+              "uuid": "a153b907-f5d6-4ccc-8ebf-69ebe76d9d64"
+            },
+            {
+              "order": 2,
+              "text": "Enable network flow logging to support security visibility and incident investigation.",
+              "uuid": "42c8b772-7d6a-4bb4-91c7-234420a93ce6"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "A WAF sits in front of your API and filters malicious HTTP requests \u2014 SQL injection, cross-site scripting, and other OWASP Top 10 attacks \u2014 before they reach your application code.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Filter web traffic and protect against common web exploits with AWS WAF",
+                  "provider": "aws",
+                  "title": "AWS WAF Overview",
+                  "url": "https://docs.aws.amazon.com/waf/latest/developerguide/what-is-aws-waf.html"
+                },
+                {
+                  "description": "Protect your applications from common exploits with Azure WAF",
+                  "provider": "azure",
+                  "title": "Azure Web Application Firewall",
+                  "url": "https://learn.microsoft.com/azure/web-application-firewall/overview"
+                },
+                {
+                  "description": "Protect your GCP services with Cloud Armor WAF rules and preconfigured policies",
+                  "provider": "gcp",
+                  "title": "Cloud Armor WAF Overview",
+                  "url": "https://docs.cloud.google.com/armor/docs/cloud-armor-overview"
+                }
+              ],
+              "order": 1,
+              "slug": "phase6-topic3-read-web-application-firewall",
+              "tips": [],
+              "title": "Web Application Firewall (WAF)",
+              "url": null,
+              "uuid": "63dd2cdd-79c6-4f07-82cf-e82f9a8e4fb3"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "DDoS attacks flood your service with traffic to take it offline. Every major cloud provider includes a baseline DDoS protection tier automatically. Read what protection is included and when to consider enabling advanced coverage.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "AWS Shield Standard is automatic and free \u2014 Shield Advanced adds detection and response support",
+                  "provider": "aws",
+                  "title": "AWS Shield",
+                  "url": "https://docs.aws.amazon.com/waf/latest/developerguide/shield-chapter.html"
+                },
+                {
+                  "description": "Azure DDoS Protection tiers and what is included by default",
+                  "provider": "azure",
+                  "title": "Azure DDoS Protection",
+                  "url": "https://learn.microsoft.com/azure/ddos-protection/ddos-protection-overview"
+                },
+                {
+                  "description": "Adaptive Protection and DDoS mitigations in Cloud Armor",
+                  "provider": "gcp",
+                  "title": "Cloud Armor DDoS Mitigation",
+                  "url": "https://docs.cloud.google.com/armor/docs/adaptive-protection-overview"
+                }
+              ],
+              "order": 2,
+              "slug": "phase6-topic3-read-ddos-protection-by-provider",
+              "tips": [],
+              "title": "DDoS protection by provider",
+              "url": null,
+              "uuid": "910a764f-8ef8-46e1-b17e-462ddb81baef"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Review the network security recommendations for your provider. Focus on what applies to your Journal API \u2014 particularly controlling inbound and outbound traffic and encrypting data in transit.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Security best practices for Amazon VPC",
+                  "provider": "aws",
+                  "title": "AWS VPC Security Best Practices",
+                  "url": "https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-best-practices.html"
+                },
+                {
+                  "description": "Network security best practices for Azure deployments",
+                  "provider": "azure",
+                  "title": "Azure Network Security Best Practices",
+                  "url": "https://learn.microsoft.com/azure/security/fundamentals/network-best-practices"
+                },
+                {
+                  "description": "Network security design principles in Google Cloud",
+                  "provider": "gcp",
+                  "title": "GCP Networking Security Best Practices",
+                  "url": "https://docs.cloud.google.com/docs/security/infrastructure/design#network-security"
+                }
+              ],
+              "order": 3,
+              "slug": "phase6-topic3-read-network-security-best-practices",
+              "tips": [],
+              "title": "Network security best practices by provider",
+              "url": null,
+              "uuid": "7f720c9b-3311-4041-8ce9-99d4e9c21fd7"
+            },
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "VPC flow logs record accepted and rejected traffic at the network level. Use them to investigate suspicious connections, verify your security rules are working, and build an evidence trail for incident response.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Capture IP traffic flow information for your VPC interfaces",
+                  "provider": "aws",
+                  "title": "VPC Flow Logs",
+                  "url": "https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html"
+                },
+                {
+                  "description": "Log network traffic to and from Azure network security groups",
+                  "provider": "azure",
+                  "title": "NSG Flow Logs",
+                  "url": "https://learn.microsoft.com/azure/network-watcher/vnet-flow-logs-overview?tabs=Americas"
+                },
+                {
+                  "description": "Record network flows to and from VMs and GKE nodes in GCP",
+                  "provider": "gcp",
+                  "title": "VPC Flow Logs",
+                  "url": "https://docs.cloud.google.com/vpc/docs/flow-logs"
+                }
+              ],
+              "order": 4,
+              "slug": "phase6-topic3-read-enable-network-flow-logs",
+              "tips": [],
+              "title": "Enable network flow logs",
+              "url": null,
+              "uuid": "e6fce6ef-d7ee-40f4-99e8-a35d1da4b7d2"
+            },
+            {
+              "action": "watch",
+              "checklist": [],
+              "code": null,
+              "description": "Follow along in your own account if you can.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Official AWS walkthrough of DDoS protection using Shield and WAF",
+                  "provider": "aws",
+                  "title": "DDoS Protection on AWS with Shield and WAF",
+                  "url": "https://www.youtube.com/watch?v=-9YzrRCzaKM"
+                },
+                {
+                  "description": "Microsoft Security Community walkthrough of Azure DDoS and WAF controls",
+                  "provider": "azure",
+                  "title": "Multi-Layered Security with Azure DDoS Protection and WAF",
+                  "url": "https://www.youtube.com/watch?v=qPz5ldEBrk0"
+                },
+                {
+                  "description": "Deep dive walkthrough of Cloud Armor WAF rules, Adaptive Protection, and DDoS mitigation on GCP",
+                  "provider": "gcp",
+                  "title": "Google Cloud Armor - Deep Dive",
+                  "url": "https://www.youtube.com/watch?v=RsXbmOb3L2E"
+                }
+              ],
+              "order": 5,
+              "slug": "phase6-topic3-watch-cloud-network-security-walkthrough",
+              "tips": [],
+              "title": "Watch a cloud network security walkthrough for your provider",
+              "url": null,
+              "uuid": "d38513a8-1310-4ebe-bb19-21c48ae2776a"
+            }
+          ],
+          "name": "Network Security",
+          "order": 2,
+          "slug": "network-security",
+          "uuid": "6dc2f02b-b059-4688-a826-66a65680566d"
+        },
+        {
+          "description": "Set up logging and alerts so you know when something goes wrong, and have a basic plan for what to do when it does.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Configure monitoring and audit logging needed for cloud security visibility.",
+              "uuid": "f27b1a64-990b-4446-8d60-097ef6dee345"
+            },
+            {
+              "order": 2,
+              "text": "Implement targeted alerts for critical security-relevant events.",
+              "uuid": "552ecf9c-f00b-4ab8-9787-63d190c50dd4"
+            },
+            {
+              "order": 3,
+              "text": "Create an actionable incident response baseline for common compromise scenarios.",
+              "uuid": "1958f8a4-4964-4b39-9acb-1614553eb93c"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "read",
+              "checklist": [],
+              "code": null,
+              "description": "Each cloud provider has monitoring (metrics) and audit logging (who did what). Read the overview for your provider.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Metrics, logs, and alerts in Azure",
+                  "provider": "azure",
+                  "title": "Azure Monitor Overview",
+                  "url": "https://learn.microsoft.com/azure/azure-monitor/fundamentals/overview"
+                },
+                {
+                  "description": "Monitoring and observability in AWS",
+                  "provider": "aws",
+                  "title": "AWS CloudWatch",
+                  "url": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html"
+                },
+                {
+                  "description": "Monitoring in Google Cloud",
+                  "provider": "gcp",
+                  "title": "GCP Cloud Monitoring",
+                  "url": "https://docs.cloud.google.com/monitoring/docs/monitoring-overview"
+                }
+              ],
+              "order": 1,
+              "slug": "phase6-topic4-read-cloud-monitoring-overview",
+              "tips": [],
+              "title": "Cloud Monitoring Overview",
+              "url": null,
+              "uuid": "43f1641a-9837-4502-a771-825b409ac904"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Enable CloudTrail (AWS), Activity Log (Azure), or Cloud Logging (GCP) so you have a record of all actions taken on your cloud resources.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Tutorial for creating and managing CloudTrail trails",
+                  "provider": "aws",
+                  "title": "Getting Started with AWS CloudTrail",
+                  "url": "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-tutorial.html"
+                },
+                {
+                  "description": "Platform log for control-plane events on Azure resources",
+                  "provider": "azure",
+                  "title": "Azure Activity Log",
+                  "url": "https://learn.microsoft.com/azure/azure-monitor/platform/activity-log"
+                },
+                {
+                  "description": "Audit logging for Google Cloud services and APIs",
+                  "provider": "gcp",
+                  "title": "Cloud Audit Logs Overview",
+                  "url": "https://docs.cloud.google.com/logging/docs/audit"
+                }
+              ],
+              "order": 2,
+              "slug": "phase6-topic4-practice-enable-audit-logging-for",
+              "tips": [],
+              "title": "Enable audit logging for your cloud services",
+              "url": null,
+              "uuid": "dfcfa2e6-43a5-4a29-b5b3-af7c344eb5f9"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Create at least one alert \u2014 for example, notify you when someone modifies a security group or when there are repeated failed login attempts.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Create, describe, and manage CloudWatch alarms",
+                  "provider": "aws",
+                  "title": "Getting Started with CloudWatch Alarms",
+                  "url": "https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/example_cloudwatch_Scenario_GettingStarted_section.html"
+                },
+                {
+                  "description": "Configure alert rules and action groups in Azure Monitor",
+                  "provider": "azure",
+                  "title": "Azure Monitor Alerts Overview",
+                  "url": "https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-overview"
+                },
+                {
+                  "description": "Create alerting policies for metrics, logs, and uptime checks",
+                  "provider": "gcp",
+                  "title": "Cloud Monitoring Alerting Overview",
+                  "url": "https://docs.cloud.google.com/monitoring/alerts"
+                }
+              ],
+              "order": 3,
+              "slug": "phase6-topic4-practice-set-up-an-alert",
+              "tips": [],
+              "title": "Set up an alert for a critical security event",
+              "url": null,
+              "uuid": "7476a6e8-f134-4d7a-bf07-4d979c9d48cc"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Turn on the managed threat detection service that scans your environment for suspicious activity.",
+              "done_when": null,
+              "options": [
+                {
+                  "description": "Cloud-native SIEM and threat detection",
+                  "provider": "azure",
+                  "title": "Microsoft Sentinel",
+                  "url": "https://learn.microsoft.com/azure/sentinel/overview"
+                },
+                {
+                  "description": "Intelligent threat detection in AWS",
+                  "provider": "aws",
+                  "title": "AWS GuardDuty",
+                  "url": "https://docs.aws.amazon.com/guardduty/latest/ug/what-is-guardduty.html"
+                },
+                {
+                  "description": "Threat detection in Google Cloud",
+                  "provider": "gcp",
+                  "title": "Security Command Center",
+                  "url": "https://docs.cloud.google.com/security-command-center/docs/security-command-center-overview"
+                }
+              ],
+              "order": 4,
+              "slug": "phase6-topic4-practice-enable-your-cloud-providers",
+              "tips": [],
+              "title": "Enable your cloud provider's threat detection service",
+              "url": null,
+              "uuid": "87dbdc81-57c1-45fe-92b7-e3171300bc1a"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Enable GitHub CodeQL code scanning on your journal-starter fork. Use **advanced setup** (not default setup): from the Security tab choose CodeQL advanced setup, which commits a workflow to `.github/workflows/codeql.yml`. Set the language to **Python**, keep the push, pull_request, and schedule triggers, and enable GitHub Actions on your fork so the workflow runs. Make sure the latest run is green on `main`. This is what the phase verification checks: it confirms a successful CodeQL run for your most recent commit on `main`. Dependabot (a `.github/dependabot.yml` file) is recommended as defense-in-depth but is not required.",
+              "done_when": null,
+              "options": [],
+              "order": 5,
+              "slug": "phase6-topic4-practice-github-security-scanning",
+              "tips": [],
+              "title": "GitHub Security Scanning",
+              "url": "https://docs.github.com/code-security/tutorials",
+              "uuid": "51dbcfaa-6647-4961-9591-591f078e7f02"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Write a short runbook answering \"What do we do if credentials are leaked?\" Include steps to rotate credentials, check for unauthorized access, and notify stakeholders.",
+              "done_when": null,
+              "options": [],
+              "order": 6,
+              "slug": "phase6-topic4-practice-write-a-basic-incident",
+              "tips": [],
+              "title": "Write a basic incident response runbook",
+              "url": "https://rootly.com/incident-response/runbooks",
+              "uuid": "68bbb198-ba76-47c4-abc5-2d386d377bce"
+            }
+          ],
+          "name": "Monitoring & Incident Response",
+          "order": 3,
+          "slug": "monitoring-incident-response",
+          "uuid": "16f07808-1272-48e1-874b-6271e5efd51b"
+        },
+        {
+          "description": "Apply everything from this phase to harden your Journal API with real security controls. By the end, your app will be production-ready.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Apply layered security controls to harden your deployed Journal API.",
+              "uuid": "f48146c0-831d-49a1-ab8d-4f431bf9e347"
+            },
+            {
+              "order": 2,
+              "text": "Implement IAM, secret handling, network controls, and monitoring in a production mindset.",
+              "uuid": "5c9c6e63-d54a-4a02-9099-fd4f94d70ebc"
+            },
+            {
+              "order": 3,
+              "text": "Demonstrate verifiable security posture improvements through scanning and operational checks.",
+              "uuid": "5bdc6d77-f343-4592-9f43-c479b9256fd7"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "practice",
+              "checklist": [
+                "**Create the identity** \u2014 A service principal (Azure), IAM role (AWS), or service account (GCP) dedicated to your Journal API",
+                "**Scope permissions** \u2014 Grant only what the API needs: database access, secrets read, and container registry pull. No admin rights",
+                "**Assign to your VM or container** \u2014 Attach the identity so your app authenticates automatically without storing credentials",
+                "**Remove personal credentials** \u2014 Delete any personal access keys or passwords from your `.env` and VM"
+              ],
+              "code": null,
+              "description": "Stop using your personal credentials. Create a service account (or managed identity) with **only** the permissions your API needs.",
+              "done_when": "Your API runs using the service account's identity, not your personal credentials, and the service account has no more permissions than necessary.",
+              "options": [],
+              "order": 1,
+              "slug": "phase6-capstone-practice-create-a-dedicated-service",
+              "tips": [],
+              "title": "Create a dedicated service account for your Journal API",
+              "url": null,
+              "uuid": "d9163b7c-2c94-4715-8de2-2824a3983eda"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Create the vault** \u2014 Azure Key Vault, AWS Secrets Manager, or GCP Secret Manager",
+                "**Store each secret** \u2014 `DATABASE_URL`, `OPENAI_API_KEY`, and any other API keys or tokens",
+                "**Grant your service account** (from Step 1) read-only access to the vault",
+                "**Update your app** to retrieve secrets from the vault at startup instead of reading `.env`",
+                "**Delete the `.env` file** from your VM"
+              ],
+              "code": null,
+              "description": "Move your database password, LLM API key, and any other secrets out of `.env` files and into a managed secrets service.",
+              "done_when": "Your app starts successfully with all secrets loaded from the vault, and no plaintext secrets exist on disk.",
+              "options": [],
+              "order": 2,
+              "slug": "phase6-capstone-practice-move-secrets-to-a",
+              "tips": [],
+              "title": "Move secrets to a cloud secrets manager",
+              "url": null,
+              "uuid": "53510b1d-2c77-49c2-8041-4692eee7b96f"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Check firewall rules** \u2014 Only allow inbound on port 5432 from the API subnet's CIDR range",
+                "**Check public IP** \u2014 Your database VM should have no public IP attached (remove the temporary one from Phase 4 if you haven't already)",
+                "**Test from outside** \u2014 Attempt to connect from your local machine \u2014 it should fail",
+                "**Test from inside** \u2014 Connect from your API VM \u2014 it should succeed"
+              ],
+              "code": null,
+              "description": "Confirm your database is **not** accessible from the public internet \u2014 it should only accept connections from your API server's subnet.",
+              "done_when": "The database is unreachable from the internet and only accepts connections from your API server.",
+              "options": [],
+              "order": 3,
+              "slug": "phase6-capstone-practice-verify-your-database-is",
+              "tips": [],
+              "title": "Verify your database is in a private subnet",
+              "url": null,
+              "uuid": "0bd35d1d-88e6-4175-ac71-56dfd47bd393"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Verify TLS** \u2014 `curl -v https://yourdomain/entries` shows a valid certificate",
+                "**Block HTTP** \u2014 Either redirect HTTP\u2192HTTPS in your reverse proxy, or remove port 80 from your security group entirely",
+                "**Test plaintext** \u2014 `curl http://yourdomain/entries` should either redirect to HTTPS or fail to connect"
+              ],
+              "code": null,
+              "description": "Ensure your API **only** accepts HTTPS connections. No plaintext HTTP traffic should reach your application.",
+              "done_when": "All API traffic is encrypted, and `curl http://yourdomain/entries` does not return a plaintext `200 OK`.",
+              "options": [],
+              "order": 4,
+              "slug": "phase6-capstone-practice-configure-https-for-all",
+              "tips": [],
+              "title": "Configure HTTPS for all API traffic",
+              "url": null,
+              "uuid": "58a1b003-1828-4475-9960-a0f5e23707ce"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Enable the service** \u2014 CloudTrail (AWS), Activity Log + Diagnostic Settings (Azure), or Cloud Audit Logs (GCP)",
+                "**Verify events** \u2014 Perform an action (e.g., restart your VM) and confirm it appears in the logs",
+                "**Set retention** \u2014 Ensure logs are retained for at least 90 days"
+              ],
+              "code": null,
+              "description": "Enable cloud-native audit logging so you can track who did what across your infrastructure.",
+              "done_when": "You can view audit events for your infrastructure actions in your cloud console's logging dashboard.",
+              "options": [],
+              "order": 5,
+              "slug": "phase6-capstone-practice-enable-audit-logging",
+              "tips": [
+                {
+                  "text": "Most cloud platforms enable some audit logging by default, but you may need to configure a storage destination or enable additional log categories.",
+                  "type": "tip"
+                }
+              ],
+              "title": "Enable audit logging",
+              "url": null,
+              "uuid": "69d24a4d-881b-44eb-946e-0c23f9ffccef"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Choose an event** \u2014 e.g., failed SSH logins, security group changes, unusual traffic, or unexpected secret access",
+                "**Create the alert rule** in your cloud monitoring service",
+                "**Configure a notification channel** \u2014 email, Slack, or webhook",
+                "**Trigger a test event** and verify you receive the alert"
+              ],
+              "code": null,
+              "description": "Create at least one automated alert for a security-relevant event in your infrastructure.",
+              "done_when": "You trigger a test event and receive an alert notification.",
+              "options": [],
+              "order": 6,
+              "slug": "phase6-capstone-practice-set-up-at-least",
+              "tips": [],
+              "title": "Set up at least one security alert",
+              "url": null,
+              "uuid": "0ba614b5-943c-44e6-ba9a-2cfdf6d60b7e"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Enable CodeQL advanced setup**, following the [advanced setup guide](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/configuring-advanced-setup-for-code-scanning). This commits `.github/workflows/codeql.yml` to your fork",
+                "**Target Python**: per [customizing your advanced setup](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning), set the workflow language to `python` and keep the push, pull_request, and schedule triggers",
+                "**Enable Actions and confirm a green run**: make sure Actions is on for your fork (see [managing Actions settings](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository)) so the CodeQL workflow runs on `main`",
+                "**Enable Dependabot** (recommended): follow [configuring Dependabot alerts](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/configuring-dependabot-alerts) for defense-in-depth",
+                "**Review findings**: triage any critical or high severity [code scanning alerts](https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/about-code-scanning-alerts)"
+              ],
+              "code": null,
+              "description": "Enable automated security scanning on your GitHub repository to catch vulnerabilities in your code and dependencies. Use CodeQL [advanced setup](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/configuring-advanced-setup-for-code-scanning), which commits the workflow to your repo as `.github/workflows/codeql.yml` so it can be verified.",
+              "done_when": "The CodeQL workflow is committed as `.github/workflows/codeql.yml`, targets Python, and its latest run is green on your `main` branch.",
+              "options": [],
+              "order": 7,
+              "slug": "phase6-capstone-practice-enable-security-scanning-on",
+              "tips": [],
+              "title": "Enable security scanning on your repository",
+              "url": "https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/configuring-advanced-setup-for-code-scanning",
+              "uuid": "e2b8c099-6322-446d-9118-a1406c1ad6b8"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "VMs, disks, and public IPs",
+                "Virtual networks, subnets, and security groups",
+                "Secrets manager entries and service accounts",
+                "AI service deployments",
+                "Monitoring or logging configurations that incur cost"
+              ],
+              "code": null,
+              "description": "You've finished the hands-on cloud work \u2014 delete **all** cloud resources to avoid ongoing charges. (The final phase, Interview & Job Prep, needs no cloud infrastructure.)",
+              "done_when": "Your cloud console shows no remaining billable resources from this project.",
+              "options": [],
+              "order": 8,
+              "slug": "phase6-capstone-practice-clean-up-your-cloud",
+              "tips": [
+                {
+                  "text": "If you used resource groups or tags, deleting the group removes everything at once.",
+                  "type": "tip"
+                }
+              ],
+              "title": "Clean up your cloud resources",
+              "url": null,
+              "uuid": "831a7907-14bc-4a99-b03d-d7dc1fc4d742"
+            },
+            {
+              "action": "reflect",
+              "checklist": [],
+              "code": null,
+              "description": "Push your work to GitHub. Write a brief retrospective covering:\n\n- What security controls you implemented and why\n- What you'd do differently or add given more time\n- Key takeaways about cloud security\n\nShare on LinkedIn or with the Learn to Cloud community to celebrate hardening your app. One phase left \u2014 Interview & Job Prep \u2014 to turn this work into a job.",
+              "done_when": null,
+              "options": [],
+              "order": 9,
+              "slug": "phase6-capstone-reflect-share-your-progress",
+              "tips": [],
+              "title": "Share Your Progress",
+              "url": null,
+              "uuid": "31c6ef21-d9a3-43fc-b102-8d58ecbe4342"
+            }
+          ],
+          "name": "Capstone: Secure Your Journal API",
+          "order": 4,
+          "slug": "capstone",
+          "uuid": "ca57ab23-c56b-4352-bb47-9cbd0530e78b"
+        }
+      ],
+      "uuid": "4fb2871c-ba79-4de7-933c-76bad9639f8e"
+    },
+    {
+      "capstone": null,
+      "description": "Finishing this curriculum proves discipline, but it does not make you unique. What makes you stand out is what you explored, improved, and built beyond the outline, and this phase helps you turn that into interviews and opportunities. A lot of it is inspired by Cassidoo's [getting-a-gig](https://github.com/cassidoo/getting-a-gig) guide and her excellent [weekly newsletter](https://cassidoo.co/newsletter/), and by [some thoughts I wrote in a community discussion](https://github.com/learntocloud/learn-to-cloud-app/discussions/330#discussioncomment-16742472).",
+      "hands_on_verification": {
+        "requirement_slugs": [
+          "career-reflection"
+        ],
+        "requirements": [
+          {
+            "description": "Answer three reflection questions about your interview story, your target role and skill gaps, and a project you're excited about. Write them as if you're preparing for a real interview, thoughtful, specific, and in your own words.",
+            "name": "Reflect on Your Job-Search Readiness",
+            "slug": "career-reflection",
+            "submission_type": "career_reflection",
+            "type_config": {
+              "min_answer_length": 200,
+              "questions": [
+                {
+                  "id": "behavioral-story",
+                  "prompt": "Describe a real challenge you faced, at work, in Learn to Cloud, or in a personal project. What was the situation, what did you do, and what was the outcome?"
+                },
+                {
+                  "id": "target-role-and-gaps",
+                  "prompt": "Pick a real job you'd want. What skills and tools does the listing ask for, which do you already have, and how will you close the gaps?"
+                },
+                {
+                  "id": "project-you-love",
+                  "prompt": "Describe a project you genuinely enjoy talking about and how you'd explain it to an interviewer. What you built, why it interested you, and what was hard."
+                }
+              ]
+            },
+            "uuid": "f0779139-1c79-4e33-b90e-b4c73e66ec62"
+          }
+        ]
+      },
+      "name": "Interview & Job Prep",
+      "objectives": [],
+      "order": 7,
+      "short_description": "Turn your cloud skills into a job. Network, tailor your resume, prepare your interview stories, and learn to talk about your work with confidence.",
+      "slug": "phase7",
+      "topic_slugs": [
+        "you-are-not-unique",
+        "resume-and-applications",
+        "interview-prep",
+        "networking",
+        "job-search-capstone"
+      ],
+      "topics": [
+        {
+          "description": "Finishing this curriculum proves you can follow through, but it does not make you stand out. Thousands of people have done the exact same thing. Before you touch your resume, get honest about what you actually did that was your own, and turn that into something real you can talk about.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Get honest about why completing a shared curriculum does not make you stand out.",
+              "uuid": "009e56b8-c909-4d4f-84d4-51dedd49e8d3"
+            },
+            {
+              "order": 2,
+              "text": "Identify the work that is genuinely your own and build on it.",
+              "uuid": "4c38edfa-8cf1-4bda-9067-03b94a57d0b2"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "reflect",
+              "checklist": [],
+              "code": null,
+              "description": "Going through a curriculum, a bootcamp, or any content that anyone can sign up for does not make you unique. It proves you can follow instructions and finish what you start, which matters, but it is the baseline, not your edge.\n\nThat is okay. Accept it now, before you start applying, so you can spend your energy on what actually sets you apart instead of leaning on a certificate of completion.",
+              "done_when": "You accept that finishing shared content is the starting line, not what makes you stand out.",
+              "options": [],
+              "order": 1,
+              "slug": "phase7-unique-reflect-finishing-is-not-your-edge",
+              "tips": [],
+              "title": "Accept that finishing the curriculum is not your edge",
+              "url": null,
+              "uuid": "60766b3e-acad-4bdb-9657-4855cb1138af"
+            },
+            {
+              "action": "review",
+              "checklist": [
+                "**Re-read your own work.** Walk back through each phase and your capstones, and notice where you went past what was asked",
+                "**Mark what pulled you in.** Note the topics or problems you actually wanted to keep working on",
+                "**Turn interest into next steps.** For each one, write a concrete next step that pushes it further than the outline ever did"
+              ],
+              "code": null,
+              "description": "Go back through your work in this curriculum and look for the parts that were yours. The places you went further than the instructions, the topics that genuinely pulled you in, and the questions you chased on your own are where your real story lives.",
+              "done_when": "You have a written list of where you went beyond the outline and the topics you want to take further.",
+              "options": [],
+              "order": 2,
+              "slug": "phase7-unique-review-find-what-you-did-beyond",
+              "tips": [],
+              "title": "Find what you did beyond the outline",
+              "url": null,
+              "uuid": "afca5e31-216c-4fe7-b291-ff0456eab50a"
+            },
+            {
+              "action": "reflect",
+              "checklist": [
+                "**Write your uniqueness statement.** A few honest sentences naming what you explored or improved on your own, and why it mattered to you",
+                "**Point to real work.** Tie every claim to something you actually built or changed, not something you simply completed",
+                "**Be honest with yourself.** If you read it back and it is just 'I finished the curriculum', that is your signal to keep going"
+              ],
+              "code": null,
+              "description": "Write a short, honest reflection about what makes you unique. Be specific and real, for example: \"Yes, I went through the Learn to Cloud curriculum. When I built the journal API I got interested in how AI fit into it, so I added this improvement and learned this from it.\"\n\nRead it back honestly. If you cannot point to anything that was your own, do not move on yet.",
+              "done_when": "You have an honest written statement of what makes you unique, backed by work you did yourself. If you could not write one, you went back and improved a capstone until you could.",
+              "options": [],
+              "order": 3,
+              "slug": "phase7-unique-reflect-write-what-makes-you-unique",
+              "tips": [
+                {
+                  "text": "If you did nothing of your own, stop here. Go back into one of the capstones you built and improve something real until it becomes yours. Learn to Cloud has thousands of students. Saying you completed a capstone is not, by itself, worth anything. What you did with it is.",
+                  "type": "important"
+                }
+              ],
+              "title": "Write what actually makes you unique",
+              "url": null,
+              "uuid": "00da95cb-aced-4e83-b1c2-8a139b79c69c"
+            },
+            {
+              "action": "reflect",
+              "checklist": [],
+              "code": null,
+              "description": "Quick gut check before you continue: this market is hard, even for experienced candidates.\n\nLanding a role takes time and rejection. That is part of the process, not proof you are failing. Decide now that you are in this for the long haul.",
+              "done_when": "You've set a realistic expectation. This will take time and persistence, and rejection is part of the process.",
+              "options": [],
+              "order": 4,
+              "slug": "phase7-unique-reflect-accept-this-takes-time",
+              "tips": [],
+              "title": "Accept that this takes time",
+              "url": null,
+              "uuid": "91d0440e-b11b-471b-9e29-131b7f8741ee"
+            }
+          ],
+          "name": "Find What Makes You Brilliant",
+          "order": 1,
+          "slug": "you-are-not-unique",
+          "uuid": "021b0faf-9c61-41b9-9f9b-4bb3e978d13e"
+        },
+        {
+          "description": "Research the roles you actually want, then tailor your resume to match them and close the obvious skill gaps.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Research the roles you want and the skills they actually ask for.",
+              "uuid": "0fd19471-a03c-41c7-85ee-1e99777865e6"
+            },
+            {
+              "order": 2,
+              "text": "Tailor your resume to the specific roles you're applying for.",
+              "uuid": "2c916e32-917f-4ad7-a4ae-361df666fc82"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "practice",
+              "checklist": [
+                "**Collect 5 to 10 real listings.** Roles you'd genuinely be excited to get (cloud support, junior cloud/DevOps engineer, cloud associate)",
+                "**List the recurring skills.** Note the tools and technologies that appear again and again across listings",
+                "**Spot the patterns.** These recurring requirements tell you what to emphasize and what to learn",
+                "**Save 2 to 3 strong examples.** Keep listings you can reuse when tailoring your resume and preparing interview answers",
+                "**Commit to applying broadly.** Do not filter yourself out over title perfection if the role is a reasonable fit"
+              ],
+              "code": null,
+              "description": "Before editing your resume, collect real listings for roles you want and extract the recurring skills, tools, and responsibilities.",
+              "done_when": "You have a written list of target roles, recurring skills, and a clear commitment to apply broadly.",
+              "options": [],
+              "order": 1,
+              "slug": "phase7-resume-practice-research-target-roles",
+              "tips": [],
+              "title": "Research the roles you actually want",
+              "url": null,
+              "uuid": "54424b10-748a-4a44-9890-93216576ff81"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Match their language.** Mirror the skills and tools from the listings where you genuinely have them",
+                "**Skip the generic objective.** Use that space for specific projects, results, and relevant experience",
+                "**Lead with your differentiators.** Put the work from your uniqueness statement front and center: the improvements, experiments, and ownership choices that were genuinely yours",
+                "**Make it easy to scan.** Clear section headings and visible links to GitHub, LinkedIn, and your portfolio",
+                "**Only list what you can back up.** For each skill on your resume, make sure you understand the basics, and spend a little time closing the gaps on anything you can't (you'll rehearse explaining these out loud in Interview Preparation)",
+                "**Read and apply one idea.** Review [Getting a Gig: Your Resume](https://github.com/cassidoo/getting-a-gig/blob/main/README.md#your-resume) and apply one improvement immediately"
+              ],
+              "code": null,
+              "description": "Use your role research to tailor your resume, then close the biggest skill gaps so you can speak confidently about what target roles require.",
+              "done_when": "Your resume is tailored to target roles and you can explain the key skills those roles ask for.",
+              "options": [],
+              "order": 2,
+              "slug": "phase7-resume-practice-tailor-and-close-gaps",
+              "tips": [
+                {
+                  "text": "It's normal not to have professional experience with everything. The goal is to never be caught completely unable to talk about a skill the role explicitly asks for.",
+                  "type": "tip"
+                }
+              ],
+              "title": "Tailor your resume and close obvious gaps",
+              "url": null,
+              "uuid": "973e6244-6566-4adf-af29-451143d179fb"
+            }
+          ],
+          "name": "Resume & Applications",
+          "order": 2,
+          "slug": "resume-and-applications",
+          "uuid": "2587efd9-e847-4fc9-84a9-e002a7ea0d81"
+        },
+        {
+          "description": "Interview performance is mostly preparation. Build clear stories, practice common questions out loud, and be ready to explain the technologies in your target roles.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Prepare specific stories from your experience before the interview, not during it.",
+              "uuid": "d42f5f81-a2ee-4529-967c-8399e81c288b"
+            },
+            {
+              "order": 2,
+              "text": "Practice answering common behavioral and technical questions out loud.",
+              "uuid": "13f84a18-2e43-4870-ad05-733ca1d00086"
+            },
+            {
+              "order": 3,
+              "text": "Practice explaining your technical work out loud, including diagrams, code, and pipelines you've built.",
+              "uuid": "885d2efa-df93-46d6-8e10-de0db78431b4"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "practice",
+              "checklist": [
+                "**List your raw material.** Past jobs, personal projects, volunteering, and the work from your uniqueness statement",
+                "**Write 4 to 6 short stories.** Each with the situation, what you did, and how it turned out",
+                "**Cover a range.** A technical challenge, a time you learned something fast, a time you worked with others",
+                "**Keep each story concrete.** Name your exact actions and the outcome so your answers sound specific, not generic",
+                "**Read and apply one idea.** Review [Getting a Gig: Your Skills](https://github.com/cassidoo/getting-a-gig/blob/main/README.md#your-skills) and [Selling Them](https://github.com/cassidoo/getting-a-gig/blob/main/README.md#selling-them), then apply one tactic to your stories"
+              ],
+              "code": null,
+              "description": "Outline your stories before interviews. Pull examples from past jobs, personal projects, and the work from your uniqueness statement.\n\nUse a simple structure for each story: situation, task, action, and result. The goal is to recall prepared stories, not improvise under pressure.",
+              "done_when": "You have a written set of specific stories from your experience that you can pull from in an interview.",
+              "options": [],
+              "order": 1,
+              "slug": "phase7-interview-practice-outline-your-stories",
+              "tips": [],
+              "title": "Outline your experience stories in advance",
+              "url": null,
+              "uuid": "17535c6b-4d47-4d48-9c34-014d29d986a0"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Match stories to questions.** Pick which prepared story best answers each common question",
+                "**Answer out loud.** Say your answers aloud, not just in your head. It feels different and exposes the rough spots",
+                "**Keep them concrete.** Specific details and results beat vague generalities",
+                "**Practice one a week.** Keep a steady rhythm of answering at least one new behavioral question each week so your stories stay sharp",
+                "**Prepare before the interview day.** Do this prep early so you are ready, not improvising under pressure"
+              ],
+              "code": null,
+              "description": "A few questions show up in almost every interview. Prepare them now using the stories you already outlined:\n\n- \"Tell me a time you implemented X.\"\n- \"Tell me a difficult challenge you faced and how you overcame it.\"\n- \"Tell me a time you had to give or were given feedback and how you handled that.\"\n\nMap your stories to these questions so you always have a strong, specific answer ready.",
+              "done_when": "You can answer each common behavioral question with a specific, prepared story and deliver it confidently without improvising.",
+              "options": [],
+              "order": 2,
+              "slug": "phase7-interview-practice-universal-questions",
+              "tips": [],
+              "title": "Prepare answers to the universal questions",
+              "url": null,
+              "uuid": "e6ca0c7a-a003-4af8-87e8-fe4944fb674b"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Review your target listings.** Pull the skills and tools they ask for",
+                "**Rehearse a short explanation.** For each, be able to say what it is and where you've used it",
+                "**Be honest about gaps.** For things you haven't used, say so and show you understand the concept",
+                "**Practice without tools.** Rehearse a few answers and technical explanations without notes, autocomplete, or AI assistance"
+              ],
+              "code": null,
+              "description": "Interviewers will ask about tools in the job listing. Be ready to explain what each one is, why teams use it, and where you have used it.",
+              "done_when": "You can confidently discuss every technology listed on your target roles.",
+              "options": [],
+              "order": 3,
+              "slug": "phase7-interview-practice-talk-about-the-tech",
+              "tips": [],
+              "title": "Be ready to talk about the tech on the listing",
+              "url": null,
+              "uuid": "9c1698e8-345c-41bb-a8d1-7bbde29eef21"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Diagram a common architecture from memory.** A 3-tier setup (web, application, data) is a frequent example. Practice sketching one and talking through how a request flows through it and why you'd split it that way",
+                "**Walk through a piece of your own code.** Pick something you've written, Python or otherwise, and explain what it does and why, as if a teammate is reading over your shoulder",
+                "**Explain a pipeline or process you've built.** A CI/CD pipeline is a common one. Talk through each stage and what happens if a stage fails",
+                "**Practice without notes.** Rehearse each explanation out loud a few times until it flows without a script"
+              ],
+              "code": null,
+              "description": "Technical interviews for cloud engineering roles usually go beyond trivia questions. Interviewers want to see how you think, so you may be asked to sketch something on a whiteboard or screen, or to walk through work you've done and explain the reasoning behind it. The exact ask varies by company, but a few kinds of exercises come up often enough to be worth rehearsing.\n\nPractice these out loud, the same way you practiced your stories. Saying it out loud surfaces the gaps that just thinking about it hides.",
+              "done_when": "You can diagram a system, walk through your own code, and explain a pipeline or process out loud, without notes.",
+              "options": [],
+              "order": 4,
+              "slug": "phase7-interview-practice-explain-your-technical-work",
+              "tips": [],
+              "title": "Explain your technical work out loud",
+              "url": null,
+              "uuid": "82af6650-c3db-4341-b94c-19b855d4ba96"
+            }
+          ],
+          "name": "Interview Preparation",
+          "order": 3,
+          "slug": "interview-prep",
+          "uuid": "d57fde28-0c92-442c-bda2-d639683a33e4"
+        },
+        {
+          "description": "Networking helps you practice your story, meet people in the industry, and create opportunities beyond online applications. Get your introduction ready first, then go put it to use in a real conversation.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Practice talking about your technical skills and experience with other people.",
+              "uuid": "2a4f955a-e5a5-4cec-a813-2900fd1e4d42"
+            },
+            {
+              "order": 2,
+              "text": "Build relationships in the tech community, both in person and online.",
+              "uuid": "48a46959-72cb-4e58-8606-17f46e45ac40"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "practice",
+              "checklist": [
+                "**Who you are.** Your background and where you're coming from (help desk, career changer, recent grad)",
+                "**What you can do.** The concrete cloud skills you've built (deployed and secured a real API on a cloud provider)",
+                "**What you want.** The kind of role you're aiming for"
+              ],
+              "code": null,
+              "description": "Before you walk into a room or a call, prepare a short introduction you can use in networking chats and interviews. Keep it clear, specific, and natural so it sounds like you.",
+              "done_when": "You can deliver a natural, confident two or three sentence introduction without notes.",
+              "options": [],
+              "order": 1,
+              "slug": "phase7-networking-practice-write-your-introduction",
+              "tips": [],
+              "title": "Write your one-line introduction",
+              "url": null,
+              "uuid": "084a7831-8433-400e-9d32-4a6dab14f7bb"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Find an event.** Search Meetup, local cloud or DevOps user groups, your cloud provider's community days, or check the [Learn to Cloud Discussions](https://github.com/learntocloud/learn-to-cloud-app/discussions) for what others are attending",
+                "**Show up.** Go in with low pressure. Your only job is to have a few genuine conversations",
+                "**Use your introduction when it fits.** You practiced it for a reason, so lean on it when a conversation starts, and pay attention to how it lands",
+                "**Talk about the work you actually care about.** Bring up something you've explored or focused on, see how people respond, and let their reactions spark more of your own exploration",
+                "**Stay in touch with people you click with.** If a conversation goes well, swap contact info so you can pick it back up later"
+              ],
+              "code": null,
+              "description": "Now go use the introduction you practiced. Attend one tech event. In-person is ideal, but online is fine if needed. The goal is practice and relationship building, not instant job offers.",
+              "done_when": "You attended a tech event and had at least one real conversation about your technical work.",
+              "options": [],
+              "order": 2,
+              "slug": "phase7-networking-practice-attend-one-tech-event",
+              "tips": [],
+              "title": "Attend one tech event",
+              "url": null,
+              "uuid": "fefbcd92-7e8d-45e5-87ab-61f81b4197e6"
+            }
+          ],
+          "name": "Build Your Network",
+          "order": 4,
+          "slug": "networking",
+          "uuid": "7204db15-b6cf-4908-adc7-ea45b227753f"
+        },
+        {
+          "description": "This is where everything comes together. Get comfortable talking about the work that is genuinely yours, set up a simple job search routine if it helps you stay consistent, then answer your readiness reflection. The reflection is the one graded check in this phase.",
+          "learning_objectives": [
+            {
+              "order": 1,
+              "text": "Get comfortable talking about the work that is genuinely yours.",
+              "uuid": "e12e1374-2c39-49eb-919b-c225d29f61c9"
+            },
+            {
+              "order": 2,
+              "text": "Be ready to apply, and submit your readiness reflection.",
+              "uuid": "1bf858dc-41aa-4d6c-be6a-a6cdff162caa"
+            }
+          ],
+          "learning_steps": [
+            {
+              "action": "practice",
+              "checklist": [
+                "**Revisit your uniqueness statement.** Reread what you wrote in the first topic of this phase",
+                "**Pick the part you're most excited about.** The improvement or project that genuinely came from you",
+                "**Know its story.** Why you built it, the choices you made, and what you'd do next",
+                "**Say it out loud.** Practice until it sounds like you, not a rehearsed pitch"
+              ],
+              "code": null,
+              "description": "Go back to the uniqueness statement you wrote in \"Find What Makes You Brilliant.\" That statement is the work that is genuinely yours, the project, the improvement, and the choices you made on your own. Now get comfortable talking about it out loud, with real enthusiasm.",
+              "done_when": "You can talk about the work that's genuinely yours with real enthusiasm.",
+              "options": [],
+              "order": 1,
+              "slug": "phase7-capstone-practice-project-youre-excited-about",
+              "tips": [],
+              "title": "Practice talking about what makes you unique",
+              "url": null,
+              "uuid": "4a272641-6301-44ab-80bb-925bae1234c3"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Create the artifact.** Start one document or spreadsheet named `Job Search Plan`",
+                "**Add three sections.** `Roles to target`, `Weekly rhythm`, and `Application + follow-up tracker`",
+                "**Set target roles.** List the role titles and 2 to 3 companies you are actively targeting this month",
+                "**Set an application target.** A realistic weekly number you can actually keep up",
+                "**Schedule networking.** Recurring time for events, online communities, and reaching out",
+                "**Schedule interview practice.** Block weekly time to run the story and question reps from Interview Preparation so your answers stay sharp",
+                "**Plan referral follow-ups.** Track who you met, when to follow up, and where a warm intro would make sense",
+                "**Track your applications.** Include columns for role, company, date applied, status, and next follow-up date"
+              ],
+              "code": "# Job Search Plan\n\n## Roles to target\n- Role titles:\n- Top companies this month:\n\n## Weekly rhythm\n- Applications per week:\n- Networking actions per week:\n- Interview practice session:\n\n## Application + follow-up tracker\n| Role | Company | Date applied | Status | Next follow-up |\n| --- | --- | --- | --- | --- |\n|  |  |  |  |  |",
+              "description": "This one is just for you. Nothing here gets submitted. If a simple weekly routine helps you stay consistent, set up a plan you will actually use, and keep it as light or as detailed as you want.",
+              "done_when": "You have a personal job search routine set up the way you want, or you've decided you don't need one.",
+              "options": [],
+              "order": 2,
+              "slug": "phase7-capstone-practice-build-job-search-routine",
+              "tips": [],
+              "title": "Set up a job search routine (optional)",
+              "url": null,
+              "uuid": "8307f1cb-c125-4e76-a39a-074d931d10c5"
+            },
+            {
+              "action": "practice",
+              "checklist": [
+                "**Write a real behavioral story.** Use one of the stories you outlined, with situation, action, and result",
+                "**Name a target role and your gaps.** Be specific about the skills you have and the ones you're closing",
+                "**Describe a project you love.** The one from your uniqueness statement that you're genuinely excited to talk about"
+              ],
+              "code": null,
+              "description": "This is the one graded check in this phase. Answer the three reflection questions in your own words, using the stories, role research, and uniqueness statement you built earlier. Be specific and honest so it reflects real readiness.",
+              "done_when": "You've submitted the career reflection and it has been graded as passing.",
+              "options": [],
+              "order": 3,
+              "slug": "phase7-capstone-practice-complete-the-reflection",
+              "tips": [],
+              "title": "Submit your readiness reflection",
+              "url": null,
+              "uuid": "a68f4251-0e15-4e40-a51e-3e9b328437f6"
+            },
+            {
+              "action": "reflect",
+              "checklist": [],
+              "code": null,
+              "description": "Pause and recognize what you finished: foundations, deployment, automation, security, and communication of real project work.\n\nFrom here, persistence matters most. Keep applying, networking, and practicing. You have the skills and proof of work to support your next step.",
+              "done_when": "You've recognized how far you've come and you're ready to take it into your job search.",
+              "options": [],
+              "order": 4,
+              "slug": "phase7-capstone-reflect-you-finished-learn-to-cloud",
+              "tips": [],
+              "title": "You finished Learn to Cloud",
+              "url": null,
+              "uuid": "1e8433f7-1833-47a2-bb01-ff65fe444735"
+            }
+          ],
+          "name": "Get Ready to Apply",
+          "order": 5,
+          "slug": "job-search-capstone",
+          "uuid": "a6af5633-1cb8-49f3-9632-3e21fb84e69b"
+        }
+      ],
+      "uuid": "b73ba847-5c51-449e-9e61-4b96af6175f3"
+    }
+  ]
+}

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
@@ -1,0 +1,8 @@
+# Authoritative curriculum content version (issue: curriculum artifact compiler).
+#
+# Bump this integer any time authored curriculum content changes in a way
+# that should be reflected in a new compiled artifact (phases, topics,
+# steps, objectives, or requirements). The compiler enforces that this
+# value strictly increases relative to the previously committed
+# curriculum.json artifact -- it will refuse to compile otherwise.
+curriculum_version: 1

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_catalog.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_catalog.py
@@ -1,0 +1,253 @@
+"""Curriculum catalog: process-level reader of the compiled artifact.
+
+Loads the packaged ``curriculum.json`` artifact (see
+``content_compiler.py``) once per process and builds indexed lookups
+over it (by UUID, by slug, by phase). This is separate from -- and does
+not replace -- the DB-backed runtime reads in ``content_service``. It
+exists so the API can fail fast at startup if the packaged artifact is
+missing, stale, or corrupted, and so callers that only need curriculum
+identity or structural metadata don't have to touch the database.
+
+Do not wire this into request-serving curriculum reads yet -- the DB
+loader remains the production reader until a follow-up PR switches it
+over.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from functools import lru_cache
+from importlib.resources import files
+from types import MappingProxyType
+from uuid import UUID
+
+from learn_to_cloud_shared.content_compiler import (
+    ARTIFACT_SCHEMA_VERSION,
+    compute_content_hash,
+)
+from learn_to_cloud_shared.schemas import (
+    HandsOnRequirement,
+    LearningStep,
+    Phase,
+    Topic,
+)
+
+#: Package-relative location of the compiled artifact, as passed to
+#: ``importlib.resources.files(...).joinpath(*ARTIFACT_PACKAGE_PATH)``.
+ARTIFACT_PACKAGE_PATH = ("content", "curriculum.json")
+
+#: Shared empty sentinel for Mapping-typed dataclass field defaults.
+_EMPTY_MAPPING: Mapping = MappingProxyType({})
+
+
+class CurriculumCatalogError(Exception):
+    """Raised when the packaged curriculum artifact can't be loaded or trusted."""
+
+
+@dataclass(frozen=True, slots=True)
+class CurriculumCatalog:
+    """Immutable, indexed view over the compiled curriculum artifact.
+
+    Build once per process via :func:`get_curriculum_catalog`. Lookup
+    fields are ``Mapping``/``frozenset``/``tuple`` -- backed by
+    ``MappingProxyType`` so item assignment raises ``TypeError``, not
+    just plain dicts that happen to be typed as read-only. Values are
+    the same Pydantic model instances found in ``phases``.
+    """
+
+    artifact_schema_version: int
+    curriculum_version: int
+    content_hash: str
+    phases: tuple[Phase, ...]
+
+    phases_by_slug: Mapping[str, Phase] = field(default_factory=lambda: _EMPTY_MAPPING)
+    phases_by_order: Mapping[int, Phase] = field(default_factory=lambda: _EMPTY_MAPPING)
+    topics_by_uuid: Mapping[UUID, Topic] = field(default_factory=lambda: _EMPTY_MAPPING)
+    topics_by_phase_and_slug: Mapping[tuple[str, str], Topic] = field(
+        default_factory=lambda: _EMPTY_MAPPING
+    )
+    steps_by_uuid: Mapping[UUID, LearningStep] = field(
+        default_factory=lambda: _EMPTY_MAPPING
+    )
+    steps_by_phase_slug: Mapping[str, tuple[LearningStep, ...]] = field(
+        default_factory=lambda: _EMPTY_MAPPING
+    )
+    requirements_by_uuid: Mapping[UUID, HandsOnRequirement] = field(
+        default_factory=lambda: _EMPTY_MAPPING
+    )
+    requirements_by_slug: Mapping[str, HandsOnRequirement] = field(
+        default_factory=lambda: _EMPTY_MAPPING
+    )
+    requirements_by_phase_slug: Mapping[str, tuple[HandsOnRequirement, ...]] = field(
+        default_factory=lambda: _EMPTY_MAPPING
+    )
+    active_phase_uuids: frozenset[UUID] = field(default_factory=frozenset)
+    active_topic_uuids: frozenset[UUID] = field(default_factory=frozenset)
+    active_step_uuids: frozenset[UUID] = field(default_factory=frozenset)
+    active_requirement_uuids: frozenset[UUID] = field(default_factory=frozenset)
+
+    @property
+    def phase_count(self) -> int:
+        return len(self.phases)
+
+    @property
+    def topic_count(self) -> int:
+        return len(self.topics_by_uuid)
+
+    @property
+    def step_count(self) -> int:
+        return len(self.steps_by_uuid)
+
+    @property
+    def requirement_count(self) -> int:
+        return len(self.requirements_by_uuid)
+
+    @classmethod
+    def from_phases(
+        cls,
+        phases: tuple[Phase, ...],
+        *,
+        artifact_schema_version: int,
+        curriculum_version: int,
+        content_hash: str,
+    ) -> CurriculumCatalog:
+        """Build every index in a single pass over the phase tree."""
+        phases_by_slug: dict[str, Phase] = {}
+        phases_by_order: dict[int, Phase] = {}
+        topics_by_uuid: dict[UUID, Topic] = {}
+        topics_by_phase_and_slug: dict[tuple[str, str], Topic] = {}
+        steps_by_uuid: dict[UUID, LearningStep] = {}
+        steps_by_phase_slug: dict[str, list[LearningStep]] = {}
+        requirements_by_uuid: dict[UUID, HandsOnRequirement] = {}
+        requirements_by_slug: dict[str, HandsOnRequirement] = {}
+        requirements_by_phase_slug: dict[str, list[HandsOnRequirement]] = {}
+
+        for phase in phases:
+            phases_by_slug[phase.slug] = phase
+            phases_by_order[phase.order] = phase
+            steps_by_phase_slug.setdefault(phase.slug, [])
+            requirements_by_phase_slug.setdefault(phase.slug, [])
+
+            for topic in phase.topics:
+                topics_by_uuid[topic.uuid] = topic
+                topics_by_phase_and_slug[(phase.slug, topic.slug)] = topic
+                for step in topic.learning_steps:
+                    steps_by_uuid[step.uuid] = step
+                    steps_by_phase_slug[phase.slug].append(step)
+
+            if phase.hands_on_verification:
+                for req in phase.hands_on_verification.requirements:
+                    requirements_by_uuid[req.uuid] = req
+                    requirements_by_slug[req.slug] = req
+                    requirements_by_phase_slug[phase.slug].append(req)
+
+        return cls(
+            artifact_schema_version=artifact_schema_version,
+            curriculum_version=curriculum_version,
+            content_hash=content_hash,
+            phases=phases,
+            phases_by_slug=MappingProxyType(phases_by_slug),
+            phases_by_order=MappingProxyType(phases_by_order),
+            topics_by_uuid=MappingProxyType(topics_by_uuid),
+            topics_by_phase_and_slug=MappingProxyType(topics_by_phase_and_slug),
+            steps_by_uuid=MappingProxyType(steps_by_uuid),
+            steps_by_phase_slug=MappingProxyType(
+                {slug: tuple(steps) for slug, steps in steps_by_phase_slug.items()}
+            ),
+            requirements_by_uuid=MappingProxyType(requirements_by_uuid),
+            requirements_by_slug=MappingProxyType(requirements_by_slug),
+            requirements_by_phase_slug=MappingProxyType(
+                {slug: tuple(reqs) for slug, reqs in requirements_by_phase_slug.items()}
+            ),
+            active_phase_uuids=frozenset(p.uuid for p in phases),
+            active_topic_uuids=frozenset(topics_by_uuid),
+            active_step_uuids=frozenset(steps_by_uuid),
+            active_requirement_uuids=frozenset(requirements_by_uuid),
+        )
+
+
+def _read_artifact_payload() -> dict:
+    """Read and JSON-parse the packaged artifact, without validating it."""
+    resource = files("learn_to_cloud_shared").joinpath(*ARTIFACT_PACKAGE_PATH)
+    if not resource.is_file():
+        raise CurriculumCatalogError(
+            f"packaged curriculum artifact not found: {resource}. Run "
+            "'uv run python scripts/compile_curriculum.py' in "
+            "packages/learn-to-cloud-shared and commit the result."
+        )
+
+    raw = resource.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CurriculumCatalogError(
+            f"packaged curriculum artifact is not valid JSON: {exc}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise CurriculumCatalogError(
+            "packaged curriculum artifact must be a JSON object"
+        )
+    return payload
+
+
+def _validate_artifact_payload(payload: dict) -> None:
+    """Fail fast on a schema mismatch or a corrupted/hand-edited artifact."""
+    schema_version = payload.get("artifact_schema_version")
+    if schema_version != ARTIFACT_SCHEMA_VERSION:
+        raise CurriculumCatalogError(
+            f"packaged curriculum artifact schema_version {schema_version!r} does "
+            f"not match the version this code expects ({ARTIFACT_SCHEMA_VERSION}); "
+            "recompile with a matching learn-to-cloud-shared release."
+        )
+
+    content_hash = payload.get("content_hash")
+    if not isinstance(content_hash, str) or not content_hash:
+        raise CurriculumCatalogError(
+            "packaged curriculum artifact is missing content_hash"
+        )
+
+    payload_without_hash = {k: v for k, v in payload.items() if k != "content_hash"}
+    expected_hash = compute_content_hash(payload_without_hash)
+    if content_hash != expected_hash:
+        raise CurriculumCatalogError(
+            "packaged curriculum artifact content_hash does not match its "
+            "payload -- the file may be corrupted or hand-edited"
+        )
+
+
+def load_curriculum_catalog() -> CurriculumCatalog:
+    """Load, validate, and index the packaged curriculum artifact.
+
+    Not cached -- call :func:`get_curriculum_catalog` for the
+    process-level singleton. Exposed separately so tests can exercise
+    fresh loads without touching the shared cache.
+    """
+    payload = _read_artifact_payload()
+    _validate_artifact_payload(payload)
+
+    phases = tuple(Phase.model_validate(p) for p in payload["phases"])
+    return CurriculumCatalog.from_phases(
+        phases,
+        artifact_schema_version=payload["artifact_schema_version"],
+        curriculum_version=payload["curriculum_version"],
+        content_hash=payload["content_hash"],
+    )
+
+
+@lru_cache(maxsize=1)
+def get_curriculum_catalog() -> CurriculumCatalog:
+    """Get the process-level curriculum catalog singleton.
+
+    Loaded once per process. Call this eagerly during API startup so a
+    missing/stale/corrupted artifact fails the deploy instead of the
+    first request that happens to need it.
+    """
+    return load_curriculum_catalog()
+
+
+def clear_catalog_cache() -> None:
+    """Clear the cached catalog singleton (useful for testing)."""
+    get_curriculum_catalog.cache_clear()

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_compiler.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_compiler.py
@@ -1,0 +1,235 @@
+"""Deterministic curriculum artifact compiler.
+
+Compiles the authored curriculum YAML tree into a single canonical JSON
+artifact (``curriculum.json``) that ships as package data with the
+``learn-to-cloud-shared`` wheel. The compiler is strict: it fails on
+missing, skipped, malformed, or inconsistent content instead of silently
+tolerating it (unlike ``content_yaml_loader.get_all_phases_from_yaml``,
+which is intentionally tolerant so the running app survives one bad
+file).
+
+The artifact is:
+
+- **Canonical**: object keys are sorted, so key ordering never depends
+  on dict insertion order or field-declaration order drifting. Array
+  element order is left untouched -- it carries curriculum meaning
+  (phase/topic/step order, requirement declaration order) that
+  alphabetizing would destroy.
+- **Deterministic**: compiling the same YAML twice produces
+  byte-identical output. CI regenerates the artifact and diffs it
+  against the committed copy to catch drift (see
+  ``scripts/compile_curriculum.py``).
+- **Versioned**: ``artifact_schema_version`` is the shape of this JSON
+  artifact itself; ``curriculum_version`` is an authored integer bumped
+  by curriculum maintainers in ``curriculum.meta.yaml`` -- it may repeat
+  while content is unchanged, must never decrease, and must strictly
+  increase whenever content changes (see ``_check_version_policy``);
+  ``content_hash`` is a SHA-256 over the canonical payload (everything
+  except the hash field itself), letting any consumer verify the
+  artifact wasn't corrupted or hand-edited.
+
+This module does not affect runtime curriculum reads -- those still go
+through ``content_service`` (DB-backed). See ``content_catalog.py`` for
+the process-level reader of the compiled artifact.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from learn_to_cloud_shared.content_yaml_loader import (
+    get_all_phases_from_yaml_strict,
+    get_content_root_dir,
+    validate_content,
+)
+from learn_to_cloud_shared.schemas import Phase
+
+#: Shape of the compiled artifact. Bump when the top-level JSON structure
+#: changes in a way that requires readers (CurriculumCatalog) to change.
+ARTIFACT_SCHEMA_VERSION = 1
+
+ARTIFACT_FILENAME = "curriculum.json"
+META_FILENAME = "curriculum.meta.yaml"
+
+
+class ContentCompileError(Exception):
+    """Raised when the curriculum cannot be compiled into an artifact."""
+
+
+def _read_curriculum_version(content_root: Path) -> int:
+    """Read the authored version from ``curriculum.meta.yaml``."""
+    meta_file = content_root / META_FILENAME
+    if not meta_file.exists():
+        raise ContentCompileError(f"missing curriculum metadata file: {meta_file}")
+
+    with open(meta_file, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict) or "curriculum_version" not in data:
+        raise ContentCompileError(
+            f"{meta_file} must define an integer 'curriculum_version'"
+        )
+
+    version = data["curriculum_version"]
+    if not isinstance(version, int) or isinstance(version, bool) or version < 1:
+        raise ContentCompileError(
+            f"{meta_file}: curriculum_version must be a positive integer, "
+            f"got {version!r}"
+        )
+    return version
+
+
+def _content_without_version_and_hash(payload: dict[str, Any]) -> dict[str, Any]:
+    """Strip the two fields that don't count as "content" for version policy."""
+    excluded = ("curriculum_version", "content_hash")
+    return {k: v for k, v in payload.items() if k not in excluded}
+
+
+def _check_version_policy(
+    new_version: int,
+    new_payload_without_hash: dict[str, Any],
+    previous_path: Path,
+) -> None:
+    """Enforce the curriculum_version policy against a previous artifact.
+
+    - A missing previous artifact (first-ever compile) always passes.
+    - A version decrease always fails.
+    - An unchanged version is only allowed if the content (everything
+      but ``curriculum_version``/``content_hash``) is unchanged too --
+      a content change requires a strictly higher version.
+    """
+    if not previous_path.exists():
+        return
+
+    with open(previous_path, encoding="utf-8") as f:
+        previous_payload = json.load(f)
+
+    previous_version = previous_payload.get("curriculum_version")
+    if not isinstance(previous_version, int):
+        raise ContentCompileError(
+            f"{previous_path}: previous artifact has no integer curriculum_version"
+        )
+
+    if new_version < previous_version:
+        raise ContentCompileError(
+            f"curriculum_version must not decrease: previous artifact has "
+            f"{previous_version}, authored metadata has {new_version}."
+        )
+
+    if new_version == previous_version:
+        previous_content = _content_without_version_and_hash(previous_payload)
+        new_content = _content_without_version_and_hash(new_payload_without_hash)
+        if previous_content != new_content:
+            raise ContentCompileError(
+                f"curriculum content changed but curriculum_version "
+                f"({new_version}) was not bumped. Bump curriculum_version in "
+                f"{META_FILENAME}."
+            )
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    """Serialize with sorted object keys for a stable, hashable form.
+
+    Array element order is preserved as-is (it's meaningful curriculum
+    ordering, not incidental). Shared by the compiler (to compute
+    ``content_hash``) and the catalog (to verify it on load).
+    """
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def compute_content_hash(payload_without_hash: dict[str, Any]) -> str:
+    """SHA-256 over the canonical form of a payload excluding ``content_hash``."""
+    canonical = canonical_json(payload_without_hash).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _build_payload(
+    phases: tuple[Phase, ...], curriculum_version: int
+) -> dict[str, Any]:
+    """Build the artifact payload (without ``content_hash``) from loaded phases.
+
+    Reuses the existing Pydantic schema types directly via
+    ``model_dump`` rather than hand-building a parallel JSON shape, so
+    the artifact can never drift from the validated curriculum types.
+    None of these models carry timestamps or filesystem paths.
+    """
+    return {
+        "artifact_schema_version": ARTIFACT_SCHEMA_VERSION,
+        "curriculum_version": curriculum_version,
+        "phases": [phase.model_dump(mode="json") for phase in phases],
+    }
+
+
+def compile_curriculum_artifact(
+    *, previous_artifact_path: Path | None = None
+) -> dict[str, Any]:
+    """Compile the authored YAML curriculum into a canonical artifact dict.
+
+    Strict end to end: raises ``ContentCompileError`` (or propagates the
+    underlying ``ContentValidationError``/``ValidationError``/
+    ``yaml.YAMLError`` from the strict loader) on any missing file,
+    malformed YAML, failed schema validation, or cross-file
+    inconsistency (duplicate UUIDs, unresolved slugs, non-sequential
+    phase order, ...).
+
+    ``previous_artifact_path``, when given and it exists, is checked
+    against the curriculum_version policy (see
+    ``_check_version_policy``). This is opt-in (default: no check) so
+    plain regeneration from an unchanged source tree -- what CI's
+    drift-detection diff relies on -- stays idempotent.
+    """
+    content_root = get_content_root_dir()
+    curriculum_version = _read_curriculum_version(content_root)
+
+    phases = get_all_phases_from_yaml_strict()
+    if not phases:
+        raise ContentCompileError("no phases loaded from YAML; refusing to compile")
+
+    errors = validate_content(phases)
+    if errors:
+        joined = "\n  - ".join(errors)
+        raise ContentCompileError(f"curriculum validation failed:\n  - {joined}")
+
+    payload_without_hash = _build_payload(phases, curriculum_version)
+
+    if previous_artifact_path is not None:
+        _check_version_policy(
+            curriculum_version, payload_without_hash, previous_artifact_path
+        )
+
+    content_hash = compute_content_hash(payload_without_hash)
+
+    return {**payload_without_hash, "content_hash": content_hash}
+
+
+def render_artifact_file(payload: dict[str, Any]) -> str:
+    """Render the compiled payload as commit-ready file contents.
+
+    Pretty-printed (sorted keys, 2-space indent) for readable diffs,
+    with a trailing newline. Deterministic given the same payload --
+    this is what CI regenerates and byte-compares against the committed
+    file.
+    """
+    return json.dumps(payload, sort_keys=True, indent=2, ensure_ascii=True) + "\n"
+
+
+def compile_and_write(
+    output_path: Path | None = None, *, previous_artifact_path: Path | None = None
+) -> Path:
+    """Compile the curriculum and write the canonical artifact file to disk.
+
+    Returns the path written. Used by ``scripts/compile_curriculum.py``
+    (developer regeneration and the CI drift check). Pass
+    ``previous_artifact_path`` to enforce the curriculum_version policy
+    against a prior artifact; omitted by default so regenerating from
+    an unchanged tree reproduces the same bytes.
+    """
+    content_root = get_content_root_dir()
+    target = output_path or (content_root / ARTIFACT_FILENAME)
+    payload = compile_curriculum_artifact(previous_artifact_path=previous_artifact_path)
+    target.write_text(render_artifact_file(payload), encoding="utf-8")
+    return target

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
@@ -72,30 +72,58 @@ def _get_content_dir() -> Path:
     return get_worker_settings().content.dir_path
 
 
-def _load_topic(phase_dir: Path, topic_slug: str, *, order: int) -> Topic | None:
+def get_content_root_dir() -> Path:
+    """Get the ``content/`` directory (parent of ``phases/``).
+
+    Used by the deterministic artifact compiler to locate
+    ``curriculum.meta.yaml`` and to write the compiled
+    ``curriculum.json`` next to ``phases/`` and ``schemas/``.
+    """
+    return _get_content_dir().parent
+
+
+def _build_topic(topic_file: Path, *, order: int) -> Topic:
+    """Parse and validate one topic YAML file into a ``Topic``."""
+    with open(topic_file, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if isinstance(data, dict) and "order" in data:
+        raise ContentValidationError(
+            f"topic {topic_file.name}: 'order' field is no longer allowed. "
+            "Topic order is derived from the position in _phase.yaml's "
+            "'topics:' list -- remove the 'order' field from this file."
+        )
+    _validate_topic_payload(data, topic_file)
+    data["order"] = order
+    return Topic.model_validate(data)
+
+
+def _load_topic(
+    phase_dir: Path, topic_slug: str, *, order: int, strict: bool = False
+) -> Topic | None:
     """Load a single topic from its YAML file.
 
     ``order`` is supplied by the caller from the topic's position in the
     parent phase's ``topics:`` slug list. Topic YAML files must not
     carry their own ``order`` field; the loader rejects it to keep one
     source of truth (issue #463).
+
+    In tolerant mode (``strict=False``, the default), a missing file or
+    any validation failure is logged and skipped so the app keeps
+    running on partially-bad content. In strict mode (used by the
+    deterministic artifact compiler), the same failures raise instead
+    of being swallowed.
     """
     topic_file = phase_dir / f"{topic_slug}.yaml"
     if not topic_file.exists():
+        if strict:
+            raise ContentValidationError(f"missing topic file: {topic_file}")
         return None
 
+    if strict:
+        return _build_topic(topic_file, order=order)
+
     try:
-        with open(topic_file, encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-        if isinstance(data, dict) and "order" in data:
-            raise ContentValidationError(
-                f"topic {topic_file.name}: 'order' field is no longer allowed. "
-                "Topic order is derived from the position in _phase.yaml's "
-                "'topics:' list -- remove the 'order' field from this file."
-            )
-        _validate_topic_payload(data, topic_file)
-        data["order"] = order
-        return Topic.model_validate(data)
+        return _build_topic(topic_file, order=order)
     except (yaml.YAMLError, ContentValidationError, ValueError, KeyError):
         logger.exception(
             "content.topic.load_failed",
@@ -107,32 +135,45 @@ def _load_topic(phase_dir: Path, topic_slug: str, *, order: int) -> Topic | None
         return None
 
 
-def _load_requirement(phase_dir: Path, requirement_slug: str) -> Any | None:
+def _build_requirement(req_file: Path) -> Any:
+    """Parse and validate one requirement YAML file into a typed requirement."""
+    with open(req_file, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ContentValidationError(
+            f"requirement {req_file.name} must be a YAML mapping"
+        )
+    file_stem = req_file.stem
+    yaml_slug = str(data.get("slug", "")).strip()
+    if yaml_slug != file_stem:
+        raise ContentValidationError(
+            f"requirement {req_file.name}: slug '{yaml_slug}' does not "
+            f"match filename stem '{file_stem}'"
+        )
+    return HandsOnRequirementAdapter.validate_python(data)
+
+
+def _load_requirement(
+    phase_dir: Path, requirement_slug: str, *, strict: bool = False
+) -> Any | None:
     """Load a single hands-on requirement from its YAML file.
 
     Returns one of the typed ``HandsOnRequirement`` subclasses (resolved
-    via the discriminated union) or ``None`` if the file is missing or
-    fails validation.
+    via the discriminated union). In tolerant mode (the default),
+    returns ``None`` if the file is missing or fails validation. In
+    strict mode, the same conditions raise instead.
     """
     req_file = phase_dir / "requirements" / f"{requirement_slug}.yaml"
     if not req_file.exists():
+        if strict:
+            raise ContentValidationError(f"missing requirement file: {req_file}")
         return None
 
+    if strict:
+        return _build_requirement(req_file)
+
     try:
-        with open(req_file, encoding="utf-8") as f:
-            data = yaml.safe_load(f)
-        if not isinstance(data, dict):
-            raise ContentValidationError(
-                f"requirement {req_file.name} must be a YAML mapping"
-            )
-        file_stem = req_file.stem
-        yaml_slug = str(data.get("slug", "")).strip()
-        if yaml_slug != file_stem:
-            raise ContentValidationError(
-                f"requirement {req_file.name}: slug '{yaml_slug}' does not "
-                f"match filename stem '{file_stem}'"
-            )
-        return HandsOnRequirementAdapter.validate_python(data)
+        return _build_requirement(req_file)
     except (
         yaml.YAMLError,
         ContentValidationError,
@@ -150,50 +191,67 @@ def _load_requirement(phase_dir: Path, requirement_slug: str) -> Any | None:
         return None
 
 
-def _load_phase(phase_slug: str) -> Phase | None:
-    """Load a single phase from its directory."""
+def _build_phase(
+    phase_slug: str, phase_dir: Path, meta_file: Path, *, strict: bool
+) -> Phase:
+    """Parse and validate one phase directory into a ``Phase``."""
+    with open(meta_file, encoding="utf-8") as f:
+        data: dict = yaml.safe_load(f)
+
+    # The phase directory name is authoritative -- the loader injects
+    # the slug here rather than trusting any YAML field, so a file
+    # accidentally placed in the wrong directory still ends up tagged
+    # with that directory's slug.
+    data["slug"] = phase_slug
+
+    topic_slugs: list[str] = data.get("topics", [])
+    topics = [
+        t
+        for idx, slug in enumerate(topic_slugs)
+        if (t := _load_topic(phase_dir, slug, order=idx + 1, strict=strict)) is not None
+    ]
+    data["topic_slugs"] = topic_slugs
+    data["topics"] = topics
+
+    hov = data.get("hands_on_verification")
+    if isinstance(hov, dict):
+        requirement_slugs: list[str] = hov.get("requirements", []) or []
+        if not all(isinstance(s, str) for s in requirement_slugs):
+            raise ContentValidationError(
+                f"phase '{phase_slug}' hands_on_verification.requirements "
+                "must be a list of slug strings"
+            )
+        loaded_requirements = [
+            r
+            for slug in requirement_slugs
+            if (r := _load_requirement(phase_dir, slug, strict=strict)) is not None
+        ]
+        hov["requirement_slugs"] = requirement_slugs
+        hov["requirements"] = loaded_requirements
+
+    return Phase.model_validate(data)
+
+
+def _load_phase(phase_slug: str, *, strict: bool = False) -> Phase | None:
+    """Load a single phase from its directory.
+
+    In tolerant mode (the default), a missing ``_phase.yaml`` or any
+    validation failure (in this phase or any of its topics/requirements)
+    is logged and skipped. In strict mode, the same failures raise.
+    """
     phase_dir = _get_content_dir() / phase_slug
     meta_file = phase_dir / "_phase.yaml"
 
     if not meta_file.exists():
+        if strict:
+            raise ContentValidationError(f"missing phase metadata file: {meta_file}")
         return None
 
+    if strict:
+        return _build_phase(phase_slug, phase_dir, meta_file, strict=strict)
+
     try:
-        with open(meta_file, encoding="utf-8") as f:
-            data: dict = yaml.safe_load(f)
-
-        # The phase directory name is authoritative -- the loader injects
-        # the slug here rather than trusting any YAML field, so a file
-        # accidentally placed in the wrong directory still ends up tagged
-        # with that directory's slug.
-        data["slug"] = phase_slug
-
-        topic_slugs: list[str] = data.get("topics", [])
-        topics = [
-            t
-            for idx, slug in enumerate(topic_slugs)
-            if (t := _load_topic(phase_dir, slug, order=idx + 1)) is not None
-        ]
-        data["topic_slugs"] = topic_slugs
-        data["topics"] = topics
-
-        hov = data.get("hands_on_verification")
-        if isinstance(hov, dict):
-            requirement_slugs: list[str] = hov.get("requirements", []) or []
-            if not all(isinstance(s, str) for s in requirement_slugs):
-                raise ContentValidationError(
-                    f"phase '{phase_slug}' hands_on_verification.requirements "
-                    "must be a list of slug strings"
-                )
-            loaded_requirements = [
-                r
-                for slug in requirement_slugs
-                if (r := _load_requirement(phase_dir, slug)) is not None
-            ]
-            hov["requirement_slugs"] = requirement_slugs
-            hov["requirements"] = loaded_requirements
-
-        return Phase.model_validate(data)
+        return _build_phase(phase_slug, phase_dir, meta_file, strict=strict)
     except (yaml.YAMLError, ContentValidationError, ValueError, KeyError):
         logger.exception(
             "content.phase.load_failed",
@@ -205,27 +263,50 @@ def _load_phase(phase_slug: str) -> Phase | None:
         return None
 
 
+def _discover_phases(*, strict: bool) -> tuple[Phase, ...]:
+    """Load every phase directory under the content dir, in directory order."""
+    phases: list[Phase] = []
+    content_dir = _get_content_dir()
+    if not content_dir.exists():
+        if strict:
+            raise ContentValidationError(
+                f"content directory does not exist: {content_dir}"
+            )
+        return ()
+
+    for phase_dir in sorted(content_dir.iterdir()):
+        if phase_dir.is_dir() and phase_dir.name.startswith("phase"):
+            phase = _load_phase(phase_dir.name, strict=strict)
+            if phase:
+                phases.append(phase)
+
+    return tuple(sorted(phases, key=lambda p: p.order))
+
+
 @lru_cache(maxsize=1)
 def get_all_phases_from_yaml() -> tuple[Phase, ...]:
     """Get all phases in order from authored YAML files.
 
     Results are cached for performance. Dynamically discovers phase
-    directories (phase0, phase1, ...). Used by ``content_sync.py``
-    (deploy-time YAML to DB sync) and by the strict cross-file validators
-    invoked in CI.
+    directories (phase0, phase1, ...). Tolerant of broken individual
+    files (logs and skips) -- used by the API's process-level content
+    cache. Used by ``content_sync.py`` (deploy-time YAML to DB sync) and
+    by the strict cross-file validators invoked in CI.
     """
-    phases: list[Phase] = []
-    content_dir = _get_content_dir()
-    if not content_dir.exists():
-        return ()
+    return _discover_phases(strict=False)
 
-    for phase_dir in sorted(content_dir.iterdir()):
-        if phase_dir.is_dir() and phase_dir.name.startswith("phase"):
-            phase = _load_phase(phase_dir.name)
-            if phase:
-                phases.append(phase)
 
-    return tuple(sorted(phases, key=lambda p: p.order))
+def get_all_phases_from_yaml_strict() -> tuple[Phase, ...]:
+    """Get all phases in order, raising on any missing/malformed content.
+
+    Unlike ``get_all_phases_from_yaml``, this never silently skips a
+    broken file -- every phase, topic, and requirement must parse and
+    validate cleanly. Used by the deterministic curriculum artifact
+    compiler, which must fail the build rather than emit a
+    partially-populated artifact. Not cached: it's only invoked from a
+    one-shot compile step.
+    """
+    return _discover_phases(strict=True)
 
 
 def clear_cache() -> None:
@@ -361,18 +442,40 @@ def _check_requirement_slugs_globally_unique(
     return errors
 
 
-def validate_content() -> list[str]:
-    """Run all cross-file validators against the YAML-loaded content.
+def _check_phase_order_sequence(phases: tuple[Phase, ...]) -> list[str]:
+    """Return errors unless phase orders form a gapless 0..N-1 sequence.
+
+    Phase ``order`` is author-supplied in ``_phase.yaml`` (unlike topic
+    and step order, it isn't derived from list position), so it can
+    drift -- a duplicate or a gap would silently break the ``/phase/{order}``
+    URL contract and phase navigation.
+    """
+    orders = sorted(phase.order for phase in phases)
+    expected = list(range(len(phases)))
+    if orders == expected:
+        return []
+    return [
+        f"Phase orders must be a gapless 0..{len(phases) - 1} sequence with no "
+        f"duplicates; found {orders}"
+    ]
+
+
+def validate_content(phases: tuple[Phase, ...] | None = None) -> list[str]:
+    """Run all cross-file validators against the given (or YAML-loaded) content.
 
     Returns a list of error messages; empty list means no issues. Does
-    not raise -- callers (CI scripts, the sync step) decide how to
-    handle the result.
+    not raise -- callers (CI scripts, the sync step, the artifact
+    compiler) decide how to handle the result. Pass ``phases`` to
+    validate an already-loaded (e.g. strictly-loaded) tree instead of
+    re-reading the tolerant cached loader.
     """
-    phases = get_all_phases_from_yaml()
+    if phases is None:
+        phases = get_all_phases_from_yaml()
     errors: list[str] = []
     errors.extend(_check_uuid_uniqueness(phases))
     errors.extend(_check_topic_slugs_resolve(phases))
     errors.extend(_check_step_order_uniqueness(phases))
     errors.extend(_check_requirement_slugs_resolve(phases))
     errors.extend(_check_requirement_slugs_globally_unique(phases))
+    errors.extend(_check_phase_order_sequence(phases))
     return errors

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -409,6 +409,9 @@ class HealthResponse(BaseModel):
 
     status: str
     service: str
+    curriculum_version: int | None = None
+    artifact_schema_version: int | None = None
+    content_hash: str | None = None
 
 
 class StepCompletionResult(FrozenModel):

--- a/packages/learn-to-cloud-shared/tests/services/test_content_catalog.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_catalog.py
@@ -1,0 +1,212 @@
+"""Unit tests for the curriculum catalog (process-level artifact reader).
+
+Covers:
+- Catalog lookup indices (by UUID, by slug, by phase, active sets/counts)
+- Loading the real packaged artifact end to end
+- Schema compatibility (artifact_schema_version mismatch fails fast)
+- Strict failure on a missing/corrupted/tampered artifact
+- Process-level singleton caching
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from learn_to_cloud_shared.content_catalog import (
+    CurriculumCatalog,
+    CurriculumCatalogError,
+    clear_catalog_cache,
+    get_curriculum_catalog,
+    load_curriculum_catalog,
+)
+from learn_to_cloud_shared.content_compiler import (
+    ARTIFACT_SCHEMA_VERSION,
+    compile_curriculum_artifact,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _clear_catalog_cache():
+    clear_catalog_cache()
+    yield
+    clear_catalog_cache()
+
+
+@pytest.fixture
+def real_payload() -> dict:
+    """Compile the real authored curriculum for use as fake package data."""
+    return compile_curriculum_artifact()
+
+
+class _FakeResource:
+    """Minimal stand-in for the ``importlib.resources`` Traversable API."""
+
+    def __init__(self, text: str | None):
+        self._text = text
+
+    def is_file(self) -> bool:
+        return self._text is not None
+
+    def read_text(self, encoding: str = "utf-8") -> str:
+        assert self._text is not None
+        return self._text
+
+    def joinpath(self, *parts: str) -> _FakeResource:
+        return self
+
+
+def _patched_resource(text: str | None):
+    return patch(
+        "learn_to_cloud_shared.content_catalog.files",
+        autospec=True,
+        return_value=_FakeResource(text),
+    )
+
+
+class TestLoadCurriculumCatalog:
+    def test_loads_real_packaged_artifact(self):
+        """The artifact actually committed to the wheel loads cleanly."""
+        catalog = load_curriculum_catalog()
+        assert catalog.phase_count > 0
+        assert catalog.artifact_schema_version == ARTIFACT_SCHEMA_VERSION
+
+    def test_missing_artifact_raises(self):
+        with (
+            _patched_resource(None),
+            pytest.raises(CurriculumCatalogError, match="not found"),
+        ):
+            load_curriculum_catalog()
+
+    def test_invalid_json_raises(self):
+        with (
+            _patched_resource("{not valid json"),
+            pytest.raises(CurriculumCatalogError, match="not valid JSON"),
+        ):
+            load_curriculum_catalog()
+
+    def test_non_object_json_raises(self):
+        with (
+            _patched_resource("[1, 2, 3]"),
+            pytest.raises(CurriculumCatalogError, match="JSON object"),
+        ):
+            load_curriculum_catalog()
+
+    def test_schema_version_mismatch_raises(self, real_payload: dict):
+        bad_payload = {**real_payload, "artifact_schema_version": 999}
+        with (
+            _patched_resource(json.dumps(bad_payload)),
+            pytest.raises(CurriculumCatalogError, match="schema_version"),
+        ):
+            load_curriculum_catalog()
+
+    def test_missing_content_hash_raises(self, real_payload: dict):
+        bad_payload = {k: v for k, v in real_payload.items() if k != "content_hash"}
+        with (
+            _patched_resource(json.dumps(bad_payload)),
+            pytest.raises(CurriculumCatalogError, match="missing content_hash"),
+        ):
+            load_curriculum_catalog()
+
+    def test_tampered_payload_fails_hash_check(self, real_payload: dict):
+        """Hand-editing a field without recomputing the hash must be caught."""
+        tampered = json.loads(json.dumps(real_payload))
+        tampered["phases"][0]["name"] = "Tampered Name"
+        with (
+            _patched_resource(json.dumps(tampered)),
+            pytest.raises(CurriculumCatalogError, match="content_hash does not match"),
+        ):
+            load_curriculum_catalog()
+
+
+class TestCurriculumCatalogIndices:
+    @pytest.fixture
+    def catalog(self, real_payload: dict) -> CurriculumCatalog:
+        with _patched_resource(json.dumps(real_payload)):
+            return load_curriculum_catalog()
+
+    def test_phase_lookup_by_slug_and_order_agree(self, catalog: CurriculumCatalog):
+        phase0 = catalog.phases_by_slug["phase0"]
+        assert catalog.phases_by_order[phase0.order] is phase0
+
+    def test_topic_lookup_by_uuid_and_phase_slug_agree(
+        self, catalog: CurriculumCatalog
+    ):
+        phase0 = catalog.phases_by_slug["phase0"]
+        topic = phase0.topics[0]
+        assert catalog.topics_by_uuid[topic.uuid] is topic
+        assert catalog.topics_by_phase_and_slug[(phase0.slug, topic.slug)] is topic
+
+    def test_step_lookup_by_uuid_and_phase(self, catalog: CurriculumCatalog):
+        phase0 = catalog.phases_by_slug["phase0"]
+        topic = phase0.topics[0]
+        step = topic.learning_steps[0]
+        assert catalog.steps_by_uuid[step.uuid] is step
+        assert step in catalog.steps_by_phase_slug[phase0.slug]
+
+    def test_requirement_lookup_by_uuid_slug_and_phase(
+        self, catalog: CurriculumCatalog
+    ):
+        phase = next(p for p in catalog.phases if p.hands_on_verification)
+        req = phase.hands_on_verification.requirements[0]
+        assert catalog.requirements_by_uuid[req.uuid] is req
+        assert catalog.requirements_by_slug[req.slug] is req
+        assert req in catalog.requirements_by_phase_slug[phase.slug]
+
+    def test_active_uuid_sets_and_counts(self, catalog: CurriculumCatalog):
+        assert catalog.phase_count == len(catalog.phases)
+        assert catalog.topic_count == len(catalog.active_topic_uuids)
+        assert catalog.step_count == len(catalog.active_step_uuids)
+        assert catalog.requirement_count == len(catalog.active_requirement_uuids)
+        assert all(p.uuid in catalog.active_phase_uuids for p in catalog.phases)
+
+
+class TestCurriculumCatalogImmutability:
+    @pytest.fixture
+    def catalog(self, real_payload: dict) -> CurriculumCatalog:
+        with _patched_resource(json.dumps(real_payload)):
+            return load_curriculum_catalog()
+
+    @pytest.mark.parametrize(
+        "attr",
+        [
+            "phases_by_slug",
+            "phases_by_order",
+            "topics_by_uuid",
+            "topics_by_phase_and_slug",
+            "steps_by_uuid",
+            "steps_by_phase_slug",
+            "requirements_by_uuid",
+            "requirements_by_slug",
+            "requirements_by_phase_slug",
+        ],
+    )
+    def test_mapping_fields_reject_item_assignment(
+        self, catalog: CurriculumCatalog, attr: str
+    ):
+        mapping = getattr(catalog, attr)
+        some_key = next(iter(mapping))
+        with pytest.raises(TypeError):
+            mapping[some_key] = mapping[some_key]
+
+    def test_dataclass_fields_reject_reassignment(self, catalog: CurriculumCatalog):
+        with pytest.raises(AttributeError):
+            catalog.curriculum_version = 999
+
+
+class TestGetCurriculumCatalogSingleton:
+    def test_returns_same_instance_across_calls(self):
+        first = get_curriculum_catalog()
+        second = get_curriculum_catalog()
+        assert first is second
+
+    def test_clear_cache_forces_reload(self):
+        first = get_curriculum_catalog()
+        clear_catalog_cache()
+        second = get_curriculum_catalog()
+        assert first is not second
+        assert first == second

--- a/packages/learn-to-cloud-shared/tests/services/test_content_compiler.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_compiler.py
@@ -1,0 +1,373 @@
+"""Unit tests for the deterministic curriculum artifact compiler.
+
+Covers:
+- Compiler determinism (same YAML in -> byte-identical artifact out)
+- content_hash correctness (recomputes over the canonical payload)
+- Strict failure on missing/malformed/inconsistent content (fails
+  instead of skipping, unlike the tolerant YAML loader)
+- curriculum_version policy checks (unchanged/decrease/bump)
+- Compiling the real authored curriculum cleanly
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from learn_to_cloud_shared.content_compiler import (
+    ARTIFACT_SCHEMA_VERSION,
+    ContentCompileError,
+    compile_and_write,
+    compile_curriculum_artifact,
+    compute_content_hash,
+    render_artifact_file,
+)
+from learn_to_cloud_shared.content_yaml_loader import ContentValidationError
+
+pytestmark = pytest.mark.unit
+
+
+def _patched_content_dir(phases_dir: Path):
+    """Patch the content_yaml_loader's private content dir resolver."""
+    return patch(
+        "learn_to_cloud_shared.content_yaml_loader._get_content_dir",
+        autospec=True,
+        return_value=phases_dir,
+    )
+
+
+def _write_meta(content_root: Path, *, curriculum_version: object = 1) -> None:
+    (content_root / "curriculum.meta.yaml").write_text(
+        yaml.safe_dump({"curriculum_version": curriculum_version})
+    )
+
+
+def _write_minimal_phase(
+    phases_dir: Path,
+    *,
+    phase_uuid: str = "11111111-1111-1111-1111-111111111111",
+    order: int = 0,
+    topic_uuid: str = "22222222-2222-2222-2222-222222222222",
+    step_uuid: str = "33333333-3333-3333-3333-333333333333",
+    topic_slug: str = "basics",
+) -> None:
+    """Write a single-phase, single-topic, single-step content tree."""
+    phase_dir = phases_dir / "phase0"
+    phase_dir.mkdir(parents=True, exist_ok=True)
+    (phase_dir / "_phase.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "uuid": phase_uuid,
+                "name": "Phase Zero",
+                "order": order,
+                "topics": [topic_slug],
+            }
+        )
+    )
+    (phase_dir / f"{topic_slug}.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "uuid": topic_uuid,
+                "slug": topic_slug,
+                "name": "Basics",
+                "description": "Learn the basics",
+                "learning_steps": [
+                    {
+                        "uuid": step_uuid,
+                        "slug": "step-1",
+                        "order": 1,
+                        "title": "First step",
+                    }
+                ],
+            }
+        )
+    )
+
+
+@pytest.fixture
+def minimal_content_root(tmp_path: Path) -> Path:
+    """A tmp content/ root with phases/ + curriculum.meta.yaml, patched in."""
+    phases_dir = tmp_path / "phases"
+    phases_dir.mkdir()
+    _write_minimal_phase(phases_dir)
+    _write_meta(tmp_path)
+    return tmp_path
+
+
+class TestCompileCurriculumArtifact:
+    def test_compiles_minimal_curriculum(self, minimal_content_root: Path):
+        with _patched_content_dir(minimal_content_root / "phases"):
+            payload = compile_curriculum_artifact()
+
+        assert payload["artifact_schema_version"] == ARTIFACT_SCHEMA_VERSION
+        assert payload["curriculum_version"] == 1
+        assert len(payload["phases"]) == 1
+        assert payload["phases"][0]["slug"] == "phase0"
+        assert isinstance(payload["content_hash"], str)
+        assert len(payload["content_hash"]) == 64  # sha256 hex digest
+
+    def test_determinism_across_repeated_compiles(self, minimal_content_root: Path):
+        with _patched_content_dir(minimal_content_root / "phases"):
+            first = compile_curriculum_artifact()
+            second = compile_curriculum_artifact()
+
+        assert render_artifact_file(first) == render_artifact_file(second)
+        assert first == second
+
+    def test_content_hash_matches_recomputation(self, minimal_content_root: Path):
+        with _patched_content_dir(minimal_content_root / "phases"):
+            payload = compile_curriculum_artifact()
+
+        without_hash = {k: v for k, v in payload.items() if k != "content_hash"}
+        assert payload["content_hash"] == compute_content_hash(without_hash)
+
+    def test_array_order_is_meaningful_not_sorted(self, tmp_path: Path):
+        """Phases keep declared order, not e.g. alphabetical-by-uuid order."""
+        phases_dir = tmp_path / "phases"
+        phases_dir.mkdir()
+        for slug, order, phase_uuid in [
+            ("phase1", 1, "22222222-2222-2222-2222-222222222222"),
+            ("phase0", 0, "11111111-1111-1111-1111-111111111111"),
+        ]:
+            phase_dir = phases_dir / slug
+            phase_dir.mkdir()
+            (phase_dir / "_phase.yaml").write_text(
+                yaml.safe_dump({"uuid": phase_uuid, "name": slug, "order": order})
+            )
+        _write_meta(tmp_path)
+
+        with _patched_content_dir(phases_dir):
+            payload = compile_curriculum_artifact()
+
+        assert [p["slug"] for p in payload["phases"]] == ["phase0", "phase1"]
+
+    def test_real_authored_curriculum_compiles_cleanly(self):
+        """The actual repo content must compile without errors end to end."""
+        payload = compile_curriculum_artifact()
+        assert payload["artifact_schema_version"] == ARTIFACT_SCHEMA_VERSION
+        assert len(payload["phases"]) > 0
+
+
+class TestStrictFailure:
+    def test_missing_curriculum_meta_raises(self, tmp_path: Path):
+        phases_dir = tmp_path / "phases"
+        phases_dir.mkdir()
+        _write_minimal_phase(phases_dir)
+        # No curriculum.meta.yaml written.
+
+        with (
+            _patched_content_dir(phases_dir),
+            pytest.raises(ContentCompileError, match="missing curriculum metadata"),
+        ):
+            compile_curriculum_artifact()
+
+    def test_non_integer_curriculum_version_raises(self, tmp_path: Path):
+        phases_dir = tmp_path / "phases"
+        phases_dir.mkdir()
+        _write_minimal_phase(phases_dir)
+        _write_meta(tmp_path, curriculum_version="not-a-number")
+
+        with (
+            _patched_content_dir(phases_dir),
+            pytest.raises(ContentCompileError, match="positive integer"),
+        ):
+            compile_curriculum_artifact()
+
+    def test_non_positive_curriculum_version_raises(self, tmp_path: Path):
+        phases_dir = tmp_path / "phases"
+        phases_dir.mkdir()
+        _write_minimal_phase(phases_dir)
+        _write_meta(tmp_path, curriculum_version=0)
+
+        with (
+            _patched_content_dir(phases_dir),
+            pytest.raises(ContentCompileError, match="positive integer"),
+        ):
+            compile_curriculum_artifact()
+
+    def test_empty_curriculum_raises(self, tmp_path: Path):
+        phases_dir = tmp_path / "phases"
+        phases_dir.mkdir()
+        _write_meta(tmp_path)
+
+        with (
+            _patched_content_dir(phases_dir),
+            pytest.raises(ContentCompileError, match="no phases loaded"),
+        ):
+            compile_curriculum_artifact()
+
+    def test_missing_topic_file_raises_instead_of_skipping(self, tmp_path: Path):
+        """Unlike the tolerant loader, a dangling topic slug must fail loudly."""
+        phases_dir = tmp_path / "phases"
+        phase_dir = phases_dir / "phase0"
+        phase_dir.mkdir(parents=True)
+        (phase_dir / "_phase.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "uuid": "11111111-1111-1111-1111-111111111111",
+                    "name": "Phase Zero",
+                    "order": 0,
+                    "topics": ["missing-topic"],
+                }
+            )
+        )
+        _write_meta(tmp_path)
+
+        with (
+            _patched_content_dir(phases_dir),
+            pytest.raises(ContentValidationError, match="missing topic file"),
+        ):
+            compile_curriculum_artifact()
+
+    def test_malformed_yaml_raises(self, tmp_path: Path):
+        phases_dir = tmp_path / "phases"
+        phase_dir = phases_dir / "phase0"
+        phase_dir.mkdir(parents=True)
+        (phase_dir / "_phase.yaml").write_text("{not: valid: yaml: [")
+        _write_meta(tmp_path)
+
+        with (
+            _patched_content_dir(phases_dir),
+            pytest.raises(yaml.YAMLError),
+        ):
+            compile_curriculum_artifact()
+
+    def test_duplicate_uuid_raises(self, tmp_path: Path):
+        """Cross-file validation (uuid uniqueness) is reused, not duplicated."""
+        phases_dir = tmp_path / "phases"
+        shared_uuid = "11111111-1111-1111-1111-111111111111"
+        _write_minimal_phase(phases_dir, phase_uuid=shared_uuid, topic_uuid=shared_uuid)
+        _write_meta(tmp_path)
+
+        with (
+            _patched_content_dir(phases_dir),
+            pytest.raises(ContentCompileError, match="Duplicate uuid"),
+        ):
+            compile_curriculum_artifact()
+
+    def test_non_sequential_phase_order_raises(self, tmp_path: Path):
+        phases_dir = tmp_path / "phases"
+        phases_dir.mkdir()
+        for slug, order, phase_uuid in [
+            ("phase0", 0, "11111111-1111-1111-1111-111111111111"),
+            ("phase1", 2, "22222222-2222-2222-2222-222222222222"),
+        ]:
+            phase_dir = phases_dir / slug
+            phase_dir.mkdir()
+            (phase_dir / "_phase.yaml").write_text(
+                yaml.safe_dump({"uuid": phase_uuid, "name": slug, "order": order})
+            )
+        _write_meta(tmp_path)
+
+        with (
+            _patched_content_dir(phases_dir),
+            pytest.raises(ContentCompileError, match="gapless"),
+        ):
+            compile_curriculum_artifact()
+
+
+class TestVersionPolicy:
+    def _compile(self, phases_dir: Path) -> dict:
+        with _patched_content_dir(phases_dir):
+            return compile_curriculum_artifact()
+
+    def test_unchanged_payload_same_version_passes(
+        self, minimal_content_root: Path, tmp_path: Path
+    ):
+        previous = tmp_path / "previous.json"
+        previous.write_text(json.dumps(self._compile(minimal_content_root / "phases")))
+
+        with _patched_content_dir(minimal_content_root / "phases"):
+            payload = compile_curriculum_artifact(previous_artifact_path=previous)
+
+        assert payload["curriculum_version"] == 1
+
+    def test_changed_payload_same_version_raises(
+        self, minimal_content_root: Path, tmp_path: Path
+    ):
+        previous_payload = self._compile(minimal_content_root / "phases")
+        previous_payload["phases"][0]["name"] = "A Different Name"
+        previous = tmp_path / "previous.json"
+        previous.write_text(json.dumps(previous_payload))
+
+        with (
+            _patched_content_dir(minimal_content_root / "phases"),
+            pytest.raises(ContentCompileError, match="was not bumped"),
+        ):
+            compile_curriculum_artifact(previous_artifact_path=previous)
+
+    def test_version_decrease_raises(self, minimal_content_root: Path, tmp_path: Path):
+        previous_payload = self._compile(minimal_content_root / "phases")
+        previous_payload["curriculum_version"] = 5
+        previous = tmp_path / "previous.json"
+        previous.write_text(json.dumps(previous_payload))
+
+        with (
+            _patched_content_dir(minimal_content_root / "phases"),
+            pytest.raises(ContentCompileError, match="must not decrease"),
+        ):
+            compile_curriculum_artifact(previous_artifact_path=previous)
+
+    def test_changed_payload_higher_version_passes(self, tmp_path: Path):
+        phases_dir = tmp_path / "phases"
+        phases_dir.mkdir()
+        _write_minimal_phase(phases_dir)
+        _write_meta(tmp_path, curriculum_version=2)
+
+        previous = tmp_path / "previous.json"
+        previous.write_text(
+            json.dumps(
+                {
+                    "artifact_schema_version": ARTIFACT_SCHEMA_VERSION,
+                    "curriculum_version": 1,
+                    "phases": [],
+                    "content_hash": "irrelevant",
+                }
+            )
+        )
+
+        with _patched_content_dir(phases_dir):
+            payload = compile_curriculum_artifact(previous_artifact_path=previous)
+
+        assert payload["curriculum_version"] == 2
+
+    def test_missing_previous_artifact_never_blocks(
+        self, minimal_content_root: Path, tmp_path: Path
+    ):
+        previous = tmp_path / "does-not-exist.json"
+
+        with _patched_content_dir(minimal_content_root / "phases"):
+            payload = compile_curriculum_artifact(previous_artifact_path=previous)
+
+        assert payload["curriculum_version"] == 1
+
+
+class TestCompileAndWrite:
+    def test_writes_file_and_is_idempotent(self, minimal_content_root: Path):
+        with _patched_content_dir(minimal_content_root / "phases"):
+            path1 = compile_and_write()
+            contents1 = path1.read_text()
+            path2 = compile_and_write()
+            contents2 = path2.read_text()
+
+        assert path1 == path2
+        assert contents1 == contents2
+        assert contents1.endswith("\n")
+
+    def test_writes_to_explicit_output_path(
+        self, minimal_content_root: Path, tmp_path: Path
+    ):
+        target = tmp_path / "out" / "curriculum.json"
+        target.parent.mkdir()
+
+        with _patched_content_dir(minimal_content_root / "phases"):
+            written = compile_and_write(target)
+
+        assert written == target
+        assert json.loads(target.read_text())["artifact_schema_version"] == (
+            ARTIFACT_SCHEMA_VERSION
+        )


### PR DESCRIPTION
## Why

Curriculum was authored in YAML, copied into PostgreSQL, then read back at runtime. This layer creates one deterministic application artifact so later PRs can remove that duplicate database representation safely.

## What changed

- compile all curriculum YAML into canonical, versioned `curriculum.json`
- package the artifact with `learn-to-cloud-shared` and index it in `CurriculumCatalog`
- fail on malformed content, duplicate identifiers, broken references, or artifact drift
- load the catalog during API startup and expose its identity in health metadata
- add compiler, package-data, catalog, and determinism coverage

## Stack position

Foundation PR. Runtime curriculum reads still use PostgreSQL until #658.

## Validation

`uv run poe check`