### PR TITLE
Add unified verification attempt schema

### DIFF
--- a/api/alembic/versions/0049_add_verification_attempts_and_step_completions.py
+++ b/api/alembic/versions/0049_add_verification_attempts_and_step_completions.py
@@ -1,0 +1,529 @@
+"""add verification_attempts and learner_step_completions (expand)
+
+Why this change: PR3 of the verification-schema refactor. Introduces the
+two curriculum-decoupled tables that later PRs migrate onto:
+``verification_attempts`` (one row per attempt, keyed by its Durable
+orchestration id) and ``learner_step_completions`` (step completions
+keyed by ``step_uuid`` with no FK to the curriculum). This is an
+EXPAND-ONLY step: existing readers/writers keep using ``step_progress``,
+``submissions`` and ``verification_jobs`` unchanged. A temporary trigger
+mirrors ``step_progress`` INSERT/DELETE into ``learner_step_completions``
+so the new table stays consistent while legacy revisions remain the
+writers; the explicit dual-writes land in later PRs.
+
+Schema effect:
+- Creates ``learner_step_completions`` (composite PK ``(user_id,
+  step_uuid)``) and backfills every ``step_progress`` row.
+- Creates ``verification_attempts`` with the identity/snapshot,
+  submitted-value, and lifecycle columns plus their CHECK constraints,
+  and backfills it from ``verification_jobs`` + ``submissions``.
+- Installs the ``step_progress`` mirroring trigger (idempotent) before
+  the backfill so no concurrent legacy write is missed.
+- Grants the verification Functions role SELECT/INSERT/UPDATE on
+  ``verification_attempts`` (table-level for now; a later bridge narrows
+  to column privileges).
+
+This revision runs entirely inside one transaction (no
+``autocommit_block``) so it stamps atomically. The active/succeeded/latest
+indexes are created CONCURRENTLY in the follow-up revision 0050 so a
+failed/retried index build never leaves this revision half-applied.
+
+Backfill rules:
+- Linked verification_jobs -> attempt id = job id, terminal outcome
+  derived from the linked submission (is_validated -> succeeded, else
+  verification_completed -> failed, else server_error). Every job is
+  preserved, including multiple jobs linked to one submission.
+- Unlinked verification_jobs -> active attempt (outcome/completed_at
+  NULL) for the PR4 reconciler.
+- Submission with no job -> deterministic UUIDv5 attempt id from a fixed
+  namespace + legacy submission id.
+- Migrated rows use ``snapshot_source='reconstructed'`` and only claim a
+  requirement snapshot that can be honestly reconstructed from the
+  current ``requirements`` row; artifact metadata stays NULL.
+
+Safety:
+- Preflight aborts (rather than silently dropping data) if unlinked jobs
+  already violate the one-active-attempt invariant that revision 0050's
+  partial unique index enforces, or if a derived orphan id collides with
+  an unrelated existing attempt.
+- Backfill INSERTs are ``ON CONFLICT (id) DO NOTHING`` and the trigger is
+  ``DROP ... IF EXISTS`` + ``CREATE OR REPLACE`` so a re-run is a no-op.
+
+Rollback notes: downgrade drops the trigger, function, and both tables
+(grants go with them; the concurrent indexes are dropped first by
+revision 0050's downgrade). Backfilled history is not preserved on
+downgrade because the legacy tables still hold the source rows.
+
+Revision ID: 0049_add_verification_attempts_and_step_completions
+Revises: 0048_validate_deployment_architecture_type
+Create Date: 2026-07-14
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from learn_to_cloud_shared.verification_provenance import (
+    attempt_id_for_orphan_submission,
+    derive_outcome,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import context, op
+
+revision: str = "0049_add_verification_attempts_and_step_completions"
+down_revision: str | None = "0048_validate_deployment_architecture_type"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_MIRROR_FUNCTION = "mirror_step_progress_to_completions"
+_MIRROR_TRIGGER = "trg_mirror_step_progress_to_completions"
+
+
+def _verification_functions_role() -> str | None:
+    """Return the validated Functions DB role name, or None when unset."""
+    role = os.environ.get("POSTGRES_VERIFICATION_FUNCTIONS_ROLE")
+    if not role:
+        return None
+    if not (role[0].isalpha() or role[0] == "_") or not all(
+        c.isalnum() or c == "_" for c in role
+    ):
+        raise RuntimeError(
+            f"POSTGRES_VERIFICATION_FUNCTIONS_ROLE is not a valid identifier: {role!r}"
+        )
+    return role
+
+
+def _create_tables() -> None:
+    op.create_table(
+        "learner_step_completions",
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("step_uuid", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint(
+            "user_id", "step_uuid", name="pk_learner_step_completions"
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_learner_step_completions_user_id",
+            ondelete="CASCADE",
+        ),
+    )
+
+    op.create_table(
+        "verification_attempts",
+        sa.Column("id", sa.Uuid(as_uuid=True), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("requirement_uuid", sa.Uuid(as_uuid=True), nullable=False),
+        # Identity / snapshot. Text/BigInteger throughout to satisfy squawk's
+        # prefer-text-field and prefer-bigint-over-int rules for new columns.
+        sa.Column("artifact_schema_version", sa.BigInteger(), nullable=True),
+        sa.Column("curriculum_version", sa.BigInteger(), nullable=True),
+        sa.Column("content_hash", sa.Text(), nullable=True),
+        sa.Column("requirement_snapshot", JSONB(), nullable=True),
+        sa.Column("requirement_snapshot_hash", sa.Text(), nullable=True),
+        sa.Column("snapshot_source", sa.Text(), nullable=False),
+        sa.Column("payload_version", sa.BigInteger(), nullable=True),
+        # Submitted identity / value.
+        sa.Column("github_username_snapshot", sa.Text(), nullable=True),
+        sa.Column("submission_value_kind", sa.Text(), nullable=False),
+        sa.Column("submitted_value", sa.Text(), nullable=False),
+        sa.Column("cloud_provider", sa.Text(), nullable=True),
+        sa.Column("traceparent", sa.Text(), nullable=True),
+        # Lifecycle / result.
+        sa.Column("outcome", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("feedback_json", JSONB(), nullable=True),
+        sa.Column("validation_message", sa.Text(), nullable=True),
+        sa.Column("error_code", sa.Text(), nullable=True),
+        sa.Column("terminal_source", sa.Text(), nullable=True),
+        # Temporary migration provenance.
+        sa.Column("legacy_job_id", sa.Uuid(as_uuid=True), nullable=True),
+        sa.Column("legacy_submission_id", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_verification_attempts"),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name="fk_verification_attempts_user_id",
+            ondelete="CASCADE",
+        ),
+        sa.CheckConstraint(
+            "submission_value_kind IN ('github_url', 'token', 'deployed_url', 'text')",
+            name="ck_verification_attempts_value_kind",
+        ),
+        sa.CheckConstraint(
+            "length(btrim(submitted_value)) > 0",
+            name="ck_verification_attempts_submitted_value_nonempty",
+        ),
+        sa.CheckConstraint(
+            "outcome IS NULL OR outcome IN "
+            "('succeeded', 'failed', 'server_error', 'cancelled')",
+            name="ck_verification_attempts_outcome",
+        ),
+        sa.CheckConstraint(
+            "(outcome IS NULL) = (completed_at IS NULL)",
+            name="ck_verification_attempts_outcome_completed_at",
+        ),
+        sa.CheckConstraint(
+            "snapshot_source IN ('submitted', 'reconstructed')",
+            name="ck_verification_attempts_snapshot_source",
+        ),
+        sa.CheckConstraint(
+            "snapshot_source = 'reconstructed' OR ("
+            "requirement_snapshot IS NOT NULL "
+            "AND requirement_snapshot_hash IS NOT NULL)",
+            name="ck_verification_attempts_submitted_snapshot_present",
+        ),
+    )
+
+
+def _install_mirror_trigger() -> None:
+    op.execute(
+        f"""
+        CREATE OR REPLACE FUNCTION {_MIRROR_FUNCTION}()
+        RETURNS trigger AS $$
+        BEGIN
+            IF (TG_OP = 'INSERT') THEN
+                INSERT INTO learner_step_completions
+                    (user_id, step_uuid, completed_at)
+                VALUES (NEW.user_id, NEW.step_uuid, NEW.completed_at)
+                ON CONFLICT (user_id, step_uuid) DO NOTHING;
+                RETURN NEW;
+            ELSIF (TG_OP = 'DELETE') THEN
+                DELETE FROM learner_step_completions
+                WHERE user_id = OLD.user_id
+                  AND step_uuid = OLD.step_uuid;
+                RETURN OLD;
+            END IF;
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(f"DROP TRIGGER IF EXISTS {_MIRROR_TRIGGER} ON step_progress")
+    op.execute(
+        f"""
+        CREATE TRIGGER {_MIRROR_TRIGGER}
+        AFTER INSERT OR DELETE ON step_progress
+        FOR EACH ROW EXECUTE FUNCTION {_MIRROR_FUNCTION}();
+        """
+    )
+
+
+def _preflight_active_uniqueness() -> None:
+    """Abort if unlinked jobs already break the one-active-attempt rule."""
+    if context.is_offline_mode():
+        return
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text(
+            """
+            SELECT user_id, requirement_uuid, count(*) AS n
+            FROM verification_jobs
+            WHERE result_submission_id IS NULL
+            GROUP BY user_id, requirement_uuid
+            HAVING count(*) > 1
+            """
+        )
+    ).all()
+    if result:
+        offenders = ", ".join(
+            f"(user_id={row.user_id}, requirement_uuid={row.requirement_uuid}: "
+            f"{row.n} active jobs)"
+            for row in result
+        )
+        raise RuntimeError(
+            "Cannot backfill verification_attempts: unlinked verification_jobs "
+            "already violate the one-active-attempt-per-(user, requirement) "
+            f"invariant: {offenders}. Resolve the duplicates before migrating."
+        )
+
+
+def _backfill_step_completions() -> None:
+    op.execute(
+        """
+        INSERT INTO learner_step_completions (user_id, step_uuid, completed_at)
+        SELECT user_id, step_uuid, completed_at
+        FROM step_progress
+        ON CONFLICT (user_id, step_uuid) DO NOTHING
+        """
+    )
+
+
+def _backfill_job_attempts() -> None:
+    op.execute(
+        """
+        INSERT INTO verification_attempts (
+            id, user_id, requirement_uuid,
+            artifact_schema_version, curriculum_version, content_hash,
+            requirement_snapshot, requirement_snapshot_hash,
+            snapshot_source, payload_version,
+            github_username_snapshot, submission_value_kind, submitted_value,
+            cloud_provider, traceparent,
+            outcome, started_at, completed_at, feedback_json, validation_message,
+            error_code, terminal_source, legacy_job_id, legacy_submission_id,
+            created_at, updated_at
+        )
+        SELECT
+            vj.id,
+            vj.user_id,
+            vj.requirement_uuid,
+            NULL, NULL, NULL,
+            CASE WHEN r.uuid IS NOT NULL THEN jsonb_build_object(
+                'uuid', r.uuid::text,
+                'slug', r.slug,
+                'name', r.name,
+                'submission_type', r.submission_type,
+                'submission_value_kind', r.submission_value_kind,
+                'reconstructed', true
+            ) ELSE NULL END,
+            NULL,
+            'reconstructed',
+            NULL,
+            vj.extracted_username,
+            vj.submission_value_kind,
+            vj.submitted_value,
+            vj.cloud_provider,
+            vj.traceparent,
+            CASE
+                WHEN vj.result_submission_id IS NULL THEN NULL
+                WHEN s.is_validated THEN 'succeeded'
+                WHEN s.verification_completed THEN 'failed'
+                ELSE 'server_error'
+            END,
+            vj.created_at,
+            CASE
+                WHEN vj.result_submission_id IS NULL THEN NULL
+                ELSE COALESCE(
+                    s.validated_at, s.updated_at, s.created_at, vj.created_at, now()
+                )
+            END,
+            CASE WHEN vj.result_submission_id IS NULL THEN NULL
+                 ELSE s.feedback_json END,
+            CASE WHEN vj.result_submission_id IS NULL THEN NULL
+                 ELSE s.validation_message END,
+            NULL,
+            CASE WHEN vj.result_submission_id IS NULL THEN NULL
+                 ELSE 'migration' END,
+            vj.id,
+            vj.result_submission_id,
+            COALESCE(vj.created_at, now()),
+            COALESCE(vj.updated_at, vj.created_at, now())
+        FROM verification_jobs vj
+        LEFT JOIN submissions s ON s.id = vj.result_submission_id
+        LEFT JOIN requirements r ON r.uuid = vj.requirement_uuid
+        ON CONFLICT (id) DO NOTHING
+        """
+    )
+
+
+def _orphan_attempts_table() -> sa.TableClause:
+    return sa.table(
+        "verification_attempts",
+        sa.column("id", sa.Uuid(as_uuid=True)),
+        sa.column("user_id", sa.BigInteger()),
+        sa.column("requirement_uuid", sa.Uuid(as_uuid=True)),
+        sa.column("requirement_snapshot", JSONB()),
+        sa.column("snapshot_source", sa.Text()),
+        sa.column("github_username_snapshot", sa.Text()),
+        sa.column("submission_value_kind", sa.Text()),
+        sa.column("submitted_value", sa.Text()),
+        sa.column("cloud_provider", sa.Text()),
+        sa.column("outcome", sa.Text()),
+        sa.column("started_at", sa.DateTime(timezone=True)),
+        sa.column("completed_at", sa.DateTime(timezone=True)),
+        sa.column("feedback_json", JSONB()),
+        sa.column("validation_message", sa.Text()),
+        sa.column("terminal_source", sa.Text()),
+        sa.column("legacy_submission_id", sa.BigInteger()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+
+def _backfill_orphan_submission_attempts() -> None:
+    """Backfill attempts for submissions that never had a job.
+
+    Uses a deterministic UUIDv5 id so the mapping is stable and
+    re-runnable. Runs online only: the ``--sql`` render can't read rows to
+    compute the ids, and these INSERTs only touch the brand-new
+    ``verification_attempts`` table, so skipping them there is safe.
+    """
+    if context.is_offline_mode():
+        op.execute(
+            "-- orphan-submission attempt backfill runs online only "
+            "(UUIDv5 ids are computed in Python)"
+        )
+        return
+
+    bind = op.get_bind()
+    rows = (
+        bind.execute(
+            sa.text(
+                """
+                SELECT
+                    s.id AS submission_id,
+                    s.user_id,
+                    s.requirement_uuid,
+                    s.extracted_username,
+                    s.submission_value_kind,
+                    s.submitted_value,
+                    s.cloud_provider,
+                    s.is_validated,
+                    s.verification_completed,
+                    s.validated_at,
+                    s.updated_at,
+                    s.created_at,
+                    s.feedback_json,
+                    s.validation_message,
+                    r.uuid AS r_uuid,
+                    r.slug AS r_slug,
+                    r.name AS r_name,
+                    r.submission_type AS r_submission_type,
+                    r.submission_value_kind AS r_value_kind
+                FROM submissions s
+                LEFT JOIN requirements r ON r.uuid = s.requirement_uuid
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM verification_jobs vj
+                    WHERE vj.result_submission_id = s.id
+                )
+                """
+            )
+        )
+        .mappings()
+        .all()
+    )
+    if not rows:
+        return
+
+    computed = {
+        attempt_id_for_orphan_submission(row["submission_id"]): row for row in rows
+    }
+
+    # Collision preflight: any pre-existing attempt sharing a derived id must
+    # be the same orphan (idempotent re-run). Otherwise abort rather than
+    # silently discard either row.
+    existing = bind.execute(
+        sa.text(
+            """
+            SELECT id, legacy_submission_id
+            FROM verification_attempts
+            WHERE id = ANY(:ids)
+            """
+        ),
+        {"ids": list(computed.keys())},
+    ).all()
+    existing_ids: set = set()
+    for existing_row in existing:
+        source = computed[existing_row.id]
+        if existing_row.legacy_submission_id != source["submission_id"]:
+            raise RuntimeError(
+                "Derived orphan-submission attempt id "
+                f"{existing_row.id} collides with an unrelated attempt "
+                f"(existing legacy_submission_id="
+                f"{existing_row.legacy_submission_id}, "
+                f"backfill submission_id={source['submission_id']}). Aborting."
+            )
+        existing_ids.add(existing_row.id)
+
+    to_insert = []
+    for attempt_id, row in computed.items():
+        if attempt_id in existing_ids:
+            continue
+        completed_at = row["validated_at"] or row["updated_at"] or row["created_at"]
+        snapshot = None
+        if row["r_uuid"] is not None:
+            snapshot = {
+                "uuid": str(row["r_uuid"]),
+                "slug": row["r_slug"],
+                "name": row["r_name"],
+                "submission_type": row["r_submission_type"],
+                "submission_value_kind": row["r_value_kind"],
+                "reconstructed": True,
+            }
+        to_insert.append(
+            {
+                "id": attempt_id,
+                "user_id": row["user_id"],
+                "requirement_uuid": row["requirement_uuid"],
+                "requirement_snapshot": snapshot,
+                "snapshot_source": "reconstructed",
+                "github_username_snapshot": row["extracted_username"],
+                "submission_value_kind": row["submission_value_kind"],
+                "submitted_value": row["submitted_value"],
+                "cloud_provider": row["cloud_provider"],
+                "outcome": derive_outcome(
+                    is_validated=row["is_validated"],
+                    verification_completed=row["verification_completed"],
+                ).value,
+                "started_at": row["created_at"],
+                "completed_at": completed_at,
+                "feedback_json": row["feedback_json"],
+                "validation_message": row["validation_message"],
+                "terminal_source": "migration",
+                "legacy_submission_id": row["submission_id"],
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"] or row["created_at"],
+            }
+        )
+
+    if to_insert:
+        bind.execute(sa.insert(_orphan_attempts_table()), to_insert)
+
+
+def _grant_functions_role() -> None:
+    role = _verification_functions_role()
+    if not role:
+        return
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                GRANT SELECT, INSERT, UPDATE
+                ON verification_attempts
+                TO "{role}";
+            END IF;
+        END $$;
+        """
+    )
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '5min'")
+
+    _create_tables()
+    # Install the mirror trigger BEFORE backfilling step completions so
+    # there is no window where a concurrent legacy write to step_progress
+    # is missed: any row the trigger races ahead of is still picked up by
+    # the ON CONFLICT DO NOTHING backfill, and vice versa.
+    _install_mirror_trigger()
+    _backfill_step_completions()
+
+    _preflight_active_uniqueness()
+    _backfill_job_attempts()
+    _backfill_orphan_submission_attempts()
+
+    _grant_functions_role()
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+
+    op.execute(f"DROP TRIGGER IF EXISTS {_MIRROR_TRIGGER} ON step_progress")
+    op.execute(f"DROP FUNCTION IF EXISTS {_MIRROR_FUNCTION}()")
+
+    # Dropping the tables removes their role grants. The concurrent indexes
+    # are owned by revision 0050 and dropped by its downgrade before this
+    # revision runs.
+    op.drop_table("verification_attempts")
+    op.drop_table("learner_step_completions")

--- a/api/alembic/versions/0050_verification_attempts_concurrent_indexes.py
+++ b/api/alembic/versions/0050_verification_attempts_concurrent_indexes.py
@@ -1,0 +1,110 @@
+"""create verification_attempts indexes concurrently
+
+Why this change: split out from revision 0049 so the table creation,
+backfill, trigger, and grants stamp atomically inside one transaction,
+while the three supporting indexes on ``verification_attempts`` build
+CONCURRENTLY here. Isolating the concurrent builds means a failed or
+retried index revision can never leave 0049 half-applied.
+
+Retry safety: a failed ``CREATE INDEX CONCURRENTLY`` leaves an *invalid*
+index behind, and a bare ``IF NOT EXISTS`` retry would see the name and
+skip the rebuild, letting Alembic stamp this revision with a broken
+index. So each index is ``DROP INDEX CONCURRENTLY IF EXISTS``-ed first --
+removing any invalid/partial leftover -- before being (re)created. The
+``IF NOT EXISTS`` on the create is retained only to satisfy the repo's
+migration lint; because the drop always runs first, it never causes an
+invalid index to be skipped. Every run converges on a fresh, valid index.
+
+Timeout handling: the concurrent builds run in autocommit mode, where a
+top-level ``SET LOCAL`` would not survive (autocommit_block commits the
+surrounding transaction). We keep the ``SET LOCAL`` at the top only to
+satisfy the repository's migration-lint timeout convention, and set
+*session-level* ``lock_timeout`` / ``statement_timeout`` inside the
+autocommit block to actually bound the builds, ``RESET``-ing them in a
+``finally`` so nothing leaks onto the pooled connection.
+
+Schema effect (all CONCURRENTLY, in an autocommit block):
+- ``uq_verification_attempts_active_user_req`` -- partial UNIQUE on
+  ``(user_id, requirement_uuid) WHERE outcome IS NULL`` (one active
+  attempt per user/requirement).
+- ``ix_verification_attempts_succeeded_user_req`` -- partial on
+  ``(user_id, requirement_uuid) WHERE outcome = 'succeeded'``.
+- ``ix_verification_attempts_user_req_created`` -- latest-history lookup
+  on ``(user_id, requirement_uuid, created_at DESC)``.
+
+Rollback notes: downgrade drops the three indexes CONCURRENTLY.
+
+Revision ID: 0050_verification_attempts_concurrent_indexes
+Revises: 0049_add_verification_attempts_and_step_completions
+Create Date: 2026-07-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0050_verification_attempts_concurrent_indexes"
+down_revision: str | None = "0049_add_verification_attempts_and_step_completions"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# (index name, CREATE statement). Order is not significant; each build is
+# independent and idempotent via the drop-then-create pattern below.
+_INDEXES: tuple[tuple[str, str], ...] = (
+    (
+        "uq_verification_attempts_active_user_req",
+        "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+        "uq_verification_attempts_active_user_req "
+        "ON verification_attempts (user_id, requirement_uuid) "
+        "WHERE outcome IS NULL",
+    ),
+    (
+        "ix_verification_attempts_succeeded_user_req",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "ix_verification_attempts_succeeded_user_req "
+        "ON verification_attempts (user_id, requirement_uuid) "
+        "WHERE outcome = 'succeeded'",
+    ),
+    (
+        "ix_verification_attempts_user_req_created",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "ix_verification_attempts_user_req_created "
+        "ON verification_attempts (user_id, requirement_uuid, created_at DESC)",
+    ),
+)
+
+
+def upgrade() -> None:
+    # SET LOCAL keeps the repo's migration-lint timeout convention happy for
+    # this transaction; the effective bounds for the concurrent builds are
+    # the session-level settings applied inside the autocommit block below.
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '10min'")
+
+    with op.get_context().autocommit_block():
+        op.execute("SET lock_timeout = '5s'")
+        op.execute("SET statement_timeout = '10min'")
+        try:
+            for name, create_stmt in _INDEXES:
+                # Drop any prior (possibly INVALID) build first, then create
+                # fresh so a retried run cannot stamp an invalid index.
+                op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+                op.execute(create_stmt)
+        finally:
+            op.execute("RESET statement_timeout")
+            op.execute("RESET lock_timeout")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET lock_timeout = '5s'")
+        op.execute("SET statement_timeout = '10min'")
+        try:
+            for name, _ in reversed(_INDEXES):
+                op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+        finally:
+            op.execute("RESET statement_timeout")
+            op.execute("RESET lock_timeout")

--- a/api/scripts/reconcile_verification_backfill.py
+++ b/api/scripts/reconcile_verification_backfill.py
@@ -1,0 +1,58 @@
+"""Read-only reconciliation report for the verification-attempt backfill.
+
+Run after the expand backfill (migration
+``0049_add_verification_attempts_and_step_completions``) and after later
+deployments to confirm ``verification_attempts`` /
+``learner_step_completions`` agree with the legacy tables. The tool only
+runs SELECTs -- it never mutates data.
+
+Usage from the ``api/`` directory::
+
+    uv run python scripts/reconcile_verification_backfill.py
+
+Exit codes:
+    0  Fully reconciled (no divergences).
+    1  Divergences found (see the printed report).
+    2  Could not connect / query error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from learn_to_cloud_shared.verification_reconciliation import (
+    format_report,
+    run_reconciliation,
+)
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+
+async def _main() -> int:
+    database_url = os.environ.get(
+        "DATABASE__URL",
+        "postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud",
+    )
+    engine = create_async_engine(database_url)
+    try:
+        session_maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with session_maker() as session:
+            report = await run_reconciliation(session)
+    finally:
+        await engine.dispose()
+
+    print(format_report(report))
+    return 0 if report.ok else 1
+
+
+def main() -> int:
+    try:
+        return asyncio.run(_main())
+    except Exception as exc:  # pragma: no cover - operational tool
+        print(f"Reconciliation failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/api/tests/test_verification_backfill_migration.py
+++ b/api/tests/test_verification_backfill_migration.py
@@ -1,0 +1,658 @@
+"""Data-driven tests for the verification-attempt / step-completion backfill.
+
+Seeds representative legacy shapes at revision 0048, runs migration 0049,
+and asserts the backfill, mirroring trigger, and preflight behaviour.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from learn_to_cloud_shared.verification_provenance import (
+    attempt_id_for_orphan_submission,
+)
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+MIGRATION_DB = "test_verification_backfill_migrations"
+_BEFORE = "0048_validate_deployment_architecture_type"
+_TABLES = "0049_add_verification_attempts_and_step_completions"
+_INDEXES = "0050_verification_attempts_concurrent_indexes"
+
+os.environ.setdefault(
+    "POSTGRES_VERIFICATION_FUNCTIONS_ROLE",
+    "ltc_verification_functions_dev",
+)
+
+
+def _sync_url() -> str:
+    raw = os.environ.get(
+        "DATABASE__URL",
+        "postgresql+asyncpg://postgres:postgres@db:5432/learntocloud",
+    )
+    return raw.replace("+asyncpg", "+psycopg2")
+
+
+def _admin_url() -> str:
+    return _sync_url().rsplit("/", 1)[0] + "/postgres"
+
+
+@pytest.fixture()
+def alembic_config():
+    from pytest_alembic.config import Config
+
+    return Config(
+        config_options={
+            "file": str(Path(__file__).parent.parent / "alembic.ini"),
+            "script_location": str(Path(__file__).parent.parent / "alembic"),
+        },
+    )
+
+
+@pytest.fixture()
+def alembic_engine():
+    admin_eng = create_engine(_admin_url(), isolation_level="AUTOCOMMIT")
+    with admin_eng.connect() as conn:
+        conn.execute(
+            text(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                f"WHERE datname = '{MIGRATION_DB}' AND pid <> pg_backend_pid()"
+            )
+        )
+        conn.execute(text(f"DROP DATABASE IF EXISTS {MIGRATION_DB}"))
+        conn.execute(text(f"CREATE DATABASE {MIGRATION_DB}"))
+    admin_eng.dispose()
+
+    mig_url = _sync_url().rsplit("/", 1)[0] + f"/{MIGRATION_DB}"
+    engine = create_engine(mig_url)
+    yield engine
+    engine.dispose()
+
+    admin_eng = create_engine(_admin_url(), isolation_level="AUTOCOMMIT")
+    with admin_eng.connect() as conn:
+        conn.execute(
+            text(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                f"WHERE datname = '{MIGRATION_DB}' AND pid <> pg_backend_pid()"
+            )
+        )
+        conn.execute(text(f"DROP DATABASE IF EXISTS {MIGRATION_DB}"))
+    admin_eng.dispose()
+
+
+_NOW = datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def _seed_curriculum(session: Session) -> dict[str, uuid.UUID]:
+    """Insert a phase/topic/step plus github + token requirements."""
+    from learn_to_cloud_shared.models import (
+        CurriculumPhase,
+        CurriculumRequirement,
+        CurriculumStep,
+        CurriculumTopic,
+    )
+
+    phase = CurriculumPhase(
+        uuid=uuid.uuid4(),
+        slug="phase0",
+        name="Phase 0",
+        description="d",
+        short_description="s",
+        order=0,
+    )
+    session.add(phase)
+    session.flush()
+    topic = CurriculumTopic(
+        uuid=uuid.uuid4(),
+        phase_uuid=phase.uuid,
+        slug="topic0",
+        name="Topic 0",
+        description="d",
+        order=0,
+    )
+    session.add(topic)
+    session.flush()
+    step = CurriculumStep(
+        uuid=uuid.uuid4(),
+        topic_uuid=topic.uuid,
+        slug="step0",
+        order=0,
+    )
+    stale_step = CurriculumStep(
+        uuid=uuid.uuid4(),
+        topic_uuid=topic.uuid,
+        slug="step-stale",
+        order=1,
+        deleted_at=_NOW,
+    )
+    req_github = CurriculumRequirement(
+        uuid=uuid.uuid4(),
+        phase_uuid=phase.uuid,
+        slug="req-github",
+        name="GitHub requirement",
+        description="d",
+        submission_type="profile_readme",
+        submission_value_kind="github_url",
+        order=0,
+    )
+    req_token = CurriculumRequirement(
+        uuid=uuid.uuid4(),
+        phase_uuid=phase.uuid,
+        slug="req-token",
+        name="Token requirement",
+        description="d",
+        submission_type="ctf_token",
+        submission_value_kind="token",
+        order=1,
+    )
+    session.add_all([step, stale_step, req_github, req_token])
+    session.flush()
+    return {
+        "step": step.uuid,
+        "stale_step": stale_step.uuid,
+        "req_github": req_github.uuid,
+        "req_token": req_token.uuid,
+    }
+
+
+def _make_submission(
+    session: Session,
+    *,
+    user_id: int,
+    requirement_uuid: uuid.UUID,
+    is_validated: bool,
+    verification_completed: bool,
+) -> int:
+    from learn_to_cloud_shared.models import Submission
+
+    submission = Submission(
+        user_id=user_id,
+        requirement_uuid=requirement_uuid,
+        submitted_value="https://github.com/octocat/repo",
+        submission_value_kind="github_url",
+        github_url="https://github.com/octocat/repo",
+        is_validated=is_validated,
+        validated_at=_NOW if is_validated else None,
+        verification_completed=verification_completed,
+    )
+    session.add(submission)
+    session.flush()
+    return submission.id
+
+
+def _make_job(
+    session: Session,
+    *,
+    user_id: int,
+    requirement_uuid: uuid.UUID,
+    value_kind: str = "github_url",
+    result_submission_id: int | None = None,
+) -> uuid.UUID:
+    from learn_to_cloud_shared.models import VerificationJob
+
+    job_id = uuid.uuid4()
+    if value_kind == "github_url":
+        typed = {
+            "github_url": "https://github.com/octocat/repo",
+            "submitted_value": "https://github.com/octocat/repo",
+        }
+    else:
+        typed = {"token_value": "tok-123", "submitted_value": "tok-123"}
+    job = VerificationJob(
+        id=job_id,
+        user_id=user_id,
+        requirement_uuid=requirement_uuid,
+        submission_value_kind=value_kind,
+        result_submission_id=result_submission_id,
+        traceparent="00-abc-def-01",
+        **typed,
+    )
+    session.add(job)
+    session.flush()
+    return job_id
+
+
+def _seed(engine) -> dict:
+    """Seed every representative shape. Returns identifiers for assertions."""
+    from learn_to_cloud_shared.models import StepProgress, User
+
+    with Session(engine) as session:
+        user = User(id=1001, github_username="octocat")
+        session.add(user)
+        session.flush()
+        cur = _seed_curriculum(session)
+
+        # Step progress: one active step + one stale (soft-deleted) step.
+        session.add_all(
+            [
+                StepProgress(user_id=1001, step_uuid=cur["step"], completed_at=_NOW),
+                StepProgress(
+                    user_id=1001, step_uuid=cur["stale_step"], completed_at=_NOW
+                ),
+            ]
+        )
+
+        # 1. linked job -> validated submission (succeeded)
+        s1 = _make_submission(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            is_validated=True,
+            verification_completed=True,
+        )
+        j1 = _make_job(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            result_submission_id=s1,
+        )
+        # 2. linked job -> completed-not-validated submission (failed)
+        s2 = _make_submission(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            is_validated=False,
+            verification_completed=True,
+        )
+        j2 = _make_job(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            result_submission_id=s2,
+        )
+        # 3. linked job -> not-completed submission (server_error)
+        s3 = _make_submission(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            is_validated=False,
+            verification_completed=False,
+        )
+        j3 = _make_job(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            result_submission_id=s3,
+        )
+        # 4. two jobs linked to one submission (both succeeded, both kept)
+        s4 = _make_submission(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            is_validated=True,
+            verification_completed=True,
+        )
+        j4a = _make_job(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            result_submission_id=s4,
+        )
+        j4b = _make_job(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            result_submission_id=s4,
+        )
+        # 5. unlinked job (active) on a different requirement
+        j5 = _make_job(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_token"],
+            value_kind="token",
+            result_submission_id=None,
+        )
+        # 6. orphan submission with no job (succeeded)
+        s6 = _make_submission(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            is_validated=True,
+            verification_completed=True,
+        )
+        session.commit()
+
+    return {
+        "cur": cur,
+        "j1": j1,
+        "j2": j2,
+        "j3": j3,
+        "j4a": j4a,
+        "j4b": j4b,
+        "j5": j5,
+        "s6": s6,
+    }
+
+
+def _maybe_attempt(engine, attempt_id: uuid.UUID) -> dict | None:
+    with engine.connect() as conn:
+        row = (
+            conn.execute(
+                text("SELECT * FROM verification_attempts WHERE id = :id"),
+                {"id": attempt_id},
+            )
+            .mappings()
+            .first()
+        )
+    return dict(row) if row else None
+
+
+def _fetch_attempt(engine, attempt_id: uuid.UUID) -> dict:
+    attempt = _maybe_attempt(engine, attempt_id)
+    assert attempt is not None, f"expected attempt {attempt_id} to exist"
+    return attempt
+
+
+@pytest.mark.migration_chain
+def test_backfill_all_shapes(alembic_runner, alembic_engine):
+    alembic_runner.migrate_up_to(_BEFORE)
+    ids = _seed(alembic_engine)
+    alembic_runner.migrate_up_one()
+
+    # 1-3: linked outcome mappings.
+    assert _fetch_attempt(alembic_engine, ids["j1"])["outcome"] == "succeeded"
+    assert _fetch_attempt(alembic_engine, ids["j2"])["outcome"] == "failed"
+    assert _fetch_attempt(alembic_engine, ids["j3"])["outcome"] == "server_error"
+
+    a1 = _fetch_attempt(alembic_engine, ids["j1"])
+    assert a1["snapshot_source"] == "reconstructed"
+    assert a1["legacy_job_id"] == ids["j1"]
+    assert a1["completed_at"] is not None
+    assert a1["requirement_snapshot"] is not None
+    assert a1["terminal_source"] == "migration"
+    assert a1["traceparent"] == "00-abc-def-01"
+
+    # 4: both jobs linked to one submission are preserved as succeeded.
+    assert _fetch_attempt(alembic_engine, ids["j4a"])["outcome"] == "succeeded"
+    assert _fetch_attempt(alembic_engine, ids["j4b"])["outcome"] == "succeeded"
+
+    # 5: unlinked job -> active attempt.
+    a5 = _fetch_attempt(alembic_engine, ids["j5"])
+    assert a5["outcome"] is None
+    assert a5["completed_at"] is None
+    assert a5["legacy_submission_id"] is None
+
+    # 6: orphan submission -> deterministic UUIDv5 attempt.
+    orphan_id = attempt_id_for_orphan_submission(ids["s6"])
+    a6 = _maybe_attempt(alembic_engine, orphan_id)
+    assert a6 is not None
+    assert a6["outcome"] == "succeeded"
+    assert a6["legacy_job_id"] is None
+    assert a6["legacy_submission_id"] == ids["s6"]
+
+
+@pytest.mark.migration_chain
+def test_concurrent_indexes_created_by_0050(alembic_runner, alembic_engine):
+    alembic_runner.migrate_up_to(_BEFORE)
+    _seed(alembic_engine)
+    # Runs 0049 (tables + backfill) then 0050 (concurrent index builds).
+    alembic_runner.migrate_up_to(_INDEXES)
+
+    with alembic_engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                """
+                SELECT c.relname AS name, i.indisvalid
+                FROM pg_index i
+                JOIN pg_class c ON c.oid = i.indexrelid
+                JOIN pg_class t ON t.oid = i.indrelid
+                WHERE t.relname = 'verification_attempts'
+                """
+            )
+        ).all()
+
+    by_name = {r.name: r.indisvalid for r in rows}
+    for index_name in (
+        "uq_verification_attempts_active_user_req",
+        "ix_verification_attempts_succeeded_user_req",
+        "ix_verification_attempts_user_req_created",
+    ):
+        assert index_name in by_name, f"{index_name} missing"
+        assert by_name[index_name] is True, f"{index_name} is INVALID"
+
+
+def _index_is_valid(engine, index_name: str) -> bool | None:
+    with engine.connect() as conn:
+        return conn.execute(
+            text(
+                """
+                SELECT i.indisvalid
+                FROM pg_index i
+                JOIN pg_class c ON c.oid = i.indexrelid
+                WHERE c.relname = :name
+                """
+            ),
+            {"name": index_name},
+        ).scalar()
+
+
+@pytest.mark.migration_chain
+def test_0050_recovers_invalid_index_on_retry(alembic_runner, alembic_engine):
+    index_name = "uq_verification_attempts_active_user_req"
+    alembic_runner.migrate_up_to(_BEFORE)
+    ids = _seed(alembic_engine)
+    # Run 0049 so verification_attempts exists and is backfilled; 0050 has
+    # NOT run yet, so the unique index is absent.
+    alembic_runner.migrate_up_to(_TABLES)
+    assert _index_is_valid(alembic_engine, index_name) is None
+
+    # Simulate a prior failed 0050 run: force a CREATE UNIQUE INDEX
+    # CONCURRENTLY to fail (two active attempts on the same user/req),
+    # which leaves the index behind in an INVALID state.
+    dup_id = uuid.uuid4()
+    with alembic_engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO verification_attempts (
+                    id, user_id, requirement_uuid, snapshot_source,
+                    submission_value_kind, submitted_value, outcome,
+                    created_at, updated_at
+                ) VALUES (
+                    :id, 1001, :req, 'reconstructed', 'token', 'tok-dup',
+                    NULL, :t, :t
+                )
+                """
+            ),
+            {"id": dup_id, "req": ids["cur"]["req_token"], "t": _NOW},
+        )
+
+    autocommit = alembic_engine.execution_options(isolation_level="AUTOCOMMIT")
+    with autocommit.connect() as conn:
+        with pytest.raises(Exception):
+            conn.execute(
+                text(
+                    "CREATE UNIQUE INDEX CONCURRENTLY "
+                    f"{index_name} "
+                    "ON verification_attempts (user_id, requirement_uuid) "
+                    "WHERE outcome IS NULL"
+                )
+            )
+    # The failed build left an INVALID index that IF NOT EXISTS alone would
+    # skip on retry.
+    assert _index_is_valid(alembic_engine, index_name) is False
+
+    # Remove the duplicate so the rebuild can succeed, then run 0050.
+    with alembic_engine.begin() as conn:
+        conn.execute(
+            text("DELETE FROM verification_attempts WHERE id = :id"),
+            {"id": dup_id},
+        )
+    alembic_runner.migrate_up_one()
+
+    # 0050 dropped the invalid index and rebuilt it valid.
+    assert _index_is_valid(alembic_engine, index_name) is True
+
+
+@pytest.mark.migration_chain
+def test_step_completions_backfill_and_stale_uuid(alembic_runner, alembic_engine):
+    alembic_runner.migrate_up_to(_BEFORE)
+    ids = _seed(alembic_engine)
+    alembic_runner.migrate_up_one()
+
+    with alembic_engine.connect() as conn:
+        rows = (
+            conn.execute(
+                text(
+                    "SELECT step_uuid FROM learner_step_completions "
+                    "WHERE user_id = 1001 ORDER BY step_uuid"
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    # Both the active and the stale (soft-deleted) step completions mirror,
+    # because learner_step_completions has no FK to the curriculum.
+    assert set(rows) == {ids["cur"]["step"], ids["cur"]["stale_step"]}
+
+
+@pytest.mark.migration_chain
+def test_mirror_trigger_insert_delete_and_idempotent(alembic_runner, alembic_engine):
+    alembic_runner.migrate_up_to(_BEFORE)
+    _seed(alembic_engine)
+    alembic_runner.migrate_up_one()
+
+    new_step = _extra_step(alembic_engine)
+
+    with alembic_engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO step_progress (user_id, step_uuid, completed_at) "
+                "VALUES (1001, :s, :t)"
+            ),
+            {"s": new_step, "t": _NOW},
+        )
+    assert _completion_count(alembic_engine, new_step) == 1
+
+    # Idempotent: a duplicate step_progress insert (same key) must not raise
+    # or create a second mirror row.
+    with alembic_engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO step_progress (user_id, step_uuid, completed_at) "
+                "VALUES (1001, :s, :t) "
+                "ON CONFLICT (user_id, step_uuid) DO NOTHING"
+            ),
+            {"s": new_step, "t": _NOW},
+        )
+    assert _completion_count(alembic_engine, new_step) == 1
+
+    # DELETE mirrors through to the completion table.
+    with alembic_engine.begin() as conn:
+        conn.execute(
+            text("DELETE FROM step_progress WHERE user_id = 1001 AND step_uuid = :s"),
+            {"s": new_step},
+        )
+    assert _completion_count(alembic_engine, new_step) == 0
+
+
+@pytest.mark.migration_chain
+def test_active_uniqueness_preflight_aborts(alembic_runner, alembic_engine):
+    alembic_runner.migrate_up_to(_BEFORE)
+    ids = _seed(alembic_engine)
+
+    # Force a second active (unlinked) job for the same (user, requirement)
+    # by dropping the guarding unique index first, so the backfill would
+    # break the one-active-attempt invariant.
+    with alembic_engine.begin() as conn:
+        conn.execute(
+            text("DROP INDEX IF EXISTS uq_verification_jobs_active_user_req_uuid")
+        )
+    with Session(alembic_engine) as session:
+        _make_job(
+            session,
+            user_id=1001,
+            requirement_uuid=ids["cur"]["req_token"],
+            value_kind="token",
+            result_submission_id=None,
+        )
+        session.commit()
+
+    with pytest.raises(Exception, match="one-active-attempt"):
+        alembic_runner.migrate_up_one()
+
+
+def _extra_step(engine) -> uuid.UUID:
+    from learn_to_cloud_shared.models import CurriculumStep
+
+    step_uuid = uuid.uuid4()
+    with Session(engine) as session:
+        topic_uuid = session.execute(
+            text("SELECT uuid FROM topics LIMIT 1")
+        ).scalar_one()
+        session.add(
+            CurriculumStep(
+                uuid=step_uuid,
+                topic_uuid=topic_uuid,
+                slug="step-extra",
+                order=99,
+            )
+        )
+        session.commit()
+    return step_uuid
+
+
+def _completion_count(engine, step_uuid: uuid.UUID) -> int:
+    with engine.connect() as conn:
+        return conn.execute(
+            text(
+                "SELECT count(*) FROM learner_step_completions "
+                "WHERE user_id = 1001 AND step_uuid = :s"
+            ),
+            {"s": step_uuid},
+        ).scalar_one()
+
+
+@pytest.mark.migration_chain
+def test_functions_role_grants(alembic_runner, alembic_engine, monkeypatch):
+    role = f"ltc_recon_grant_{uuid.uuid4().hex[:10]}"
+    monkeypatch.setenv("POSTGRES_VERIFICATION_FUNCTIONS_ROLE", role)
+
+    try:
+        # Migrate to the base first with the role absent so earlier
+        # grant/revoke migrations no-op; then create the role so only the
+        # 0049 grant under test runs against it.
+        alembic_runner.migrate_up_to(_BEFORE)
+
+        admin = create_engine(_admin_url(), isolation_level="AUTOCOMMIT")
+        with admin.connect() as conn:
+            conn.execute(text(f'CREATE ROLE "{role}"'))
+        admin.dispose()
+
+        _seed(alembic_engine)
+        alembic_runner.migrate_up_one()
+
+        with alembic_engine.connect() as conn:
+            granted = set(
+                conn.execute(
+                    text(
+                        """
+                        SELECT privilege_type
+                        FROM information_schema.role_table_grants
+                        WHERE grantee = :role
+                          AND table_name = 'verification_attempts'
+                        """
+                    ),
+                    {"role": role},
+                ).scalars()
+            )
+        assert {"SELECT", "INSERT", "UPDATE"} <= granted
+        # Least privilege: no DELETE/TRUNCATE at this expand stage.
+        assert "DELETE" not in granted
+    finally:
+        admin = create_engine(_admin_url(), isolation_level="AUTOCOMMIT")
+        with admin.connect() as conn:
+            conn.execute(
+                text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    f"WHERE datname = '{MIGRATION_DB}' AND pid <> pg_backend_pid()"
+                )
+            )
+            conn.execute(text(f"DROP DATABASE IF EXISTS {MIGRATION_DB}"))
+            conn.execute(text(f'DROP ROLE IF EXISTS "{role}"'))
+        admin.dispose()

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -130,6 +130,31 @@ class SubmissionValueKind(StrEnum):
     TEXT = "text"
 
 
+class VerificationAttemptOutcome(StrEnum):
+    """Terminal result of a verification attempt.
+
+    ``NULL`` (absent) marks an active, in-flight attempt; the values here
+    are only ever set once the attempt reaches a terminal state.
+    """
+
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    SERVER_ERROR = "server_error"
+    CANCELLED = "cancelled"
+
+
+class VerificationSnapshotSource(StrEnum):
+    """Provenance of an attempt's requirement snapshot.
+
+    ``submitted`` attempts carry the requirement definition captured at
+    submission time; ``reconstructed`` attempts were built by a backfill
+    from legacy rows and may honestly lack the original artifact metadata.
+    """
+
+    SUBMITTED = "submitted"
+    RECONSTRUCTED = "reconstructed"
+
+
 class Submission(TimestampMixin, Base):
     """Tracks validated submissions for hands-on verification.
 
