### PR TITLE
Add unified verification attempt bridge

### DIFF
--- a/api/alembic/versions/0051_narrow_functions_role_attempt_grants.py
+++ b/api/alembic/versions/0051_narrow_functions_role_attempt_grants.py
@@ -1,0 +1,149 @@
+"""narrow Functions role verification_attempts grants to column level
+
+Why this change: PR4 of the verification refactor (the bridge) has the
+Functions role read attempts to prepare/reconcile and write only the
+result/lifecycle columns to finalize. Revision 0049 granted it table-level
+``SELECT, INSERT, UPDATE`` on ``verification_attempts`` as a placeholder; this
+revision narrows that to least privilege now that the exact column surface is
+known.
+
+Schema effect (Functions role only; no-op when the role env var is unset or
+the role does not exist):
+- REVOKE ALL ON ``verification_attempts`` (drops the 0049 table-level
+  SELECT/INSERT/UPDATE, and INSERT/DELETE the bridge never needs).
+- GRANT SELECT on only the identity/snapshot/lifecycle columns the prepare,
+  reconcile, and legacy-mirror reads touch.
+- GRANT UPDATE on only the lifecycle/result columns prepare and finalize write
+  (``started_at``, ``outcome``, ``error_code``, ``validation_message``,
+  ``terminal_source``, ``feedback_json``, ``completed_at``, ``updated_at``).
+  The immutable user/requirement/snapshot/submitted-value identity columns are
+  intentionally excluded, so the role cannot rewrite what an attempt was
+  submitted against.
+- Leaves the legacy ``submissions`` (SELECT/INSERT) and ``verification_jobs``
+  (SELECT/UPDATE) grants untouched: the bridge still mirrors/links legacy rows.
+
+Rollback notes: downgrade REVOKEs the column grants and restores the 0049
+table-level ``SELECT, INSERT, UPDATE`` so the chain is reversible.
+
+Revision ID: 0051_narrow_functions_role_attempt_grants
+Revises: 0050_verification_attempts_concurrent_indexes
+Create Date: 2026-07-14
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0051_narrow_functions_role_attempt_grants"
+down_revision: str | None = "0050_verification_attempts_concurrent_indexes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Columns the prepare, reconcile, status, and legacy-mirror reads need. Keep in
+# sync with VerificationAttemptRepository's projections.
+_SELECT_COLUMNS: tuple[str, ...] = (
+    "id",
+    "user_id",
+    "requirement_uuid",
+    "snapshot_source",
+    "payload_version",
+    "requirement_snapshot",
+    "requirement_snapshot_hash",
+    "submission_value_kind",
+    "submitted_value",
+    "github_username_snapshot",
+    "cloud_provider",
+    "traceparent",
+    "outcome",
+    "started_at",
+    "created_at",
+    "completed_at",
+    "error_code",
+    "validation_message",
+    "terminal_source",
+    "feedback_json",
+    "legacy_job_id",
+)
+
+# Only lifecycle/result columns are writable. No immutable identity column is
+# updatable by the Functions role.
+_UPDATE_COLUMNS: tuple[str, ...] = (
+    "outcome",
+    "error_code",
+    "validation_message",
+    "terminal_source",
+    "feedback_json",
+    "started_at",
+    "completed_at",
+    "updated_at",
+)
+
+
+def _verification_functions_role() -> str | None:
+    """Return the validated Functions DB role name, or None when unset."""
+    role = os.environ.get("POSTGRES_VERIFICATION_FUNCTIONS_ROLE")
+    if not role:
+        return None
+    if not (role[0].isalpha() or role[0] == "_") or not all(
+        c.isalnum() or c == "_" for c in role
+    ):
+        raise RuntimeError(
+            f"POSTGRES_VERIFICATION_FUNCTIONS_ROLE is not a valid identifier: {role!r}"
+        )
+    return role
+
+
+def _apply_grants(role: str, *, select_cols: str, update_cols: str) -> None:
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                REVOKE ALL ON verification_attempts FROM "{role}";
+                GRANT SELECT ({select_cols})
+                    ON verification_attempts TO "{role}";
+                GRANT UPDATE ({update_cols})
+                    ON verification_attempts TO "{role}";
+            END IF;
+        END $$;
+        """
+    )
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    role = _verification_functions_role()
+    if not role:
+        return
+    _apply_grants(
+        role,
+        select_cols=", ".join(_SELECT_COLUMNS),
+        update_cols=", ".join(_UPDATE_COLUMNS),
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    role = _verification_functions_role()
+    if not role:
+        return
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                REVOKE ALL ON verification_attempts FROM "{role}";
+                GRANT SELECT, INSERT, UPDATE
+                    ON verification_attempts TO "{role}";
+            END IF;
+        END $$;
+        """
+    )

--- a/api/tests/test_verification_attempt_grants_migration.py
+++ b/api/tests/test_verification_attempt_grants_migration.py
@@ -1,0 +1,183 @@
+"""Grants test for the column-level Functions role migration (0051).
+
+Creates the Functions role, runs the migration chain through the column-grant
+narrowing, and asserts the role can SELECT the prepare/reconcile columns and
+UPDATE only the result/lifecycle columns -- never the immutable
+user/requirement/snapshot/submitted-value identity, and never INSERT/DELETE.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+MIGRATION_DB = "test_verification_attempt_grants"
+_BEFORE = "0048_validate_deployment_architecture_type"
+_HEAD = "0051_narrow_functions_role_attempt_grants"
+
+_EXPECTED_UPDATE_COLUMNS = {
+    "outcome",
+    "error_code",
+    "validation_message",
+    "terminal_source",
+    "feedback_json",
+    "started_at",
+    "completed_at",
+    "updated_at",
+}
+
+_IMMUTABLE_COLUMNS = (
+    "id",
+    "user_id",
+    "requirement_uuid",
+    "requirement_snapshot",
+    "requirement_snapshot_hash",
+    "snapshot_source",
+    "payload_version",
+    "submission_value_kind",
+    "submitted_value",
+    "github_username_snapshot",
+    "legacy_job_id",
+)
+
+
+def _sync_url() -> str:
+    raw = os.environ.get(
+        "DATABASE__URL",
+        "******db:5432/learntocloud",
+    )
+    return raw.replace("+asyncpg", "+psycopg2")
+
+
+def _admin_url() -> str:
+    return _sync_url().rsplit("/", 1)[0] + "/postgres"
+
+
+@pytest.fixture()
+def alembic_config():
+    from pytest_alembic.config import Config
+
+    return Config(
+        config_options={
+            "file": str(Path(__file__).parent.parent / "alembic.ini"),
+            "script_location": str(Path(__file__).parent.parent / "alembic"),
+        },
+    )
+
+
+@pytest.fixture()
+def alembic_engine():
+    admin_eng = create_engine(_admin_url(), isolation_level="AUTOCOMMIT")
+    with admin_eng.connect() as conn:
+        conn.execute(
+            text(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                f"WHERE datname = '{MIGRATION_DB}' AND pid <> pg_backend_pid()"
+            )
+        )
+        conn.execute(text(f"DROP DATABASE IF EXISTS {MIGRATION_DB}"))
+        conn.execute(text(f"CREATE DATABASE {MIGRATION_DB}"))
+    admin_eng.dispose()
+
+    mig_url = _sync_url().rsplit("/", 1)[0] + f"/{MIGRATION_DB}"
+    engine = create_engine(mig_url)
+    yield engine
+    engine.dispose()
+
+    admin_eng = create_engine(_admin_url(), isolation_level="AUTOCOMMIT")
+    with admin_eng.connect() as conn:
+        conn.execute(
+            text(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                f"WHERE datname = '{MIGRATION_DB}' AND pid <> pg_backend_pid()"
+            )
+        )
+        conn.execute(text(f"DROP DATABASE IF EXISTS {MIGRATION_DB}"))
+    admin_eng.dispose()
+
+
+def test_functions_role_column_grants(alembic_runner, alembic_engine, monkeypatch):
+    role = f"ltc_attempt_grant_{uuid.uuid4().hex[:10]}"
+    monkeypatch.setenv("POSTGRES_VERIFICATION_FUNCTIONS_ROLE", role)
+
+    try:
+        alembic_runner.migrate_up_to(_BEFORE)
+
+        admin = create_engine(_admin_url(), isolation_level="AUTOCOMMIT")
+        with admin.connect() as conn:
+            conn.execute(text(f'CREATE ROLE "{role}"'))
+        admin.dispose()
+
+        alembic_runner.migrate_up_to(_HEAD)
+
+        with alembic_engine.connect() as conn:
+            update_columns = set(
+                conn.execute(
+                    text(
+                        """
+                        SELECT column_name
+                        FROM information_schema.column_privileges
+                        WHERE grantee = :role
+                          AND table_name = 'verification_attempts'
+                          AND privilege_type = 'UPDATE'
+                        """
+                    ),
+                    {"role": role},
+                ).scalars()
+            )
+
+            # No table-level INSERT/DELETE/UPDATE at column-narrowed stage.
+            table_grants = set(
+                conn.execute(
+                    text(
+                        """
+                        SELECT privilege_type
+                        FROM information_schema.role_table_grants
+                        WHERE grantee = :role
+                          AND table_name = 'verification_attempts'
+                        """
+                    ),
+                    {"role": role},
+                ).scalars()
+            )
+
+            select_ok = conn.execute(
+                text(
+                    "SELECT has_column_privilege("
+                    ":role, 'verification_attempts', 'submitted_value', 'SELECT')"
+                ),
+                {"role": role},
+            ).scalar_one()
+
+            immutable_update = {
+                col: conn.execute(
+                    text(
+                        "SELECT has_column_privilege("
+                        ":role, 'verification_attempts', :col, 'UPDATE')"
+                    ),
+                    {"role": role, "col": col},
+                ).scalar_one()
+                for col in _IMMUTABLE_COLUMNS
+            }
+
+        assert update_columns == _EXPECTED_UPDATE_COLUMNS
+        assert "INSERT" not in table_grants
+        assert "DELETE" not in table_grants
+        assert select_ok is True
+        assert not any(immutable_update.values()), immutable_update
+    finally:
+        admin = create_engine(_admin_url(), isolation_level="AUTOCOMMIT")
+        with admin.connect() as conn:
+            conn.execute(
+                text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    f"WHERE datname = '{MIGRATION_DB}' AND pid <> pg_backend_pid()"
+                )
+            )
+            conn.execute(text(f"DROP DATABASE IF EXISTS {MIGRATION_DB}"))
+            conn.execute(text(f'DROP ROLE IF EXISTS "{role}"'))
+        admin.dispose()

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -10,6 +10,8 @@ import os
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
 from uuid import UUID
 
 import azure.durable_functions as df
@@ -18,10 +20,28 @@ from learn_to_cloud_shared.core.config import get_worker_settings
 from learn_to_cloud_shared.core.database import create_engine, create_session_maker
 from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE, configure_logging
 from learn_to_cloud_shared.core.observability import configure_observability
+from learn_to_cloud_shared.models import utcnow
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    AttemptTerminalState,
+    VerificationAttemptRepository,
+)
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
 from learn_to_cloud_shared.submission_values import submission_value_from_columns
