### PR TITLE
Serve curriculum from packaged catalog

### DIFF
--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -171,14 +171,13 @@ def _status_error_response(message: str, *, status_code: int = 400) -> HTMLRespo
 
 async def _render_processing_card(
     request: Request,
-    db: DbSession,
     current_user: AuthenticatedUser,
     token_data: VerificationStatusToken,
     token: str,
     *,
     delay_seconds: int,
 ) -> HTMLResponse:
-    requirement = await get_requirement_by_slug(db, token_data.requirement_slug)
+    requirement = get_requirement_by_slug(token_data.requirement_slug)
     if requirement is None:
         return HTMLResponse(_reload_verification_html())
 
@@ -312,7 +311,6 @@ async def htmx_uncomplete_step(
 @limiter.limit("10/minute")
 async def htmx_submit_verification(
     request: Request,
-    db: DbSession,
     current_user: CurrentUser,
     requirement_slug: Annotated[str, Form(max_length=100)],
     submitted_value: Annotated[str, Form(max_length=2048)] = "",
@@ -329,7 +327,7 @@ async def htmx_submit_verification(
     user_id = current_user.user_id
     github_username = current_user.github_username
 
-    requirement = await get_requirement_by_slug(db, requirement_slug)
+    requirement = get_requirement_by_slug(requirement_slug)
 
     session_maker = request.app.state.session_maker
 
@@ -528,7 +526,6 @@ async def _start_async_job_and_render(
 @router.get("/verification/jobs/status", response_class=HTMLResponse)
 async def htmx_verification_job_status(
     request: Request,
-    db: DbSession,
     token: Annotated[str, Query(max_length=4096)],
     current_user: CurrentUser,
 ) -> HTMLResponse:
@@ -579,7 +576,6 @@ async def htmx_verification_job_status(
     if status in _ACTIVE_DURABLE_STATUSES:
         return await _render_processing_card(
             request,
-            db,
             current_user,
             token_data,
             token,
@@ -591,7 +587,7 @@ async def htmx_verification_job_status(
         if not deleted:
             return HTMLResponse(_reload_verification_html())
 
-        requirement = await get_requirement_by_slug(db, token_data.requirement_slug)
+        requirement = get_requirement_by_slug(token_data.requirement_slug)
         if requirement is None:
             return HTMLResponse(_reload_verification_html())
 

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -73,7 +73,7 @@ async def home_page(
 ) -> HTMLResponse:
     """Home page with phase overview."""
     user = await _get_user_or_none(db, user_id)
-    phases = await get_curriculum_overview(db)
+    phases = get_curriculum_overview()
 
     return templates.TemplateResponse(
         request,
@@ -90,7 +90,7 @@ async def curriculum_page(
 ) -> HTMLResponse:
     """Full curriculum overview with all phases and topics."""
     user = await _get_user_or_none(db, user_id)
-    phases = await get_curriculum_overview(db)
+    phases = get_curriculum_overview()
 
     return templates.TemplateResponse(
         request,
@@ -112,7 +112,7 @@ async def phase_page(
 ) -> HTMLResponse:
     """Single phase detail with topics and verification (requires auth)."""
     user = await _get_user_or_none(db, user_id)
-    phase = await get_phase_by_slug(db, f"phase{phase_id}")
+    phase = get_phase_by_slug(f"phase{phase_id}")
     if phase is None:
         return templates.TemplateResponse(
             request,
@@ -211,7 +211,7 @@ async def topic_page(
     """Single topic with learning steps (requires auth)."""
     user = await _get_user_or_none(db, user_id)
     phase_slug = f"phase{phase_id}"
-    phase = await get_phase_by_slug(db, phase_slug)
+    phase = get_phase_by_slug(phase_slug)
     topic = None
     if phase is not None:
         topic = next((t for t in phase.topics if t.slug == topic_slug), None)

--- a/api/src/learn_to_cloud/services/dashboard_service.py
+++ b/api/src/learn_to_cloud/services/dashboard_service.py
@@ -46,7 +46,7 @@ async def get_dashboard_data(
     Returns phase list, overall stats, and continue-phase pointer.
     For unauthenticated users, returns phases only with zeroed stats.
     """
-    phases = await get_curriculum_overview(db)
+    phases = get_curriculum_overview()
 
     if user_id is None:
         return DashboardData(

--- a/api/src/learn_to_cloud/services/progress_service.py
+++ b/api/src/learn_to_cloud/services/progress_service.py
@@ -7,13 +7,15 @@ Progress is a derived value, not stored state:
 Data sources:
 - Step completions: ``step_progress`` table (canonical)
 - Hands-on validations: ``submissions`` table (canonical)
-- Curriculum shape: DB-backed via ``content_service`` (synced from YAML
-  at deploy time)
+- Curriculum shape: packaged catalog via ``content_service`` (in-memory,
+  no DB reads)
 """
 
 import logging
+from collections import defaultdict
 from uuid import UUID
 
+from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
 from learn_to_cloud_shared.content_service import (
     get_curriculum_overview,
     get_required_step_counts_by_phase,
@@ -64,12 +66,13 @@ async def fetch_user_progress(
     *,
     phase_overview: tuple[PhaseOverview, ...] | None = None,
 ) -> UserProgress:
-    """Fetch complete progress data for a user, via SQL aggregate queries.
+    """Fetch complete progress data for a user, via two learner-state queries.
 
-    Computes per-phase totals with GROUP BY queries instead of loading
-    the full curriculum tree and walking it in Python. Only the
-    canonical phase list (order + name, shape B) is needed to know
-    which phases exist at all.
+    Reads only ``step_progress``/``submissions`` UUIDs for this user (no
+    curriculum-table joins), then groups them by phase order in Python
+    using the packaged catalog's ``phase_order_by_step_uuid`` /
+    ``phase_order_by_requirement_uuid`` maps. A stale/retired UUID (not
+    in the catalog) is simply absent from those maps and drops out.
 
     Args:
         db: Database session.
@@ -80,21 +83,29 @@ async def fetch_user_progress(
     Returns a UserProgress object with all phase completion data.
     """
     if phase_overview is None:
-        phase_overview = await get_curriculum_overview(db)
+        phase_overview = get_curriculum_overview()
 
-    phase_order_by_uuid = {phase.uuid: phase.order for phase in phase_overview}
-    req_index = await load_requirement_index(
-        db, phase_order_by_uuid=phase_order_by_uuid
-    )
-    required_steps_by_phase = await get_required_step_counts_by_phase(db)
+    req_index = load_requirement_index()
+    required_steps_by_phase = get_required_step_counts_by_phase()
+    catalog = get_curriculum_catalog()
 
     sub_repo = SubmissionRepository(db)
-    validated_by_phase = await sub_repo.count_validated_by_phase_for_user(user_id)
+    validated_req_uuids = await sub_repo.get_validated_requirement_uuids(user_id)
+    validated_by_phase: dict[int, int] = defaultdict(int)
+    for req_uuid in validated_req_uuids:
+        phase_order = catalog.phase_order_by_requirement_uuid.get(req_uuid)
+        if phase_order is not None:
+            validated_by_phase[phase_order] += 1
 
     step_repo = StepProgressRepository(db)
-    completed_steps_by_phase = await step_repo.count_completed_steps_by_phase_for_user(
-        user_id
+    completed_step_uuids = await step_repo.get_completed_step_uuids(
+        user_id, catalog.active_step_uuids
     )
+    completed_steps_by_phase: dict[int, int] = defaultdict(int)
+    for step_uuid in completed_step_uuids:
+        phase_order = catalog.phase_order_by_step_uuid.get(step_uuid)
+        if phase_order is not None:
+            completed_steps_by_phase[phase_order] += 1
 
     phase_progress_map: dict[int, PhaseProgress] = {}
     for phase in phase_overview:

--- a/api/src/learn_to_cloud/services/stats_service.py
+++ b/api/src/learn_to_cloud/services/stats_service.py
@@ -12,6 +12,7 @@ GitHub helper.
 
 import logging
 
+from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
 from learn_to_cloud_shared.content_service import (
     get_curriculum_overview,
     get_requirement_counts_by_phase,
@@ -33,12 +34,15 @@ logger = logging.getLogger(__name__)
 
 async def get_stats_page_data(db: AsyncSession) -> StatsPageData:
     """Build the full /stats payload."""
-    phases = await get_curriculum_overview(db)
+    phases = get_curriculum_overview()
     phase_names = {phase.order: phase.name for phase in phases}
 
-    requirement_counts = await get_requirement_counts_by_phase(db)
+    requirement_counts = get_requirement_counts_by_phase()
+    phase_order_by_requirement_uuid = (
+        get_curriculum_catalog().phase_order_by_requirement_uuid
+    )
     completions = await SubmissionRepository(db).list_phase_completions(
-        requirement_counts
+        requirement_counts, phase_order_by_requirement_uuid
     )
 
     # Group completions into a per-phase set of completer ids.

--- a/api/src/learn_to_cloud/services/steps_service.py
+++ b/api/src/learn_to_cloud/services/steps_service.py
@@ -32,15 +32,14 @@ class StepNotFoundError(StepValidationError):
         super().__init__(f"Unknown step_uuid: {step_uuid}")
 
 
-async def _find_step(db: AsyncSession, step_uuid: UUID) -> tuple["Topic", LearningStep]:
+def _find_step(step_uuid: UUID) -> tuple["Topic", LearningStep]:
     """Resolve a step UUID to its parent topic + step model.
 
-    Scoped to one topic's subtree (a single indexed lookup plus a
-    handful of sibling steps), not the entire curriculum tree. Raises
-    :class:`StepNotFoundError` for unknown/soft-deleted UUIDs, keeping
+    In-memory catalog lookup, not the entire curriculum tree walked per
+    call. Raises :class:`StepNotFoundError` for unknown UUIDs, keeping
     the surface uniform with the verification request paths.
     """
-    result = await get_topic_containing_step(db, step_uuid)
+    result = get_topic_containing_step(step_uuid)
     if result is None:
         raise StepNotFoundError(step_uuid)
     return result
@@ -72,7 +71,7 @@ async def complete_step(
     that topic) tuple so the HTMX caller can re-render the step partial
     and the topic progress bar without re-loading the curriculum.
     """
-    topic, step = await _find_step(db, step_uuid)
+    topic, step = _find_step(step_uuid)
 
     step_repo = StepProgressRepository(db)
     step_progress = await step_repo.create_if_not_exists(
@@ -125,7 +124,7 @@ async def uncomplete_step(
     Raises:
         StepNotFoundError: If step_uuid doesn't exist in active content.
     """
-    topic, step = await _find_step(db, step_uuid)
+    topic, step = _find_step(step_uuid)
 
     step_repo = StepProgressRepository(db)
     deleted = await step_repo.delete_step(user_id, step.uuid)

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -160,20 +160,21 @@ async def _check_submission_preconditions(
 
     Validates requirement existence, already-validated status, and phase gating.
 
-    Opens a short-lived DB session for reads, then releases it before returning.
+    Opens a short-lived DB session for the learner-state reads (existing
+    submission, prior-phase validation), then releases it before returning.
     """
+    index = load_requirement_index()
+    requirement = index.by_slug.get(requirement_slug)
+    if not requirement:
+        raise RequirementNotFoundError(f"Requirement not found: {requirement_slug}")
+
+    phase_order = index.phase_order_by_req_slug.get(requirement_slug)
+    if phase_order is None:
+        raise RequirementNotFoundError(
+            f"Requirement not mapped to a phase: {requirement_slug}"
+        )
+
     async with session_maker() as read_session:
-        index = await load_requirement_index(read_session)
-        requirement = index.by_slug.get(requirement_slug)
-        if not requirement:
-            raise RequirementNotFoundError(f"Requirement not found: {requirement_slug}")
-
-        phase_order = index.phase_order_by_req_slug.get(requirement_slug)
-        if phase_order is None:
-            raise RequirementNotFoundError(
-                f"Requirement not mapped to a phase: {requirement_slug}"
-            )
-
         submission_repo = SubmissionRepository(read_session)
 
         existing = await submission_repo.get_by_user_and_requirement(
@@ -271,8 +272,7 @@ async def run_submit_smoke_check(
 
     Returns the slug it exercised so callers can log what was checked.
     """
-    async with session_maker() as read_session:
-        index = await load_requirement_index(read_session)
+    index = load_requirement_index()
 
     requirement = _pick_smoke_requirement(index)
 

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -265,7 +265,6 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
-                AsyncMock(),
                 current_user,
                 requirement_slug="req-1",
                 submitted_value="https://github.com/user/repo",
@@ -299,7 +298,6 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
-                AsyncMock(),
                 current_user,
                 requirement_slug="req-1",
                 submitted_value="test",
@@ -355,7 +353,6 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
-                AsyncMock(),
                 current_user,
                 requirement_slug="req-1",
                 submitted_value="https://github.com/user/repo",
@@ -413,7 +410,6 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
-                AsyncMock(),
                 current_user,
                 requirement_slug="req-1",
                 submitted_value="https://github.com/user/repo",
@@ -478,7 +474,6 @@ class TestHtmxSubmitVerification:
         ):
             await htmx_submit_verification(
                 request,
-                AsyncMock(),
                 current_user,
                 requirement_slug="req-1",
                 submitted_value="https://github.com/user/repo",
@@ -534,7 +529,6 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
-                AsyncMock(),
                 current_user,
                 requirement_slug="req-1",
                 submitted_value="https://github.com/user/repo",
@@ -604,7 +598,6 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
-                AsyncMock(),
                 current_user,
                 requirement_slug="deployment-architecture",
                 architecture_description=long_description,
@@ -639,7 +632,6 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
-                AsyncMock(),
                 current_user,
                 requirement_slug="deployment-architecture",
                 architecture_description="   ",
@@ -686,7 +678,6 @@ class TestHtmxSubmitVerification:
         ):
             result = await htmx_submit_verification(
                 request,
-                AsyncMock(),
                 current_user,
                 requirement_slug="req-1",
                 submitted_value="https://github.com/user/repo",
@@ -727,7 +718,6 @@ class TestHtmxVerificationJobStatus:
         ):
             result = await htmx_verification_job_status(
                 request,
-                AsyncMock(),
                 token="signed-token",
                 current_user=current_user,
             )
@@ -762,7 +752,6 @@ class TestHtmxVerificationJobStatus:
         ):
             result = await htmx_verification_job_status(
                 request,
-                AsyncMock(),
                 token="signed-token",
                 current_user=current_user,
             )
@@ -814,7 +803,6 @@ class TestHtmxVerificationJobStatus:
 
             result = await htmx_verification_job_status(
                 request,
-                AsyncMock(),
                 token="signed-token",
                 current_user=current_user,
             )
@@ -873,7 +861,6 @@ class TestHtmxVerificationJobStatus:
 
             result = await htmx_verification_job_status(
                 request,
-                AsyncMock(),
                 token="signed-token",
                 current_user=current_user,
             )
@@ -918,7 +905,6 @@ class TestHtmxVerificationJobStatus:
 
             result = await htmx_verification_job_status(
                 request,
-                AsyncMock(),
                 token="signed-token",
                 current_user=current_user,
             )

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -84,7 +84,6 @@ class TestHomePage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_curriculum_overview",
-                new_callable=AsyncMock,
                 return_value=phases,
             ),
             patch(
@@ -112,7 +111,6 @@ class TestHomePage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_curriculum_overview",
-                new_callable=AsyncMock,
                 return_value=phases,
             ),
             patch(
@@ -140,7 +138,6 @@ class TestCurriculumPage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_curriculum_overview",
-                new_callable=AsyncMock,
                 return_value=phases,
             ),
             patch(
@@ -168,7 +165,6 @@ class TestPhasePage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
-                new_callable=AsyncMock,
                 return_value=None,
             ),
             patch(
@@ -198,7 +194,6 @@ class TestPhasePage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
-                new_callable=AsyncMock,
                 return_value=phase,
             ),
             patch(
@@ -253,7 +248,6 @@ class TestTopicPage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
-                new_callable=AsyncMock,
                 return_value=None,
             ),
             patch(
@@ -278,7 +272,6 @@ class TestTopicPage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
-                new_callable=AsyncMock,
                 return_value=phase,
             ),
             patch(
@@ -304,7 +297,6 @@ class TestTopicPage:
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
-                new_callable=AsyncMock,
                 return_value=phase,
             ),
             patch(

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -105,18 +105,11 @@ async def _patched_content():
         for phase in yaml_phases
     )
 
-    async def _curriculum_overview(_db):
+    def _curriculum_overview():
         return yaml_overview
 
-    async def _phase_by_slug(_db, slug):
+    def _phase_by_slug(slug):
         return next((p for p in yaml_phases if p.slug == slug), None)
-
-    async def _topic_by_id(_db, topic_id):
-        for phase in yaml_phases:
-            for topic in phase.topics:
-                if topic.slug == topic_id:
-                    return topic
-        return None
 
     with (
         patch(

--- a/api/tests/services/test_dashboard_service.py
+++ b/api/tests/services/test_dashboard_service.py
@@ -334,7 +334,7 @@ class TestGetDashboardDataQueryCount:
         db_session.add(user)
         await db_session.flush()
 
-        req_index = await load_requirement_index(db_session)
+        req_index = load_requirement_index()
         first_phase_order = min(req_index.by_phase_order)
         reqs = req_index.requirements_for_phase(first_phase_order)
         if reqs:
@@ -380,7 +380,8 @@ class TestGetDashboardDataQueryCount:
             result = await get_dashboard_data(db_session, user_id=user.id)
 
         assert result.total_phases > 0
-        # Small, fixed number of aggregate/overview queries -- not one row
-        # scan per step. See progress_service.fetch_user_progress /
-        # dashboard_service.get_dashboard_data for the exact breakdown.
-        assert len(statements) == 6
+        # Small, fixed number of learner-state aggregate queries -- curriculum
+        # shape comes from the in-memory catalog now, so this counts only the
+        # two SQL aggregates over step_progress/submissions. See
+        # progress_service.fetch_user_progress for the exact breakdown.
+        assert len(statements) == 2

--- a/api/tests/services/test_progress_service.py
+++ b/api/tests/services/test_progress_service.py
@@ -7,7 +7,7 @@ Tests cover:
 - fetch_phase_progress per-topic breakdown
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -178,22 +178,29 @@ class TestFetchUserProgress:
         phase_overview = (
             PhaseOverview(uuid=uuid4(), name="Phase 0", slug="phase0", order=0),
         )
+        step_uuid = uuid4()
+        fake_catalog = MagicMock(
+            active_step_uuids=frozenset({step_uuid}),
+            phase_order_by_step_uuid={step_uuid: 0},
+            phase_order_by_requirement_uuid={},
+        )
 
         with (
             patch(
                 "learn_to_cloud.services.progress_service.get_curriculum_overview",
-                new_callable=AsyncMock,
                 return_value=phase_overview,
             ),
             patch(
                 "learn_to_cloud.services.progress_service.get_required_step_counts_by_phase",
-                new_callable=AsyncMock,
                 return_value={0: 3},
             ),
             patch(
                 "learn_to_cloud.services.progress_service.load_requirement_index",
-                new_callable=AsyncMock,
                 return_value=RequirementIndex(),
+            ),
+            patch(
+                "learn_to_cloud.services.progress_service.get_curriculum_catalog",
+                return_value=fake_catalog,
             ),
             patch(
                 "learn_to_cloud.services.progress_service.SubmissionRepository",
@@ -204,16 +211,81 @@ class TestFetchUserProgress:
                 autospec=True,
             ) as MockStepRepo,
         ):
-            MockSubRepo.return_value.count_validated_by_phase_for_user = AsyncMock(
-                return_value={}
+            MockSubRepo.return_value.get_validated_requirement_uuids = AsyncMock(
+                return_value=set()
             )
-            MockStepRepo.return_value.count_completed_steps_by_phase_for_user = (
-                AsyncMock(return_value={0: 1})
+            MockStepRepo.return_value.get_completed_step_uuids = AsyncMock(
+                return_value={step_uuid}
             )
             result = await fetch_user_progress(AsyncMock(), user_id=1)
             assert result.user_id == 1
             assert result.phases[0].steps_completed == 1
             assert result.phases[0].steps_required == 3
+
+    @pytest.mark.asyncio
+    async def test_groups_hands_on_validations_by_phase_and_ignores_stale_uuids(self):
+        """Validated/completed UUIDs no longer in the catalog are dropped.
+
+        Simulates a retired step and a retired requirement (validated by
+        the user in the past, but absent from ``phase_order_by_*_uuid``
+        because the content was since removed) alongside one current
+        step and one current requirement, each in a different phase.
+        """
+        from learn_to_cloud_shared.requirements import RequirementIndex
+        from learn_to_cloud_shared.schemas import PhaseOverview
+
+        phase_overview = (
+            PhaseOverview(uuid=uuid4(), name="Phase 0", slug="phase0", order=0),
+            PhaseOverview(uuid=uuid4(), name="Phase 1", slug="phase1", order=1),
+        )
+        current_step_uuid = uuid4()
+        stale_step_uuid = uuid4()
+        current_req_uuid = uuid4()
+        stale_req_uuid = uuid4()
+        fake_catalog = MagicMock(
+            active_step_uuids=frozenset({current_step_uuid}),
+            phase_order_by_step_uuid={current_step_uuid: 0},
+            phase_order_by_requirement_uuid={current_req_uuid: 1},
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.services.progress_service.get_curriculum_overview",
+                return_value=phase_overview,
+            ),
+            patch(
+                "learn_to_cloud.services.progress_service.get_required_step_counts_by_phase",
+                return_value={0: 1, 1: 0},
+            ),
+            patch(
+                "learn_to_cloud.services.progress_service.load_requirement_index",
+                return_value=RequirementIndex(),
+            ),
+            patch(
+                "learn_to_cloud.services.progress_service.get_curriculum_catalog",
+                return_value=fake_catalog,
+            ),
+            patch(
+                "learn_to_cloud.services.progress_service.SubmissionRepository",
+                autospec=True,
+            ) as MockSubRepo,
+            patch(
+                "learn_to_cloud.services.progress_service.StepProgressRepository",
+                autospec=True,
+            ) as MockStepRepo,
+        ):
+            MockSubRepo.return_value.get_validated_requirement_uuids = AsyncMock(
+                return_value={current_req_uuid, stale_req_uuid}
+            )
+            MockStepRepo.return_value.get_completed_step_uuids = AsyncMock(
+                return_value={current_step_uuid, stale_step_uuid}
+            )
+            result = await fetch_user_progress(AsyncMock(), user_id=1)
+
+        # Only UUIDs mapped by the catalog count toward a phase; stale
+        # step/requirement UUIDs (not in phase_order_by_*_uuid) drop out.
+        assert result.phases[0].steps_completed == 1
+        assert result.phases[1].hands_on_validated == 1
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/services/test_stats_service.py
+++ b/api/tests/services/test_stats_service.py
@@ -75,7 +75,7 @@ class TestGetStatsPageData:
         clear_cache()
         await sync_curriculum_to_db(db_session)
         reqs_by_phase = await _reqs_by_phase(db_session)
-        counts = await get_requirement_counts_by_phase(db_session)
+        counts = get_requirement_counts_by_phase()
         completable = sorted(o for o, c in counts.items() if c > 0)
 
         # graduate: validates every requirement in every completable phase.

--- a/api/tests/services/test_steps_service.py
+++ b/api/tests/services/test_steps_service.py
@@ -45,7 +45,6 @@ class TestCompleteStep:
         with (
             patch(
                 "learn_to_cloud.services.steps_service.get_topic_containing_step",
-                new_callable=AsyncMock,
                 return_value=(topic, step),
             ),
             patch(
@@ -69,7 +68,6 @@ class TestCompleteStep:
     async def test_unknown_step_raises(self):
         with patch(
             "learn_to_cloud.services.steps_service.get_topic_containing_step",
-            new_callable=AsyncMock,
             return_value=None,
         ):
             with pytest.raises(StepNotFoundError):
@@ -86,7 +84,6 @@ class TestUncompleteStep:
         with (
             patch(
                 "learn_to_cloud.services.steps_service.get_topic_containing_step",
-                new_callable=AsyncMock,
                 return_value=(topic, step),
             ),
             patch(

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -146,7 +146,6 @@ class TestSubmissionValidationErrors:
         with (
             patch(
                 "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
                 return_value=_build_index(None),
             ),
             pytest.raises(RequirementNotFoundError),
@@ -170,7 +169,6 @@ class TestAlreadyValidatedShortCircuit:
         with (
             patch(
                 "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
                 return_value=_build_index(mock_requirement),
             ),
             patch(
@@ -201,7 +199,6 @@ class TestAlreadyValidatedShortCircuit:
         with (
             patch(
                 "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
                 return_value=_build_index(mock_requirement),
             ),
             patch(
@@ -251,7 +248,6 @@ class TestSequentialPhaseGating:
         with (
             patch(
                 "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
                 return_value=_build_index(
                     mock_requirement,
                     phase_id=4,
@@ -291,7 +287,6 @@ class TestSequentialPhaseGating:
         with (
             patch(
                 "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
                 return_value=_build_index(
                     mock_requirement,
                     phase_id=4,
@@ -348,7 +343,6 @@ class TestCreateVerificationJob:
         with (
             patch(
                 "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
                 return_value=_build_index(mock_requirement),
             ),
             patch(
@@ -394,7 +388,6 @@ class TestCreateVerificationJob:
         with (
             patch(
                 "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
                 return_value=_build_index(mock_requirement),
             ),
             patch(
@@ -439,7 +432,6 @@ class TestCreateVerificationJob:
         with (
             patch(
                 "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
                 return_value=_build_index(mock_requirement),
             ),
             patch(
@@ -642,7 +634,6 @@ class TestRunSubmitSmokeCheck:
         with (
             patch(
                 "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
                 return_value=_build_index(mock_requirement),
             ),
             patch(
@@ -678,7 +669,6 @@ class TestRunSubmitSmokeCheck:
         with (
             patch(
                 "learn_to_cloud.services.submissions_service.load_requirement_index",
-                new_callable=AsyncMock,
                 return_value=_build_index(mock_requirement),
             ),
             patch(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_catalog.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_catalog.py
@@ -2,15 +2,15 @@
 
 Loads the packaged ``curriculum.json`` artifact (see
 ``content_compiler.py``) once per process and builds indexed lookups
-over it (by UUID, by slug, by phase). This is separate from -- and does
-not replace -- the DB-backed runtime reads in ``content_service``. It
-exists so the API can fail fast at startup if the packaged artifact is
-missing, stale, or corrupted, and so callers that only need curriculum
-identity or structural metadata don't have to touch the database.
+over it (by UUID, by slug, by phase). This is the production reader for
+request-serving curriculum reads (see ``content_service``); it exists so
+the API can fail fast at startup if the packaged artifact is missing,
+stale, or corrupted, and so callers never touch the database just to
+read curriculum shape.
 
-Do not wire this into request-serving curriculum reads yet -- the DB
-loader remains the production reader until a follow-up PR switches it
-over.
+The PostgreSQL curriculum tables (populated by ``content_sync.py`` at
+deploy time) and ``content_db_loader.py`` remain in place as a
+compatibility shadow, but no request path reads them anymore.
 """
 
 from __future__ import annotations
@@ -74,6 +74,18 @@ class CurriculumCatalog:
     steps_by_phase_slug: Mapping[str, tuple[LearningStep, ...]] = field(
         default_factory=lambda: _EMPTY_MAPPING
     )
+    #: Resolves a step UUID straight to its owning topic (with sibling
+    #: steps), so callers don't walk every topic to find the one that
+    #: contains a given step.
+    topic_by_step_uuid: Mapping[UUID, Topic] = field(
+        default_factory=lambda: _EMPTY_MAPPING
+    )
+    #: Resolves a step UUID straight to its owning phase's order, so
+    #: per-user progress aggregation can group learner-state UUIDs by
+    #: phase without a curriculum-table join.
+    phase_order_by_step_uuid: Mapping[UUID, int] = field(
+        default_factory=lambda: _EMPTY_MAPPING
+    )
     requirements_by_uuid: Mapping[UUID, HandsOnRequirement] = field(
         default_factory=lambda: _EMPTY_MAPPING
     )
@@ -81,6 +93,11 @@ class CurriculumCatalog:
         default_factory=lambda: _EMPTY_MAPPING
     )
     requirements_by_phase_slug: Mapping[str, tuple[HandsOnRequirement, ...]] = field(
+        default_factory=lambda: _EMPTY_MAPPING
+    )
+    #: Resolves a requirement UUID straight to its owning phase's order,
+    #: the cross-user stats mirror of ``phase_order_by_step_uuid``.
+    phase_order_by_requirement_uuid: Mapping[UUID, int] = field(
         default_factory=lambda: _EMPTY_MAPPING
     )
     active_phase_uuids: frozenset[UUID] = field(default_factory=frozenset)
@@ -120,9 +137,12 @@ class CurriculumCatalog:
         topics_by_phase_and_slug: dict[tuple[str, str], Topic] = {}
         steps_by_uuid: dict[UUID, LearningStep] = {}
         steps_by_phase_slug: dict[str, list[LearningStep]] = {}
+        topic_by_step_uuid: dict[UUID, Topic] = {}
+        phase_order_by_step_uuid: dict[UUID, int] = {}
         requirements_by_uuid: dict[UUID, HandsOnRequirement] = {}
         requirements_by_slug: dict[str, HandsOnRequirement] = {}
         requirements_by_phase_slug: dict[str, list[HandsOnRequirement]] = {}
+        phase_order_by_requirement_uuid: dict[UUID, int] = {}
 
         for phase in phases:
             phases_by_slug[phase.slug] = phase
@@ -136,12 +156,15 @@ class CurriculumCatalog:
                 for step in topic.learning_steps:
                     steps_by_uuid[step.uuid] = step
                     steps_by_phase_slug[phase.slug].append(step)
+                    topic_by_step_uuid[step.uuid] = topic
+                    phase_order_by_step_uuid[step.uuid] = phase.order
 
             if phase.hands_on_verification:
                 for req in phase.hands_on_verification.requirements:
                     requirements_by_uuid[req.uuid] = req
                     requirements_by_slug[req.slug] = req
                     requirements_by_phase_slug[phase.slug].append(req)
+                    phase_order_by_requirement_uuid[req.uuid] = phase.order
 
         return cls(
             artifact_schema_version=artifact_schema_version,
@@ -156,10 +179,15 @@ class CurriculumCatalog:
             steps_by_phase_slug=MappingProxyType(
                 {slug: tuple(steps) for slug, steps in steps_by_phase_slug.items()}
             ),
+            topic_by_step_uuid=MappingProxyType(topic_by_step_uuid),
+            phase_order_by_step_uuid=MappingProxyType(phase_order_by_step_uuid),
             requirements_by_uuid=MappingProxyType(requirements_by_uuid),
             requirements_by_slug=MappingProxyType(requirements_by_slug),
             requirements_by_phase_slug=MappingProxyType(
                 {slug: tuple(reqs) for slug, reqs in requirements_by_phase_slug.items()}
+            ),
+            phase_order_by_requirement_uuid=MappingProxyType(
+                phase_order_by_requirement_uuid
             ),
             active_phase_uuids=frozenset(p.uuid for p in phases),
             active_topic_uuids=frozenset(topics_by_uuid),

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_compiler.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_compiler.py
@@ -28,9 +28,9 @@ The artifact is:
   except the hash field itself), letting any consumer verify the
   artifact wasn't corrupted or hand-edited.
 
-This module does not affect runtime curriculum reads -- those still go
-through ``content_service`` (DB-backed). See ``content_catalog.py`` for
-the process-level reader of the compiled artifact.
+This module does not affect runtime curriculum reads directly -- those
+go through ``content_service``, which reads the compiled artifact via
+``content_catalog.py`` (the process-level reader of this artifact).
 """
 
 from __future__ import annotations

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py
@@ -1,15 +1,15 @@
-"""Public curriculum read API (DB-backed).
+"""Public curriculum read API (catalog-backed).
 
-After Phase C (issue #461), runtime reads in the API go through the DB
-loader populated at deploy time by ``content_sync.py``. This module
-provides the thin async wrappers callers use: pass an
-``AsyncSession`` and get back the same Pydantic shape the YAML loader
-used to return.
+Runtime reads in the API go through the packaged, process-level
+:class:`~learn_to_cloud_shared.content_catalog.CurriculumCatalog`
+instead of the database. The catalog is loaded once per process (at
+startup, and lazily via ``get_curriculum_catalog``'s ``lru_cache``), so
+every function here is a synchronous, in-memory lookup -- no
+``AsyncSession``, no I/O.
 
-Per-request loads are uncached by design -- the curriculum is small
-(~466 active rows, all indexed, 5 simple SELECTs) and a process-level
-cache without invalidation creates a class of stale-data bugs we want
-to avoid.
+The PostgreSQL curriculum tables and ``content_db_loader.py`` remain in
+place (populated at deploy time by ``content_sync.py``) as a
+compatibility shadow, but no request path reads them.
 
 For the deploy-time YAML to DB sync and the strict cross-file
 validators, use ``learn_to_cloud_shared.content_yaml_loader``.
@@ -19,76 +19,85 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from learn_to_cloud_shared.content_db_loader import (
-    load_all_phases_from_db,
-    load_curriculum_overview_from_db,
-    load_phase_by_slug_from_db,
-    load_required_step_counts_by_phase_from_db,
-    load_requirement_counts_by_phase_from_db,
-    load_requirements_by_phase_order_from_db,
-    load_topic_containing_step_from_db,
-)
+from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
 from learn_to_cloud_shared.schemas import (
     HandsOnRequirement,
     LearningStep,
     Phase,
     PhaseOverview,
     Topic,
+    TopicOverview,
 )
 
 
-async def get_all_phases(db: AsyncSession) -> tuple[Phase, ...]:
-    """Get all active phases in order, with nested topics and requirements."""
-    return await load_all_phases_from_db(db)
+def get_all_phases() -> tuple[Phase, ...]:
+    """Get all phases in order, with nested topics and requirements."""
+    return get_curriculum_catalog().phases
 
 
-async def get_phase_by_slug(db: AsyncSession, slug: str) -> Phase | None:
+def get_phase_by_slug(slug: str) -> Phase | None:
     """Get a phase by its slug (e.g. ``phase1``)."""
-    return await load_phase_by_slug_from_db(db, slug)
+    return get_curriculum_catalog().phases_by_slug.get(slug)
 
 
-async def get_curriculum_overview(db: AsyncSession) -> tuple[PhaseOverview, ...]:
+def get_curriculum_overview() -> tuple[PhaseOverview, ...]:
     """Get the lightweight phase+topic overview for browse-level pages.
 
     No step/objective/requirement content -- see ``PhaseOverview``.
     """
-    return await load_curriculum_overview_from_db(db)
-
-
-async def get_topic_containing_step(
-    db: AsyncSession, step_uuid: UUID
-) -> tuple[Topic, LearningStep] | None:
-    """Resolve a step UUID to its parent topic (with sibling steps).
-
-    Scoped to one topic's subtree, not the full curriculum tree.
-    """
-    return await load_topic_containing_step_from_db(db, step_uuid)
-
-
-async def get_requirements_by_phase_order(
-    db: AsyncSession,
-    *,
-    phase_order_by_uuid: dict[UUID, int] | None = None,
-) -> dict[int, list[HandsOnRequirement]]:
-    """Get all active requirements grouped by parent phase order.
-
-    Scoped to the ``requirements``/``phases`` tables only, not the full
-    curriculum tree. Pass ``phase_order_by_uuid`` when the caller
-    already has one (e.g. from ``get_curriculum_overview``) to skip a
-    redundant phases query.
-    """
-    return await load_requirements_by_phase_order_from_db(
-        db, phase_order_by_uuid=phase_order_by_uuid
+    catalog = get_curriculum_catalog()
+    return tuple(
+        PhaseOverview(
+            uuid=phase.uuid,
+            order=phase.order,
+            name=phase.name,
+            slug=phase.slug,
+            description=phase.description,
+            short_description=phase.short_description,
+            topics=[
+                TopicOverview(uuid=topic.uuid, slug=topic.slug, name=topic.name)
+                for topic in phase.topics
+            ],
+        )
+        for phase in catalog.phases
     )
 
 
-async def get_required_step_counts_by_phase(db: AsyncSession) -> dict[int, int]:
-    """Get the count of active required steps per phase order."""
-    return await load_required_step_counts_by_phase_from_db(db)
+def get_topic_containing_step(step_uuid: UUID) -> tuple[Topic, LearningStep] | None:
+    """Resolve a step UUID to its parent topic (with sibling steps)."""
+    catalog = get_curriculum_catalog()
+    step = catalog.steps_by_uuid.get(step_uuid)
+    if step is None:
+        return None
+    topic = catalog.topic_by_step_uuid.get(step_uuid)
+    if topic is None:
+        return None
+    return topic, step
 
 
-async def get_requirement_counts_by_phase(db: AsyncSession) -> dict[int, int]:
-    """Get the count of active hands-on requirements per phase order."""
-    return await load_requirement_counts_by_phase_from_db(db)
+def get_requirements_by_phase_order() -> dict[int, list[HandsOnRequirement]]:
+    """Get all requirements grouped by parent phase order."""
+    catalog = get_curriculum_catalog()
+    return {
+        phase.order: list(catalog.requirements_by_phase_slug.get(phase.slug, ()))
+        for phase in catalog.phases
+        if catalog.requirements_by_phase_slug.get(phase.slug)
+    }
+
+
+def get_required_step_counts_by_phase() -> dict[int, int]:
+    """Get the count of required steps per phase order."""
+    catalog = get_curriculum_catalog()
+    return {
+        phase.order: len(catalog.steps_by_phase_slug.get(phase.slug, ()))
+        for phase in catalog.phases
+    }
+
+
+def get_requirement_counts_by_phase() -> dict[int, int]:
+    """Get the count of hands-on requirements per phase order."""
+    catalog = get_curriculum_catalog()
+    return {
+        phase.order: len(catalog.requirements_by_phase_slug.get(phase.slug, ()))
+        for phase in catalog.phases
+    }

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
@@ -1,14 +1,17 @@
 """YAML-backed curriculum loader (authoring source of truth).
 
-This module loads the curriculum tree from the authored YAML files. After
-Phase C (issue #461), runtime reads in the API go through the DB loader in
-``content_db_loader.py`` via the public ``content_service`` module. The YAML
-loader is still authoritative for deploy-time YAML to DB sync
-(``content_sync.py``) and for the strict cross-file validators run in CI.
-Production migration jobs provide the YAML path through ``CONTENT__DIR``.
+This module loads the curriculum tree from the authored YAML files.
+Runtime reads in the API go through the packaged curriculum catalog
+(``content_catalog.py``) via the public ``content_service`` module. The
+YAML loader is still authoritative for the deterministic artifact
+compiler (``content_compiler.py``), the deploy-time YAML to DB sync
+(``content_sync.py``, kept as a compatibility shadow), and the strict
+cross-file validators run in CI. Production migration jobs provide the
+YAML path through ``CONTENT__DIR``.
 
 Do not import from this module in request-serving code paths. Use
-``learn_to_cloud_shared.content_service`` (async, DB-backed) instead.
+``learn_to_cloud_shared.content_service`` (catalog-backed, in-memory)
+instead.
 """
 
 from __future__ import annotations

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/progress_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/progress_repository.py
@@ -9,16 +9,11 @@ the human-readable step IDs when needed.
 from collections.abc import Iterable
 from uuid import UUID
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from learn_to_cloud_shared.models import (
-    CurriculumPhase,
-    CurriculumStep,
-    CurriculumTopic,
-    StepProgress,
-)
+from learn_to_cloud_shared.models import StepProgress
 
 
 class StepProgressRepository:
@@ -35,9 +30,10 @@ class StepProgressRepository:
         """Return which of the given step UUIDs the user has completed.
 
         Caller passes the candidate UUIDs (typically a topic's
-        ``learning_steps[].uuid``); only intersecting completions come
-        back. Returning an empty set for an empty input avoids a
-        round-trip with an empty IN-list.
+        ``learning_steps[].uuid``, or the catalog's full
+        ``active_step_uuids`` for whole-curriculum progress); only
+        intersecting completions come back. Returning an empty set for
+        an empty input avoids a round-trip with an empty IN-list.
         """
         uuids = list(step_uuids)
         if not uuids:
@@ -88,28 +84,3 @@ class StepProgressRepository:
             )
         )
         return getattr(result, "rowcount", 0) or 0
-
-    async def count_completed_steps_by_phase_for_user(
-        self, user_id: int
-    ) -> dict[int, int]:
-        """Count completed steps per phase, in one aggregate query.
-
-        Joins ``step_progress -> steps -> topics -> phases`` and groups
-        by ``phases.order``, so dashboard-wide progress totals don't
-        require loading the curriculum tree or per-topic UUID sets.
-        """
-        result = await self.db.execute(
-            select(CurriculumPhase.order, func.count(StepProgress.step_uuid))
-            .select_from(StepProgress)
-            .join(CurriculumStep, StepProgress.step_uuid == CurriculumStep.uuid)
-            .join(CurriculumTopic, CurriculumStep.topic_uuid == CurriculumTopic.uuid)
-            .join(CurriculumPhase, CurriculumTopic.phase_uuid == CurriculumPhase.uuid)
-            .where(
-                StepProgress.user_id == user_id,
-                CurriculumStep.deleted_at.is_(None),
-                CurriculumTopic.deleted_at.is_(None),
-                CurriculumPhase.deleted_at.is_(None),
-            )
-            .group_by(CurriculumPhase.order)
-        )
-        return {order: count for order, count in result.all()}

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/submission_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/submission_repository.py
@@ -6,18 +6,13 @@ speak UUIDs; callers translate to/from the human-readable requirement
 ids at the boundary (templates and DTOs).
 """
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import Integer, Uuid, column, func, select, values
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from learn_to_cloud_shared.models import (
-    CurriculumPhase,
-    CurriculumRequirement,
-    Submission,
-    utcnow,
-)
+from learn_to_cloud_shared.models import Submission, utcnow
 from learn_to_cloud_shared.submission_values import SubmittedValue
 
 
@@ -179,39 +174,10 @@ class SubmissionRepository:
         )
         return result.scalar_one() or 0
 
-    async def count_validated_by_phase_for_user(self, user_id: int) -> dict[int, int]:
-        """Count validated requirements per phase, in one aggregate query.
-
-        Joins ``submissions -> requirements -> phases`` and groups by
-        ``phases.order``, so dashboard-wide progress totals don't
-        require loading the curriculum tree or any per-phase UUID sets.
-        """
-        result = await self.db.execute(
-            select(
-                CurriculumPhase.order,
-                func.count(func.distinct(Submission.requirement_uuid)),
-            )
-            .select_from(Submission)
-            .join(
-                CurriculumRequirement,
-                Submission.requirement_uuid == CurriculumRequirement.uuid,
-            )
-            .join(
-                CurriculumPhase,
-                CurriculumRequirement.phase_uuid == CurriculumPhase.uuid,
-            )
-            .where(
-                Submission.user_id == user_id,
-                Submission.is_validated.is_(True),
-                CurriculumRequirement.deleted_at.is_(None),
-                CurriculumPhase.deleted_at.is_(None),
-            )
-            .group_by(CurriculumPhase.order)
-        )
-        return {order: count for order, count in result.all()}
-
     async def list_phase_completions(
-        self, requirement_counts_by_phase: dict[int, int]
+        self,
+        requirement_counts_by_phase: dict[int, int],
+        phase_order_by_requirement_uuid: Mapping[UUID, int],
     ) -> list[tuple[int, int]]:
         """List ``(phase_order, user_id)`` for fully-completed phases.
 
@@ -222,10 +188,14 @@ class SubmissionRepository:
         completion threshold; phases absent from that map or with a
         non-positive total are treated as not completable and excluded.
 
-        Single aggregate over ``submissions -> requirements -> phases``:
-        groups by phase + user and keeps only groups whose distinct
-        validated requirement count matches the phase total. Drives both
-        the ``/stats`` phase funnel counts and the completer lists.
+        ``phase_order_by_requirement_uuid`` (from the packaged curriculum
+        catalog) supplies the requirement-to-phase mapping as a small
+        in-memory ``VALUES`` relation, so this stays a single aggregate
+        query over ``submissions`` without joining the ``requirements``/
+        ``phases`` tables: groups by phase + user and keeps only groups
+        whose distinct validated requirement count matches the phase
+        total. Drives both the ``/stats`` phase funnel counts and the
+        completer lists.
         """
         completable = {
             order: total
@@ -235,9 +205,23 @@ class SubmissionRepository:
         if not completable:
             return []
 
+        requirement_phase_rows = [
+            (req_uuid, order)
+            for req_uuid, order in phase_order_by_requirement_uuid.items()
+            if order in completable
+        ]
+        if not requirement_phase_rows:
+            return []
+
+        requirement_phase_map = values(
+            column("requirement_uuid", Uuid(as_uuid=True)),
+            column("phase_order", Integer),
+            name="requirement_phase_map",
+        ).data(requirement_phase_rows)
+
         result = await self.db.execute(
             select(
-                CurriculumPhase.order,
+                requirement_phase_map.c.phase_order,
                 Submission.user_id,
                 func.count(func.distinct(Submission.requirement_uuid)).label(
                     "validated"
@@ -245,20 +229,11 @@ class SubmissionRepository:
             )
             .select_from(Submission)
             .join(
-                CurriculumRequirement,
-                Submission.requirement_uuid == CurriculumRequirement.uuid,
+                requirement_phase_map,
+                Submission.requirement_uuid == requirement_phase_map.c.requirement_uuid,
             )
-            .join(
-                CurriculumPhase,
-                CurriculumRequirement.phase_uuid == CurriculumPhase.uuid,
-            )
-            .where(
-                Submission.is_validated.is_(True),
-                CurriculumRequirement.deleted_at.is_(None),
-                CurriculumPhase.deleted_at.is_(None),
-                CurriculumPhase.order.in_(completable.keys()),
-            )
-            .group_by(CurriculumPhase.order, Submission.user_id)
+            .where(Submission.is_validated.is_(True))
+            .group_by(requirement_phase_map.c.phase_order, Submission.user_id)
         )
         return [
             (order, user_id)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/requirements.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/requirements.py
@@ -1,10 +1,10 @@
 """Phase hands-on requirements lookup helpers.
 
-Backed by the DB curriculum (see ``content_service``). Each convenience
-helper loads the lightweight requirement index (requirements + phases
-only, not the full curriculum tree) and builds a ``RequirementIndex``;
-hot paths that need several lookups should load the index once and
-reuse it to avoid redundant queries.
+Backed by the packaged curriculum catalog (see ``content_service``).
+Each convenience helper loads the requirement index (requirements
+grouped by phase order) and builds a ``RequirementIndex``; this is a
+synchronous, in-memory lookup, so hot paths can call it as often as
+needed without worrying about redundant queries.
 
 Phases here are keyed by ``phase.order`` (the int 0..7), matching the
 URL contract and the numeric phase id. Slugs (``"phase0"`` etc.) are
@@ -66,31 +66,16 @@ class RequirementIndex:
         return [req.uuid for req in self.requirements_for_phase(phase_order)]
 
 
-async def load_requirement_index(
-    db: AsyncSession,
-    *,
-    phase_order_by_uuid: dict[UUID, int] | None = None,
-) -> RequirementIndex:
-    """Load the lightweight requirement index (requirements+phases only).
-
-    Does not load the curriculum tree -- only the ``requirements`` and
-    ``phases`` tables (~18 rows in production), since callers here only
-    ever need UUIDs, slugs, and gating/validation metadata. Pass
-    ``phase_order_by_uuid`` when the caller already has one to skip a
-    redundant phases query.
-    """
+def load_requirement_index() -> RequirementIndex:
+    """Load the requirement index (requirements grouped by phase order)."""
     return RequirementIndex.from_requirements_by_phase_order(
-        await get_requirements_by_phase_order(
-            db, phase_order_by_uuid=phase_order_by_uuid
-        )
+        get_requirements_by_phase_order()
     )
 
 
-async def get_requirement_by_slug(
-    db: AsyncSession, requirement_slug: str
-) -> HandsOnRequirement | None:
+def get_requirement_by_slug(requirement_slug: str) -> HandsOnRequirement | None:
     """Get a specific requirement by its slug."""
-    idx = await load_requirement_index(db)
+    idx = load_requirement_index()
     return idx.by_slug.get(requirement_slug)
 
 
@@ -130,9 +115,7 @@ async def is_phase_verification_locked(
     if prereq is None:
         return False, None
 
-    prereq_req_uuids = (await load_requirement_index(db)).requirement_uuids_for_phase(
-        prereq
-    )
+    prereq_req_uuids = load_requirement_index().requirement_uuids_for_phase(prereq)
     if not prereq_req_uuids:
         return False, None
 

--- a/packages/learn-to-cloud-shared/tests/repositories/test_stats_aggregates.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_stats_aggregates.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
 from learn_to_cloud_shared.content_service import get_requirement_counts_by_phase
 from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
 from learn_to_cloud_shared.content_yaml_loader import clear_cache
@@ -94,9 +95,12 @@ class TestListPhaseCompletions:
         await _validate_all(db_session, user_id, reqs_by_phase[single_phase])
         await db_session.flush()
 
-        counts = await get_requirement_counts_by_phase(db_session)
+        counts = get_requirement_counts_by_phase()
+        phase_order_by_requirement_uuid = (
+            get_curriculum_catalog().phase_order_by_requirement_uuid
+        )
         completions = await SubmissionRepository(db_session).list_phase_completions(
-            counts
+            counts, phase_order_by_requirement_uuid
         )
 
         assert (single_phase, user_id) in completions
@@ -113,16 +117,19 @@ class TestListPhaseCompletions:
         await _validate_all(db_session, user_id, reqs_by_phase[multi_phase][:1])
         await db_session.flush()
 
-        counts = await get_requirement_counts_by_phase(db_session)
+        counts = get_requirement_counts_by_phase()
+        phase_order_by_requirement_uuid = (
+            get_curriculum_catalog().phase_order_by_requirement_uuid
+        )
         completions = await SubmissionRepository(db_session).list_phase_completions(
-            counts
+            counts, phase_order_by_requirement_uuid
         )
 
         assert (multi_phase, user_id) not in completions
 
     async def test_empty_counts_returns_empty(self, db_session: AsyncSession):
         repo = SubmissionRepository(db_session)
-        assert await repo.list_phase_completions({}) == []
+        assert await repo.list_phase_completions({}, {}) == []
 
     async def test_deleted_requirements_do_not_inflate_threshold(
         self, db_session: AsyncSession, reqs_by_phase
@@ -139,9 +146,47 @@ class TestListPhaseCompletions:
         await _validate_all(db_session, user_id, reqs_by_phase[multi_phase])
         await db_session.flush()
 
-        counts = await get_requirement_counts_by_phase(db_session)
+        counts = get_requirement_counts_by_phase()
+        phase_order_by_requirement_uuid = (
+            get_curriculum_catalog().phase_order_by_requirement_uuid
+        )
         completions = await SubmissionRepository(db_session).list_phase_completions(
-            counts
+            counts, phase_order_by_requirement_uuid
         )
 
         assert (multi_phase, user_id) in completions
+
+    async def test_stale_requirement_uuid_is_ignored(
+        self, db_session: AsyncSession, reqs_by_phase
+    ):
+        """A validated submission for a retired requirement UUID (no longer
+        in the catalog's ``phase_order_by_requirement_uuid`` map) must not
+        produce a phantom completion or otherwise blow up the aggregate.
+
+        Simulates retirement by validating a single-requirement phase
+        normally, then dropping that same requirement's UUID from the
+        phase-order map passed to ``list_phase_completions`` (as if the
+        catalog no longer knows about it). The join is inner, so an
+        unmapped UUID simply can't match any row -- the user must no
+        longer show up as a completer for that phase.
+        """
+        single_phase = next(
+            order for order, reqs in reqs_by_phase.items() if len(reqs) == 1
+        )
+        user_id = 50004
+        await UserRepository(db_session).upsert(user_id, github_username="stalecase")
+        await _validate_all(db_session, user_id, reqs_by_phase[single_phase])
+        await db_session.flush()
+
+        retired_req_uuid = reqs_by_phase[single_phase][0][0]
+        counts = get_requirement_counts_by_phase()
+        phase_order_by_requirement_uuid = dict(
+            get_curriculum_catalog().phase_order_by_requirement_uuid
+        )
+        del phase_order_by_requirement_uuid[retired_req_uuid]
+
+        completions = await SubmissionRepository(db_session).list_phase_completions(
+            counts, phase_order_by_requirement_uuid
+        )
+
+        assert (single_phase, user_id) not in completions

--- a/packages/learn-to-cloud-shared/tests/services/test_content_catalog.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_catalog.py
@@ -147,6 +147,8 @@ class TestCurriculumCatalogIndices:
         step = topic.learning_steps[0]
         assert catalog.steps_by_uuid[step.uuid] is step
         assert step in catalog.steps_by_phase_slug[phase0.slug]
+        assert catalog.topic_by_step_uuid[step.uuid] is topic
+        assert catalog.phase_order_by_step_uuid[step.uuid] == phase0.order
 
     def test_requirement_lookup_by_uuid_slug_and_phase(
         self, catalog: CurriculumCatalog
@@ -156,6 +158,7 @@ class TestCurriculumCatalogIndices:
         assert catalog.requirements_by_uuid[req.uuid] is req
         assert catalog.requirements_by_slug[req.slug] is req
         assert req in catalog.requirements_by_phase_slug[phase.slug]
+        assert catalog.phase_order_by_requirement_uuid[req.uuid] == phase.order
 
     def test_active_uuid_sets_and_counts(self, catalog: CurriculumCatalog):
         assert catalog.phase_count == len(catalog.phases)
@@ -180,9 +183,12 @@ class TestCurriculumCatalogImmutability:
             "topics_by_phase_and_slug",
             "steps_by_uuid",
             "steps_by_phase_slug",
+            "topic_by_step_uuid",
+            "phase_order_by_step_uuid",
             "requirements_by_uuid",
             "requirements_by_slug",
             "requirements_by_phase_slug",
+            "phase_order_by_requirement_uuid",
         ],
     )
     def test_mapping_fields_reject_item_assignment(

--- a/packages/learn-to-cloud-shared/tests/services/test_content_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_service.py
@@ -1,0 +1,109 @@
+"""Unit tests for the catalog-backed curriculum read API.
+
+These are pure in-memory lookups over the process-level
+``CurriculumCatalog`` singleton (the real packaged artifact), so no DB
+or mocking is needed -- every function here is synchronous.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
+from learn_to_cloud_shared.content_service import (
+    get_all_phases,
+    get_curriculum_overview,
+    get_phase_by_slug,
+    get_required_step_counts_by_phase,
+    get_requirement_counts_by_phase,
+    get_requirements_by_phase_order,
+    get_topic_containing_step,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestGetAllPhases:
+    def test_returns_catalog_phases(self):
+        assert get_all_phases() == get_curriculum_catalog().phases
+
+
+class TestGetPhaseBySlug:
+    def test_known_slug_returns_phase(self):
+        phase = get_phase_by_slug("phase0")
+        assert phase is not None
+        assert phase.slug == "phase0"
+
+    def test_unknown_slug_returns_none(self):
+        assert get_phase_by_slug("not-a-real-phase") is None
+
+
+class TestGetCurriculumOverview:
+    def test_matches_phase_shape_without_step_content(self):
+        catalog = get_curriculum_catalog()
+        overview = get_curriculum_overview()
+
+        assert len(overview) == len(catalog.phases)
+        for phase_overview, phase in zip(overview, catalog.phases, strict=True):
+            assert phase_overview.uuid == phase.uuid
+            assert phase_overview.order == phase.order
+            assert phase_overview.slug == phase.slug
+            assert phase_overview.name == phase.name
+            assert [t.uuid for t in phase_overview.topics] == [
+                t.uuid for t in phase.topics
+            ]
+
+
+class TestGetTopicContainingStep:
+    def test_known_step_resolves_to_parent_topic(self):
+        catalog = get_curriculum_catalog()
+        phase = next(p for p in catalog.phases if p.topics)
+        topic = next(t for t in phase.topics if t.learning_steps)
+        step = topic.learning_steps[0]
+
+        result = get_topic_containing_step(step.uuid)
+
+        assert result is not None
+        found_topic, found_step = result
+        assert found_topic.uuid == topic.uuid
+        assert found_step.uuid == step.uuid
+
+    def test_unknown_step_uuid_returns_none(self):
+        assert get_topic_containing_step(uuid4()) is None
+
+
+class TestGetRequirementsByPhaseOrder:
+    def test_only_includes_phases_with_requirements(self):
+        catalog = get_curriculum_catalog()
+        by_order = get_requirements_by_phase_order()
+
+        for phase in catalog.phases:
+            expected = catalog.requirements_by_phase_slug.get(phase.slug, ())
+            if expected:
+                assert by_order[phase.order] == list(expected)
+            else:
+                assert phase.order not in by_order
+
+
+class TestGetRequiredStepCountsByPhase:
+    def test_counts_match_catalog_steps_by_phase(self):
+        catalog = get_curriculum_catalog()
+        counts = get_required_step_counts_by_phase()
+
+        for phase in catalog.phases:
+            assert counts[phase.order] == len(
+                catalog.steps_by_phase_slug.get(phase.slug, ())
+            )
+
+
+class TestGetRequirementCountsByPhase:
+    def test_counts_match_catalog_requirements_by_phase(self):
+        catalog = get_curriculum_catalog()
+        counts = get_requirement_counts_by_phase()
+
+        for phase in catalog.phases:
+            assert counts[phase.order] == len(
+                catalog.requirements_by_phase_slug.get(phase.slug, ())
+            )

--- a/packages/learn-to-cloud-shared/tests/services/test_phase_requirements_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_phase_requirements_service.py
@@ -79,27 +79,23 @@ class TestRequirementIndex:
 
 
 @pytest.mark.unit
-class TestAsyncRequirementLookups:
-    @pytest.mark.asyncio
-    async def test_get_requirement_by_slug_found(self):
+class TestSyncRequirementLookups:
+    def test_get_requirement_by_slug_found(self):
         by_phase_order = _make_requirements_by_phase_order(3, ["req-a"])
         with patch(
             "learn_to_cloud_shared.requirements.get_requirements_by_phase_order",
-            new_callable=AsyncMock,
             return_value=by_phase_order,
         ):
-            req = await get_requirement_by_slug(AsyncMock(), "req-a")
+            req = get_requirement_by_slug("req-a")
         assert req is not None
         assert req.slug == "req-a"
 
-    @pytest.mark.asyncio
-    async def test_get_requirement_by_slug_not_found(self):
+    def test_get_requirement_by_slug_not_found(self):
         with patch(
             "learn_to_cloud_shared.requirements.get_requirements_by_phase_order",
-            new_callable=AsyncMock,
             return_value={},
         ):
-            assert await get_requirement_by_slug(AsyncMock(), "nonexistent") is None
+            assert get_requirement_by_slug("nonexistent") is None
 
 
 @pytest.mark.unit
@@ -120,7 +116,6 @@ class TestIsPhaseVerificationLocked:
         with (
             patch(
                 "learn_to_cloud_shared.requirements.get_requirements_by_phase_order",
-                new_callable=AsyncMock,
                 return_value=by_phase_order,
             ),
             patch(
@@ -146,7 +141,6 @@ class TestIsPhaseVerificationLocked:
         with (
             patch(
                 "learn_to_cloud_shared.requirements.get_requirements_by_phase_order",
-                new_callable=AsyncMock,
                 return_value=by_phase_order,
             ),
             patch(

--- a/scripts/seed_progress.py
+++ b/scripts/seed_progress.py
@@ -1,7 +1,8 @@
 """Seed all progress data for a user so they can test full completion.
 
-Reads curriculum from the DB (synced from YAML at deploy time) and writes
-step_progress + submissions rows so the user shows as fully complete.
+Reads curriculum from the packaged catalog artifact and writes
+step_progress + submissions rows (FK'd to the curriculum tables synced
+from YAML at deploy time) so the user shows as fully complete.
 
 Usage: uv run --directory api python ../scripts/seed_progress.py <github_username>
 """
@@ -13,7 +14,7 @@ from datetime import UTC, datetime
 
 from learn_to_cloud_shared.content_service import get_all_phases
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import create_async_engine
 
 database_url = os.environ.get(
     "DATABASE__URL", "postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud"
@@ -22,14 +23,12 @@ database_url = os.environ.get(
 
 async def main(github_username: str) -> None:
     engine = create_async_engine(database_url)
-    session_maker = async_sessionmaker(engine, expire_on_commit=False)
     try:
-        async with session_maker() as session:
-            phases = await get_all_phases(session)
+        phases = get_all_phases()
         if not phases:
-            print("ERROR: No curriculum loaded from DB. Run the sync job first.")
+            print("ERROR: No curriculum in the packaged catalog artifact.")
             sys.exit(1)
-        print(f"Loaded {len(phases)} phases from curriculum DB")
+        print(f"Loaded {len(phases)} phases from the curriculum catalog")
 
         async with engine.begin() as conn:
             row = (


### PR DESCRIPTION
## Why

Once curriculum is a packaged artifact, serving it from PostgreSQL adds synchronization work and makes static content depend on database availability. This layer moves runtime reads to the in-memory catalog without removing the compatibility tables yet.

## What changed

- serve phases, topics, steps, requirements, counts, and lookups from `CurriculumCatalog`
- remove database-session dependencies from curriculum-only APIs
- validate steps and derive verification requirements from artifact indexes
- update routes, dashboard, stats metadata, seeds, and tests for catalog-backed reads
- assert curriculum rendering no longer performs curriculum SQL

## Stack position

Depends on #657. PostgreSQL curriculum tables and deployment sync remain as compatibility shadows until the final contract layers.

## Validation

`uv run poe check`