@@ -454,6 +479,159 @@ class StepProgress(Base):
     )
 
     user: Mapped["User"] = relationship(back_populates="step_progress")
+
+
+class LearnerStepCompletion(Base):
+    """Curriculum-decoupled record of a learner completing a step.
+
+    Expand-only companion to :class:`StepProgress`. Keyed on
+    ``step_uuid`` with no FK to the curriculum tables so a step whose
+    definition is later soft-deleted or renumbered never blocks writes.
+    While legacy API revisions remain the writers of ``step_progress``,
+    a temporary database trigger mirrors inserts and deletes here; the
+    explicit new-table writes land in a later PR.
+    """
+
+    __tablename__ = "learner_step_completions"
+
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    step_uuid: Mapped[UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        primary_key=True,
+    )
+    completed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utcnow,
+    )
+
+    user: Mapped["User"] = relationship()
+
+
+class VerificationAttempt(TimestampMixin, Base):
+    """One verification attempt, keyed by its Durable orchestration id.
+
+    ``id`` doubles as the Durable Functions instance id (matching the
+    legacy ``verification_jobs`` contract). ``requirement_uuid`` carries
+    no FK to the curriculum tables so history survives curriculum
+    churn. An attempt is *active* while ``outcome`` is ``NULL`` and
+    *terminal* once an outcome and ``completed_at`` are set together.
+
+    Expand-only: this table is populated by backfill and (later)
+    dual-writes; active runtime readers/writers are unchanged in this PR.
+    """
+
+    __tablename__ = "verification_attempts"
+    __table_args__ = (
+        CheckConstraint(
+            "submission_value_kind IN ('github_url', 'token', 'deployed_url', 'text')",
+            name="ck_verification_attempts_value_kind",
+        ),
+        CheckConstraint(
+            "length(btrim(submitted_value)) > 0",
+            name="ck_verification_attempts_submitted_value_nonempty",
+        ),
+        CheckConstraint(
+            "outcome IS NULL OR outcome IN "
+            "('succeeded', 'failed', 'server_error', 'cancelled')",
+            name="ck_verification_attempts_outcome",
+        ),
+        CheckConstraint(
+            "(outcome IS NULL) = (completed_at IS NULL)",
+            name="ck_verification_attempts_outcome_completed_at",
+        ),
+        CheckConstraint(
+            "snapshot_source IN ('submitted', 'reconstructed')",
+            name="ck_verification_attempts_snapshot_source",
+        ),
+        # New ``submitted`` attempts must carry a real requirement snapshot
+        # and its hash. ``reconstructed`` migrated history may honestly
+        # leave the artifact metadata NULL.
+        CheckConstraint(
+            "snapshot_source = 'reconstructed' OR ("
+            "requirement_snapshot IS NOT NULL "
+            "AND requirement_snapshot_hash IS NOT NULL)",
+            name="ck_verification_attempts_submitted_snapshot_present",
+        ),
+        Index(
+            "uq_verification_attempts_active_user_req",
+            "user_id",
+            "requirement_uuid",
+            unique=True,
+            postgresql_where=text("outcome IS NULL"),
+        ),
+        Index(
+            "ix_verification_attempts_succeeded_user_req",
+            "user_id",
+            "requirement_uuid",
+            postgresql_where=text("outcome = 'succeeded'"),
+        ),
+        Index(
+            "ix_verification_attempts_user_req_created",
+            "user_id",
+            "requirement_uuid",
+            text("created_at DESC"),
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+    )
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    requirement_uuid: Mapped[UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        nullable=False,
+    )
+
+    # Identity / snapshot of the curriculum artifact and requirement.
+    # Text/BigInteger throughout to satisfy squawk's prefer-text-field and
+    # prefer-bigint-over-int safety rules for new columns.
+    artifact_schema_version: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True
+    )
+    curriculum_version: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    content_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    requirement_snapshot: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    requirement_snapshot_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    snapshot_source: Mapped[str] = mapped_column(Text, nullable=False)
+    payload_version: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+    # Submitted identity / value.
+    github_username_snapshot: Mapped[str | None] = mapped_column(Text, nullable=True)
+    submission_value_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    submitted_value: Mapped[str] = mapped_column(Text, nullable=False)
+    cloud_provider: Mapped[str | None] = mapped_column(Text, nullable=True)
+    traceparent: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Lifecycle / result.
+    outcome: Mapped[str | None] = mapped_column(Text, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    feedback_json: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
+    validation_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    terminal_source: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Temporary migration provenance, retained until the final contract PR.
+    legacy_job_id: Mapped[UUID | None] = mapped_column(
+        Uuid(as_uuid=True), nullable=True
+    )
+    legacy_submission_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+    user: Mapped["User"] = relationship()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -482,15 +482,7 @@ class StepProgress(Base):
 
 
 class LearnerStepCompletion(Base):
-    """Curriculum-decoupled record of a learner completing a step.
-
-    Expand-only companion to :class:`StepProgress`. Keyed on
-    ``step_uuid`` with no FK to the curriculum tables so a step whose
-    definition is later soft-deleted or renumbered never blocks writes.
-    While legacy API revisions remain the writers of ``step_progress``,
-    a temporary database trigger mirrors inserts and deletes here; the
-    explicit new-table writes land in a later PR.
-    """
+    """Record a learner completing a catalog step UUID."""
 
     __tablename__ = "learner_step_completions"
 
@@ -512,17 +504,7 @@ class LearnerStepCompletion(Base):
 
 
 class VerificationAttempt(TimestampMixin, Base):
-    """One verification attempt, keyed by its Durable orchestration id.
-
-    ``id`` doubles as the Durable Functions instance id (matching the
-    legacy ``verification_jobs`` contract). ``requirement_uuid`` carries
-    no FK to the curriculum tables so history survives curriculum
-    churn. An attempt is *active* while ``outcome`` is ``NULL`` and
-    *terminal* once an outcome and ``completed_at`` are set together.
-
-    Expand-only: this table is populated by backfill and (later)
-    dual-writes; active runtime readers/writers are unchanged in this PR.
-    """
+    """Persist a verification attempt using its UUID as the Durable instance ID."""
 
     __tablename__ = "verification_attempts"
     __table_args__ = (
@@ -625,7 +607,6 @@ class VerificationAttempt(TimestampMixin, Base):
     error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
     terminal_source: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    # Temporary migration provenance, retained until the final contract PR.
     legacy_job_id: Mapped[UUID | None] = mapped_column(
         Uuid(as_uuid=True), nullable=True
     )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_provenance.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_provenance.py
@@ -1,0 +1,45 @@
+"""Deterministic provenance helpers for the verification-attempt backfill.
+
+Shared by the expand migration, the reconciliation report, and their
+tests so the id derivation and outcome mapping stay in exact agreement.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid5
+
+from learn_to_cloud_shared.models import VerificationAttemptOutcome
+
+# Fixed, documented namespace for deriving a verification-attempt id from a
+# legacy submission that never had a verification_jobs row. UUIDv5 keeps the
+# mapping deterministic so the backfill is idempotent and re-runnable. Do not
+# change this value: it anchors every orphan-submission attempt id in history.
+ORPHAN_SUBMISSION_ATTEMPT_NAMESPACE = UUID("b27a6ab3-3d05-4918-8de2-0ef02aac06a9")
+
+_ORPHAN_NAME_PREFIX = "submission:"
+
+
+def attempt_id_for_orphan_submission(submission_id: int) -> UUID:
+    """Return the deterministic attempt id for a job-less submission."""
+    return uuid5(
+        ORPHAN_SUBMISSION_ATTEMPT_NAMESPACE,
+        f"{_ORPHAN_NAME_PREFIX}{submission_id}",
+    )
+
+
+def derive_outcome(
+    *,
+    is_validated: bool,
+    verification_completed: bool,
+) -> VerificationAttemptOutcome:
+    """Map a legacy submission's flags to a terminal attempt outcome.
+
+    ``is_validated`` wins (succeeded); a completed-but-not-validated run is a
+    genuine ``failed`` verification; anything else never finished verifying
+    and is recorded as ``server_error``.
+    """
+    if is_validated:
+        return VerificationAttemptOutcome.SUCCEEDED
+    if verification_completed:
+        return VerificationAttemptOutcome.FAILED
+    return VerificationAttemptOutcome.SERVER_ERROR

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_reconciliation.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_reconciliation.py
@@ -1,0 +1,342 @@
+"""Read-only reconciliation report for the verification-attempt backfill.
+
+Run after the expand backfill and after later deployments to confirm the
+new ``verification_attempts`` / ``learner_step_completions`` tables agree
+with the legacy ``verification_jobs`` / ``submissions`` / ``step_progress``
+tables. The report never mutates data -- it only runs SELECTs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Shared with the backfill migration so the expected-outcome mapping stays
+# identical on both sides of the comparison.
+_EXPECTED_OUTCOME_SQL = (
+    "CASE WHEN {alias}.is_validated THEN 'succeeded' "
+    "WHEN {alias}.verification_completed THEN 'failed' "
+    "ELSE 'server_error' END"
+)
+
+
+@dataclass(frozen=True)
+class OutcomeMismatch:
+    attempt_id: UUID
+    user_id: int
+    requirement_uuid: UUID
+    actual_outcome: str | None
+    expected_outcome: str
+
+
+@dataclass(frozen=True)
+class ActiveUniquenessViolation:
+    user_id: int
+    requirement_uuid: UUID
+    active_count: int
+
+
+@dataclass(frozen=True)
+class ReconciliationReport:
+    """Structured result of a reconciliation pass. Read-only."""
+
+    row_counts: dict[str, int] = field(default_factory=dict)
+    linked_outcome_mismatches: list[OutcomeMismatch] = field(default_factory=list)
+    orphan_outcome_mismatches: list[OutcomeMismatch] = field(default_factory=list)
+    active_uniqueness_violations: list[ActiveUniquenessViolation] = field(
+        default_factory=list
+    )
+    legacy_only_jobs: list[UUID] = field(default_factory=list)
+    legacy_only_submissions: list[int] = field(default_factory=list)
+    dangling_job_provenance: list[UUID] = field(default_factory=list)
+    dangling_submission_provenance: list[UUID] = field(default_factory=list)
+    attempts_without_provenance: list[UUID] = field(default_factory=list)
+    step_completions_missing: list[tuple[int, UUID]] = field(default_factory=list)
+    step_completions_extra: list[tuple[int, UUID]] = field(default_factory=list)
+
+    @property
+    def divergences(self) -> dict[str, int]:
+        """Named divergence categories mapped to their row counts."""
+        return {
+            "linked_outcome_mismatches": len(self.linked_outcome_mismatches),
+            "orphan_outcome_mismatches": len(self.orphan_outcome_mismatches),
+            "active_uniqueness_violations": len(self.active_uniqueness_violations),
+            "legacy_only_jobs": len(self.legacy_only_jobs),
+            "legacy_only_submissions": len(self.legacy_only_submissions),
+            "dangling_job_provenance": len(self.dangling_job_provenance),
+            "dangling_submission_provenance": len(self.dangling_submission_provenance),
+            "attempts_without_provenance": len(self.attempts_without_provenance),
+            "step_completions_missing": len(self.step_completions_missing),
+            "step_completions_extra": len(self.step_completions_extra),
+        }
+
+    @property
+    def ok(self) -> bool:
+        """True when every divergence category is empty."""
+        return not any(self.divergences.values())
+
+
+async def _scalar_count(session: AsyncSession, table: str) -> int:
+    result = await session.execute(text(f"SELECT count(*) FROM {table}"))
+    return int(result.scalar_one())
+
+
+async def run_reconciliation(session: AsyncSession) -> ReconciliationReport:
+    """Compute a reconciliation report. Runs SELECTs only, never mutates."""
+    row_counts = {
+        "step_progress": await _scalar_count(session, "step_progress"),
+        "learner_step_completions": await _scalar_count(
+            session, "learner_step_completions"
+        ),
+        "submissions": await _scalar_count(session, "submissions"),
+        "verification_jobs": await _scalar_count(session, "verification_jobs"),
+        "verification_attempts": await _scalar_count(session, "verification_attempts"),
+    }
+
+    linked_outcome_mismatches = [
+        OutcomeMismatch(
+            attempt_id=r.id,
+            user_id=r.user_id,
+            requirement_uuid=r.requirement_uuid,
+            actual_outcome=r.outcome,
+            expected_outcome=r.expected_outcome,
+        )
+        for r in (
+            await session.execute(
+                text(
+                    f"""
+                    SELECT a.id, a.user_id, a.requirement_uuid, a.outcome,
+                           {_EXPECTED_OUTCOME_SQL.format(alias="s")}
+                               AS expected_outcome
+                    FROM verification_attempts a
+                    JOIN verification_jobs vj ON vj.id = a.legacy_job_id
+                    JOIN submissions s ON s.id = vj.result_submission_id
+                    WHERE a.outcome IS DISTINCT FROM
+                        {_EXPECTED_OUTCOME_SQL.format(alias="s")}
+                    ORDER BY a.id
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    orphan_outcome_mismatches = [
+        OutcomeMismatch(
+            attempt_id=r.id,
+            user_id=r.user_id,
+            requirement_uuid=r.requirement_uuid,
+            actual_outcome=r.outcome,
+            expected_outcome=r.expected_outcome,
+        )
+        for r in (
+            await session.execute(
+                text(
+                    f"""
+                    SELECT a.id, a.user_id, a.requirement_uuid, a.outcome,
+                           {_EXPECTED_OUTCOME_SQL.format(alias="s")}
+                               AS expected_outcome
+                    FROM verification_attempts a
+                    JOIN submissions s ON s.id = a.legacy_submission_id
+                    WHERE a.legacy_job_id IS NULL
+                      AND a.outcome IS DISTINCT FROM
+                          {_EXPECTED_OUTCOME_SQL.format(alias="s")}
+                    ORDER BY a.id
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    active_uniqueness_violations = [
+        ActiveUniquenessViolation(
+            user_id=r.user_id,
+            requirement_uuid=r.requirement_uuid,
+            active_count=r.active_count,
+        )
+        for r in (
+            await session.execute(
+                text(
+                    """
+                    SELECT user_id, requirement_uuid, count(*) AS active_count
+                    FROM verification_attempts
+                    WHERE outcome IS NULL
+                    GROUP BY user_id, requirement_uuid
+                    HAVING count(*) > 1
+                    ORDER BY user_id, requirement_uuid
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    legacy_only_jobs = [
+        r.id
+        for r in (
+            await session.execute(
+                text(
+                    """
+                    SELECT vj.id
+                    FROM verification_jobs vj
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM verification_attempts a
+                        WHERE a.legacy_job_id = vj.id
+                    )
+                    ORDER BY vj.id
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    legacy_only_submissions = [
+        r.id
+        for r in (
+            await session.execute(
+                text(
+                    """
+                    SELECT s.id
+                    FROM submissions s
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM verification_attempts a
+                        WHERE a.legacy_submission_id = s.id
+                    )
+                    ORDER BY s.id
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    dangling_job_provenance = [
+        r.id
+        for r in (
+            await session.execute(
+                text(
+                    """
+                    SELECT a.id
+                    FROM verification_attempts a
+                    WHERE a.legacy_job_id IS NOT NULL
+                      AND NOT EXISTS (
+                        SELECT 1 FROM verification_jobs vj
+                        WHERE vj.id = a.legacy_job_id
+                    )
+                    ORDER BY a.id
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    dangling_submission_provenance = [
+        r.id
+        for r in (
+            await session.execute(
+                text(
+                    """
+                    SELECT a.id
+                    FROM verification_attempts a
+                    WHERE a.legacy_submission_id IS NOT NULL
+                      AND NOT EXISTS (
+                        SELECT 1 FROM submissions s
+                        WHERE s.id = a.legacy_submission_id
+                    )
+                    ORDER BY a.id
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    # Only reconstructed/backfilled attempts are expected to carry legacy
+    # provenance. Genuine future ``submitted`` attempts legitimately have no
+    # legacy_job_id/legacy_submission_id, so they must not be flagged.
+    attempts_without_provenance = [
+        r.id
+        for r in (
+            await session.execute(
+                text(
+                    """
+                    SELECT id
+                    FROM verification_attempts
+                    WHERE legacy_job_id IS NULL
+                      AND legacy_submission_id IS NULL
+                      AND snapshot_source = 'reconstructed'
+                    ORDER BY id
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    step_completions_missing = [
+        (r.user_id, r.step_uuid)
+        for r in (
+            await session.execute(
+                text(
+                    """
+                    SELECT sp.user_id, sp.step_uuid
+                    FROM step_progress sp
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM learner_step_completions lsc
+                        WHERE lsc.user_id = sp.user_id
+                          AND lsc.step_uuid = sp.step_uuid
+                    )
+                    ORDER BY sp.user_id, sp.step_uuid
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    step_completions_extra = [
+        (r.user_id, r.step_uuid)
+        for r in (
+            await session.execute(
+                text(
+                    """
+                    SELECT lsc.user_id, lsc.step_uuid
+                    FROM learner_step_completions lsc
+                    WHERE NOT EXISTS (
+                        SELECT 1 FROM step_progress sp
+                        WHERE sp.user_id = lsc.user_id
+                          AND sp.step_uuid = lsc.step_uuid
+                    )
+                    ORDER BY lsc.user_id, lsc.step_uuid
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    return ReconciliationReport(
+        row_counts=row_counts,
+        linked_outcome_mismatches=linked_outcome_mismatches,
+        orphan_outcome_mismatches=orphan_outcome_mismatches,
+        active_uniqueness_violations=active_uniqueness_violations,
+        legacy_only_jobs=legacy_only_jobs,
+        legacy_only_submissions=legacy_only_submissions,
+        dangling_job_provenance=dangling_job_provenance,
+        dangling_submission_provenance=dangling_submission_provenance,
+        attempts_without_provenance=attempts_without_provenance,
+        step_completions_missing=step_completions_missing,
+        step_completions_extra=step_completions_extra,
+    )
+
+
+def format_report(report: ReconciliationReport) -> str:
+    """Render a human-readable summary of a reconciliation report."""
+    lines = ["Verification backfill reconciliation report", ""]
+    lines.append("Row counts:")
+    for table, count in report.row_counts.items():
+        lines.append(f"  {table:<28} {count}")
+    lines.append("")
+    lines.append("Divergences:")
+    for name, count in report.divergences.items():
+        marker = "ok" if count == 0 else "!!"
+        lines.append(f"  [{marker}] {name:<32} {count}")
+    lines.append("")
+    lines.append("RESULT: " + ("OK -- fully reconciled" if report.ok else "DIVERGENT"))
+    return "\n".join(lines)

--- a/packages/learn-to-cloud-shared/tests/test_verification_provenance.py
+++ b/packages/learn-to-cloud-shared/tests/test_verification_provenance.py
@@ -1,0 +1,80 @@
+"""Unit tests for verification-attempt provenance helpers."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from learn_to_cloud_shared.models import VerificationAttemptOutcome
+from learn_to_cloud_shared.verification_provenance import (
+    ORPHAN_SUBMISSION_ATTEMPT_NAMESPACE,
+    attempt_id_for_orphan_submission,
+    derive_outcome,
+)
+
+
+class TestDeriveOutcome:
+    def test_validated_is_succeeded(self):
+        outcome = derive_outcome(is_validated=True, verification_completed=True)
+        assert outcome is VerificationAttemptOutcome.SUCCEEDED
+
+    def test_completed_not_validated_is_failed(self):
+        outcome = derive_outcome(is_validated=False, verification_completed=True)
+        assert outcome is VerificationAttemptOutcome.FAILED
+
+    def test_not_completed_is_server_error(self):
+        outcome = derive_outcome(is_validated=False, verification_completed=False)
+        assert outcome is VerificationAttemptOutcome.SERVER_ERROR
+
+    def test_validated_wins_over_incomplete(self):
+        # is_validated should dominate even if verification_completed is False.
+        outcome = derive_outcome(is_validated=True, verification_completed=False)
+        assert outcome is VerificationAttemptOutcome.SUCCEEDED
+
+
+class TestOrphanAttemptId:
+    def test_is_deterministic(self):
+        assert attempt_id_for_orphan_submission(42) == (
+            attempt_id_for_orphan_submission(42)
+        )
+
+    def test_distinct_ids_for_distinct_submissions(self):
+        assert attempt_id_for_orphan_submission(1) != (
+            attempt_id_for_orphan_submission(2)
+        )
+
+    def test_is_uuid5_of_documented_namespace(self):
+        from uuid import uuid5
+
+        expected = uuid5(ORPHAN_SUBMISSION_ATTEMPT_NAMESPACE, "submission:7")
+        assert attempt_id_for_orphan_submission(7) == expected
+
+    def test_namespace_is_pinned(self):
+        # This value anchors every orphan-submission attempt id in history
+        # and must never change.
+        assert ORPHAN_SUBMISSION_ATTEMPT_NAMESPACE == UUID(
+            "b27a6ab3-3d05-4918-8de2-0ef02aac06a9"
+        )
+
+
+def test_outcome_enum_values():
+    assert {o.value for o in VerificationAttemptOutcome} == {
+        "succeeded",
+        "failed",
+        "server_error",
+        "cancelled",
+    }
+
+
+def test_snapshot_source_enum_values():
+    from learn_to_cloud_shared.models import VerificationSnapshotSource
+
+    assert {s.value for s in VerificationSnapshotSource} == {
+        "submitted",
+        "reconstructed",
+    }
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/packages/learn-to-cloud-shared/tests/test_verification_reconciliation.py
+++ b/packages/learn-to-cloud-shared/tests/test_verification_reconciliation.py
@@ -1,0 +1,305 @@
+"""Integration tests for the read-only reconciliation report."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud_shared.models import (
+    CurriculumPhase,
+    CurriculumRequirement,
+    LearnerStepCompletion,
+    Submission,
+    User,
+    VerificationAttempt,
+    VerificationJob,
+)
+from learn_to_cloud_shared.verification_reconciliation import (
+    ReconciliationReport,
+    format_report,
+    run_reconciliation,
+)
+
+pytestmark = pytest.mark.integration
+
+_NOW = datetime(2026, 1, 1, tzinfo=UTC)
+USER_ID = 90001
+
+
+async def _make_user(db_session: AsyncSession) -> None:
+    db_session.add(User(id=USER_ID, github_username="reconuser"))
+    await db_session.flush()
+
+
+async def _make_requirement(db_session: AsyncSession) -> uuid.UUID:
+    phase = CurriculumPhase(
+        uuid=uuid.uuid4(),
+        slug=f"phase-{uuid.uuid4().hex[:8]}",
+        name="P",
+        description="d",
+        short_description="s",
+        order=0,
+    )
+    db_session.add(phase)
+    await db_session.flush()
+    requirement = CurriculumRequirement(
+        uuid=uuid.uuid4(),
+        phase_uuid=phase.uuid,
+        slug=f"req-{uuid.uuid4().hex[:8]}",
+        name="R",
+        description="d",
+        submission_type="profile_readme",
+        submission_value_kind="github_url",
+        order=0,
+    )
+    db_session.add(requirement)
+    await db_session.flush()
+    return requirement.uuid
+
+
+async def _make_submission(
+    db_session: AsyncSession,
+    requirement_uuid: uuid.UUID,
+    *,
+    is_validated: bool = True,
+) -> int:
+    submission = Submission(
+        user_id=USER_ID,
+        requirement_uuid=requirement_uuid,
+        submitted_value="https://github.com/octocat/repo",
+        submission_value_kind="github_url",
+        github_url="https://github.com/octocat/repo",
+        is_validated=is_validated,
+        validated_at=_NOW if is_validated else None,
+        verification_completed=True,
+    )
+    db_session.add(submission)
+    await db_session.flush()
+    return submission.id
+
+
+async def _make_job(
+    db_session: AsyncSession,
+    requirement_uuid: uuid.UUID,
+    *,
+    result_submission_id: int | None,
+) -> uuid.UUID:
+    job = VerificationJob(
+        id=uuid.uuid4(),
+        user_id=USER_ID,
+        requirement_uuid=requirement_uuid,
+        submission_value_kind="github_url",
+        github_url="https://github.com/octocat/repo",
+        submitted_value="https://github.com/octocat/repo",
+        result_submission_id=result_submission_id,
+    )
+    db_session.add(job)
+    await db_session.flush()
+    return job.id
+
+
+def _attempt(
+    requirement_uuid: uuid.UUID,
+    *,
+    attempt_id: uuid.UUID | None = None,
+    outcome: str | None = "succeeded",
+    legacy_job_id: uuid.UUID | None = None,
+    legacy_submission_id: int | None = None,
+    snapshot_source: str = "reconstructed",
+) -> VerificationAttempt:
+    # ``submitted`` attempts must carry a real snapshot + hash per the
+    # table CHECK; ``reconstructed`` history may leave them NULL.
+    submitted = snapshot_source == "submitted"
+    return VerificationAttempt(
+        id=attempt_id or uuid.uuid4(),
+        user_id=USER_ID,
+        requirement_uuid=requirement_uuid,
+        snapshot_source=snapshot_source,
+        requirement_snapshot={"uuid": str(requirement_uuid)} if submitted else None,
+        requirement_snapshot_hash="deadbeef" if submitted else None,
+        submission_value_kind="github_url",
+        submitted_value="https://github.com/octocat/repo",
+        outcome=outcome,
+        completed_at=_NOW if outcome is not None else None,
+        terminal_source="migration" if outcome is not None else None,
+        legacy_job_id=legacy_job_id,
+        legacy_submission_id=legacy_submission_id,
+    )
+
+
+class TestFullyReconciled:
+    async def test_ok_when_new_and_legacy_agree(self, db_session: AsyncSession):
+        await _make_user(db_session)
+        req = await _make_requirement(db_session)
+        submission_id = await _make_submission(db_session, req, is_validated=True)
+        job_id = await _make_job(db_session, req, result_submission_id=submission_id)
+        db_session.add(
+            _attempt(
+                req,
+                attempt_id=job_id,
+                outcome="succeeded",
+                legacy_job_id=job_id,
+                legacy_submission_id=submission_id,
+            )
+        )
+        await db_session.flush()
+
+        report = await run_reconciliation(db_session)
+
+        assert report.ok, report.divergences
+        assert report.row_counts["verification_attempts"] == 1
+        assert report.row_counts["verification_jobs"] == 1
+
+
+class TestDivergences:
+    async def test_linked_outcome_mismatch(self, db_session: AsyncSession):
+        await _make_user(db_session)
+        req = await _make_requirement(db_session)
+        submission_id = await _make_submission(db_session, req, is_validated=True)
+        job_id = await _make_job(db_session, req, result_submission_id=submission_id)
+        # Attempt claims 'failed' but the linked submission is validated.
+        db_session.add(
+            _attempt(
+                req,
+                attempt_id=job_id,
+                outcome="failed",
+                legacy_job_id=job_id,
+                legacy_submission_id=submission_id,
+            )
+        )
+        await db_session.flush()
+
+        report = await run_reconciliation(db_session)
+
+        assert len(report.linked_outcome_mismatches) == 1
+        mismatch = report.linked_outcome_mismatches[0]
+        assert mismatch.actual_outcome == "failed"
+        assert mismatch.expected_outcome == "succeeded"
+
+    async def test_active_uniqueness_violation(self, db_session: AsyncSession):
+        from sqlalchemy import text
+
+        await _make_user(db_session)
+        req = await _make_requirement(db_session)
+        # The partial unique index normally makes two active attempts
+        # impossible; drop it inside this rolled-back transaction so the
+        # reconciliation report's defense-in-depth check can be exercised.
+        await db_session.execute(
+            text("DROP INDEX uq_verification_attempts_active_user_req")
+        )
+        db_session.add(_attempt(req, outcome=None, legacy_job_id=uuid.uuid4()))
+        db_session.add(_attempt(req, outcome=None, legacy_job_id=uuid.uuid4()))
+        await db_session.flush()
+
+        report = await run_reconciliation(db_session)
+
+        assert len(report.active_uniqueness_violations) == 1
+        assert report.active_uniqueness_violations[0].active_count == 2
+
+    async def test_legacy_only_job_and_submission(self, db_session: AsyncSession):
+        await _make_user(db_session)
+        req = await _make_requirement(db_session)
+        submission_id = await _make_submission(db_session, req)
+        job_id = await _make_job(db_session, req, result_submission_id=submission_id)
+        # No attempts created for either legacy row.
+        report = await run_reconciliation(db_session)
+
+        assert job_id in report.legacy_only_jobs
+        assert submission_id in report.legacy_only_submissions
+
+    async def test_dangling_provenance(self, db_session: AsyncSession):
+        await _make_user(db_session)
+        req = await _make_requirement(db_session)
+        attempt_id = uuid.uuid4()
+        db_session.add(
+            _attempt(
+                req,
+                attempt_id=attempt_id,
+                legacy_job_id=uuid.uuid4(),  # points at a non-existent job
+            )
+        )
+        await db_session.flush()
+
+        report = await run_reconciliation(db_session)
+
+        assert attempt_id in report.dangling_job_provenance
+
+    async def test_reconstructed_attempt_without_provenance_is_flagged(
+        self, db_session: AsyncSession
+    ):
+        await _make_user(db_session)
+        req = await _make_requirement(db_session)
+        attempt_id = uuid.uuid4()
+        db_session.add(
+            _attempt(
+                req,
+                attempt_id=attempt_id,
+                snapshot_source="reconstructed",
+                legacy_job_id=None,
+                legacy_submission_id=None,
+            )
+        )
+        await db_session.flush()
+
+        report = await run_reconciliation(db_session)
+
+        assert attempt_id in report.attempts_without_provenance
+
+    async def test_submitted_attempt_without_provenance_is_not_flagged(
+        self, db_session: AsyncSession
+    ):
+        # Genuine future submitted attempts have no legacy provenance and
+        # must not make the report divergent.
+        await _make_user(db_session)
+        req = await _make_requirement(db_session)
+        attempt_id = uuid.uuid4()
+        db_session.add(
+            _attempt(
+                req,
+                attempt_id=attempt_id,
+                snapshot_source="submitted",
+                legacy_job_id=None,
+                legacy_submission_id=None,
+            )
+        )
+        await db_session.flush()
+
+        report = await run_reconciliation(db_session)
+
+        assert attempt_id not in report.attempts_without_provenance
+        assert report.ok, report.divergences
+
+    async def test_step_completion_divergence(self, db_session: AsyncSession):
+        await _make_user(db_session)
+        extra_step = uuid.uuid4()
+        # learner_step_completions has no FK, so an "extra" completion with
+        # no matching step_progress row is detectable directly.
+        db_session.add(
+            LearnerStepCompletion(
+                user_id=USER_ID, step_uuid=extra_step, completed_at=_NOW
+            )
+        )
+        await db_session.flush()
+
+        report = await run_reconciliation(db_session)
+
+        assert (USER_ID, extra_step) in report.step_completions_extra
+
+
+class TestFormatReport:
+    def test_ok_report_renders_ok(self):
+        report = ReconciliationReport(row_counts={"verification_attempts": 3})
+        rendered = format_report(report)
+        assert "OK -- fully reconciled" in rendered
+        assert "verification_attempts" in rendered
+
+    def test_divergent_report_flags_result(self):
+        report = ReconciliationReport(
+            row_counts={},
+            attempts_without_provenance=[uuid.uuid4()],
+        )
+        assert not report.ok
+        assert "DIVERGENT" in format_report(report)


### PR DESCRIPTION
## Why

Learner progress was coupled to curriculum tables, and one verification was split across `verification_jobs` and `submissions`. This expand-only layer introduces curriculum-independent learner state before any writer or reader is cut over.

## What changed

- add authoritative `verification_attempts` and `learner_step_completions` tables
- store stable curriculum UUIDs without curriculum-table foreign keys
- backfill historical jobs, submissions, and checked steps idempotently
- preserve historical outcomes and reconstructed requirement provenance
- add active/succeeded/latest-attempt indexes and lifecycle constraints
- mirror legacy step changes during mixed-revision deployment
- add reconciliation checks and least-privilege Functions grants

## Stack position

Depends on #658. This is schema expansion only; existing runtime paths remain unchanged until #661 and later layers.

## Validation

`uv run poe check`, including PostgreSQL migration-chain and backfill coverage