+from learn_to_cloud_shared.verification_attempt_executor import (
+    finalize_verification_attempt as finalize_attempt,
+)
+from learn_to_cloud_shared.verification_attempt_executor import (
+    prepare_verification_attempt as prepare_attempt,
+)
+from learn_to_cloud_shared.verification_attempt_executor import (
+    terminalize_verification_attempt as terminalize_attempt,
+)
+from learn_to_cloud_shared.verification_attempt_reconciler import (
+    reconcile_decision,
+    stale_cutoff,
+)
 from learn_to_cloud_shared.verification.llm_grading import (
     LLMGradingDecisionPayload,
     LLMGradingRequest,
@@ -88,6 +108,10 @@ app = df.DFApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 # data-driven -- the grading step runs only when the verify step emits
 # grading requests, so deterministic phases pass straight through.
 _ORCHESTRATOR_NAME = "verification_orchestrator"
+# Versioned orchestrator for the unified ``verification_attempts`` path. Kept
+# distinct from the legacy name so existing Durable history/replay for
+# in-flight legacy instances is untouched; the attempt id is the instance id.
+_ATTEMPT_ORCHESTRATOR_NAME = "verification_attempt_orchestrator_v1"
 _VERIFY_RETRY_OPTIONS = df.RetryOptions(
     first_retry_interval_in_milliseconds=5000,
     max_number_of_attempts=3,
@@ -783,3 +807,531 @@ async def get_verification_job_status(
             return _json_response({"error": "instance_not_found"}, status_code=404)
 
         return _json_response(status.to_json(), status_code=200)
+
+
+# ---------------------------------------------------------------------------
+# Versioned unified verification-attempt path (bridge / PR4)
+#
+# Runs against the curriculum-decoupled ``verification_attempts`` table. The
+# Durable input carries only the attempt id; every trusted field is loaded
+# from the attempt row by the prepare activity. Verification and LLM grading
+# reuse the legacy activities unchanged. Terminal state is written with a
+# compare-and-set finalize, and any authoritative failure is converted into a
+# terminal outcome via the terminalize activity instead of relying on polling.
+# ---------------------------------------------------------------------------
+
+
+def _attempt_id_from_input(context: df.DurableOrchestrationContext) -> str:
+    input_payload = context.get_input()
+    if not isinstance(input_payload, Mapping):
+        raise TypeError(
+            f"verification attempt orchestration: expected Mapping input, "
+            f"got {type(input_payload).__name__}"
+        )
+    attempt_id = input_payload.get("attempt_id")
+    if not isinstance(attempt_id, str):
+        raise TypeError("verification attempt orchestration: missing attempt_id")
+    return attempt_id
+
+
+def _finalize_attempt_step(
+    context: df.DurableOrchestrationContext,
+    outcome: _PreparedOutcome,
+    run_result: object,
+):
+    """Persist the attempt's terminal outcome via the CAS finalize activity."""
+    context.set_custom_status(
+        _job_custom_status("finalizing", outcome.job_id, outcome.prepared_job)
+    )
+    result = yield context.call_activity_with_retry(
+        "finalize_verification_attempt",
+        _TRANSIENT_RETRY_OPTIONS,
+        run_result,
+    )
+    result_payload = _activity_payload(result)
+    context.set_custom_status(
+        _result_custom_status("completed", outcome.job_id, result_payload)
+    )
+    return result
+
+
+def _terminalize_attempt_step(
+    context: df.DurableOrchestrationContext,
+    attempt_id: str,
+):
+    """Convert an authoritative orchestration failure into a terminal outcome.
+
+    Runs the terminalize activity so an exhausted-retry activity failure or an
+    orchestrator error records a trustworthy ``server_error`` instead of
+    leaving the attempt active for a browser poll that will never resolve it.
+    """
+    context.set_custom_status({"step": "terminalizing", "attempt_id": attempt_id})
+    return (
+        yield context.call_activity_with_retry(
+            "terminalize_verification_attempt",
+            _TRANSIENT_RETRY_OPTIONS,
+            {
+                "attempt_id": attempt_id,
+                "outcome": "server_error",
+                "error_code": "server_error",
+                "validation_message": "Verification could not be completed.",
+                "terminal_source": "orchestrator_exception",
+            },
+        )
+    )
+
+
+def _run_attempt_orchestration(context: df.DurableOrchestrationContext):
+    """Versioned workflow: prepare -> verify -> grade -> finalize.
+
+    Prepare loads and validates the attempt row (payload version, snapshot
+    provenance/hash, value kind, active state) and returns a runnable job the
+    existing verify/grade steps consume unchanged. Any exception in the
+    authoritative path terminalizes the attempt instead of failing silently.
+
+    Kept as a plain generator (separate from the decorated trigger) so the
+    orchestration tests can drive it directly.
+    """
+    attempt_id = _attempt_id_from_input(context)
+    _set_verification_span_attributes(job_id=attempt_id)
+    context.set_custom_status({"step": "preparing", "attempt_id": attempt_id})
+    try:
+        preparation = yield context.call_activity_with_retry(
+            "prepare_verification_attempt",
+            _TRANSIENT_RETRY_OPTIONS,
+            {"attempt_id": attempt_id},
+        )
+        prepared_job_payload = preparation["job"]
+        prepared_job = PreparedVerificationJob.from_payload(
+            _activity_payload(prepared_job_payload)
+        )
+        _set_prepared_job_span_attributes(prepared_job)
+        outcome = _PreparedOutcome(
+            job_id=attempt_id,
+            prepared_payload=prepared_job_payload,
+            prepared_job=prepared_job,
+        )
+        run_result = yield from _verify_step(context, outcome)
+        run_result = yield from _llm_grading_step(context, outcome, run_result)
+        return (yield from _finalize_attempt_step(context, outcome, run_result))
+    except Exception:
+        return (yield from _terminalize_attempt_step(context, attempt_id))
+
+
+@app.orchestration_trigger(context_name="context")
+def verification_attempt_orchestrator_v1(context: df.DurableOrchestrationContext):
+    """Run the versioned unified verification-attempt workflow."""
+    return (yield from _run_attempt_orchestration(context))
+
+
+def _terminal_state_payload(state: AttemptTerminalState) -> dict[str, object]:
+    return {
+        "attempt_id": str(state.id),
+        "outcome": state.outcome,
+        "error_code": state.error_code,
+        "validation_message": state.validation_message,
+        "terminal_source": state.terminal_source,
+        "completed_at": state.completed_at.isoformat()
+        if state.completed_at is not None
+        else None,
+    }
+
+
+@app.activity_trigger(input_name="input_payload")
+async def prepare_verification_attempt(
+    input_payload,
+    context: func.Context,
+) -> dict[str, object]:
+    """Load + validate an attempt row and return a runnable job payload."""
+    with _attached_invocation_context(context):
+        data = _activity_payload(input_payload)
+        raw_attempt_id = data.get("attempt_id")
+        if not isinstance(raw_attempt_id, str):
+            raise TypeError("prepare_verification_attempt: missing attempt_id")
+        attempt_id = UUID(raw_attempt_id)
+        _set_verification_span_attributes(job_id=str(attempt_id))
+        preparation = await prepare_attempt(
+            attempt_id,
+            session_maker=_get_session_maker(),
+        )
+        _set_prepared_job_span_attributes(preparation.job)
+        return preparation.to_payload()
+
+
+@app.activity_trigger(input_name="run_payload")
+async def finalize_verification_attempt(
+    run_payload,
+    context: func.Context,
+) -> dict[str, object]:
+    """Compare-and-set the attempt's real outcome and mirror the legacy row."""
+    with _attached_invocation_context(context):
+        run_result = VerificationRunResult.from_payload(_activity_payload(run_payload))
+        _set_prepared_job_span_attributes(run_result.job)
+        state = await finalize_attempt(
+            run_result,
+            session_maker=_get_session_maker(),
+        )
+        logger.info(
+            "verification.attempt.finalized",
+            extra={"attempt_id": str(state.id), "outcome": state.outcome},
+        )
+        return _terminal_state_payload(state)
+
+
+@app.activity_trigger(input_name="input_payload")
+async def terminalize_verification_attempt(
+    input_payload,
+    context: func.Context,
+) -> dict[str, object]:
+    """Compare-and-set a failure/cancellation outcome + mirror the legacy row."""
+    with _attached_invocation_context(context):
+        data = _activity_payload(input_payload)
+        attempt_id = UUID(str(data["attempt_id"]))
+        state = await terminalize_attempt(
+            attempt_id,
+            outcome=str(data["outcome"]),
+            error_code=str(data["error_code"]),
+            validation_message=str(data["validation_message"]),
+            terminal_source=str(data["terminal_source"]),
+            session_maker=_get_session_maker(),
+        )
+        logger.info(
+            "verification.attempt.terminalized",
+            extra={
+                "attempt_id": str(state.id),
+                "outcome": state.outcome,
+                "terminal_source": state.terminal_source,
+            },
+        )
+        return _terminal_state_payload(state)
+
+
+def _durable_instance_exists(status: object) -> bool:
+    """True when a Durable status describes a real, existing instance."""
+    if status is None:
+        return False
+    return getattr(status, "runtime_status", None) is not None
+
+
+def _runtime_status_name(status: object) -> str | None:
+    """Return a Durable status's runtime-status name, or None when absent."""
+    if status is None:
+        return None
+    runtime_status = getattr(status, "runtime_status", None)
+    if runtime_status is None:
+        return None
+    return getattr(runtime_status, "name", str(runtime_status))
+
+
+class _StartOutcome(Enum):
+    """Result of an idempotent attempt-orchestration start."""
+
+    STARTED = "started"
+    ALREADY_EXISTS = "already_exists"
+    ALREADY_CLAIMED = "already_claimed"
+    AMBIGUOUS_STARTED = "ambiguous_started"
+    START_FAILED = "start_failed"
+    ATTEMPT_NOT_FOUND = "attempt_not_found"
+
+
+class _StartClaim(Enum):
+    """Database claim state before any Durable start call."""
+
+    CLAIMED = "claimed"
+    ALREADY_CLAIMED = "already_claimed"
+    TERMINAL = "terminal"
+    MISSING = "missing"
+
+
+async def _get_instance_status(
+    client: df.DurableOrchestrationClient, instance_id: str
+) -> object:
+    return await client.get_status(
+        instance_id,
+        show_history=False,
+        show_history_output=False,
+        show_input=False,
+    )
+
+
+async def _resolve_ambiguous_start(
+    client: df.DurableOrchestrationClient,
+    instance_id: str,
+) -> object | None:
+    """Poll briefly until Durable confirms the instance exists or is absent."""
+    all_queries_succeeded = True
+    for delay_seconds in (0.0, 0.5, 1.5):
+        if delay_seconds:
+            await asyncio.sleep(delay_seconds)
+        try:
+            status = await _get_instance_status(client, instance_id)
+        except Exception:
+            all_queries_succeeded = False
+            logger.exception(
+                "verification.attempt.start.status_query_failed",
+                extra={"attempt_id": instance_id},
+            )
+            continue
+        if _durable_instance_exists(status):
+            return status
+    if not all_queries_succeeded:
+        raise RuntimeError(
+            f"Durable status could not confirm whether attempt {instance_id} started"
+        )
+    return None
+
+
+async def _claim_attempt_start(
+    attempt_id: UUID,
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> _StartClaim:
+    """Atomically claim the right to call Durable ``start_new``."""
+    async with session_maker() as db:
+        repo = VerificationAttemptRepository(db)
+        if await repo.mark_started(attempt_id):
+            await db.commit()
+            return _StartClaim.CLAIMED
+
+        status = await repo.get_status(attempt_id)
+        if status is None:
+            return _StartClaim.MISSING
+        if status.outcome is not None:
+            return _StartClaim.TERMINAL
+        return _StartClaim.ALREADY_CLAIMED
+
+
+async def _start_attempt_orchestration(
+    client: df.DurableOrchestrationClient,
+    attempt_uuid: UUID,
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> _StartOutcome:
+    """Idempotently start the attempt orchestration keyed by the attempt UUID.
+
+    The attempt UUID is the Durable instance id, so a retry re-uses the same
+    id. An already-existing instance is treated as success; an ambiguous start
+    failure is resolved by inspecting Durable status before deciding the start
+    truly failed; only a confirmed start failure terminalizes the attempt.
+    """
+    instance_id = str(attempt_uuid)
+
+    claim = await _claim_attempt_start(
+        attempt_uuid,
+        session_maker=session_maker,
+    )
+    if claim is _StartClaim.MISSING:
+        return _StartOutcome.ATTEMPT_NOT_FOUND
+    if claim is _StartClaim.TERMINAL:
+        return _StartOutcome.ALREADY_EXISTS
+    if claim is _StartClaim.ALREADY_CLAIMED:
+        existing = await _resolve_ambiguous_start(client, instance_id)
+        if not _durable_instance_exists(existing):
+            logger.info(
+                "verification.attempt.start.claimed_pending",
+                extra={"attempt_id": instance_id},
+            )
+            return _StartOutcome.ALREADY_CLAIMED
+        logger.info(
+            "verification.attempt.start.already_exists",
+            extra={
+                "attempt_id": instance_id,
+                "runtime_status": _runtime_status_name(existing),
+            },
+        )
+        return _StartOutcome.ALREADY_EXISTS
+
+    try:
+        await client.start_new(
+            _ATTEMPT_ORCHESTRATOR_NAME,
+            instance_id=instance_id,
+            client_input={"attempt_id": instance_id},
+        )
+    except Exception as exc:
+        # The start result is ambiguous (timeout / transient query failure).
+        # Inspect Durable status before deciding it failed so a race where the
+        # instance actually started is not double-counted as a failure.
+        status = await _resolve_ambiguous_start(client, instance_id)
+        if _durable_instance_exists(status):
+            logger.warning(
+                "verification.attempt.start.ambiguous_but_started",
+                extra={
+                    "attempt_id": instance_id,
+                    "runtime_status": _runtime_status_name(status),
+                },
+            )
+            return _StartOutcome.AMBIGUOUS_STARTED
+
+        logger.error(
+            "verification.attempt.start.failed",
+            extra={"attempt_id": instance_id, "error": str(exc)},
+        )
+        await terminalize_attempt(
+            attempt_uuid,
+            outcome="server_error",
+            error_code="server_error",
+            validation_message="Verification could not be started.",
+            terminal_source="start_failure",
+            session_maker=session_maker,
+        )
+        return _StartOutcome.START_FAILED
+
+    logger.info(
+        "verification.attempt.orchestration.started",
+        extra={
+            "attempt_id": instance_id,
+            "orchestrator_name": _ATTEMPT_ORCHESTRATOR_NAME,
+        },
+    )
+    return _StartOutcome.STARTED
+
+
+@app.route(route="verification/attempts/{attempt_id}/start", methods=["POST"])
+@app.durable_client_input(client_name="client")
+async def start_verification_attempt(
+    req: func.HttpRequest,
+    client: df.DurableOrchestrationClient,
+    context: func.Context,
+) -> func.HttpResponse:
+    """Start the versioned attempt orchestration, keyed by the attempt UUID."""
+    with _attached_invocation_context(context):
+        raw_attempt_id = req.route_params.get("attempt_id")
+        if raw_attempt_id is None:
+            return _json_response({"error": "missing_attempt_id"}, status_code=400)
+
+        try:
+            attempt_uuid = UUID(raw_attempt_id)
+        except ValueError:
+            return _json_response({"error": "invalid_attempt_id"}, status_code=400)
+
+        instance_id = str(attempt_uuid)
+        _set_verification_span_attributes(job_id=instance_id)
+
+        outcome = await _start_attempt_orchestration(
+            client,
+            attempt_uuid,
+            session_maker=_get_session_maker(),
+        )
+        if outcome is _StartOutcome.START_FAILED:
+            return _json_response({"error": "start_failed"}, status_code=500)
+        if outcome is _StartOutcome.ATTEMPT_NOT_FOUND:
+            return _json_response({"error": "attempt_not_found"}, status_code=404)
+        return client.create_check_status_response(req, instance_id)
+
+
+@dataclass(frozen=True)
+class _ReconcileSummary:
+    """Structured result of a reconciler pass, for logging + tests."""
+
+    candidate_count: int
+    terminalized_count: int
+
+
+async def _reconcile_stale_attempts(
+    client: df.DurableOrchestrationClient,
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+    stale_attempt_min_age_minutes: int,
+    batch_limit: int,
+    now: datetime | None = None,
+) -> _ReconcileSummary:
+    """Terminalize abandoned active attempts older than the verification window.
+
+    Asks Durable for each fixed instance's status and compare-and-set
+    terminalizes only the confirmed abandoned/failed/terminated/cancelled/
+    not-started ones; healthy Pending/Running instances are left untouched.
+    Idempotent: a re-run re-applies harmless CAS no-ops.
+    """
+    reference = now if now is not None else utcnow()
+    cutoff = stale_cutoff(reference, stale_attempt_min_age_minutes)
+    async with session_maker() as db:
+        stale = await VerificationAttemptRepository(db).list_active_older_than(
+            cutoff,
+            limit=batch_limit,
+        )
+    logger.info(
+        "verification.reconciler.scan",
+        extra={"candidate_count": len(stale), "cutoff": cutoff.isoformat()},
+    )
+
+    terminalized = 0
+    for attempt in stale:
+        instance_id = str(attempt.id)
+        try:
+            status = await _get_instance_status(client, instance_id)
+        except Exception:
+            logger.exception(
+                "verification.reconciler.status_query_failed",
+                extra={"attempt_id": instance_id},
+            )
+            continue
+        status_name = _runtime_status_name(status)
+        decision = reconcile_decision(status_name)
+        if decision is None:
+            continue
+        if status_name is None:
+            try:
+                confirmed_status = await _get_instance_status(client, instance_id)
+            except Exception:
+                logger.exception(
+                    "verification.reconciler.status_recheck_failed",
+                    extra={"attempt_id": instance_id},
+                )
+                continue
+            confirmed_name = _runtime_status_name(confirmed_status)
+            decision = reconcile_decision(confirmed_name)
+            if decision is None:
+                continue
+            status_name = confirmed_name
+        await terminalize_attempt(
+            attempt.id,
+            outcome=decision.outcome,
+            error_code=decision.error_code,
+            validation_message=decision.validation_message,
+            terminal_source=decision.terminal_source,
+            session_maker=session_maker,
+        )
+        terminalized += 1
+        logger.info(
+            "verification.reconciler.terminalized",
+            extra={
+                "attempt_id": str(attempt.id),
+                "durable_status": status_name,
+                "outcome": decision.outcome.value,
+            },
+        )
+
+    logger.info(
+        "verification.reconciler.completed",
+        extra={
+            "candidate_count": len(stale),
+            "terminalized_count": terminalized,
+        },
+    )
+    return _ReconcileSummary(
+        candidate_count=len(stale),
+        terminalized_count=terminalized,
+    )
+
+
+@app.timer_trigger(
+    arg_name="timer",
+    schedule="0 */15 * * * *",
+    run_on_startup=False,
+    use_monitor=True,
+)
+@app.durable_client_input(client_name="client")
+async def reconcile_stale_verification_attempts(
+    timer: func.TimerRequest,
+    client: df.DurableOrchestrationClient,
+    context: func.Context,
+) -> None:
+    """Scheduled reconciler for abandoned active verification attempts."""
+    with _attached_invocation_context(context):
+        cfg = get_worker_settings().reconciler
+        await _reconcile_stale_attempts(
+            client,
+            session_maker=_get_session_maker(),
+            stale_attempt_min_age_minutes=cfg.stale_attempt_min_age_minutes,
+            batch_limit=cfg.batch_limit,
+        )

--- a/apps/verification-functions/tests/test_attempt_orchestrations.py
+++ b/apps/verification-functions/tests/test_attempt_orchestrations.py
@@ -1,0 +1,526 @@
+"""Tests for the versioned unified verification-attempt path.
+
+Covers the deterministic orchestration action sequence (LLM + non-LLM),
+exception terminalization, idempotent start (already-exists / ambiguous /
+confirmed failure), and reconciler status mapping + age-boundary wiring. The
+Durable client and status are faked -- no live Azure calls.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import function_app
+import pytest
+from learn_to_cloud_shared.models import VerificationAttemptOutcome
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    AttemptStatusRow,
+)
+from learn_to_cloud_shared.testing.requirement_factories import (
+    journal_api_verifier_requirement,
+    repo_fork_requirement,
+)
+from learn_to_cloud_shared.verification_attempt_reconciler import stale_cutoff
+from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration driver (mirrors the legacy orchestration test harness)
+# --------------------------------------------------------------------------- #
+
+
+class _RecordedCall:
+    def __init__(self, kind: str, name: str, payload: object) -> None:
+        self.kind = kind
+        self.name = name
+        self.payload = payload
+
+    def as_tuple(self) -> tuple[str, str]:
+        return (self.kind, self.name)
+
+
+class _FakeOrchestrationContext:
+    def __init__(self, job_input: object) -> None:
+        self._input = job_input
+        self.statuses: list[object] = []
+
+    def get_input(self) -> object:
+        return self._input
+
+    def set_custom_status(self, status: object) -> None:
+        self.statuses.append(status)
+
+    def call_activity(self, name: str, input_: object = None) -> _RecordedCall:
+        return _RecordedCall("activity", name, input_)
+
+    def call_activity_with_retry(
+        self, name: str, retry_options: object, input_: object = None
+    ) -> _RecordedCall:
+        return _RecordedCall("activity_with_retry", name, input_)
+
+
+class _Raise:
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
+
+
+Responder = Callable[[_RecordedCall], object]
+
+
+def _drive(
+    gen: Generator[_RecordedCall, object, object], responder: Responder
+) -> tuple[list[_RecordedCall], object]:
+    calls: list[_RecordedCall] = []
+    try:
+        call = next(gen)
+    except StopIteration as stop:
+        return calls, stop.value
+    while True:
+        calls.append(call)
+        result = responder(call)
+        try:
+            if isinstance(result, _Raise):
+                call = gen.throw(result.exc)
+            else:
+                call = gen.send(result)
+        except StopIteration as stop:
+            return calls, stop.value
+
+
+def _prepared_payload(requirement: Any, value: str) -> dict[str, object]:
+    job = PreparedVerificationJob(
+        id=uuid4(),
+        user_id=1,
+        github_username="alice",
+        requirement=requirement,
+        submitted_value=value,
+    )
+    return job.to_payload()
+
+
+def _sequence(calls: list[_RecordedCall]) -> list[tuple[str, str]]:
+    return [call.as_tuple() for call in calls]
+
+
+def _make_responder(
+    prepared_payload: dict[str, object],
+    *,
+    recorded_requests: list[object] | None = None,
+    fail_activity: str | None = None,
+) -> Responder:
+    def responder(call: _RecordedCall) -> object:
+        name = call.name
+        if fail_activity is not None and name == fail_activity:
+            return _Raise(RuntimeError("activity failed"))
+        if name == "prepare_verification_attempt":
+            return {"job": prepared_payload}
+        if name == "execute_requirement_verification":
+            if recorded_requests is not None:
+                return {"status": "verified", "grading_requests": recorded_requests}
+            return {"status": "verified"}
+        if name == "ensure_grading_config":
+            return {"valid": True, "missing_vars": []}
+        if name == "run_llm_grading":
+            return {"decision": "pass"}
+        if name == "apply_llm_grading_results":
+            return {"status": "graded"}
+        if name == "finalize_verification_attempt":
+            return {"attempt_id": "a-1", "outcome": "succeeded"}
+        if name == "terminalize_verification_attempt":
+            return {"attempt_id": "a-1", "outcome": "server_error"}
+        raise AssertionError(f"unexpected activity call: {name}")
+
+    return responder
+
+
+class TestAttemptOrchestration:
+    def test_non_llm_sequence(self) -> None:
+        payload = _prepared_payload(
+            repo_fork_requirement(slug="fork", required_repo="owner/repo"),
+            "https://github.com/alice/repo",
+        )
+        ctx = _FakeOrchestrationContext({"attempt_id": "a-1"})
+        responder = _make_responder(payload, recorded_requests=[])
+        calls, result = _drive(function_app._run_attempt_orchestration(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_attempt"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity_with_retry", "finalize_verification_attempt"),
+        ]
+        assert result == {"attempt_id": "a-1", "outcome": "succeeded"}
+
+    def test_llm_sequence(self) -> None:
+        payload = _prepared_payload(
+            journal_api_verifier_requirement(slug="journal"),
+            "https://github.com/alice/journal",
+        )
+        ctx = _FakeOrchestrationContext({"attempt_id": "a-1"})
+        responder = _make_responder(payload, recorded_requests=[{"task": "a"}])
+        calls, result = _drive(function_app._run_attempt_orchestration(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_attempt"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity", "ensure_grading_config"),
+            ("activity_with_retry", "run_llm_grading"),
+            ("activity", "apply_llm_grading_results"),
+            ("activity_with_retry", "finalize_verification_attempt"),
+        ]
+        assert result == {"attempt_id": "a-1", "outcome": "succeeded"}
+
+    def test_prepare_failure_terminalizes(self) -> None:
+        payload = _prepared_payload(
+            repo_fork_requirement(slug="fork", required_repo="owner/repo"),
+            "https://github.com/alice/repo",
+        )
+        ctx = _FakeOrchestrationContext({"attempt_id": "a-1"})
+        responder = _make_responder(
+            payload, fail_activity="prepare_verification_attempt"
+        )
+        calls, result = _drive(function_app._run_attempt_orchestration(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_attempt"),
+            ("activity_with_retry", "terminalize_verification_attempt"),
+        ]
+        assert result == {"attempt_id": "a-1", "outcome": "server_error"}
+
+    def test_verify_failure_terminalizes(self) -> None:
+        payload = _prepared_payload(
+            repo_fork_requirement(slug="fork", required_repo="owner/repo"),
+            "https://github.com/alice/repo",
+        )
+        ctx = _FakeOrchestrationContext({"attempt_id": "a-1"})
+        responder = _make_responder(
+            payload, fail_activity="execute_requirement_verification"
+        )
+        calls, _ = _drive(function_app._run_attempt_orchestration(ctx), responder)
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_attempt"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity_with_retry", "terminalize_verification_attempt"),
+        ]
+
+
+class TestVersionedOrchestratorRegistered:
+    def test_versioned_name_and_symbol(self) -> None:
+        assert (
+            function_app._ATTEMPT_ORCHESTRATOR_NAME
+            == "verification_attempt_orchestrator_v1"
+        )
+        assert hasattr(function_app, function_app._ATTEMPT_ORCHESTRATOR_NAME)
+        # The legacy orchestrator name/registration is untouched.
+        assert function_app._ORCHESTRATOR_NAME == "verification_orchestrator"
+
+
+# --------------------------------------------------------------------------- #
+# Fake Durable client / status
+# --------------------------------------------------------------------------- #
+
+
+class _FakeStatus:
+    def __init__(self, runtime_status: object) -> None:
+        self.runtime_status = runtime_status
+
+
+class _FakeRuntimeStatus:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        *,
+        statuses: dict[str, object] | None = None,
+        start_raises: bool = False,
+    ) -> None:
+        self._statuses = statuses or {}
+        self._start_raises = start_raises
+        self.started: list[str] = []
+
+    async def get_status(self, instance_id, **_kwargs):
+        return self._statuses.get(instance_id)
+
+    async def start_new(self, name, *, instance_id, client_input):
+        if self._start_raises:
+            raise RuntimeError("ambiguous start")
+        self.started.append(instance_id)
+        return instance_id
+
+
+class _FakeSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _session_maker():
+    return _FakeSession()
+
+
+class TestStartIdempotency:
+    pytestmark = pytest.mark.asyncio
+
+    async def _start(
+        self,
+        client,
+        attempt_id,
+        *,
+        claim=function_app._StartClaim.CLAIMED,
+    ):
+        with patch.object(
+            function_app,
+            "_claim_attempt_start",
+            new=AsyncMock(return_value=claim),
+        ):
+            return await function_app._start_attempt_orchestration(
+                client, attempt_id, session_maker=_session_maker
+            )
+
+    async def test_already_existing_instance_is_success(self) -> None:
+        attempt_id = uuid4()
+        client = _FakeClient(
+            statuses={str(attempt_id): _FakeStatus(_FakeRuntimeStatus("Running"))}
+        )
+        outcome = await self._start(
+            client,
+            attempt_id,
+            claim=function_app._StartClaim.ALREADY_CLAIMED,
+        )
+        assert outcome is function_app._StartOutcome.ALREADY_EXISTS
+        assert client.started == []
+
+    async def test_fresh_start(self) -> None:
+        attempt_id = uuid4()
+        client = _FakeClient()
+        outcome = await self._start(client, attempt_id)
+        assert outcome is function_app._StartOutcome.STARTED
+        assert client.started == [str(attempt_id)]
+
+    async def test_ambiguous_but_started(self) -> None:
+        attempt_id = uuid4()
+        # start_new raises, but a follow-up status shows the instance exists,
+        # so the start is treated as success rather than a failure.
+        outcome = await self._start(_AmbiguousClient(attempt_id), attempt_id)
+        assert outcome is function_app._StartOutcome.AMBIGUOUS_STARTED
+
+    async def test_existing_claim_without_visible_instance_does_not_restart(
+        self,
+    ) -> None:
+        attempt_id = uuid4()
+        client = _FakeClient()
+        with patch.object(function_app.asyncio, "sleep", new=AsyncMock()):
+            outcome = await self._start(
+                client,
+                attempt_id,
+                claim=function_app._StartClaim.ALREADY_CLAIMED,
+            )
+        assert outcome is function_app._StartOutcome.ALREADY_CLAIMED
+        assert client.started == []
+
+    async def test_terminal_attempt_does_not_restart(self) -> None:
+        attempt_id = uuid4()
+        client = _FakeClient()
+        outcome = await self._start(
+            client,
+            attempt_id,
+            claim=function_app._StartClaim.TERMINAL,
+        )
+        assert outcome is function_app._StartOutcome.ALREADY_EXISTS
+        assert client.started == []
+
+    async def test_ambiguous_start_waits_for_delayed_status(self) -> None:
+        attempt_id = uuid4()
+        client = _DelayedStatusClient(attempt_id)
+        with patch.object(function_app.asyncio, "sleep", new=AsyncMock()):
+            outcome = await self._start(client, attempt_id)
+        assert outcome is function_app._StartOutcome.AMBIGUOUS_STARTED
+
+    async def test_confirmed_start_failure_terminalizes(self) -> None:
+        attempt_id = uuid4()
+        client = _FakeClient(start_raises=True)
+        with (
+            patch.object(function_app.asyncio, "sleep", new=AsyncMock()),
+            patch.object(function_app, "terminalize_attempt", new=AsyncMock()) as term,
+        ):
+            outcome = await self._start(client, attempt_id)
+        assert outcome is function_app._StartOutcome.START_FAILED
+        term.assert_awaited_once()
+        assert term.await_args.kwargs["terminal_source"] == "start_failure"
+
+    async def test_unconfirmed_start_failure_does_not_terminalize(self) -> None:
+        attempt_id = uuid4()
+        client = _UnqueryableAfterStartClient()
+        with (
+            patch.object(function_app.asyncio, "sleep", new=AsyncMock()),
+            patch.object(function_app, "terminalize_attempt", new=AsyncMock()) as term,
+            pytest.raises(RuntimeError, match="could not confirm"),
+        ):
+            await self._start(client, attempt_id)
+        term.assert_not_awaited()
+
+
+class _AmbiguousClient:
+    """A client whose instance does not exist until after start_new raises."""
+
+    def __init__(self, attempt_id) -> None:
+        self._id = str(attempt_id)
+        self._exists = False
+        self.started: list[str] = []
+
+    async def get_status(self, instance_id, **_kwargs):
+        if instance_id == self._id and self._exists:
+            return _FakeStatus(_FakeRuntimeStatus("Pending"))
+        return None
+
+    async def start_new(self, name, *, instance_id, client_input):
+        # The instance actually started, but the call surfaced an error.
+        self._exists = True
+        raise RuntimeError("ambiguous start")
+
+
+class _DelayedStatusClient:
+    def __init__(self, attempt_id) -> None:
+        self._id = str(attempt_id)
+        self._query_count = 0
+
+    async def get_status(self, instance_id, **_kwargs):
+        assert instance_id == self._id
+        self._query_count += 1
+        if self._query_count >= 2:
+            return _FakeStatus(_FakeRuntimeStatus("Pending"))
+        return None
+
+    async def start_new(self, name, *, instance_id, client_input):
+        raise RuntimeError("ambiguous start")
+
+
+class _UnqueryableAfterStartClient:
+    def __init__(self) -> None:
+        self._query_count = 0
+
+    async def get_status(self, instance_id, **_kwargs):
+        self._query_count += 1
+        raise RuntimeError("status unavailable")
+
+    async def start_new(self, name, *, instance_id, client_input):
+        raise RuntimeError("ambiguous start")
+
+
+# --------------------------------------------------------------------------- #
+# Reconciler
+# --------------------------------------------------------------------------- #
+
+
+def _status_row(attempt_id, created_at) -> AttemptStatusRow:
+    return AttemptStatusRow(
+        id=attempt_id,
+        user_id=1,
+        requirement_uuid=uuid4(),
+        outcome=None,
+        started_at=None,
+        created_at=created_at,
+        legacy_job_id=None,
+    )
+
+
+class _CapturingRepo:
+    captured_cutoff: object = None
+
+    def __init__(self, db) -> None:
+        pass
+
+    async def list_active_older_than(self, cutoff, *, limit):
+        _CapturingRepo.captured_cutoff = cutoff
+        return _CapturingRepo.rows
+
+
+class TestReconciler:
+    pytestmark = pytest.mark.asyncio
+
+    async def test_maps_statuses_and_skips_healthy(self) -> None:
+        failed = uuid4()
+        terminated = uuid4()
+        completed = uuid4()
+        missing = uuid4()
+        running = uuid4()
+        now = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        old = now - timedelta(hours=2)
+        rows = [
+            _status_row(failed, old),
+            _status_row(terminated, old),
+            _status_row(completed, old),
+            _status_row(missing, old),
+            _status_row(running, old),
+        ]
+        _CapturingRepo.rows = rows
+        client = _FakeClient(
+            statuses={
+                str(failed): _FakeStatus(_FakeRuntimeStatus("Failed")),
+                str(terminated): _FakeStatus(_FakeRuntimeStatus("Canceled")),
+                str(completed): _FakeStatus(_FakeRuntimeStatus("Completed")),
+                # ``missing`` has no status entry -> confirmed not started.
+                str(running): _FakeStatus(_FakeRuntimeStatus("Running")),
+            }
+        )
+        with (
+            patch.object(function_app, "VerificationAttemptRepository", _CapturingRepo),
+            patch.object(function_app, "terminalize_attempt", new=AsyncMock()) as term,
+        ):
+            summary = await function_app._reconcile_stale_attempts(
+                client,
+                session_maker=_session_maker,
+                stale_attempt_min_age_minutes=30,
+                batch_limit=50,
+                now=now,
+            )
+
+        assert summary.candidate_count == 5
+        assert summary.terminalized_count == 4
+        assert _CapturingRepo.captured_cutoff == stale_cutoff(now, 30)
+
+        terminalized = {
+            call.args[0]: call.kwargs["outcome"] for call in term.await_args_list
+        }
+        assert terminalized[failed] is VerificationAttemptOutcome.SERVER_ERROR
+        assert terminalized[terminated] is VerificationAttemptOutcome.CANCELLED
+        assert terminalized[completed] is VerificationAttemptOutcome.SERVER_ERROR
+        assert terminalized[missing] is VerificationAttemptOutcome.SERVER_ERROR
+        assert running not in terminalized
+
+    async def test_rechecks_missing_status_before_terminalizing(self) -> None:
+        attempt_id = uuid4()
+        now = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        _CapturingRepo.rows = [_status_row(attempt_id, now - timedelta(hours=2))]
+        client = _MissingThenRunningClient(attempt_id)
+        with (
+            patch.object(function_app, "VerificationAttemptRepository", _CapturingRepo),
+            patch.object(function_app, "terminalize_attempt", new=AsyncMock()) as term,
+        ):
+            summary = await function_app._reconcile_stale_attempts(
+                client,
+                session_maker=_session_maker,
+                stale_attempt_min_age_minutes=30,
+                batch_limit=50,
+                now=now,
+            )
+        assert summary.terminalized_count == 0
+        term.assert_not_awaited()
+
+
+class _MissingThenRunningClient:
+    def __init__(self, attempt_id) -> None:
+        self._id = str(attempt_id)
+        self._query_count = 0
+
+    async def get_status(self, instance_id, **_kwargs):
+        assert instance_id == self._id
+        self._query_count += 1
+        if self._query_count == 1:
+            return None
+        return _FakeStatus(_FakeRuntimeStatus("Running"))

--- a/build-out-notes.md
+++ b/build-out-notes.md
@@ -1,3 +1,12 @@
 # Build-out Notes
 
-No deviations from the approved plan.
+## PR 4: Durable start idempotency
+
+The plan assumed the fixed attempt UUID was enough to make Durable starts
+idempotent. The Azure Durable Python SDK documents that `start_new` can replace
+an existing instance with the same ID, so the bridge now first claims
+`verification_attempts.started_at` with a database compare-and-set. Only the
+claim winner calls `start_new`; retries inspect the existing instance and never
+restart it.
+
+The fixed instance ID, attempt lifecycle, and final schema remain unchanged.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
@@ -97,6 +97,20 @@ class HttpConfig(FrozenConfig):
     external_api_timeout: float = 15.0
 
 
+class ReconcilerConfig(FrozenConfig):
+    """Stale verification-attempt reconciler config.
+
+    ``stale_attempt_min_age_minutes`` is the age past which an attempt that is
+    still ``active`` (``outcome IS NULL``) is inspected against Durable and
+    terminalized if abandoned. It must comfortably exceed the normal
+    verification window (submit -> orchestrate -> finalize, plus retries) so a
+    healthy in-flight run is never mistaken for abandoned.
+    """
+
+    stale_attempt_min_age_minutes: int = Field(default=30, ge=1)
+    batch_limit: int = Field(default=200, ge=1)
+
+
 class ContentConfig(FrozenConfig):
     """Authored curriculum content config."""
 
@@ -222,6 +236,7 @@ class WorkerSettings(BaseSettings):
     labs: LabsConfig = LabsConfig()
     http: HttpConfig = HttpConfig()
     content: ContentConfig = ContentConfig()
+    reconciler: ReconcilerConfig = ReconcilerConfig()
 
 
 class WebSettings(BaseSettings):

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
@@ -1,0 +1,371 @@
+"""Repository for the unified ``verification_attempts`` table.
+
+The bridge (PR4) reads and finalizes attempts here. Every write to a
+terminal state goes through :meth:`VerificationAttemptRepository.finalize`,
+which is a compare-and-set (``UPDATE ... WHERE id=:id AND outcome IS NULL
+RETURNING``) so a Durable replay, a competing finalizer, and the stale-attempt
+reconciler can never overwrite a result that is already terminal.
+
+Reads are deliberately narrow: prepare/reconcile only select the columns the
+Functions role is granted, matching the column-level privileges the bridge
+migration installs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud_shared.models import (
+    VerificationAttempt,
+    VerificationAttemptOutcome,
+    utcnow,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptPrepareState:
+    """Immutable identity + submitted snapshot needed to run an attempt."""
+
+    id: UUID
+    user_id: int
+    requirement_uuid: UUID
+    snapshot_source: str
+    payload_version: int | None
+    requirement_snapshot: dict | None
+    requirement_snapshot_hash: str | None
+    submission_value_kind: str
+    submitted_value: str
+    github_username_snapshot: str | None
+    cloud_provider: str | None
+    traceparent: str | None
+    outcome: str | None
+    started_at: datetime | None
+    legacy_job_id: UUID | None
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptTerminalState:
+    """Terminal projection of an attempt after finalization."""
+
+    id: UUID
+    outcome: str | None
+    error_code: str | None
+    validation_message: str | None
+    terminal_source: str | None
+    completed_at: datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptStatusRow:
+    """Lifecycle projection used by the stale-attempt reconciler."""
+
+    id: UUID
+    user_id: int
+    requirement_uuid: UUID
+    outcome: str | None
+    started_at: datetime | None
+    created_at: datetime
+    legacy_job_id: UUID | None
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptMirrorState:
+    """Terminal attempt fields needed to mirror a legacy submission."""
+
+    id: UUID
+    user_id: int
+    requirement_uuid: UUID
+    submission_value_kind: str
+    submitted_value: str
+    github_username_snapshot: str | None
+    cloud_provider: str | None
+    outcome: str | None
+    feedback_json: list[dict] | None
+    validation_message: str | None
+    legacy_job_id: UUID | None
+
+
+@dataclass(frozen=True, slots=True)
+class FinalizeResult:
+    """Outcome of a compare-and-set finalize.
+
+    ``won`` is ``True`` when this call set the terminal state, ``False`` when
+    the attempt was already terminal (replay / competing finalizer). ``state``
+    always reflects the authoritative terminal row.
+    """
+
+    won: bool
+    state: AttemptTerminalState
+
+
+class AttemptAlreadyGoneError(Exception):
+    """The attempt row disappeared between reads (should not happen in prod)."""
+
+
+class VerificationAttemptRepository:
+    """Data access for verification attempts, scoped to the Functions role."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def get_prepare_state(self, attempt_id: UUID) -> AttemptPrepareState | None:
+        """Load the identity + submitted snapshot for one attempt."""
+        result = await self.db.execute(
+            select(
+                VerificationAttempt.id,
+                VerificationAttempt.user_id,
+                VerificationAttempt.requirement_uuid,
+                VerificationAttempt.snapshot_source,
+                VerificationAttempt.payload_version,
+                VerificationAttempt.requirement_snapshot,
+                VerificationAttempt.requirement_snapshot_hash,
+                VerificationAttempt.submission_value_kind,
+                VerificationAttempt.submitted_value,
+                VerificationAttempt.github_username_snapshot,
+                VerificationAttempt.cloud_provider,
+                VerificationAttempt.traceparent,
+                VerificationAttempt.outcome,
+                VerificationAttempt.started_at,
+                VerificationAttempt.legacy_job_id,
+            ).where(VerificationAttempt.id == attempt_id)
+        )
+        row = result.one_or_none()
+        if row is None:
+            return None
+        return AttemptPrepareState(
+            id=row.id,
+            user_id=row.user_id,
+            requirement_uuid=row.requirement_uuid,
+            snapshot_source=row.snapshot_source,
+            payload_version=row.payload_version,
+            requirement_snapshot=row.requirement_snapshot,
+            requirement_snapshot_hash=row.requirement_snapshot_hash,
+            submission_value_kind=row.submission_value_kind,
+            submitted_value=row.submitted_value,
+            github_username_snapshot=row.github_username_snapshot,
+            cloud_provider=row.cloud_provider,
+            traceparent=row.traceparent,
+            outcome=row.outcome,
+            started_at=row.started_at,
+            legacy_job_id=row.legacy_job_id,
+        )
+
+    async def mark_started(
+        self, attempt_id: UUID, *, started_at: datetime | None = None
+    ) -> bool:
+        """Record when an active attempt begins execution."""
+        now = started_at or utcnow()
+        result = await self.db.execute(
+            update(VerificationAttempt)
+            .where(
+                VerificationAttempt.id == attempt_id,
+                VerificationAttempt.outcome.is_(None),
+                VerificationAttempt.started_at.is_(None),
+            )
+            .values(started_at=now, updated_at=now)
+            .returning(VerificationAttempt.id)
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def get_status(self, attempt_id: UUID) -> AttemptStatusRow | None:
+        """Load the lifecycle projection for one attempt."""
+        result = await self.db.execute(
+            select(
+                VerificationAttempt.id,
+                VerificationAttempt.user_id,
+                VerificationAttempt.requirement_uuid,
+                VerificationAttempt.outcome,
+                VerificationAttempt.started_at,
+                VerificationAttempt.created_at,
+                VerificationAttempt.legacy_job_id,
+            ).where(VerificationAttempt.id == attempt_id)
+        )
+        row = result.one_or_none()
+        if row is None:
+            return None
+        return AttemptStatusRow(
+            id=row.id,
+            user_id=row.user_id,
+            requirement_uuid=row.requirement_uuid,
+            outcome=row.outcome,
+            started_at=row.started_at,
+            created_at=row.created_at,
+            legacy_job_id=row.legacy_job_id,
+        )
+
+    async def get_terminal_state(self, attempt_id: UUID) -> AttemptTerminalState | None:
+        """Load the terminal projection for one attempt."""
+        result = await self.db.execute(
+            select(
+                VerificationAttempt.id,
+                VerificationAttempt.outcome,
+                VerificationAttempt.error_code,
+                VerificationAttempt.validation_message,
+                VerificationAttempt.terminal_source,
+                VerificationAttempt.completed_at,
+            ).where(VerificationAttempt.id == attempt_id)
+        )
+        row = result.one_or_none()
+        if row is None:
+            return None
+        return AttemptTerminalState(
+            id=row.id,
+            outcome=row.outcome,
+            error_code=row.error_code,
+            validation_message=row.validation_message,
+            terminal_source=row.terminal_source,
+            completed_at=row.completed_at,
+        )
+
+    async def get_mirror_state(self, attempt_id: UUID) -> AttemptMirrorState | None:
+        """Load the terminal fields needed to mirror a legacy submission."""
+        result = await self.db.execute(
+            select(
+                VerificationAttempt.id,
+                VerificationAttempt.user_id,
+                VerificationAttempt.requirement_uuid,
+                VerificationAttempt.submission_value_kind,
+                VerificationAttempt.submitted_value,
+                VerificationAttempt.github_username_snapshot,
+                VerificationAttempt.cloud_provider,
+                VerificationAttempt.outcome,
+                VerificationAttempt.feedback_json,
+                VerificationAttempt.validation_message,
+                VerificationAttempt.legacy_job_id,
+            ).where(VerificationAttempt.id == attempt_id)
+        )
+        row = result.one_or_none()
+        if row is None:
+            return None
+        return AttemptMirrorState(
+            id=row.id,
+            user_id=row.user_id,
+            requirement_uuid=row.requirement_uuid,
+            submission_value_kind=row.submission_value_kind,
+            submitted_value=row.submitted_value,
+            github_username_snapshot=row.github_username_snapshot,
+            cloud_provider=row.cloud_provider,
+            outcome=row.outcome,
+            feedback_json=row.feedback_json,
+            validation_message=row.validation_message,
+            legacy_job_id=row.legacy_job_id,
+        )
+
+    async def list_active_older_than(
+        self, cutoff: datetime, *, limit: int
+    ) -> list[AttemptStatusRow]:
+        """Return active (``outcome IS NULL``) attempts created before ``cutoff``.
+
+        Ordered oldest-first and bounded by ``limit`` so a reconciler pass
+        drains the backlog deterministically without unbounded work.
+        """
+        result = await self.db.execute(
+            select(
+                VerificationAttempt.id,
+                VerificationAttempt.user_id,
+                VerificationAttempt.requirement_uuid,
+                VerificationAttempt.outcome,
+                VerificationAttempt.started_at,
+                VerificationAttempt.created_at,
+                VerificationAttempt.legacy_job_id,
+            )
+            .where(
+                VerificationAttempt.outcome.is_(None),
+                func.coalesce(
+                    VerificationAttempt.started_at,
+                    VerificationAttempt.created_at,
+                )
+                < cutoff,
+            )
+            .order_by(
+                func.coalesce(
+                    VerificationAttempt.started_at,
+                    VerificationAttempt.created_at,
+                ).asc()
+            )
+            .limit(limit)
+        )
+        return [
+            AttemptStatusRow(
+                id=row.id,
+                user_id=row.user_id,
+                requirement_uuid=row.requirement_uuid,
+                outcome=row.outcome,
+                started_at=row.started_at,
+                created_at=row.created_at,
+                legacy_job_id=row.legacy_job_id,
+            )
+            for row in result.all()
+        ]
+
+    async def finalize(
+        self,
+        attempt_id: UUID,
+        *,
+        outcome: VerificationAttemptOutcome | str,
+        error_code: str | None,
+        validation_message: str | None,
+        terminal_source: str,
+        feedback_json: list[dict] | None,
+        completed_at: datetime | None = None,
+    ) -> FinalizeResult:
+        """Compare-and-set an attempt to a terminal outcome.
+
+        Only writes when ``outcome IS NULL``. On a lost CAS (already terminal),
+        reloads and returns the authoritative terminal state without mutating
+        it, so replays and competing finalizers never clobber a result.
+        """
+        normalized_outcome = (
+            outcome.value
+            if isinstance(outcome, VerificationAttemptOutcome)
+            else VerificationAttemptOutcome(outcome).value
+        )
+        now = completed_at or utcnow()
+        stmt = (
+            update(VerificationAttempt)
+            .where(
+                VerificationAttempt.id == attempt_id,
+                VerificationAttempt.outcome.is_(None),
+            )
+            .values(
+                outcome=normalized_outcome,
+                error_code=error_code,
+                validation_message=validation_message,
+                terminal_source=terminal_source,
+                feedback_json=feedback_json,
+                completed_at=now,
+                updated_at=now,
+            )
+            .returning(
+                VerificationAttempt.id,
+                VerificationAttempt.outcome,
+                VerificationAttempt.error_code,
+                VerificationAttempt.validation_message,
+                VerificationAttempt.terminal_source,
+                VerificationAttempt.completed_at,
+            )
+        )
+        result = await self.db.execute(stmt)
+        row = result.one_or_none()
+        if row is not None:
+            return FinalizeResult(
+                won=True,
+                state=AttemptTerminalState(
+                    id=row.id,
+                    outcome=row.outcome,
+                    error_code=row.error_code,
+                    validation_message=row.validation_message,
+                    terminal_source=row.terminal_source,
+                    completed_at=row.completed_at,
+                ),
+            )
+
+        existing = await self.get_terminal_state(attempt_id)
+        if existing is None:
+            raise AttemptAlreadyGoneError(str(attempt_id))
+        return FinalizeResult(won=False, state=existing)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
@@ -133,6 +133,31 @@ class SubmittedValue:
                 return cls(kind=kind, text_value=value)
 
     @classmethod
+    def from_kind_and_value(
+        cls,
+        kind: str | SubmissionValueKind,
+        value: str,
+    ) -> SubmittedValue:
+        """Build a typed value from a stored ``(kind, submitted_value)`` pair.
+
+        The ``verification_attempts`` table keeps only the kind and the single
+        canonical ``submitted_value`` text, so this routes that text into the
+        column the kind implies without re-parsing/validating it.
+        """
+        normalized_kind = (
+            kind if isinstance(kind, SubmissionValueKind) else SubmissionValueKind(kind)
+        )
+        match normalized_kind:
+            case SubmissionValueKind.GITHUB_URL:
+                return cls(kind=normalized_kind, github_url=value)
+            case SubmissionValueKind.TOKEN:
+                return cls(kind=normalized_kind, token_value=value)
+            case SubmissionValueKind.DEPLOYED_URL:
+                return cls(kind=normalized_kind, deployed_url=value)
+            case SubmissionValueKind.TEXT:
+                return cls(kind=normalized_kind, text_value=value)
+
+    @classmethod
     def from_columns(
         cls,
         *,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
@@ -1,0 +1,335 @@
+"""Prepare, finalize, and terminalize unified verification attempts.
+
+This is the bridge (PR4) counterpart to ``verification_job_executor``: it runs
+against the curriculum-decoupled ``verification_attempts`` table instead of the
+legacy ``verification_jobs`` + ``submissions`` pair. Every trusted input comes
+from the attempt row -- the Durable input carries only the attempt id, so a
+leaked function key or a buggy caller cannot smuggle in a forged requirement.
+
+Trust boundary and idempotency:
+
+1. :func:`prepare_verification_attempt` loads the attempt, validates its
+   payload version / snapshot provenance / hash / value kind / active state,
+   deserializes the stored typed requirement snapshot, and returns a
+   :class:`PreparedVerificationJob` the existing verify/grade activities run
+   unchanged.
+2. :func:`finalize_verification_attempt` writes the terminal outcome with a
+   compare-and-set (``UPDATE ... WHERE outcome IS NULL RETURNING``) so replays
+   and competing finalizers never overwrite a result, then mirrors the legacy
+   ``submissions`` row for a linked legacy ``verification_jobs`` so old API
+   readers stay correct.
+3. :func:`terminalize_verification_attempt` is the authoritative failure path
+   (orchestrator/activity exception, or the stale-attempt reconciler): it
+   compare-and-sets a ``server_error`` / ``cancelled`` outcome and mirrors the
+   legacy submission the same idempotent way.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from opentelemetry import trace
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from learn_to_cloud_shared.models import VerificationAttemptOutcome
+from learn_to_cloud_shared.repositories.submission_repository import (
+    SubmissionRepository,
+)
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    AttemptMirrorState,
+    AttemptTerminalState,
+    VerificationAttemptRepository,
+)
+from learn_to_cloud_shared.repositories.verification_job_repository import (
+    LinkResult,
+    VerificationJobRepository,
+)
+from learn_to_cloud_shared.submission_values import (
+    SubmittedValue,
+    value_kind_for_submission_type,
+)
+from learn_to_cloud_shared.verification.execution import (
+    persisted_validation_message,
+)
+from learn_to_cloud_shared.verification_attempt_snapshot import (
+    SUPPORTED_PAYLOAD_VERSIONS,
+    AttemptSnapshotError,
+    validate_snapshot_integrity,
+)
+from learn_to_cloud_shared.verification_job_executor import (
+    PreparedVerificationJob,
+    VerificationRunResult,
+    _code_for_outcome,
+    _outcome_for,
+)
+
+tracer = trace.get_tracer(__name__)
+
+_SNAPSHOT_SOURCE_SUBMITTED = "submitted"
+_ORCHESTRATOR_TERMINAL_SOURCE = "orchestrator"
+
+
+class AttemptPreparationError(Exception):
+    """Base for attempt preparation failures (all lead to terminalization)."""
+
+
+class AttemptNotFoundError(AttemptPreparationError):
+    """The attempt id does not exist."""
+
+
+class AttemptNotActiveError(AttemptPreparationError):
+    """The attempt already reached a terminal outcome."""
+
+
+class AttemptNotRunnableError(AttemptPreparationError):
+    """The attempt cannot be executed (e.g. a reconstructed backfill row)."""
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptPreparation:
+    """A prepared attempt ready for the verify/grade/finalize activities."""
+
+    job: PreparedVerificationJob
+
+    def to_payload(self) -> dict[str, object]:
+        return {"job": self.job.to_payload()}
+
+
+def _outcome_flags(outcome: str) -> tuple[bool, bool]:
+    """Map a terminal outcome to legacy ``(is_validated, completed)`` flags."""
+    is_validated = outcome == VerificationAttemptOutcome.SUCCEEDED.value
+    verification_completed = outcome in (
+        VerificationAttemptOutcome.SUCCEEDED.value,
+        VerificationAttemptOutcome.FAILED.value,
+    )
+    return is_validated, verification_completed
+
+
+async def prepare_verification_attempt(
+    attempt_id: UUID,
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> AttemptPreparation:
+    """Validate and prepare an attempt for execution.
+
+    Loads only the granted identity/snapshot columns, then enforces every
+    trust check before returning a runnable job. Any failure raises an
+    :class:`AttemptPreparationError` subclass so the orchestrator converts it
+    into a terminal outcome instead of leaving the attempt hanging.
+    """
+    with tracer.start_as_current_span(
+        "prepare_verification_attempt",
+        attributes={"verification.attempt.id": str(attempt_id)},
+    ):
+        async with session_maker() as db:
+            repo = VerificationAttemptRepository(db)
+            state = await repo.get_prepare_state(attempt_id)
+            if state is None:
+                raise AttemptNotFoundError(str(attempt_id))
+            if state.outcome is not None:
+                raise AttemptNotActiveError(
+                    f"attempt {attempt_id} is already terminal ({state.outcome})"
+                )
+            if state.started_at is None:
+                marked_started = await repo.mark_started(attempt_id)
+                if not marked_started:
+                    current = await repo.get_status(attempt_id)
+                    if current is None:
+                        raise AttemptNotFoundError(str(attempt_id))
+                    if current.outcome is not None:
+                        raise AttemptNotActiveError(
+                            f"attempt {attempt_id} is already terminal "
+                            f"({current.outcome})"
+                        )
+                await db.commit()
+        if state.snapshot_source != _SNAPSHOT_SOURCE_SUBMITTED:
+            raise AttemptNotRunnableError(
+                f"attempt {attempt_id} has non-runnable snapshot_source "
+                f"{state.snapshot_source!r}"
+            )
+        if state.payload_version not in SUPPORTED_PAYLOAD_VERSIONS:
+            raise AttemptSnapshotError(
+                f"attempt {attempt_id} payload_version "
+                f"{state.payload_version!r} is not supported"
+            )
+
+        requirement = validate_snapshot_integrity(
+            snapshot=state.requirement_snapshot,
+            snapshot_hash=state.requirement_snapshot_hash,
+        )
+
+        expected_kind = value_kind_for_submission_type(requirement.submission_type)
+        if state.submission_value_kind != expected_kind.value:
+            raise AttemptSnapshotError(
+                f"attempt {attempt_id} submission_value_kind "
+                f"{state.submission_value_kind!r} does not match requirement "
+                f"kind {expected_kind.value!r}"
+            )
+
+        submitted_value = SubmittedValue.from_kind_and_value(
+            state.submission_value_kind,
+            state.submitted_value,
+        )
+        job = PreparedVerificationJob(
+            id=state.id,
+            user_id=state.user_id,
+            github_username=state.github_username_snapshot,
+            requirement=requirement,
+            submitted_value=submitted_value,
+        )
+        return AttemptPreparation(job=job)
+
+
+async def finalize_verification_attempt(
+    run_result: VerificationRunResult,
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> AttemptTerminalState:
+    """Persist an attempt's real verification outcome (CAS) + legacy mirror."""
+    run_result = run_result.without_evidence()
+    job = run_result.job
+    validation_result = run_result.validation_result
+    outcome = _outcome_for(validation_result)
+    error_code = _code_for_outcome(outcome)
+    validation_message = (
+        persisted_validation_message(validation_result.message)
+        if not validation_result.is_valid
+        else None
+    )
+    feedback_json = (
+        [task.model_dump() for task in validation_result.task_results]
+        if validation_result.task_results
+        else None
+    )
+
+    return await _finalize(
+        job.id,
+        session_maker=session_maker,
+        outcome=VerificationAttemptOutcome(outcome),
+        error_code=error_code,
+        validation_message=validation_message,
+        terminal_source=_ORCHESTRATOR_TERMINAL_SOURCE,
+        feedback_json=feedback_json,
+    )
+
+
+async def terminalize_verification_attempt(
+    attempt_id: UUID,
+    *,
+    outcome: VerificationAttemptOutcome | str,
+    error_code: str,
+    validation_message: str,
+    terminal_source: str,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> AttemptTerminalState:
+    """Compare-and-set a failure/cancellation outcome + legacy mirror.
+
+    Used by the orchestrator's exception path and the stale-attempt
+    reconciler. Never overwrites an already-terminal attempt.
+    """
+    normalized = (
+        outcome
+        if isinstance(outcome, VerificationAttemptOutcome)
+        else VerificationAttemptOutcome(outcome)
+    )
+    return await _finalize(
+        attempt_id,
+        session_maker=session_maker,
+        outcome=normalized,
+        error_code=error_code,
+        validation_message=validation_message,
+        terminal_source=terminal_source,
+        feedback_json=None,
+    )
+
+
+async def _finalize(
+    attempt_id: UUID,
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+    outcome: VerificationAttemptOutcome,
+    error_code: str,
+    validation_message: str | None,
+    terminal_source: str,
+    feedback_json: list[dict] | None,
+) -> AttemptTerminalState:
+    with tracer.start_as_current_span(
+        "finalize_verification_attempt",
+        attributes={
+            "verification.attempt.id": str(attempt_id),
+            "verification.outcome": outcome.value,
+        },
+    ) as span:
+        async with session_maker() as db:
+            repo = VerificationAttemptRepository(db)
+            result = await repo.finalize(
+                attempt_id,
+                outcome=outcome,
+                error_code=error_code,
+                validation_message=validation_message,
+                terminal_source=terminal_source,
+                feedback_json=feedback_json,
+            )
+            await db.commit()
+        span.set_attribute("verification.cas_won", result.won)
+
+        # Mirror the legacy submission regardless of who won the CAS: the
+        # attempt is now terminal, and the mirror is independently idempotent,
+        # so a crash between the CAS commit and the mirror is recovered by any
+        # retry.
+        await _ensure_legacy_mirror(attempt_id, session_maker=session_maker)
+        return result.state
+
+
+async def _ensure_legacy_mirror(
+    attempt_id: UUID,
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """Create + link the legacy submission for a terminalized attempt, once.
+
+    No-ops when the attempt carries no ``legacy_job_id`` (a genuinely new
+    submitted attempt), when the legacy job is gone, or when the job is already
+    linked. The ``link_submission`` compare-and-set is the duplicate guard: if
+    a competing finalizer or the legacy execution path linked first, our
+    just-inserted submission is rolled back so one attempt/job never produces
+    two legacy submissions.
+    """
+    async with session_maker() as db:
+        state = await VerificationAttemptRepository(db).get_mirror_state(attempt_id)
+        if state is None or state.legacy_job_id is None or state.outcome is None:
+            return
+
+        job_repo = VerificationJobRepository(db)
+        job = await job_repo.get_by_id(state.legacy_job_id)
+        if job is None or job.result_submission_id is not None:
+            return
+
+        submission = await _create_mirror_submission(db, state)
+        link = await job_repo.link_submission(job.id, submission.id)
+        if link is LinkResult.LINKED:
+            await db.commit()
+            return
+        # Another finalizer / the legacy path won the link race: discard our
+        # duplicate insert.
+        await db.rollback()
+
+
+async def _create_mirror_submission(db: AsyncSession, state: AttemptMirrorState):
+    is_validated, verification_completed = _outcome_flags(state.outcome or "")
+    submitted_value = SubmittedValue.from_kind_and_value(
+        state.submission_value_kind,
+        state.submitted_value,
+    )
+    return await SubmissionRepository(db).create(
+        user_id=state.user_id,
+        requirement_uuid=state.requirement_uuid,
+        submitted_value=submitted_value,
+        extracted_username=state.github_username_snapshot,
+        is_validated=is_validated,
+        verification_completed=verification_completed,
+        feedback_json=state.feedback_json,
+        validation_message=state.validation_message,
+        cloud_provider=state.cloud_provider,
+    )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_reconciler.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_reconciler.py
@@ -1,0 +1,85 @@
+"""Pure decision helpers for the stale verification-attempt reconciler.
+
+Kept separate from the Durable/DB glue so the status -> outcome mapping and age
+boundary are unit-testable without any Azure client. The reconciler proper
+(function_app) queries active attempts, asks Durable for each instance's
+status, and applies :func:`reconcile_decision` before a compare-and-set
+terminalize.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from learn_to_cloud_shared.models import VerificationAttemptOutcome
+
+# Azure Durable spells the cancelled runtime status ``Canceled`` (one L); the
+# DB outcome is ``cancelled`` (two L). Normalizing here keeps every status
+# handler in agreement.
+AZURE_CANCELED_STATUS = "Canceled"
+
+# Runtime statuses that mean the orchestration can still make progress or was
+# intentionally suspended -- never terminalize these.
+HEALTHY_STATUSES: frozenset[str] = frozenset(
+    {"Running", "Pending", "ContinuedAsNew", "Suspended"}
+)
+
+_RECONCILER_SOURCE = "reconciler"
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcileDecision:
+    """A terminal outcome the reconciler should compare-and-set for an attempt."""
+
+    outcome: VerificationAttemptOutcome
+    error_code: str
+    validation_message: str
+    terminal_source: str = _RECONCILER_SOURCE
+
+
+def reconcile_decision(status_name: str | None) -> ReconcileDecision | None:
+    """Map a Durable runtime status to a terminal decision, or ``None``.
+
+    ``None`` means "leave the attempt active": either it is genuinely healthy
+    (Pending/Running/etc.) or its status is unknown and terminalizing would be
+    unsafe. A missing status (``status_name is None``) is a confirmed
+    not-started/abandoned instance and terminalizes as ``server_error``.
+    """
+    if status_name is None:
+        return ReconcileDecision(
+            outcome=VerificationAttemptOutcome.SERVER_ERROR,
+            error_code="server_error",
+            validation_message="Verification never started and was reconciled.",
+        )
+    if status_name in HEALTHY_STATUSES:
+        return None
+    if status_name == "Completed":
+        return ReconcileDecision(
+            outcome=VerificationAttemptOutcome.SERVER_ERROR,
+            error_code="server_error",
+            validation_message=(
+                "Verification completed without recording a result and was reconciled."
+            ),
+        )
+    if status_name in {"Terminated", AZURE_CANCELED_STATUS}:
+        return ReconcileDecision(
+            outcome=VerificationAttemptOutcome.CANCELLED,
+            error_code="cancelled",
+            validation_message="Verification was cancelled.",
+        )
+    if status_name == "Failed":
+        return ReconcileDecision(
+            outcome=VerificationAttemptOutcome.SERVER_ERROR,
+            error_code="server_error",
+            validation_message="Verification failed and was reconciled.",
+        )
+    # Any status this code does not recognize is left untouched -- being
+    # conservative here means an unfamiliar-but-healthy state is never
+    # mistakenly terminalized.
+    return None
+
+
+def stale_cutoff(now: datetime, min_age_minutes: int) -> datetime:
+    """Return the newest ``created_at`` an attempt may have and still be stale."""
+    return now - timedelta(minutes=min_age_minutes)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_snapshot.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_snapshot.py
@@ -1,0 +1,99 @@
+"""Canonical requirement-snapshot helpers for verification attempts.
+
+An attempt row stores the *requirement definition* it was submitted against
+(``requirement_snapshot``) plus a hash of that snapshot
+(``requirement_snapshot_hash``) so the Functions role can run verification
+without any curriculum grants. This module is the single source of truth for
+how that snapshot is built, hashed, and validated so the API writer (a later
+PR) and the Functions reader stay in exact agreement.
+
+``ATTEMPT_PAYLOAD_VERSION`` is the contract version stamped on every
+``submitted`` attempt. The prepare activity rejects any attempt whose stored
+``payload_version`` this code cannot run, so an incompatible producer can never
+be silently mis-executed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+
+from learn_to_cloud_shared.schemas import (
+    HandsOnRequirement,
+    HandsOnRequirementAdapter,
+)
+
+# Bump only alongside a breaking change to the snapshot/hash contract.
+ATTEMPT_PAYLOAD_VERSION = 1
+
+# Snapshot payload versions this code version can execute. Kept as a set so a
+# future PR can widen support during a rolling deploy without a code branch.
+SUPPORTED_PAYLOAD_VERSIONS: frozenset[int] = frozenset({ATTEMPT_PAYLOAD_VERSION})
+
+
+class AttemptSnapshotError(ValueError):
+    """The stored requirement snapshot is missing, malformed, or inconsistent."""
+
+
+def build_requirement_snapshot(requirement: HandsOnRequirement) -> dict:
+    """Serialize a typed requirement into its stored snapshot form."""
+    return requirement.model_dump(mode="json")
+
+
+def compute_snapshot_hash(snapshot: Mapping[str, object]) -> str:
+    """Return the stable SHA-256 hash of a requirement snapshot.
+
+    The snapshot is serialized with sorted keys and compact separators so the
+    hash is independent of dict ordering and whitespace, matching whatever the
+    producer computed at submission time.
+    """
+    canonical = json.dumps(
+        dict(snapshot),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def deserialize_requirement_snapshot(
+    snapshot: Mapping[str, object],
+) -> HandsOnRequirement:
+    """Rehydrate a typed requirement from a stored snapshot.
+
+    Raises :class:`AttemptSnapshotError` when the snapshot does not deserialize
+    into a known typed requirement (e.g. a reconstructed backfill row that only
+    carries reconciliation metadata, not a runnable requirement definition).
+    """
+    try:
+        return HandsOnRequirementAdapter.validate_python(dict(snapshot))
+    except (ValueError, TypeError, KeyError) as exc:
+        raise AttemptSnapshotError(
+            f"requirement snapshot is not a runnable requirement: {exc}"
+        ) from exc
+
+
+def validate_snapshot_integrity(
+    *,
+    snapshot: Mapping[str, object] | None,
+    snapshot_hash: str | None,
+) -> HandsOnRequirement:
+    """Validate a submitted snapshot's shape + hash and return the requirement.
+
+    Enforces that the snapshot and its hash are both present and that the hash
+    matches the snapshot's canonical form (guarding against a tampered or
+    truncated row), then deserializes it into a typed requirement.
+    """
+    if snapshot is None:
+        raise AttemptSnapshotError("submitted attempt is missing requirement_snapshot")
+    if not snapshot_hash:
+        raise AttemptSnapshotError(
+            "submitted attempt is missing requirement_snapshot_hash"
+        )
+    expected = compute_snapshot_hash(snapshot)
+    if expected != snapshot_hash:
+        raise AttemptSnapshotError(
+            "requirement_snapshot_hash does not match the stored snapshot"
+        )
+    return deserialize_requirement_snapshot(snapshot)

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
@@ -1,0 +1,195 @@
+"""Integration tests for VerificationAttemptRepository (CAS + reads)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from learn_to_cloud_shared.models import (
+    VerificationAttempt,
+    VerificationAttemptOutcome,
+    utcnow,
+)
+from learn_to_cloud_shared.repositories.user_repository import UserRepository
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    VerificationAttemptRepository,
+)
+
+pytestmark = pytest.mark.integration
+
+USER_ID = 84001
+
+
+@pytest.fixture()
+def session_maker(test_engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(
+        bind=test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+
+@pytest.fixture()
+async def user(session_maker: async_sessionmaker[AsyncSession]) -> int:
+    async with session_maker() as db:
+        await UserRepository(db).upsert(USER_ID, github_username="attemptrepo")
+        await db.commit()
+    return USER_ID
+
+
+async def _insert_attempt(
+    session_maker: async_sessionmaker[AsyncSession],
+    *,
+    attempt_id: UUID | None = None,
+    created_at=None,
+    outcome: str | None = None,
+) -> UUID:
+    attempt_id = attempt_id or uuid4()
+    async with session_maker() as db:
+        attempt = VerificationAttempt(
+            id=attempt_id,
+            user_id=USER_ID,
+            requirement_uuid=uuid4(),
+            snapshot_source="reconstructed",
+            submission_value_kind="github_url",
+            submitted_value="https://github.com/attemptrepo/repo",
+            outcome=outcome,
+            completed_at=utcnow() if outcome is not None else None,
+        )
+        if created_at is not None:
+            attempt.created_at = created_at
+        db.add(attempt)
+        await db.commit()
+    return attempt_id
+
+
+async def test_finalize_sets_terminal_state(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    attempt_id = await _insert_attempt(session_maker)
+    async with session_maker() as db:
+        result = await VerificationAttemptRepository(db).finalize(
+            attempt_id,
+            outcome=VerificationAttemptOutcome.SUCCEEDED,
+            error_code="verification_succeeded",
+            validation_message=None,
+            terminal_source="orchestrator",
+            feedback_json=[{"task": "a"}],
+        )
+        await db.commit()
+    assert result.won is True
+    assert result.state.outcome == "succeeded"
+    assert result.state.completed_at is not None
+
+
+async def test_finalize_is_compare_and_set(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    attempt_id = await _insert_attempt(session_maker)
+    async with session_maker() as db:
+        first = await VerificationAttemptRepository(db).finalize(
+            attempt_id,
+            outcome=VerificationAttemptOutcome.SUCCEEDED,
+            error_code="verification_succeeded",
+            validation_message=None,
+            terminal_source="orchestrator",
+            feedback_json=None,
+        )
+        await db.commit()
+
+    # A competing finalizer with a different outcome must not overwrite.
+    async with session_maker() as db:
+        second = await VerificationAttemptRepository(db).finalize(
+            attempt_id,
+            outcome=VerificationAttemptOutcome.SERVER_ERROR,
+            error_code="server_error",
+            validation_message="late",
+            terminal_source="reconciler",
+            feedback_json=None,
+        )
+        await db.commit()
+
+    assert first.won is True
+    assert second.won is False
+    assert second.state.outcome == "succeeded"
+    assert second.state.terminal_source == "orchestrator"
+
+
+async def test_get_prepare_state_and_status(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    attempt_id = await _insert_attempt(session_maker)
+    async with session_maker() as db:
+        repo = VerificationAttemptRepository(db)
+        prepare = await repo.get_prepare_state(attempt_id)
+        status = await repo.get_status(attempt_id)
+    assert prepare is not None
+    assert prepare.submission_value_kind == "github_url"
+    assert prepare.outcome is None
+    assert status is not None
+    assert status.outcome is None
+
+
+async def test_mark_started_is_idempotent(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    attempt_id = await _insert_attempt(session_maker)
+    first_started_at = utcnow()
+    async with session_maker() as db:
+        repo = VerificationAttemptRepository(db)
+        assert await repo.mark_started(attempt_id, started_at=first_started_at)
+        await db.commit()
+
+    async with session_maker() as db:
+        repo = VerificationAttemptRepository(db)
+        assert not await repo.mark_started(
+            attempt_id, started_at=first_started_at + timedelta(minutes=1)
+        )
+        status = await repo.get_status(attempt_id)
+    assert status is not None
+    assert status.started_at == first_started_at
+
+
+async def test_list_active_older_than_filters(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    now = utcnow()
+    old_active = await _insert_attempt(
+        session_maker, created_at=now - timedelta(hours=2)
+    )
+    await _insert_attempt(session_maker, created_at=now - timedelta(minutes=1))
+    await _insert_attempt(
+        session_maker, created_at=now - timedelta(hours=3), outcome="succeeded"
+    )
+
+    async with session_maker() as db:
+        rows = await VerificationAttemptRepository(db).list_active_older_than(
+            now - timedelta(hours=1), limit=10
+        )
+    ids = {row.id for row in rows}
+    assert old_active in ids
+    assert all(row.outcome is None for row in rows)
+    assert len(ids) == 1
+
+
+async def test_list_active_older_than_uses_started_at_when_present(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    now = utcnow()
+    attempt_id = await _insert_attempt(
+        session_maker, created_at=now - timedelta(hours=2)
+    )
+    async with session_maker() as db:
+        repo = VerificationAttemptRepository(db)
+        assert await repo.mark_started(attempt_id, started_at=now)
+        await db.commit()
+
+    async with session_maker() as db:
+        rows = await VerificationAttemptRepository(db).list_active_older_than(
+            now - timedelta(hours=1), limit=10
+        )
+    assert attempt_id not in {row.id for row in rows}

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
@@ -1,0 +1,523 @@
+"""Integration tests for verification-attempt prepare/finalize/terminalize."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from learn_to_cloud_shared.content_sync import sync_curriculum_to_db
+from learn_to_cloud_shared.content_yaml_loader import clear_cache
+from learn_to_cloud_shared.models import (
+    CurriculumRequirement,
+    Submission,
+    SubmissionType,
+    VerificationAttempt,
+    VerificationAttemptOutcome,
+)
+from learn_to_cloud_shared.repositories.user_repository import UserRepository
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    VerificationAttemptRepository,
+)
+from learn_to_cloud_shared.repositories.verification_job_repository import (
+    VerificationJobRepository,
+)
+from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
+from learn_to_cloud_shared.submission_values import SubmittedValue
+from learn_to_cloud_shared.testing.requirement_factories import (
+    make_requirement,
+    repo_fork_requirement,
+)
+from learn_to_cloud_shared.verification_attempt_executor import (
+    AttemptNotActiveError,
+    AttemptNotFoundError,
+    AttemptNotRunnableError,
+    finalize_verification_attempt,
+    prepare_verification_attempt,
+    terminalize_verification_attempt,
+)
+from learn_to_cloud_shared.verification_attempt_snapshot import (
+    ATTEMPT_PAYLOAD_VERSION,
+    AttemptSnapshotError,
+    build_requirement_snapshot,
+    compute_snapshot_hash,
+)
+from learn_to_cloud_shared.verification_job_executor import (
+    PreparedVerificationJob,
+    VerificationRunResult,
+)
+
+pytestmark = pytest.mark.integration
+
+USER_ID = 85001
+_VALUE = "https://github.com/attemptexec/repo"
+
+
+@pytest.fixture()
+def session_maker(test_engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(
+        bind=test_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+    )
+
+
+@pytest.fixture()
+async def user(session_maker: async_sessionmaker[AsyncSession]) -> int:
+    async with session_maker() as db:
+        await UserRepository(db).upsert(USER_ID, github_username="attemptexec")
+        await db.commit()
+    return USER_ID
+
+
+@pytest.fixture()
+async def synced_requirement(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> HandsOnRequirement:
+    """Return a requirement whose UUID matches an active curriculum row."""
+    clear_cache()
+    async with session_maker() as db:
+        await sync_curriculum_to_db(db)
+        await UserRepository(db).upsert(USER_ID, github_username="attemptexec")
+        await db.commit()
+        row = (
+            await db.execute(
+                select(
+                    CurriculumRequirement.uuid,
+                    CurriculumRequirement.slug,
+                    CurriculumRequirement.submission_type,
+                )
+                .where(CurriculumRequirement.submission_type == "repo_fork")
+                .limit(1)
+            )
+        ).one()
+    return make_requirement(
+        SubmissionType(row.submission_type),
+        slug=row.slug,
+        name="Attempt Executor Test",
+        description="Test requirement",
+    ).model_copy(update={"uuid": row.uuid})
+
+
+async def _insert_submitted_attempt(
+    session_maker: async_sessionmaker[AsyncSession],
+    requirement: HandsOnRequirement,
+    *,
+    attempt_id: UUID | None = None,
+    payload_version: int | None = ATTEMPT_PAYLOAD_VERSION,
+    snapshot_source: str = "submitted",
+    submission_value_kind: str = "github_url",
+    legacy_job_id: UUID | None = None,
+    tamper_hash: bool = False,
+) -> UUID:
+    attempt_id = attempt_id or uuid4()
+    snapshot = build_requirement_snapshot(requirement)
+    snapshot_hash = compute_snapshot_hash(snapshot)
+    if tamper_hash:
+        snapshot_hash = "deadbeef"
+    async with session_maker() as db:
+        db.add(
+            VerificationAttempt(
+                id=attempt_id,
+                user_id=USER_ID,
+                requirement_uuid=requirement.uuid,
+                snapshot_source=snapshot_source,
+                payload_version=payload_version,
+                requirement_snapshot=snapshot,
+                requirement_snapshot_hash=snapshot_hash,
+                submission_value_kind=submission_value_kind,
+                submitted_value=_VALUE,
+                github_username_snapshot="attemptexec",
+                legacy_job_id=legacy_job_id,
+            )
+        )
+        await db.commit()
+    return attempt_id
+
+
+def _run_result(
+    attempt_id: UUID,
+    requirement: HandsOnRequirement,
+    *,
+    is_valid: bool,
+    verification_completed: bool = True,
+    message: str = "",
+) -> VerificationRunResult:
+    job = PreparedVerificationJob(
+        id=attempt_id,
+        user_id=USER_ID,
+        github_username="attemptexec",
+        requirement=requirement,
+        submitted_value=SubmittedValue.from_kind_and_value("github_url", _VALUE),
+    )
+    return VerificationRunResult(
+        job=job,
+        validation_result=ValidationResult(
+            is_valid=is_valid,
+            message=message,
+            verification_completed=verification_completed,
+        ),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# prepare
+# --------------------------------------------------------------------------- #
+
+
+async def test_prepare_returns_runnable_job(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    attempt_id = await _insert_submitted_attempt(session_maker, requirement)
+    preparation = await prepare_verification_attempt(
+        attempt_id, session_maker=session_maker
+    )
+    assert preparation.job.id == attempt_id
+    assert preparation.job.requirement == requirement
+    assert preparation.job.typed_submitted_value.as_text == _VALUE
+    async with session_maker() as db:
+        status = await VerificationAttemptRepository(db).get_status(attempt_id)
+    assert status is not None
+    assert status.started_at is not None
+
+
+async def test_prepare_missing_attempt_raises(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    with pytest.raises(AttemptNotFoundError):
+        await prepare_verification_attempt(uuid4(), session_maker=session_maker)
+
+
+async def test_prepare_rejects_terminal_attempt(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    attempt_id = await _insert_submitted_attempt(session_maker, requirement)
+    async with session_maker() as db:
+        await VerificationAttemptRepository(db).finalize(
+            attempt_id,
+            outcome=VerificationAttemptOutcome.SUCCEEDED,
+            error_code="verification_succeeded",
+            validation_message=None,
+            terminal_source="orchestrator",
+            feedback_json=None,
+        )
+        await db.commit()
+    with pytest.raises(AttemptNotActiveError):
+        await prepare_verification_attempt(attempt_id, session_maker=session_maker)
+
+
+async def test_prepare_rechecks_terminal_state_after_start_cas_loss(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    attempt_id = await _insert_submitted_attempt(session_maker, requirement)
+
+    async def terminalize_before_start_mark(
+        _repo: VerificationAttemptRepository,
+        claimed_attempt_id: UUID,
+        *,
+        started_at=None,
+    ) -> bool:
+        async with session_maker() as competing_db:
+            await VerificationAttemptRepository(competing_db).finalize(
+                claimed_attempt_id,
+                outcome=VerificationAttemptOutcome.SERVER_ERROR,
+                error_code="server_error",
+                validation_message="reconciled",
+                terminal_source="reconciler",
+                feedback_json=None,
+            )
+            await competing_db.commit()
+        return False
+
+    with (
+        patch.object(
+            VerificationAttemptRepository,
+            "mark_started",
+            new=terminalize_before_start_mark,
+        ),
+        pytest.raises(AttemptNotActiveError),
+    ):
+        await prepare_verification_attempt(attempt_id, session_maker=session_maker)
+
+
+async def test_prepare_is_idempotent_after_started_at_is_set(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    attempt_id = await _insert_submitted_attempt(session_maker, requirement)
+    first = await prepare_verification_attempt(attempt_id, session_maker=session_maker)
+    second = await prepare_verification_attempt(attempt_id, session_maker=session_maker)
+    assert first == second
+
+
+async def test_prepare_rejects_reconstructed_source(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    attempt_id = await _insert_submitted_attempt(
+        session_maker, requirement, snapshot_source="reconstructed"
+    )
+    with pytest.raises(AttemptNotRunnableError):
+        await prepare_verification_attempt(attempt_id, session_maker=session_maker)
+
+
+async def test_prepare_rejects_unsupported_payload_version(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    attempt_id = await _insert_submitted_attempt(
+        session_maker, requirement, payload_version=999
+    )
+    with pytest.raises(AttemptSnapshotError, match="payload_version"):
+        await prepare_verification_attempt(attempt_id, session_maker=session_maker)
+
+
+async def test_prepare_rejects_hash_mismatch(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    attempt_id = await _insert_submitted_attempt(
+        session_maker, requirement, tamper_hash=True
+    )
+    with pytest.raises(AttemptSnapshotError, match="hash"):
+        await prepare_verification_attempt(attempt_id, session_maker=session_maker)
+
+
+async def test_prepare_rejects_value_kind_mismatch(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    attempt_id = await _insert_submitted_attempt(
+        session_maker, requirement, submission_value_kind="token"
+    )
+    with pytest.raises(AttemptSnapshotError, match="submission_value_kind"):
+        await prepare_verification_attempt(attempt_id, session_maker=session_maker)
+
+
+# --------------------------------------------------------------------------- #
+# finalize (no legacy mirror)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("is_valid", "verification_completed", "expected"),
+    [
+        (True, True, "succeeded"),
+        (False, True, "failed"),
+        (False, False, "server_error"),
+    ],
+)
+async def test_finalize_maps_outcomes(
+    session_maker: async_sessionmaker[AsyncSession],
+    user: int,
+    is_valid: bool,
+    verification_completed: bool,
+    expected: str,
+) -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    attempt_id = await _insert_submitted_attempt(session_maker, requirement)
+    state = await finalize_verification_attempt(
+        _run_result(
+            attempt_id,
+            requirement,
+            is_valid=is_valid,
+            verification_completed=verification_completed,
+            message="nope" if not is_valid else "",
+        ),
+        session_maker=session_maker,
+    )
+    assert state.outcome == expected
+    async with session_maker() as db:
+        stored = await VerificationAttemptRepository(db).get_status(attempt_id)
+    assert stored is not None
+    assert stored.outcome == expected
+
+
+async def test_finalize_replay_does_not_overwrite(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    attempt_id = await _insert_submitted_attempt(session_maker, requirement)
+    await finalize_verification_attempt(
+        _run_result(attempt_id, requirement, is_valid=True),
+        session_maker=session_maker,
+    )
+    # A replay carrying a different (failed) result must not clobber success.
+    state = await finalize_verification_attempt(
+        _run_result(attempt_id, requirement, is_valid=False, message="late failure"),
+        session_maker=session_maker,
+    )
+    assert state.outcome == "succeeded"
+
+
+# --------------------------------------------------------------------------- #
+# legacy mirror
+# --------------------------------------------------------------------------- #
+
+
+async def _create_legacy_job(
+    session_maker: async_sessionmaker[AsyncSession],
+    requirement: HandsOnRequirement,
+) -> UUID:
+    async with session_maker() as db:
+        job = await VerificationJobRepository(db).create(
+            user_id=USER_ID,
+            requirement_uuid=requirement.uuid,
+            submitted_value=SubmittedValue.from_kind_and_value("github_url", _VALUE),
+            extracted_username="attemptexec",
+        )
+        await db.commit()
+        return job.id
+
+
+async def _count_submissions(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> int:
+    async with session_maker() as db:
+        return (
+            await db.execute(select(func.count()).select_from(Submission))
+        ).scalar_one()
+
+
+async def test_finalize_mirrors_legacy_submission(
+    session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
+) -> None:
+    job_id = await _create_legacy_job(session_maker, synced_requirement)
+    attempt_id = await _insert_submitted_attempt(
+        session_maker, synced_requirement, attempt_id=job_id, legacy_job_id=job_id
+    )
+    await finalize_verification_attempt(
+        _run_result(attempt_id, synced_requirement, is_valid=True),
+        session_maker=session_maker,
+    )
+    async with session_maker() as db:
+        job = await VerificationJobRepository(db).get_by_id(job_id)
+        assert job is not None
+        assert job.result_submission_id is not None
+        submission = await db.get(Submission, job.result_submission_id)
+    assert submission is not None
+    assert submission.is_validated is True
+    assert submission.extracted_username == "attemptexec"
+
+
+async def test_legacy_mirror_is_idempotent(
+    session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
+) -> None:
+    job_id = await _create_legacy_job(session_maker, synced_requirement)
+    attempt_id = await _insert_submitted_attempt(
+        session_maker, synced_requirement, attempt_id=job_id, legacy_job_id=job_id
+    )
+    before = await _count_submissions(session_maker)
+    await finalize_verification_attempt(
+        _run_result(attempt_id, synced_requirement, is_valid=False, message="x"),
+        session_maker=session_maker,
+    )
+    after_first = await _count_submissions(session_maker)
+    # Re-run finalize (Durable retry): no duplicate legacy submission.
+    await finalize_verification_attempt(
+        _run_result(attempt_id, synced_requirement, is_valid=False, message="x"),
+        session_maker=session_maker,
+    )
+    after_second = await _count_submissions(session_maker)
+    assert after_first == before + 1
+    assert after_second == after_first
+
+
+# --------------------------------------------------------------------------- #
+# terminalize (+ reconciler mirror)
+# --------------------------------------------------------------------------- #
+
+
+async def test_terminalize_server_error(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    attempt_id = await _insert_submitted_attempt(session_maker, requirement)
+    state = await terminalize_verification_attempt(
+        attempt_id,
+        outcome=VerificationAttemptOutcome.SERVER_ERROR,
+        error_code="server_error",
+        validation_message="Verification could not be completed.",
+        terminal_source="orchestrator_exception",
+        session_maker=session_maker,
+    )
+    assert state.outcome == "server_error"
+    assert state.terminal_source == "orchestrator_exception"
+
+
+async def test_terminalize_cancelled_mirrors_legacy(
+    session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
+) -> None:
+    job_id = await _create_legacy_job(session_maker, synced_requirement)
+    attempt_id = await _insert_submitted_attempt(
+        session_maker, synced_requirement, attempt_id=job_id, legacy_job_id=job_id
+    )
+    state = await terminalize_verification_attempt(
+        attempt_id,
+        outcome=VerificationAttemptOutcome.CANCELLED,
+        error_code="cancelled",
+        validation_message="Verification was cancelled.",
+        terminal_source="reconciler",
+        session_maker=session_maker,
+    )
+    assert state.outcome == "cancelled"
+    async with session_maker() as db:
+        job = await VerificationJobRepository(db).get_by_id(job_id)
+        assert job is not None and job.result_submission_id is not None
+        submission = await db.get(Submission, job.result_submission_id)
+    assert submission is not None
+    assert submission.is_validated is False
+    assert submission.verification_completed is False
+
+
+async def test_mirror_skips_when_legacy_job_already_linked(
+    session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
+) -> None:
+    job_id = await _create_legacy_job(session_maker, synced_requirement)
+    # The legacy execution path linked its own submission first.
+    async with session_maker() as db:
+        from learn_to_cloud_shared.repositories.submission_repository import (
+            SubmissionRepository,
+        )
+
+        submission = await SubmissionRepository(db).create(
+            user_id=USER_ID,
+            requirement_uuid=synced_requirement.uuid,
+            submitted_value=SubmittedValue.from_kind_and_value("github_url", _VALUE),
+            extracted_username="attemptexec",
+            is_validated=True,
+            verification_completed=True,
+        )
+        await VerificationJobRepository(db).link_submission(job_id, submission.id)
+        await db.commit()
+        linked_submission_id = submission.id
+
+    attempt_id = await _insert_submitted_attempt(
+        session_maker, synced_requirement, attempt_id=job_id, legacy_job_id=job_id
+    )
+    before = await _count_submissions(session_maker)
+    await terminalize_verification_attempt(
+        attempt_id,
+        outcome=VerificationAttemptOutcome.SERVER_ERROR,
+        error_code="server_error",
+        validation_message="Verification could not be completed.",
+        terminal_source="reconciler",
+        session_maker=session_maker,
+    )
+    after = await _count_submissions(session_maker)
+    assert after == before
+    async with session_maker() as db:
+        job = await VerificationJobRepository(db).get_by_id(job_id)
+    assert job is not None
+    assert job.result_submission_id == linked_submission_id

--- a/packages/learn-to-cloud-shared/tests/test_verification_attempt_reconciler.py
+++ b/packages/learn-to-cloud-shared/tests/test_verification_attempt_reconciler.py
@@ -1,0 +1,58 @@
+"""Unit tests for the stale verification-attempt reconciler decisions."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from learn_to_cloud_shared.models import VerificationAttemptOutcome
+from learn_to_cloud_shared.verification_attempt_reconciler import (
+    reconcile_decision,
+    stale_cutoff,
+)
+
+
+def test_missing_status_terminalizes_as_server_error() -> None:
+    decision = reconcile_decision(None)
+    assert decision is not None
+    assert decision.outcome is VerificationAttemptOutcome.SERVER_ERROR
+    assert decision.error_code == "server_error"
+
+
+def test_failed_maps_to_server_error() -> None:
+    decision = reconcile_decision("Failed")
+    assert decision is not None
+    assert decision.outcome is VerificationAttemptOutcome.SERVER_ERROR
+
+
+def test_terminated_maps_to_cancelled() -> None:
+    decision = reconcile_decision("Terminated")
+    assert decision is not None
+    assert decision.outcome is VerificationAttemptOutcome.CANCELLED
+
+
+def test_azure_canceled_spelling_maps_to_cancelled() -> None:
+    decision = reconcile_decision("Canceled")
+    assert decision is not None
+    assert decision.outcome is VerificationAttemptOutcome.CANCELLED
+    assert decision.error_code == "cancelled"
+
+
+def test_healthy_statuses_are_left_untouched() -> None:
+    for status in ("Running", "Pending", "ContinuedAsNew", "Suspended"):
+        assert reconcile_decision(status) is None
+
+
+def test_completed_without_persisted_outcome_maps_to_server_error() -> None:
+    decision = reconcile_decision("Completed")
+    assert decision is not None
+    assert decision.outcome is VerificationAttemptOutcome.SERVER_ERROR
+
+
+def test_unknown_status_is_left_untouched() -> None:
+    assert reconcile_decision("SomethingNew") is None
+
+
+def test_stale_cutoff_subtracts_minutes() -> None:
+    now = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    cutoff = stale_cutoff(now, 30)
+    assert cutoff == datetime(2026, 1, 1, 11, 30, tzinfo=UTC)

--- a/packages/learn-to-cloud-shared/tests/test_verification_attempt_snapshot.py
+++ b/packages/learn-to-cloud-shared/tests/test_verification_attempt_snapshot.py
@@ -1,0 +1,82 @@
+"""Unit tests for verification-attempt snapshot/hash helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from learn_to_cloud_shared.testing.requirement_factories import (
+    journal_api_verifier_requirement,
+    repo_fork_requirement,
+)
+from learn_to_cloud_shared.verification_attempt_snapshot import (
+    ATTEMPT_PAYLOAD_VERSION,
+    SUPPORTED_PAYLOAD_VERSIONS,
+    AttemptSnapshotError,
+    build_requirement_snapshot,
+    compute_snapshot_hash,
+    deserialize_requirement_snapshot,
+    validate_snapshot_integrity,
+)
+
+
+def test_payload_version_is_supported() -> None:
+    assert ATTEMPT_PAYLOAD_VERSION in SUPPORTED_PAYLOAD_VERSIONS
+
+
+def test_snapshot_round_trips_to_typed_requirement() -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    snapshot = build_requirement_snapshot(requirement)
+    restored = deserialize_requirement_snapshot(snapshot)
+    assert restored == requirement
+
+
+def test_hash_is_order_independent() -> None:
+    requirement = journal_api_verifier_requirement(slug="journal")
+    snapshot = build_requirement_snapshot(requirement)
+    reordered = dict(reversed(list(snapshot.items())))
+    assert compute_snapshot_hash(snapshot) == compute_snapshot_hash(reordered)
+
+
+def test_validate_snapshot_integrity_accepts_matching_hash() -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    snapshot = build_requirement_snapshot(requirement)
+    snapshot_hash = compute_snapshot_hash(snapshot)
+    restored = validate_snapshot_integrity(
+        snapshot=snapshot,
+        snapshot_hash=snapshot_hash,
+    )
+    assert restored == requirement
+
+
+def test_validate_snapshot_integrity_rejects_hash_mismatch() -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    snapshot = build_requirement_snapshot(requirement)
+    with pytest.raises(AttemptSnapshotError, match="hash"):
+        validate_snapshot_integrity(snapshot=snapshot, snapshot_hash="deadbeef")
+
+
+def test_validate_snapshot_integrity_rejects_missing_snapshot() -> None:
+    with pytest.raises(AttemptSnapshotError, match="missing requirement_snapshot"):
+        validate_snapshot_integrity(snapshot=None, snapshot_hash="abc")
+
+
+def test_validate_snapshot_integrity_rejects_missing_hash() -> None:
+    requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
+    snapshot = build_requirement_snapshot(requirement)
+    with pytest.raises(AttemptSnapshotError, match="missing requirement_snapshot_hash"):
+        validate_snapshot_integrity(snapshot=snapshot, snapshot_hash=None)
+
+
+def test_reconstructed_snapshot_is_not_runnable() -> None:
+    # The reconstructed backfill shape carries reconciliation metadata, not a
+    # runnable typed requirement, so it must be rejected.
+    reconstructed = {
+        "uuid": "11111111-1111-1111-1111-111111111111",
+        "slug": "legacy",
+        "name": "Legacy",
+        "submission_type": "repo_fork",
+        "submission_value_kind": "github_url",
+        "reconstructed": True,
+    }
+    with pytest.raises(AttemptSnapshotError):
+        deserialize_requirement_snapshot(reconstructed)


### PR DESCRIPTION
## Why

The expanded schema needs a replay-safe execution path before the API can create authoritative attempts. This layer bridges Durable Functions to stored attempt snapshots while preserving the old path for in-flight work.

## What changed

- add versioned `verification_attempt_orchestrator_v1` execution
- prepare from immutable attempt snapshots and finalize outcomes with compare-and-set
- claim `started_at` before Durable start to prevent duplicate instance replacement
- reconcile stale, failed, cancelled, terminated, and incomplete attempts
- mirror results to legacy submissions while old readers remain active
- narrow Functions access to required attempt columns

## Stack position

Depends on #660. The existing orchestrator remains registered for its drain cohort. The start-idempotency deviation is documented in `build-out-notes.md`.

## Validation

`uv run poe check`