### PR TITLE
Dual-write unified learner state

### DIFF
--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -19,6 +19,9 @@ from uuid import UUID
 from fastapi import APIRouter, Form, Query, Request
 from fastapi.responses import HTMLResponse
 from learn_to_cloud_shared.core.database import DbSession
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    VerificationAttemptRepository,
+)
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
@@ -32,8 +35,6 @@ from learn_to_cloud_shared.submission_derivation import (
     derive_submission_value,
     is_derivable,
 )
-from learn_to_cloud_shared.submission_values import submission_value_from_columns
-from learn_to_cloud_shared.verification_job_executor import PreparedVerificationJob
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 if TYPE_CHECKING:
@@ -52,7 +53,7 @@ from learn_to_cloud.services.durable_verification_client import (
     DurableVerificationStartError,
     DurableVerificationStatusError,
     get_verification_orchestration_status,
-    start_verification_orchestration,
+    start_verification_attempt_orchestration,
 )
 from learn_to_cloud.services.steps_service import (
     StepValidationError,
@@ -64,8 +65,8 @@ from learn_to_cloud.services.submissions_service import (
     InvalidSubmittedValueError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
-    VerificationJobSubmission,
-    create_verification_job,
+    VerificationAttemptSubmission,
+    create_verification_attempt,
 )
 from learn_to_cloud.services.users_service import (
     UserNotFoundError,
@@ -320,9 +321,10 @@ async def htmx_submit_verification(
     """Submit a hands-on verification.
 
     Every submission type runs through Durable Functions:
-    :func:`create_verification_job` validates the request and creates a
-    ``VerificationJob``; we start the Durable orchestration and return a
-    spinner card that polls for status.
+    :func:`create_verification_attempt` validates the request and creates a
+    ``VerificationAttempt`` (plus its compatibility ``VerificationJob``); we
+    start the versioned attempt orchestration and return a spinner card that
+    polls for status.
     """
     user_id = current_user.user_id
     github_username = current_user.github_username
@@ -393,9 +395,9 @@ async def htmx_submit_verification(
     else:
         derived_value = submitted_value
 
-    # ── Create the Durable verification job ────────────────────────────
+    # ── Create the unified verification attempt ─────────────────────────
     try:
-        job_submission = await create_verification_job(
+        attempt_submission = await create_verification_attempt(
             session_maker=session_maker,
             user_id=user_id,
             requirement_slug=requirement_slug,
@@ -422,57 +424,52 @@ async def htmx_submit_verification(
             ),
         )
 
-    return await _start_async_job_and_render(
+    return await _start_async_attempt_and_render(
         session_maker=session_maker,
         user_id=user_id,
         requirement_slug=requirement_slug,
-        job_submission=job_submission,
+        attempt_submission=attempt_submission,
         render_card=_render_card,
     )
 
 
-async def _start_async_job_and_render(
+async def _start_async_attempt_and_render(
     *,
     session_maker: async_sessionmaker[AsyncSession],
     user_id: int,
     requirement_slug: str,
-    job_submission: VerificationJobSubmission,
+    attempt_submission: VerificationAttemptSubmission,
     render_card: Callable[..., HTMLResponse],
 ) -> HTMLResponse:
-    """Start a Durable orchestration for an async job and render the spinner.
+    """Start the Durable attempt orchestration and render the spinner.
 
-    Builds the full :class:`PreparedVerificationJob` payload from the
-    validated requirement + github_username carried on
-    ``job_submission`` and posts it to the Functions starter. Functions
-    validates the immutable fields against the ``verification_jobs``
-    row before starting; the payload is trusted for the requirement
-    definition + username snapshot so Functions never needs to read
-    curriculum or users tables.
+    Posts no body -- the PR4 attempt starter loads identity, the
+    requirement snapshot, and the submitted value straight from the
+    ``verification_attempts`` row keyed by ``attempt_submission.attempt_id``,
+    which is shared with the compatibility ``verification_jobs`` row created
+    in the same transaction.
 
     On the rare concurrent-submit case (``created=False``) the original
     submit already kicked off Durable; we skip the start call and let
-    the poller discover the existing instance via ``job.id``. If that
+    the poller discover the existing instance via the shared id. If that
     original start never actually succeeded, the poller will see a 404
     from Durable and surface the error so the user can retry.
 
-    On Durable start failure deletes the just-created row so the
-    partial unique index doesn't block the user's retry.
+    On a Durable start-call failure that never reached Functions (config
+    error, or a transport error before the request landed), deletes the
+    just-created attempt and legacy job rows so neither blocks the user's
+    retry -- nothing ran, so there is nothing worth retaining.
     """
     try:
-        if job_submission.created:
-            prepared = PreparedVerificationJob(
-                id=job_submission.job.id,
-                user_id=user_id,
-                github_username=job_submission.github_username,
-                requirement=job_submission.requirement,
-                submitted_value=submission_value_from_columns(job_submission.job),
+        if attempt_submission.created:
+            await start_verification_attempt_orchestration(
+                attempt_submission.attempt_id
             )
-            await start_verification_orchestration(prepared)
 
         status_token = create_verification_status_token(
             user_id=user_id,
-            job_id=job_submission.job.id,
-            instance_id=str(job_submission.job.id),
+            job_id=attempt_submission.attempt_id,
+            instance_id=str(attempt_submission.attempt_id),
             requirement_slug=requirement_slug,
         )
 
@@ -500,13 +497,19 @@ async def _start_async_job_and_render(
                 ),
             },
         )
-        # Delete the just-created row so the partial unique index doesn't
-        # block the user's retry. Durable owns terminal-state messaging
-        # now; we just need to free the in-flight slot.
+        # Only an unclaimed attempt is safe to remove. A timeout can happen
+        # after Functions has claimed and started it, in which case the row
+        # must remain for the orchestration to finalize.
         async with session_maker() as write_session:
-            await VerificationJobRepository(write_session).delete_active(
-                job_submission.job.id,
+            attempt_deleted = await VerificationAttemptRepository(
+                write_session
+            ).delete_active(
+                attempt_submission.attempt_id,
             )
+            if attempt_deleted:
+                await VerificationJobRepository(write_session).delete_active(
+                    attempt_submission.attempt_id,
+                )
             await write_session.commit()
         # A config error means the verification service is misconfigured on our
         # side, so retrying will never help. A start error is usually a

--- a/api/src/learn_to_cloud/services/durable_verification_client.py
+++ b/api/src/learn_to_cloud/services/durable_verification_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any
+from uuid import UUID
 
 import httpx
 from azure.core.exceptions import AzureError
@@ -40,31 +41,20 @@ class DurableStatusResult:
     custom_status: object | None = None
 
 
-async def start_verification_orchestration(
-    prepared: PreparedVerificationJob,
+async def _post_start_request(
+    url: str,
+    *,
+    headers: dict[str, str],
+    timeout: float,
+    body: dict[str, Any] | None,
 ) -> DurableStartResult:
-    """Start the Durable orchestration for a persisted verification job.
-
-    Posts the full :class:`PreparedVerificationJob` payload to the
-    Functions starter so the orchestration has everything it needs to
-    run without reading curriculum tables. The Functions side still
-    validates the immutable fields (``user_id``, ``requirement_uuid``,
-    ``submitted_value``) against the ``verification_jobs`` row before
-    starting -- the payload is trusted only for the requirement
-    *definition* and ``github_username`` snapshot.
-    """
-    settings = get_web_settings()
-    base_url, token_scope = _verification_endpoint_config(settings)
-
-    headers = await _verification_auth_headers(token_scope)
-
-    url = f"{base_url}/api/verification/jobs/{prepared.id}/start"
-    body: dict[str, Any] = prepared.to_payload()
-
-    timeout = settings.http.external_api_timeout
+    """POST a Durable starter request and parse its ``{"id": ...}`` response."""
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
-            response = await client.post(url, headers=headers, json=body)
+            if body is None:
+                response = await client.post(url, headers=headers)
+            else:
+                response = await client.post(url, headers=headers, json=body)
     except httpx.HTTPError as exc:
         raise DurableVerificationStartError("Durable starter request failed.") from exc
 
@@ -87,6 +77,59 @@ async def start_verification_orchestration(
         )
 
     return DurableStartResult(instance_id=instance_id)
+
+
+async def start_verification_orchestration(
+    prepared: PreparedVerificationJob,
+) -> DurableStartResult:
+    """Start the legacy Durable orchestration for a persisted verification job.
+
+    Posts the full :class:`PreparedVerificationJob` payload to the
+    Functions starter so the orchestration has everything it needs to
+    run without reading curriculum tables. The Functions side still
+    validates the immutable fields (``user_id``, ``requirement_uuid``,
+    ``submitted_value``) against the ``verification_jobs`` row before
+    starting -- the payload is trusted only for the requirement
+    *definition* and ``github_username`` snapshot.
+
+    New submissions no longer call this -- see
+    :func:`start_verification_attempt_orchestration`. This stays registered
+    for any in-flight legacy instances until PR8 (legacy-drain).
+    """
+    settings = get_web_settings()
+    base_url, token_scope = _verification_endpoint_config(settings)
+    headers = await _verification_auth_headers(token_scope)
+
+    url = f"{base_url}/api/verification/jobs/{prepared.id}/start"
+    return await _post_start_request(
+        url,
+        headers=headers,
+        timeout=settings.http.external_api_timeout,
+        body=prepared.to_payload(),
+    )
+
+
+async def start_verification_attempt_orchestration(
+    attempt_id: UUID,
+) -> DurableStartResult:
+    """Start the versioned Durable attempt orchestration for a persisted attempt.
+
+    Posts no body: the Functions starter loads identity, the requirement
+    snapshot, and the submitted value straight from the ``verification_attempts``
+    row (see the PR4 bridge), so the API never sends -- and the narrowed
+    Functions role never needs to trust -- a second copy of any of that.
+    """
+    settings = get_web_settings()
+    base_url, token_scope = _verification_endpoint_config(settings)
+    headers = await _verification_auth_headers(token_scope)
+
+    url = f"{base_url}/api/verification/attempts/{attempt_id}/start"
+    return await _post_start_request(
+        url,
+        headers=headers,
+        timeout=settings.http.external_api_timeout,
+        body=None,
+    )
 
 
 async def get_verification_orchestration_status(

--- a/api/src/learn_to_cloud/services/durable_verification_client.py
+++ b/api/src/learn_to_cloud/services/durable_verification_client.py
@@ -82,20 +82,7 @@ async def _post_start_request(
 async def start_verification_orchestration(
     prepared: PreparedVerificationJob,
 ) -> DurableStartResult:
-    """Start the legacy Durable orchestration for a persisted verification job.
-
-    Posts the full :class:`PreparedVerificationJob` payload to the
-    Functions starter so the orchestration has everything it needs to
-    run without reading curriculum tables. The Functions side still
-    validates the immutable fields (``user_id``, ``requirement_uuid``,
-    ``submitted_value``) against the ``verification_jobs`` row before
-    starting -- the payload is trusted only for the requirement
-    *definition* and ``github_username`` snapshot.
-
-    New submissions no longer call this -- see
-    :func:`start_verification_attempt_orchestration`. This stays registered
-    for any in-flight legacy instances until PR8 (legacy-drain).
-    """
+    """Start the legacy Durable orchestration with a persisted job payload."""
     settings = get_web_settings()
     base_url, token_scope = _verification_endpoint_config(settings)
     headers = await _verification_auth_headers(token_scope)
@@ -112,13 +99,7 @@ async def start_verification_orchestration(
 async def start_verification_attempt_orchestration(
     attempt_id: UUID,
 ) -> DurableStartResult:
-    """Start the versioned Durable attempt orchestration for a persisted attempt.
-
-    Posts no body: the Functions starter loads identity, the requirement
-    snapshot, and the submitted value straight from the ``verification_attempts``
-    row (see the PR4 bridge), so the API never sends -- and the narrowed
-    Functions role never needs to trust -- a second copy of any of that.
-    """
+    """Start a Durable orchestration using only the persisted attempt ID."""
     settings = get_web_settings()
     base_url, token_scope = _verification_endpoint_config(settings)
     headers = await _verification_auth_headers(token_scope)

--- a/api/src/learn_to_cloud/services/steps_service.py
+++ b/api/src/learn_to_cloud/services/steps_service.py
@@ -4,6 +4,12 @@ After the Phase E follow-up that dropped legacy id columns, the unit of
 identity for steps is ``step.uuid``. The HTMX endpoints take a step
 UUID directly; the topic context is recovered (when needed for
 rendering) by walking the loaded curriculum tree.
+
+Writes go to both the legacy ``step_progress`` table and the
+curriculum-decoupled ``learner_step_completions`` table (PR5 of the
+verification/progress refactor) so PR6 can cut progress reads over to the
+new table without a backfill race. Reads stay on ``step_progress`` until
+that cutover.
 """
 
 from typing import TYPE_CHECKING
@@ -11,7 +17,10 @@ from uuid import UUID
 
 from learn_to_cloud_shared.content_service import get_topic_containing_step
 from learn_to_cloud_shared.models import utcnow
-from learn_to_cloud_shared.repositories import StepProgressRepository
+from learn_to_cloud_shared.repositories import (
+    LearnerStepCompletionRepository,
+    StepProgressRepository,
+)
 from learn_to_cloud_shared.schemas import LearningStep, StepCompletionResult
 from opentelemetry import trace
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -73,10 +82,23 @@ async def complete_step(
     """
     topic, step = _find_step(step_uuid)
 
+    completed_at = utcnow()
+    completion_repo = LearnerStepCompletionRepository(db)
     step_repo = StepProgressRepository(db)
+
+    # Write the authoritative row first: the legacy step_progress insert's
+    # mirror trigger (migration 0049) then finds the row already present and
+    # no-ops. Both writes are ON CONFLICT DO NOTHING against the same
+    # (user_id, step_uuid) key, so this is idempotent regardless of order.
+    await completion_repo.create_if_not_exists(
+        user_id=user_id,
+        step_uuid=step.uuid,
+        completed_at=completed_at,
+    )
     step_progress = await step_repo.create_if_not_exists(
         user_id=user_id,
         step_uuid=step.uuid,
+        completed_at=completed_at,
     )
 
     span = trace.get_current_span()
@@ -126,7 +148,14 @@ async def uncomplete_step(
     """
     topic, step = _find_step(step_uuid)
 
+    completion_repo = LearnerStepCompletionRepository(db)
     step_repo = StepProgressRepository(db)
+
+    # Delete the authoritative row first for the same reason as the insert
+    # order in complete_step: whichever delete (this one or the legacy
+    # step_progress mirror trigger) runs second finds nothing left to
+    # remove and is a harmless no-op.
+    await completion_repo.delete(user_id=user_id, step_uuid=step.uuid)
     deleted = await step_repo.delete_step(user_id, step.uuid)
 
     span = trace.get_current_span()

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -1,7 +1,7 @@
 """Submissions service for hands-on verification submissions.
 
 This module handles:
-- Verification job creation with pre-validation
+- Verification attempt creation with pre-validation
 - Data transformation helpers used by other services (e.g. progress)
 - Already-validated short-circuit (skip re-verification for passed requirements)
 
@@ -11,11 +11,15 @@ Routes should delegate submission business logic to this module.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from learn_to_cloud_shared.models import VerificationJob
+from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
 from learn_to_cloud_shared.repositories.submission_repository import (
     SubmissionRepository,
+)
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    AttemptAlreadyValidatedError,
+    VerificationAttemptRepository,
 )
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
@@ -35,6 +39,12 @@ from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.verification.execution import (
     to_submission_data,
 )
+from learn_to_cloud_shared.verification_attempt_snapshot import (
+    ATTEMPT_PAYLOAD_VERSION,
+    build_requirement_snapshot,
+    compute_snapshot_hash,
+)
+from opentelemetry.propagate import inject
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
@@ -135,19 +145,25 @@ class _PreValidationContext:
 
 
 @dataclass(frozen=True, slots=True)
-class VerificationJobSubmission:
-    """Result of creating or reusing a verification job (async Durable path).
+class VerificationAttemptSubmission:
+    """Result of creating or reusing a verification attempt (async Durable path).
 
-    Carries the validated requirement (and the github_username used at
-    submit time) so the route can build a complete
-    ``PreparedVerificationJob`` payload for the Durable starter without
-    re-deriving anything from the request.
+    ``attempt_id`` is shared with the compatibility ``verification_jobs`` row
+    created in the same transaction, so the caller can key the Durable start
+    call, status polling, and any failure cleanup off one id -- Functions
+    loads everything else (identity, requirement snapshot, submitted value)
+    straight from the attempt row.
     """
 
-    job: VerificationJob
+    attempt_id: UUID
     created: bool
-    requirement: HandsOnRequirement
-    github_username: str | None
+
+
+def _current_traceparent() -> str | None:
+    """Return the active W3C trace parent when telemetry is available."""
+    carrier: dict[str, str] = {}
+    inject(carrier)
+    return carrier.get("traceparent")
 
 
 async def _check_submission_preconditions(
@@ -206,19 +222,26 @@ async def _check_submission_preconditions(
     )
 
 
-async def create_verification_job(
+async def create_verification_attempt(
     session_maker: async_sessionmaker[AsyncSession],
     user_id: int,
     requirement_slug: str,
     submitted_value: str,
     github_username: str | None,
-) -> VerificationJobSubmission:
-    """Validate request preconditions and create the Durable verification job.
+) -> VerificationAttemptSubmission:
+    """Validate request preconditions and create the unified verification attempt.
 
-    Every submission type runs through Durable Functions: this validates the
-    request, creates (or reuses) the ``VerificationJob`` row, and returns a
-    :class:`VerificationJobSubmission` for the caller to start the
-    orchestration.
+    Every submission type runs through Durable Functions. This validates the
+    request, then -- inside one transaction, guarded by a transaction-scoped
+    Postgres advisory lock on ``(user_id, requirement_uuid)`` -- creates (or
+    reuses) the authoritative ``VerificationAttempt`` row plus its
+    compatibility ``VerificationJob`` row, sharing one UUID, so old API
+    readers stay valid while the attempt row becomes the source of truth.
+
+    The advisory lock serializes concurrent submits for the same
+    requirement so two racing requests can never both pass the
+    active/succeeded checks and create two active attempts; it releases
+    automatically when the transaction commits below.
     """
     ctx = await _check_submission_preconditions(
         session_maker,
@@ -231,21 +254,49 @@ async def create_verification_job(
     except ValueError as exc:
         raise InvalidSubmittedValueError(str(exc)) from exc
 
+    catalog = get_curriculum_catalog()
+    requirement_snapshot = build_requirement_snapshot(ctx.requirement)
+    requirement_snapshot_hash = compute_snapshot_hash(requirement_snapshot)
+    attempt_id = uuid4()
+    traceparent = _current_traceparent()
+
     async with session_maker() as write_session:
-        repo = VerificationJobRepository(write_session)
-        job, created = await repo.create_or_get_active(
-            user_id=user_id,
-            requirement_uuid=ctx.requirement.uuid,
-            submitted_value=typed_value,
-        )
+        attempt_repo = VerificationAttemptRepository(write_session)
+        try:
+            attempt, created = await attempt_repo.create_or_get_active(
+                id=attempt_id,
+                user_id=user_id,
+                requirement_uuid=ctx.requirement.uuid,
+                artifact_schema_version=catalog.artifact_schema_version,
+                curriculum_version=catalog.curriculum_version,
+                content_hash=catalog.content_hash,
+                requirement_snapshot=requirement_snapshot,
+                requirement_snapshot_hash=requirement_snapshot_hash,
+                payload_version=ATTEMPT_PAYLOAD_VERSION,
+                github_username_snapshot=github_username,
+                submitted_value=typed_value,
+                cloud_provider=None,
+                traceparent=traceparent,
+                legacy_job_id=attempt_id,
+            )
+        except AttemptAlreadyValidatedError as exc:
+            raise AlreadyValidatedError(
+                "You have already completed this requirement."
+            ) from exc
+
+        if created:
+            await VerificationJobRepository(write_session).create(
+                id=attempt.id,
+                user_id=user_id,
+                requirement_uuid=ctx.requirement.uuid,
+                submitted_value=typed_value,
+                extracted_username=github_username,
+                traceparent=traceparent,
+            )
+
         await write_session.commit()
 
-    return VerificationJobSubmission(
-        job=job,
-        created=created,
-        requirement=ctx.requirement,
-        github_username=github_username,
-    )
+    return VerificationAttemptSubmission(attempt_id=attempt.id, created=created)
 
 
 # Synthetic user id for the read-only smoke check. It is never a real
@@ -260,8 +311,8 @@ async def run_submit_smoke_check(
     """Exercise the verification submit read path without writing anything.
 
     Runs the same requirement loading, submissions read, phase gating, and
-    typed-value parsing that :func:`create_verification_job` performs for a
-    real submission, but against a synthetic user and an early phase, and
+    typed-value parsing that :func:`create_verification_attempt` performs for
+    a real submission, but against a synthetic user and an early phase, and
     stops before persisting anything.
 
     The goal is to catch a schema-versus-code mismatch (the class of bug

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -13,13 +13,11 @@ Testing approach:
 """
 
 from types import SimpleNamespace
-from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from fastapi.responses import HTMLResponse
-from learn_to_cloud_shared.models import SubmissionValueKind, VerificationJob
 
 from learn_to_cloud.core.auth import AuthenticatedUser
 from learn_to_cloud.routes.htmx_routes import (
@@ -37,37 +35,14 @@ from learn_to_cloud.services.durable_verification_client import (
 )
 from learn_to_cloud.services.steps_service import StepValidationError
 from learn_to_cloud.services.submissions_service import (
-    VerificationJobSubmission,
+    VerificationAttemptSubmission,
 )
 from learn_to_cloud.services.users_service import UserNotFoundError
 from learn_to_cloud.services.verification_status_tokens import VerificationStatusToken
 
 
-def _async_requirement():
-    """A real HandsOnRequirement for tests that need to build a
-    PreparedVerificationJob payload alongside a VerificationJobSubmission."""
-    from learn_to_cloud_shared.testing.requirement_factories import (
-        journal_api_verifier_requirement,
-    )
-
-    return journal_api_verifier_requirement(
-        slug="journal-api-implementation",
-        name="Journal API",
-        description="Test",
-    )
-
-
-def _mock_job(value: str = "https://github.com/user/repo") -> SimpleNamespace:
-    return SimpleNamespace(
-        id=uuid4(),
-        orchestration_instance_id=None,
-        submitted_value=value,
-        submission_value_kind=SubmissionValueKind.GITHUB_URL.value,
-        github_url=value,
-        token_value=None,
-        deployed_url=None,
-        text_value=None,
-    )
+def _mock_attempt_submission(*, created: bool = True) -> VerificationAttemptSubmission:
+    return VerificationAttemptSubmission(attempt_id=uuid4(), created=created)
 
 
 def _mock_request(*, session: dict | None = None) -> MagicMock:
@@ -217,26 +192,20 @@ class TestHtmxUncompleteStep:
 class TestHtmxSubmitVerification:
     """Tests for POST /htmx/github/submit.
 
-    The route is thin: derive URL, persist a job, start Durable, return spinner.
+    The route is thin: derive value, persist an attempt, start Durable,
+    return spinner.
     """
 
     async def test_submit_success_returns_processing_card(self):
         """Successful submission starts Durable and returns processing card."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = _mock_job()
-        job_submission = SimpleNamespace(
-            job=job,
-            created=True,
-            requirement=_async_requirement(),
-            github_username="user",
-        )
-        start_result = SimpleNamespace(instance_id=str(job.id))
+        attempt_submission = _mock_attempt_submission(created=True)
+        start_result = SimpleNamespace(instance_id=str(attempt_submission.attempt_id))
         write_session = AsyncMock()
         request.app.state.session_maker.return_value.__aenter__.return_value = (
             write_session
         )
-        repo = MagicMock()
 
         with (
             patch(
@@ -249,19 +218,16 @@ class TestHtmxSubmitVerification:
                 return_value="https://github.com/user/repo",
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                "learn_to_cloud.routes.htmx_routes.create_verification_attempt",
                 new_callable=AsyncMock,
-                return_value=job_submission,
-            ) as mock_create_job,
+                return_value=attempt_submission,
+            ) as mock_create_attempt,
             patch(
-                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                "learn_to_cloud.routes.htmx_routes."
+                "start_verification_attempt_orchestration",
                 new_callable=AsyncMock,
                 return_value=start_result,
             ) as mock_start,
-            patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
-                return_value=repo,
-            ),
         ):
             result = await htmx_submit_verification(
                 request,
@@ -272,8 +238,8 @@ class TestHtmxSubmitVerification:
 
         # Should return a processing card, not a final result
         assert result is not None
-        mock_create_job.assert_awaited_once()
-        mock_start.assert_awaited_once()
+        mock_create_attempt.assert_awaited_once()
+        mock_start.assert_awaited_once_with(attempt_submission.attempt_id)
 
     async def test_submit_unexpected_error_renders_server_error(self):
         """Unexpected exceptions render a server error card."""
@@ -291,7 +257,7 @@ class TestHtmxSubmitVerification:
                 return_value="test",
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                "learn_to_cloud.routes.htmx_routes.create_verification_attempt",
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("boom"),
             ),
@@ -306,25 +272,22 @@ class TestHtmxSubmitVerification:
         # Should render a server error card, not crash
         assert result is not None
 
-    async def test_durable_start_failure_deletes_job(self):
-        """When Durable's start_new fails, the route deletes the just-
-        created job row instead of marking it server_error. Frees the
-        partial unique index so the user can retry immediately."""
+    async def test_durable_start_failure_deletes_attempt_and_job(self):
+        """When Durable's start_new call fails before reaching Functions, the
+        route deletes both the just-created attempt and legacy job rows
+        instead of marking either terminal. Frees the partial unique
+        indexes so the user can retry immediately."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = _mock_job()
-        async_result = VerificationJobSubmission(
-            job=cast(VerificationJob, job),
-            created=True,
-            requirement=_async_requirement(),
-            github_username="user",
-        )
+        attempt_submission = _mock_attempt_submission(created=True)
         write_session = AsyncMock()
         request.app.state.session_maker.return_value.__aenter__.return_value = (
             write_session
         )
-        repo = MagicMock()
-        repo.delete_active = AsyncMock(return_value=True)
+        attempt_repo = MagicMock()
+        attempt_repo.delete_active = AsyncMock(return_value=True)
+        job_repo = MagicMock()
+        job_repo.delete_active = AsyncMock(return_value=True)
 
         with (
             patch(
@@ -337,18 +300,23 @@ class TestHtmxSubmitVerification:
                 return_value="https://github.com/user/repo",
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                "learn_to_cloud.routes.htmx_routes.create_verification_attempt",
                 new_callable=AsyncMock,
-                return_value=async_result,
+                return_value=attempt_submission,
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                "learn_to_cloud.routes.htmx_routes."
+                "start_verification_attempt_orchestration",
                 new_callable=AsyncMock,
                 side_effect=DurableVerificationStartError("boom"),
             ),
             patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
+                return_value=attempt_repo,
+            ),
+            patch(
                 "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
-                return_value=repo,
+                return_value=job_repo,
             ),
         ):
             result = await htmx_submit_verification(
@@ -359,7 +327,10 @@ class TestHtmxSubmitVerification:
             )
 
         assert isinstance(result, HTMLResponse)
-        repo.delete_active.assert_awaited_once_with(job.id)
+        attempt_repo.delete_active.assert_awaited_once_with(
+            attempt_submission.attempt_id
+        )
+        job_repo.delete_active.assert_awaited_once_with(attempt_submission.attempt_id)
         write_session.commit.assert_awaited_once()
 
     async def test_durable_config_error_does_not_invite_immediate_retry(
@@ -369,19 +340,15 @@ class TestHtmxSubmitVerification:
         helps. The banner must not tell the user to try again immediately."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = _mock_job()
-        async_result = VerificationJobSubmission(
-            job=cast(VerificationJob, job),
-            created=True,
-            requirement=_async_requirement(),
-            github_username="user",
-        )
+        attempt_submission = _mock_attempt_submission(created=True)
         write_session = AsyncMock()
         request.app.state.session_maker.return_value.__aenter__.return_value = (
             write_session
         )
-        repo = MagicMock()
-        repo.delete_active = AsyncMock(return_value=True)
+        attempt_repo = MagicMock()
+        attempt_repo.delete_active = AsyncMock(return_value=True)
+        job_repo = MagicMock()
+        job_repo.delete_active = AsyncMock(return_value=True)
 
         with (
             patch(
@@ -394,18 +361,23 @@ class TestHtmxSubmitVerification:
                 return_value="https://github.com/user/repo",
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                "learn_to_cloud.routes.htmx_routes.create_verification_attempt",
                 new_callable=AsyncMock,
-                return_value=async_result,
+                return_value=attempt_submission,
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                "learn_to_cloud.routes.htmx_routes."
+                "start_verification_attempt_orchestration",
                 new_callable=AsyncMock,
                 side_effect=DurableVerificationConfigError("not configured"),
             ),
             patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
+                return_value=attempt_repo,
+            ),
+            patch(
                 "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
-                return_value=repo,
+                return_value=job_repo,
             ),
         ):
             result = await htmx_submit_verification(
@@ -417,7 +389,10 @@ class TestHtmxSubmitVerification:
 
         assert isinstance(result, HTMLResponse)
         # The in-flight slot is still freed so a later (post-fix) retry works.
-        repo.delete_active.assert_awaited_once_with(job.id)
+        attempt_repo.delete_active.assert_awaited_once_with(
+            attempt_submission.attempt_id
+        )
+        job_repo.delete_active.assert_awaited_once_with(attempt_submission.attempt_id)
         _, _, context = _patch_templates.TemplateResponse.call_args.args
         assert context["server_error"] is True
         assert context["server_error_retryable"] is False
@@ -433,19 +408,15 @@ class TestHtmxSubmitVerification:
         """A transient start error should still mark the banner retryable."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = _mock_job()
-        async_result = VerificationJobSubmission(
-            job=cast(VerificationJob, job),
-            created=True,
-            requirement=_async_requirement(),
-            github_username="user",
-        )
+        attempt_submission = _mock_attempt_submission(created=True)
         write_session = AsyncMock()
         request.app.state.session_maker.return_value.__aenter__.return_value = (
             write_session
         )
-        repo = MagicMock()
-        repo.delete_active = AsyncMock(return_value=True)
+        attempt_repo = MagicMock()
+        attempt_repo.delete_active = AsyncMock(return_value=False)
+        job_repo = MagicMock()
+        job_repo.delete_active = AsyncMock(return_value=True)
 
         with (
             patch(
@@ -458,18 +429,23 @@ class TestHtmxSubmitVerification:
                 return_value="https://github.com/user/repo",
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                "learn_to_cloud.routes.htmx_routes.create_verification_attempt",
                 new_callable=AsyncMock,
-                return_value=async_result,
+                return_value=attempt_submission,
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                "learn_to_cloud.routes.htmx_routes."
+                "start_verification_attempt_orchestration",
                 new_callable=AsyncMock,
                 side_effect=DurableVerificationStartError("boom"),
             ),
             patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
+                return_value=attempt_repo,
+            ),
+            patch(
                 "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
-                return_value=repo,
+                return_value=job_repo,
             ),
         ):
             await htmx_submit_verification(
@@ -482,25 +458,22 @@ class TestHtmxSubmitVerification:
         _, _, context = _patch_templates.TemplateResponse.call_args.args
         assert context["server_error"] is True
         assert context["server_error_retryable"] is True
+        attempt_repo.delete_active.assert_awaited_once_with(
+            attempt_submission.attempt_id
+        )
+        job_repo.delete_active.assert_not_awaited()
 
     async def test_async_submit_still_returns_processing_card(self):
         """Regression: async submissions must keep using the
-        VerificationJobSubmission spinner-and-poll path."""
+        VerificationAttemptSubmission spinner-and-poll path."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = _mock_job()
-        async_result = VerificationJobSubmission(
-            job=cast(VerificationJob, job),
-            created=True,
-            requirement=_async_requirement(),
-            github_username="user",
-        )
-        start_result = SimpleNamespace(instance_id=str(job.id))
+        attempt_submission = _mock_attempt_submission(created=True)
+        start_result = SimpleNamespace(instance_id=str(attempt_submission.attempt_id))
         write_session = AsyncMock()
         request.app.state.session_maker.return_value.__aenter__.return_value = (
             write_session
         )
-        repo = MagicMock()
 
         with (
             patch(
@@ -513,19 +486,16 @@ class TestHtmxSubmitVerification:
                 return_value="https://github.com/user/repo",
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                "learn_to_cloud.routes.htmx_routes.create_verification_attempt",
                 new_callable=AsyncMock,
-                return_value=async_result,
+                return_value=attempt_submission,
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                "learn_to_cloud.routes.htmx_routes."
+                "start_verification_attempt_orchestration",
                 new_callable=AsyncMock,
                 return_value=start_result,
             ) as mock_start,
-            patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
-                return_value=repo,
-            ),
         ):
             result = await htmx_submit_verification(
                 request,
@@ -535,11 +505,7 @@ class TestHtmxSubmitVerification:
             )
 
         assert isinstance(result, HTMLResponse)
-        mock_start.assert_awaited_once()
-        await_args = mock_start.await_args
-        assert await_args is not None
-        (call_arg,) = await_args.args
-        assert call_arg.id == job.id
+        mock_start.assert_awaited_once_with(attempt_submission.attempt_id)
 
     async def test_deployment_architecture_long_description_reaches_derive(self):
         """A >2048-char architecture description must not be truncated by the
@@ -558,14 +524,8 @@ class TestHtmxSubmitVerification:
 
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = _mock_job()
-        async_result = VerificationJobSubmission(
-            job=cast(VerificationJob, job),
-            created=True,
-            requirement=requirement,
-            github_username="user",
-        )
-        start_result = SimpleNamespace(instance_id=str(job.id))
+        attempt_submission = _mock_attempt_submission(created=True)
+        start_result = SimpleNamespace(instance_id=str(attempt_submission.attempt_id))
         write_session = AsyncMock()
         request.app.state.session_maker.return_value.__aenter__.return_value = (
             write_session
@@ -582,19 +542,16 @@ class TestHtmxSubmitVerification:
                 return_value=long_description,
             ) as mock_derive,
             patch(
-                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                "learn_to_cloud.routes.htmx_routes.create_verification_attempt",
                 new_callable=AsyncMock,
-                return_value=async_result,
+                return_value=attempt_submission,
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                "learn_to_cloud.routes.htmx_routes."
+                "start_verification_attempt_orchestration",
                 new_callable=AsyncMock,
                 return_value=start_result,
             ) as mock_start,
-            patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
-                return_value=MagicMock(),
-            ),
         ):
             result = await htmx_submit_verification(
                 request,
@@ -626,7 +583,7 @@ class TestHtmxSubmitVerification:
                 return_value=requirement,
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                "learn_to_cloud.routes.htmx_routes.create_verification_attempt",
                 new_callable=AsyncMock,
             ) as mock_create,
         ):
@@ -641,20 +598,14 @@ class TestHtmxSubmitVerification:
         mock_create.assert_not_awaited()
 
     async def test_duplicate_submit_skips_durable_start(self):
-        """When ``create_verification_job`` returns ``created=False``
-        (concurrent submit raced into the same job row), the route does
-        NOT call ``start_verification_orchestration`` — the original
-        submit already kicked off Durable, and calling start_new again
-        with the same instance id would error."""
+        """When ``create_verification_attempt`` returns ``created=False``
+        (concurrent submit raced into the same attempt), the route does
+        NOT call ``start_verification_attempt_orchestration`` — the
+        original submit already kicked off Durable, and calling start_new
+        again with the same instance id would error."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
-        job = _mock_job()
-        async_result = VerificationJobSubmission(
-            job=cast(VerificationJob, job),
-            created=False,
-            requirement=_async_requirement(),
-            github_username="user",
-        )
+        attempt_submission = _mock_attempt_submission(created=False)
 
         with (
             patch(
@@ -667,12 +618,13 @@ class TestHtmxSubmitVerification:
                 return_value="https://github.com/user/repo",
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.create_verification_job",
+                "learn_to_cloud.routes.htmx_routes.create_verification_attempt",
                 new_callable=AsyncMock,
-                return_value=async_result,
+                return_value=attempt_submission,
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.start_verification_orchestration",
+                "learn_to_cloud.routes.htmx_routes."
+                "start_verification_attempt_orchestration",
                 new_callable=AsyncMock,
             ) as mock_start,
         ):

--- a/api/tests/services/test_durable_verification_client.py
+++ b/api/tests/services/test_durable_verification_client.py
@@ -18,6 +18,7 @@ from learn_to_cloud.services.durable_verification_client import (
     DurableVerificationStartError,
     DurableVerificationStatusError,
     get_verification_orchestration_status,
+    start_verification_attempt_orchestration,
     start_verification_orchestration,
 )
 
@@ -220,6 +221,79 @@ async def test_transport_error_raises_start_error():
         pytest.raises(DurableVerificationStartError, match="request failed"),
     ):
         await start_verification_orchestration(_prepared())
+
+
+async def test_starts_attempt_orchestration_with_no_body():
+    """The PR4 attempt starter needs no payload -- Functions loads
+    everything from the ``verification_attempts`` row keyed by the URL id."""
+    attempt_id = uuid4()
+    client, context_manager = _async_client(httpx.Response(202, json={"id": "abc"}))
+
+    with (
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_web_settings",
+            return_value=_settings(),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_azure_token",
+            new=AsyncMock(return_value="access-token"),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.httpx.AsyncClient",
+            return_value=context_manager,
+        ) as async_client,
+    ):
+        result = await start_verification_attempt_orchestration(attempt_id)
+
+    assert result.instance_id == "abc"
+    async_client.assert_called_once_with(timeout=3.0)
+    client.post.assert_awaited_once_with(
+        f"http://localhost:7071/api/verification/attempts/{attempt_id}/start",
+        headers={"Authorization": "Bearer access-token"},
+    )
+
+
+async def test_attempt_orchestration_http_error_raises_start_error():
+    _, context_manager = _async_client(httpx.Response(500, json={"error": "boom"}))
+
+    with (
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_web_settings",
+            return_value=_settings(),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_azure_token",
+            new=AsyncMock(return_value="access-token"),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.httpx.AsyncClient",
+            return_value=context_manager,
+        ),
+        pytest.raises(DurableVerificationStartError, match="HTTP 500"),
+    ):
+        await start_verification_attempt_orchestration(uuid4())
+
+
+async def test_attempt_orchestration_transport_error_raises_start_error():
+    request = httpx.Request("POST", "http://localhost:7071")
+    _, context_manager = _async_client(httpx.ConnectError("down", request=request))
+
+    with (
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_web_settings",
+            return_value=_settings(),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_azure_token",
+            new=AsyncMock(return_value="access-token"),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.httpx.AsyncClient",
+            return_value=context_manager,
+        ),
+        pytest.raises(DurableVerificationStartError, match="request failed"),
+    ):
+        await start_verification_attempt_orchestration(uuid4())
 
 
 async def test_gets_orchestration_status_with_bearer_token_header():

--- a/api/tests/services/test_steps_service.py
+++ b/api/tests/services/test_steps_service.py
@@ -51,10 +51,17 @@ class TestCompleteStep:
                 "learn_to_cloud.services.steps_service.StepProgressRepository",
                 autospec=True,
             ) as MockRepo,
+            patch(
+                "learn_to_cloud.services.steps_service.LearnerStepCompletionRepository",
+                autospec=True,
+            ) as MockCompletionRepo,
         ):
             repo = MockRepo.return_value
             repo.create_if_not_exists = AsyncMock(return_value=mock_progress)
             repo.get_completed_step_uuids = AsyncMock(return_value={step.uuid})
+
+            completion_repo = MockCompletionRepo.return_value
+            completion_repo.create_if_not_exists = AsyncMock(return_value=MagicMock())
 
             result, returned_topic, completed = await complete_step(
                 AsyncMock(), user_id=1, step_uuid=step.uuid
@@ -63,6 +70,19 @@ class TestCompleteStep:
         assert result.step_slug == step.slug
         assert returned_topic.uuid == topic.uuid
         assert step.uuid in completed
+        # Both the authoritative and legacy tables get the dual write, with
+        # one shared completed_at timestamp.
+        completion_repo.create_if_not_exists.assert_awaited_once()
+        repo.create_if_not_exists.assert_awaited_once()
+        completion_await_args = completion_repo.create_if_not_exists.await_args
+        legacy_await_args = repo.create_if_not_exists.await_args
+        assert completion_await_args is not None
+        assert legacy_await_args is not None
+        completion_kwargs = completion_await_args.kwargs
+        legacy_kwargs = legacy_await_args.kwargs
+        assert completion_kwargs["user_id"] == 1
+        assert completion_kwargs["step_uuid"] == step.uuid
+        assert completion_kwargs["completed_at"] == legacy_kwargs["completed_at"]
 
     @pytest.mark.asyncio
     async def test_unknown_step_raises(self):
@@ -90,10 +110,17 @@ class TestUncompleteStep:
                 "learn_to_cloud.services.steps_service.StepProgressRepository",
                 autospec=True,
             ) as MockRepo,
+            patch(
+                "learn_to_cloud.services.steps_service.LearnerStepCompletionRepository",
+                autospec=True,
+            ) as MockCompletionRepo,
         ):
             repo = MockRepo.return_value
             repo.delete_step = AsyncMock(return_value=1)
             repo.get_completed_step_uuids = AsyncMock(return_value=set())
+
+            completion_repo = MockCompletionRepo.return_value
+            completion_repo.delete = AsyncMock(return_value=1)
 
             deleted, returned_topic, returned_step, completed = await uncomplete_step(
                 AsyncMock(), user_id=1, step_uuid=step.uuid
@@ -102,6 +129,8 @@ class TestUncompleteStep:
         assert deleted == 1
         assert returned_step.uuid == step.uuid
         assert completed == set()
+        completion_repo.delete.assert_awaited_once_with(user_id=1, step_uuid=step.uuid)
+        repo.delete_step.assert_awaited_once_with(1, step.uuid)
 
 
 @pytest.mark.unit

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -9,9 +9,13 @@ from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from learn_to_cloud_shared.models import SubmissionType, SubmissionValueKind
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    AttemptAlreadyValidatedError,
+)
 from learn_to_cloud_shared.requirements import RequirementIndex
 from learn_to_cloud_shared.schemas import HandsOnRequirement, Phase
 
@@ -22,8 +26,8 @@ from learn_to_cloud.services.submissions_service import (
     AlreadyValidatedError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
-    VerificationJobSubmission,
-    create_verification_job,
+    VerificationAttemptSubmission,
+    create_verification_attempt,
     get_phase_submission_context,
     run_submit_smoke_check,
 )
@@ -92,6 +96,11 @@ def _mock_session_maker():
     return _factory
 
 
+def _mock_attempt(attempt_id=None) -> MagicMock:
+    """Create a mock VerificationAttempt with an ``id`` for submission tests."""
+    return MagicMock(id=attempt_id or uuid4())
+
+
 def _build_index(
     requirement: HandsOnRequirement | None,
     *,
@@ -137,7 +146,7 @@ def _build_index(
 
 @pytest.mark.unit
 class TestSubmissionValidationErrors:
-    """Tests for error handling in create_verification_job."""
+    """Tests for error handling in create_verification_attempt."""
 
     @pytest.mark.asyncio
     async def test_requirement_not_found_raises_error(self):
@@ -150,7 +159,7 @@ class TestSubmissionValidationErrors:
             ),
             pytest.raises(RequirementNotFoundError),
         ):
-            await create_verification_job(
+            await create_verification_attempt(
                 session_maker=mock_session_maker,
                 user_id=123,
                 requirement_slug="nonexistent",
@@ -183,7 +192,49 @@ class TestAlreadyValidatedShortCircuit:
             mock_repo_class.return_value = mock_repo
 
             with pytest.raises(AlreadyValidatedError):
-                await create_verification_job(
+                await create_verification_attempt(
+                    session_maker=mock_session_maker,
+                    user_id=123,
+                    requirement_slug="test-requirement",
+                    submitted_value="https://github.com/user/repo",
+                    github_username="user",
+                )
+
+    @pytest.mark.asyncio
+    async def test_already_validated_attempt_raises_error(self):
+        """A succeeded attempt discovered under the advisory lock (a race
+        with a concurrent finalize) also raises AlreadyValidatedError, even
+        though the earlier submissions-table check passed."""
+        mock_session_maker = _mock_session_maker()
+        mock_requirement = _make_mock_requirement()
+
+        with (
+            patch(
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                return_value=_build_index(mock_requirement),
+            ),
+            patch(
+                "learn_to_cloud.services.submissions_service.SubmissionRepository",
+                autospec=True,
+            ) as mock_repo_class,
+            patch(
+                "learn_to_cloud.services.submissions_service."
+                "VerificationAttemptRepository",
+                autospec=True,
+            ) as mock_attempt_repo_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
+            mock_repo_class.return_value = mock_repo
+
+            mock_attempt_repo = MagicMock()
+            mock_attempt_repo.create_or_get_active = AsyncMock(
+                side_effect=AttemptAlreadyValidatedError("already succeeded")
+            )
+            mock_attempt_repo_class.return_value = mock_attempt_repo
+
+            with pytest.raises(AlreadyValidatedError):
+                await create_verification_attempt(
                     session_maker=mock_session_maker,
                     user_id=123,
                     requirement_slug="test-requirement",
@@ -206,6 +257,11 @@ class TestAlreadyValidatedShortCircuit:
                 autospec=True,
             ) as mock_repo_class,
             patch(
+                "learn_to_cloud.services.submissions_service."
+                "VerificationAttemptRepository",
+                autospec=True,
+            ) as mock_attempt_repo_class,
+            patch(
                 "learn_to_cloud.services.submissions_service.VerificationJobRepository",
                 autospec=True,
             ) as mock_job_repo_class,
@@ -216,14 +272,18 @@ class TestAlreadyValidatedShortCircuit:
             )
             mock_repo_class.return_value = mock_repo
 
-            mock_job = MagicMock()
-            mock_job_repo = MagicMock()
-            mock_job_repo.create_or_get_active = AsyncMock(
-                return_value=(mock_job, True)
+            mock_attempt = _mock_attempt()
+            mock_attempt_repo = MagicMock()
+            mock_attempt_repo.create_or_get_active = AsyncMock(
+                return_value=(mock_attempt, True)
             )
+            mock_attempt_repo_class.return_value = mock_attempt_repo
+
+            mock_job_repo = MagicMock()
+            mock_job_repo.create = AsyncMock(return_value=MagicMock())
             mock_job_repo_class.return_value = mock_job_repo
 
-            result = await create_verification_job(
+            result = await create_verification_attempt(
                 session_maker=mock_session_maker,
                 user_id=123,
                 requirement_slug="test-requirement",
@@ -231,9 +291,10 @@ class TestAlreadyValidatedShortCircuit:
                 github_username="user",
             )
 
-            assert isinstance(result, VerificationJobSubmission)
-            assert result.job is mock_job
+            assert isinstance(result, VerificationAttemptSubmission)
+            assert result.attempt_id == mock_attempt.id
             assert result.created is True
+            mock_job_repo.create.assert_awaited_once()
 
 
 @pytest.mark.unit
@@ -266,7 +327,7 @@ class TestSequentialPhaseGating:
             mock_repo_class.return_value = mock_repo
 
             with pytest.raises(PriorPhaseNotCompleteError) as exc_info:
-                await create_verification_job(
+                await create_verification_attempt(
                     session_maker=mock_session_maker,
                     user_id=123,
                     requirement_slug="test-requirement",
@@ -299,6 +360,11 @@ class TestSequentialPhaseGating:
                 autospec=True,
             ) as mock_repo_class,
             patch(
+                "learn_to_cloud.services.submissions_service."
+                "VerificationAttemptRepository",
+                autospec=True,
+            ) as mock_attempt_repo_class,
+            patch(
                 "learn_to_cloud.services.submissions_service.VerificationJobRepository",
                 autospec=True,
             ) as mock_job_repo_class,
@@ -308,14 +374,18 @@ class TestSequentialPhaseGating:
             mock_repo.are_all_requirements_validated = AsyncMock(return_value=True)
             mock_repo_class.return_value = mock_repo
 
-            mock_job = MagicMock()
-            mock_job_repo = MagicMock()
-            mock_job_repo.create_or_get_active = AsyncMock(
-                return_value=(mock_job, True)
+            mock_attempt = _mock_attempt()
+            mock_attempt_repo = MagicMock()
+            mock_attempt_repo.create_or_get_active = AsyncMock(
+                return_value=(mock_attempt, True)
             )
+            mock_attempt_repo_class.return_value = mock_attempt_repo
+
+            mock_job_repo = MagicMock()
+            mock_job_repo.create = AsyncMock(return_value=MagicMock())
             mock_job_repo_class.return_value = mock_job_repo
 
-            result = await create_verification_job(
+            result = await create_verification_attempt(
                 session_maker=mock_session_maker,
                 user_id=123,
                 requirement_slug="test-requirement",
@@ -323,22 +393,22 @@ class TestSequentialPhaseGating:
                 github_username="user",
             )
 
-            assert isinstance(result, VerificationJobSubmission)
-            assert result.job is mock_job
+            assert isinstance(result, VerificationAttemptSubmission)
+            assert result.attempt_id == mock_attempt.id
             assert result.created is True
-            mock_job_repo.create_or_get_active.assert_awaited_once()
+            mock_attempt_repo.create_or_get_active.assert_awaited_once()
 
 
 @pytest.mark.unit
-class TestCreateVerificationJob:
+class TestCreateVerificationAttempt:
     @pytest.mark.asyncio
-    async def test_formerly_inline_type_creates_verification_job(self):
-        """Types that used to run inline (phases 0-2) now create a job too."""
+    async def test_formerly_inline_type_creates_verification_attempt(self):
+        """Types that used to run inline (phases 0-2) now create an attempt too."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.PROFILE_README,
         )
-        mock_job = MagicMock()
+        mock_attempt = _mock_attempt()
 
         with (
             patch(
@@ -350,21 +420,36 @@ class TestCreateVerificationJob:
                 autospec=True,
             ) as mock_repo_class,
             patch(
+                "learn_to_cloud.services.submissions_service."
+                "VerificationAttemptRepository",
+                autospec=True,
+            ) as mock_attempt_repo_class,
+            patch(
                 "learn_to_cloud.services.submissions_service.VerificationJobRepository",
                 autospec=True,
             ) as mock_job_repo_class,
+            patch(
+                "learn_to_cloud.services.submissions_service._current_traceparent",
+                return_value=(
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+                ),
+            ),
         ):
             mock_repo = MagicMock()
             mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
             mock_repo_class.return_value = mock_repo
 
-            mock_job_repo = MagicMock()
-            mock_job_repo.create_or_get_active = AsyncMock(
-                return_value=(mock_job, True)
+            mock_attempt_repo = MagicMock()
+            mock_attempt_repo.create_or_get_active = AsyncMock(
+                return_value=(mock_attempt, True)
             )
+            mock_attempt_repo_class.return_value = mock_attempt_repo
+
+            mock_job_repo = MagicMock()
+            mock_job_repo.create = AsyncMock(return_value=MagicMock())
             mock_job_repo_class.return_value = mock_job_repo
 
-            result = await create_verification_job(
+            result = await create_verification_attempt(
                 session_maker=mock_session_maker,
                 user_id=123,
                 requirement_slug="test-requirement",
@@ -372,18 +457,27 @@ class TestCreateVerificationJob:
                 github_username="user",
             )
 
-        assert isinstance(result, VerificationJobSubmission)
-        assert result.job is mock_job
+        assert isinstance(result, VerificationAttemptSubmission)
+        assert result.attempt_id == mock_attempt.id
         assert result.created is True
-        mock_job_repo.create_or_get_active.assert_awaited_once()
+        mock_attempt_repo.create_or_get_active.assert_awaited_once()
+        mock_job_repo.create.assert_awaited_once()
+        job_create_await_args = mock_job_repo.create.await_args
+        assert job_create_await_args is not None
+        assert job_create_await_args.kwargs["id"] == mock_attempt.id
+        expected_traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        attempt_create_await_args = mock_attempt_repo.create_or_get_active.await_args
+        assert attempt_create_await_args is not None
+        assert attempt_create_await_args.kwargs["traceparent"] == expected_traceparent
+        assert job_create_await_args.kwargs["traceparent"] == expected_traceparent
 
     @pytest.mark.asyncio
-    async def test_returns_verification_job_submission(self):
+    async def test_returns_verification_attempt_submission(self):
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.JOURNAL_API_VERIFIER,
         )
-        mock_job = MagicMock()
+        mock_attempt = _mock_attempt()
 
         with (
             patch(
@@ -395,6 +489,11 @@ class TestCreateVerificationJob:
                 autospec=True,
             ) as mock_repo_class,
             patch(
+                "learn_to_cloud.services.submissions_service."
+                "VerificationAttemptRepository",
+                autospec=True,
+            ) as mock_attempt_repo_class,
+            patch(
                 "learn_to_cloud.services.submissions_service.VerificationJobRepository",
                 autospec=True,
             ) as mock_job_repo_class,
@@ -403,13 +502,17 @@ class TestCreateVerificationJob:
             mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
             mock_repo_class.return_value = mock_repo
 
-            mock_job_repo = MagicMock()
-            mock_job_repo.create_or_get_active = AsyncMock(
-                return_value=(mock_job, True)
+            mock_attempt_repo = MagicMock()
+            mock_attempt_repo.create_or_get_active = AsyncMock(
+                return_value=(mock_attempt, True)
             )
+            mock_attempt_repo_class.return_value = mock_attempt_repo
+
+            mock_job_repo = MagicMock()
+            mock_job_repo.create = AsyncMock(return_value=MagicMock())
             mock_job_repo_class.return_value = mock_job_repo
 
-            result = await create_verification_job(
+            result = await create_verification_attempt(
                 session_maker=mock_session_maker,
                 user_id=123,
                 requirement_slug="test-requirement",
@@ -417,10 +520,65 @@ class TestCreateVerificationJob:
                 github_username="user",
             )
 
-        assert isinstance(result, VerificationJobSubmission)
-        assert result.job is mock_job
+        assert isinstance(result, VerificationAttemptSubmission)
+        assert result.attempt_id == mock_attempt.id
         assert result.created is True
-        mock_job_repo.create_or_get_active.assert_awaited_once()
+        mock_attempt_repo.create_or_get_active.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_submit_reuses_active_attempt_without_new_job(self):
+        """When the attempt repo reports ``created=False`` (an active attempt
+        already exists), no second compatibility job row is created."""
+        mock_session_maker = _mock_session_maker()
+        mock_requirement = _make_mock_requirement(
+            submission_type=SubmissionType.JOURNAL_API_VERIFIER,
+        )
+        mock_attempt = _mock_attempt()
+
+        with (
+            patch(
+                "learn_to_cloud.services.submissions_service.load_requirement_index",
+                return_value=_build_index(mock_requirement),
+            ),
+            patch(
+                "learn_to_cloud.services.submissions_service.SubmissionRepository",
+                autospec=True,
+            ) as mock_repo_class,
+            patch(
+                "learn_to_cloud.services.submissions_service."
+                "VerificationAttemptRepository",
+                autospec=True,
+            ) as mock_attempt_repo_class,
+            patch(
+                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
+                autospec=True,
+            ) as mock_job_repo_class,
+        ):
+            mock_repo = MagicMock()
+            mock_repo.get_by_user_and_requirement = AsyncMock(return_value=None)
+            mock_repo_class.return_value = mock_repo
+
+            mock_attempt_repo = MagicMock()
+            mock_attempt_repo.create_or_get_active = AsyncMock(
+                return_value=(mock_attempt, False)
+            )
+            mock_attempt_repo_class.return_value = mock_attempt_repo
+
+            mock_job_repo = MagicMock()
+            mock_job_repo.create = AsyncMock()
+            mock_job_repo_class.return_value = mock_job_repo
+
+            result = await create_verification_attempt(
+                session_maker=mock_session_maker,
+                user_id=123,
+                requirement_slug="test-requirement",
+                submitted_value="https://github.com/user/repo",
+                github_username="user",
+            )
+
+        assert result.attempt_id == mock_attempt.id
+        assert result.created is False
+        mock_job_repo.create.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_preconditions_still_enforced(self):
@@ -439,9 +597,10 @@ class TestCreateVerificationJob:
                 autospec=True,
             ) as mock_repo_class,
             patch(
-                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
+                "learn_to_cloud.services.submissions_service."
+                "VerificationAttemptRepository",
                 autospec=True,
-            ) as mock_job_repo_class,
+            ) as mock_attempt_repo_class,
         ):
             mock_repo = MagicMock()
             mock_repo.get_by_user_and_requirement = AsyncMock(
@@ -450,7 +609,7 @@ class TestCreateVerificationJob:
             mock_repo_class.return_value = mock_repo
 
             with pytest.raises(AlreadyValidatedError):
-                await create_verification_job(
+                await create_verification_attempt(
                     session_maker=mock_session_maker,
                     user_id=123,
                     requirement_slug="test-requirement",
@@ -458,7 +617,7 @@ class TestCreateVerificationJob:
                     github_username="user",
                 )
 
-        mock_job_repo_class.assert_not_called()
+        mock_attempt_repo_class.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_verification_backfill_migration.py
+++ b/api/tests/test_verification_backfill_migration.py
@@ -552,6 +552,59 @@ def test_mirror_trigger_insert_delete_and_idempotent(alembic_runner, alembic_eng
 
 
 @pytest.mark.migration_chain
+def test_explicit_dual_write_is_safe_alongside_mirror_trigger(
+    alembic_runner, alembic_engine
+):
+    """PR5's explicit dual-write (learner_step_completions insert, then the
+    legacy step_progress insert) must coexist with the 0049 mirror trigger:
+    the trigger's own INSERT/DELETE against learner_step_completions is
+    ``ON CONFLICT DO NOTHING`` / a plain ``DELETE``, so it becomes a no-op
+    once the explicit write already landed -- regardless of write order."""
+    alembic_runner.migrate_up_to(_BEFORE)
+    _seed(alembic_engine)
+    alembic_runner.migrate_up_one()
+
+    new_step = _extra_step(alembic_engine)
+
+    # Explicit authoritative write first (what LearnerStepCompletionRepository
+    # does), then the legacy write the trigger mirrors from.
+    with alembic_engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO learner_step_completions "
+                "(user_id, step_uuid, completed_at) "
+                "VALUES (1001, :s, :t) "
+                "ON CONFLICT (user_id, step_uuid) DO NOTHING"
+            ),
+            {"s": new_step, "t": _NOW},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO step_progress (user_id, step_uuid, completed_at) "
+                "VALUES (1001, :s, :t)"
+            ),
+            {"s": new_step, "t": _NOW},
+        )
+    # No unique-violation from the trigger's own insert, and no duplicate row.
+    assert _completion_count(alembic_engine, new_step) == 1
+
+    # Explicit delete first, then the legacy delete the trigger mirrors from.
+    with alembic_engine.begin() as conn:
+        conn.execute(
+            text(
+                "DELETE FROM learner_step_completions "
+                "WHERE user_id = 1001 AND step_uuid = :s"
+            ),
+            {"s": new_step},
+        )
+        conn.execute(
+            text("DELETE FROM step_progress WHERE user_id = 1001 AND step_uuid = :s"),
+            {"s": new_step},
+        )
+    assert _completion_count(alembic_engine, new_step) == 0
+
+
+@pytest.mark.migration_chain
 def test_active_uniqueness_preflight_aborts(alembic_runner, alembic_engine):
     alembic_runner.migrate_up_to(_BEFORE)
     ids = _seed(alembic_engine)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/__init__.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/__init__.py
@@ -8,6 +8,9 @@ on HTTP handling. This separation provides:
 - Reusable queries across multiple endpoints
 """
 
+from learn_to_cloud_shared.repositories.learner_step_completion_repository import (
+    LearnerStepCompletionRepository,
+)
 from learn_to_cloud_shared.repositories.progress_repository import (
     StepProgressRepository,
 )
@@ -15,13 +18,18 @@ from learn_to_cloud_shared.repositories.submission_repository import (
     SubmissionRepository,
 )
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    VerificationAttemptRepository,
+)
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
 
 __all__ = [
+    "LearnerStepCompletionRepository",
     "StepProgressRepository",
     "SubmissionRepository",
     "UserRepository",
+    "VerificationAttemptRepository",
     "VerificationJobRepository",
 ]

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/learner_step_completion_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/learner_step_completion_repository.py
@@ -1,0 +1,69 @@
+"""Repository for the authoritative ``learner_step_completions`` table.
+
+Coexists with :class:`~learn_to_cloud_shared.repositories.progress_repository.
+StepProgressRepository` during the PR5/PR6 migration window: callers now
+explicitly dual-write here alongside ``step_progress``, while a temporary
+database trigger (migration 0049) also mirrors any remaining legacy-only
+``step_progress`` writer into this table. Both the explicit writes and the
+trigger use ``ON CONFLICT DO NOTHING`` / a plain ``DELETE``, so whichever one
+runs first in a transaction makes the other a no-op -- order between them
+does not matter for correctness.
+
+Reads stay on ``step_progress`` until PR6 cuts progress calculation over to
+this table, so no read methods are added here yet.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud_shared.models import LearnerStepCompletion
+
+
+class LearnerStepCompletionRepository:
+    """Repository for learner step completion (curriculum-decoupled) records."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def create_if_not_exists(
+        self,
+        *,
+        user_id: int,
+        step_uuid: UUID,
+        completed_at: datetime | None = None,
+    ) -> LearnerStepCompletion | None:
+        """Atomically create a completion record if it doesn't exist.
+
+        Returns the created row, or ``None`` if one already existed (either
+        from a prior call here or from the ``step_progress`` mirror
+        trigger).
+        """
+        values: dict[str, object] = {"user_id": user_id, "step_uuid": step_uuid}
+        if completed_at is not None:
+            values["completed_at"] = completed_at
+        stmt = (
+            pg_insert(LearnerStepCompletion)
+            .values(**values)
+            .on_conflict_do_nothing(
+                index_elements=["user_id", "step_uuid"],
+            )
+            .returning(LearnerStepCompletion)
+        )
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def delete(self, *, user_id: int, step_uuid: UUID) -> int:
+        """Delete a single completion record, if present."""
+        result = await self.db.execute(
+            delete(LearnerStepCompletion).where(
+                LearnerStepCompletion.user_id == user_id,
+                LearnerStepCompletion.step_uuid == step_uuid,
+            )
+        )
+        return getattr(result, "rowcount", 0) or 0

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/progress_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/progress_repository.py
@@ -7,6 +7,7 @@ the human-readable step IDs when needed.
 """
 
 from collections.abc import Iterable
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import delete, select
@@ -51,18 +52,26 @@ class StepProgressRepository:
         self,
         user_id: int,
         step_uuid: UUID,
+        completed_at: datetime | None = None,
     ) -> StepProgress | None:
         """Atomically create a step progress record if it doesn't exist.
 
         Uses INSERT ... ON CONFLICT DO NOTHING RETURNING to check and
         insert in a single round-trip instead of SELECT + INSERT.
+        ``completed_at`` lets a caller share one timestamp with the
+        authoritative ``learner_step_completions`` write (see
+        ``LearnerStepCompletionRepository``); omit it to use the model's own
+        default.
 
         Returns:
             The created StepProgress if inserted, or None if already existed.
         """
+        values: dict[str, object] = {"user_id": user_id, "step_uuid": step_uuid}
+        if completed_at is not None:
+            values["completed_at"] = completed_at
         stmt = (
             pg_insert(StepProgress)
-            .values(user_id=user_id, step_uuid=step_uuid)
+            .values(**values)
             .on_conflict_do_nothing(
                 constraint="uq_step_progress_user_step",
             )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
@@ -13,18 +13,21 @@ migration installs.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import func, select, update
+from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from learn_to_cloud_shared.models import (
     VerificationAttempt,
     VerificationAttemptOutcome,
+    VerificationSnapshotSource,
     utcnow,
 )
+from learn_to_cloud_shared.submission_values import SubmittedValue
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,11 +110,138 @@ class AttemptAlreadyGoneError(Exception):
     """The attempt row disappeared between reads (should not happen in prod)."""
 
 
+class AttemptAlreadyValidatedError(Exception):
+    """A succeeded attempt already exists for this (user, requirement)."""
+
+
 class VerificationAttemptRepository:
-    """Data access for verification attempts, scoped to the Functions role."""
+    """Data access for verification attempts.
+
+    Most methods here run under the Functions role's narrowed column
+    grants (see migration 0051). :meth:`create_or_get_active` and
+    :meth:`delete_active` are the API-side submission-creation path and run
+    under the API's normal (unrestricted) role instead.
+    """
 
     def __init__(self, db: AsyncSession) -> None:
         self.db = db
+
+    async def create_or_get_active(
+        self,
+        *,
+        id: UUID,
+        user_id: int,
+        requirement_uuid: UUID,
+        artifact_schema_version: int,
+        curriculum_version: int,
+        content_hash: str,
+        requirement_snapshot: Mapping[str, object],
+        requirement_snapshot_hash: str,
+        payload_version: int,
+        github_username_snapshot: str | None,
+        submitted_value: SubmittedValue,
+        cloud_provider: str | None,
+        traceparent: str | None,
+        legacy_job_id: UUID,
+    ) -> tuple[VerificationAttempt, bool]:
+        """Create a new attempt, or return the active one, under an advisory lock.
+
+        Takes a transaction-scoped advisory lock keyed on ``(user_id,
+        requirement_uuid)`` before checking anything, so two concurrent
+        submits for the same requirement can never interleave their reads
+        and writes. With the lock held, this rechecks both an existing
+        *succeeded* attempt (closing the race between a concurrent
+        successful finalization and a new submit) and an existing *active*
+        attempt (the one-active-attempt invariant) before inserting a
+        brand-new row. The lock releases automatically when the caller
+        commits or rolls back the transaction.
+        """
+        await self._acquire_submission_lock(user_id, requirement_uuid)
+
+        succeeded = await self.db.execute(
+            select(VerificationAttempt.id)
+            .where(
+                VerificationAttempt.user_id == user_id,
+                VerificationAttempt.requirement_uuid == requirement_uuid,
+                VerificationAttempt.outcome
+                == VerificationAttemptOutcome.SUCCEEDED.value,
+            )
+            .limit(1)
+        )
+        if succeeded.scalar_one_or_none() is not None:
+            raise AttemptAlreadyValidatedError(
+                f"user {user_id} already has a succeeded attempt for "
+                f"requirement {requirement_uuid}"
+            )
+
+        active = await self.db.execute(
+            select(VerificationAttempt)
+            .where(
+                VerificationAttempt.user_id == user_id,
+                VerificationAttempt.requirement_uuid == requirement_uuid,
+                VerificationAttempt.outcome.is_(None),
+            )
+            .limit(1)
+        )
+        existing = active.scalar_one_or_none()
+        if existing is not None:
+            return existing, False
+
+        attempt = VerificationAttempt(
+            id=id,
+            user_id=user_id,
+            requirement_uuid=requirement_uuid,
+            artifact_schema_version=artifact_schema_version,
+            curriculum_version=curriculum_version,
+            content_hash=content_hash,
+            requirement_snapshot=dict(requirement_snapshot),
+            requirement_snapshot_hash=requirement_snapshot_hash,
+            snapshot_source=VerificationSnapshotSource.SUBMITTED.value,
+            payload_version=payload_version,
+            github_username_snapshot=github_username_snapshot,
+            cloud_provider=cloud_provider,
+            traceparent=traceparent,
+            legacy_job_id=legacy_job_id,
+            submission_value_kind=submitted_value.kind.value,
+            submitted_value=submitted_value.as_text,
+        )
+        self.db.add(attempt)
+        await self.db.flush()
+        return attempt, True
+
+    async def delete_active(self, attempt_id: UUID) -> bool:
+        """Delete an attempt that never started, freeing its active slot.
+
+        Used only when the API's own Durable start call fails before
+        reaching Functions (a config error, or a transport error before the
+        request landed) -- the attempt never ran, so nothing about it is
+        worth retaining. The lifecycle guards preserve rows already claimed
+        by Functions or terminalized by an authoritative writer.
+        """
+        stmt = delete(VerificationAttempt).where(
+            VerificationAttempt.id == attempt_id,
+            VerificationAttempt.outcome.is_(None),
+            VerificationAttempt.started_at.is_(None),
+        )
+        result = await self.db.execute(stmt)
+        return (getattr(result, "rowcount", 0) or 0) > 0
+
+    async def _acquire_submission_lock(
+        self, user_id: int, requirement_uuid: UUID
+    ) -> None:
+        """Take a transaction-scoped advisory lock for one (user, requirement).
+
+        ``hashtextextended`` folds the composite key into the single
+        64-bit value ``pg_advisory_xact_lock`` takes, so the lock target is
+        deterministic and collision-resistant without a second, session-level
+        unlock call to remember -- Postgres releases a ``_xact_lock``
+        automatically at commit or rollback.
+        """
+        lock_key = f"verification_attempt:{user_id}:{requirement_uuid}"
+        await self.db.execute(
+            text("SELECT pg_advisory_xact_lock(hashtextextended(:lock_key, 0))"),
+            {"lock_key": lock_key},
+        )
 
     async def get_prepare_state(self, attempt_id: UUID) -> AttemptPrepareState | None:
         """Load the identity + submitted snapshot for one attempt."""

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_job_repository.py
@@ -53,11 +53,17 @@ class VerificationJobRepository:
         extracted_username: str | None = None,
         cloud_provider: str | None = None,
         traceparent: str | None = None,
+        id: UUID | None = None,
     ) -> VerificationJob:
-        """Create a verification job and let DB constraints enforce uniqueness."""
+        """Create a verification job and let DB constraints enforce uniqueness.
+
+        ``id`` lets a caller share the id of an already-created
+        ``verification_attempts`` row (the unified-attempt submission path);
+        omit it to generate a fresh id (the legacy job-only path).
+        """
         value_columns = submitted_value.to_columns()
         job = VerificationJob(
-            id=uuid4(),
+            id=id or uuid4(),
             user_id=user_id,
             requirement_uuid=requirement_uuid,
             **value_columns,

--- a/packages/learn-to-cloud-shared/tests/repositories/test_learner_step_completion_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_learner_step_completion_repository.py
@@ -1,0 +1,94 @@
+"""Integration tests for LearnerStepCompletionRepository.
+
+Unlike ``StepProgressRepository``, this table has no FK to the curriculum
+(``steps.uuid``), so tests use arbitrary UUIDs instead of syncing the real
+curriculum.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud_shared.models import utcnow
+from learn_to_cloud_shared.repositories.learner_step_completion_repository import (
+    LearnerStepCompletionRepository,
+)
+from learn_to_cloud_shared.repositories.user_repository import UserRepository
+
+pytestmark = pytest.mark.integration
+
+USER_ID = 71001
+
+
+@pytest.fixture()
+async def user(db_session: AsyncSession):
+    """Create a test user for FK constraints."""
+    repo = UserRepository(db_session)
+    return await repo.upsert(USER_ID, github_username="completionuser")
+
+
+class TestCreateIfNotExists:
+    async def test_creates_record(self, db_session: AsyncSession, user):
+        step_uuid = uuid4()
+        repo = LearnerStepCompletionRepository(db_session)
+
+        completion = await repo.create_if_not_exists(
+            user_id=USER_ID, step_uuid=step_uuid
+        )
+
+        assert completion is not None
+        assert completion.user_id == USER_ID
+        assert completion.step_uuid == step_uuid
+        assert completion.completed_at is not None
+
+    async def test_returns_none_on_duplicate(self, db_session: AsyncSession, user):
+        step_uuid = uuid4()
+        repo = LearnerStepCompletionRepository(db_session)
+        await repo.create_if_not_exists(user_id=USER_ID, step_uuid=step_uuid)
+        await db_session.flush()
+
+        duplicate = await repo.create_if_not_exists(
+            user_id=USER_ID, step_uuid=step_uuid
+        )
+        assert duplicate is None
+
+    async def test_accepts_explicit_completed_at(self, db_session: AsyncSession, user):
+        """Callers dual-writing alongside ``step_progress`` pass one shared
+        timestamp so both tables agree on when the step was completed."""
+        step_uuid = uuid4()
+        shared_completed_at = utcnow()
+        repo = LearnerStepCompletionRepository(db_session)
+
+        completion = await repo.create_if_not_exists(
+            user_id=USER_ID,
+            step_uuid=step_uuid,
+            completed_at=shared_completed_at,
+        )
+
+        assert completion is not None
+        assert completion.completed_at == shared_completed_at
+
+
+class TestDelete:
+    async def test_deletes_only_specified_step(self, db_session: AsyncSession, user):
+        step_a, step_b = uuid4(), uuid4()
+        repo = LearnerStepCompletionRepository(db_session)
+        await repo.create_if_not_exists(user_id=USER_ID, step_uuid=step_a)
+        await repo.create_if_not_exists(user_id=USER_ID, step_uuid=step_b)
+        await db_session.flush()
+
+        deleted = await repo.delete(user_id=USER_ID, step_uuid=step_a)
+
+        assert deleted == 1
+        # step_b is untouched: a follow-up create_if_not_exists still hits
+        # the existing row and returns None (conflict), never re-created.
+        remaining = await repo.create_if_not_exists(user_id=USER_ID, step_uuid=step_b)
+        assert remaining is None
+
+    async def test_returns_zero_when_nothing_to_delete(
+        self, db_session: AsyncSession, user
+    ):
+        repo = LearnerStepCompletionRepository(db_session)
+        deleted = await repo.delete(user_id=USER_ID, step_uuid=uuid4())
+        assert deleted == 0

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
@@ -2,21 +2,26 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from uuid import UUID, uuid4
 
 import pytest
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.models import (
+    SubmissionValueKind,
     VerificationAttempt,
     VerificationAttemptOutcome,
     utcnow,
 )
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
 from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    AttemptAlreadyValidatedError,
     VerificationAttemptRepository,
 )
+from learn_to_cloud_shared.submission_values import SubmittedValue
 
 pytestmark = pytest.mark.integration
 
@@ -45,7 +50,9 @@ async def _insert_attempt(
     session_maker: async_sessionmaker[AsyncSession],
     *,
     attempt_id: UUID | None = None,
+    requirement_uuid: UUID | None = None,
     created_at=None,
+    started_at=None,
     outcome: str | None = None,
 ) -> UUID:
     attempt_id = attempt_id or uuid4()
@@ -53,10 +60,11 @@ async def _insert_attempt(
         attempt = VerificationAttempt(
             id=attempt_id,
             user_id=USER_ID,
-            requirement_uuid=uuid4(),
+            requirement_uuid=requirement_uuid or uuid4(),
             snapshot_source="reconstructed",
             submission_value_kind="github_url",
             submitted_value="https://github.com/attemptrepo/repo",
+            started_at=started_at,
             outcome=outcome,
             completed_at=utcnow() if outcome is not None else None,
         )
@@ -65,6 +73,12 @@ async def _insert_attempt(
         db.add(attempt)
         await db.commit()
     return attempt_id
+
+
+def _submitted_value(
+    value: str = "https://github.com/attemptrepo/repo",
+) -> SubmittedValue:
+    return SubmittedValue(kind=SubmissionValueKind.GITHUB_URL, github_url=value)
 
 
 async def test_finalize_sets_terminal_state(
@@ -193,3 +207,210 @@ async def test_list_active_older_than_uses_started_at_when_present(
             now - timedelta(hours=1), limit=10
         )
     assert attempt_id not in {row.id for row in rows}
+
+
+def _create_kwargs(
+    *,
+    id: UUID,
+    requirement_uuid: UUID,
+    submitted_value: SubmittedValue,
+    legacy_job_id: UUID | None = None,
+    requirement_snapshot: dict | None = None,
+    requirement_snapshot_hash: str = "snapshot-hash",
+) -> dict:
+    """Shared kwargs for ``create_or_get_active`` so each test only overrides
+    what it cares about."""
+    return {
+        "id": id,
+        "user_id": USER_ID,
+        "requirement_uuid": requirement_uuid,
+        "artifact_schema_version": 1,
+        "curriculum_version": 1,
+        "content_hash": "content-hash",
+        "requirement_snapshot": requirement_snapshot or {"slug": "test-requirement"},
+        "requirement_snapshot_hash": requirement_snapshot_hash,
+        "payload_version": 1,
+        "github_username_snapshot": "attemptrepo",
+        "submitted_value": submitted_value,
+        "cloud_provider": None,
+        "traceparent": None,
+        "legacy_job_id": legacy_job_id if legacy_job_id is not None else id,
+    }
+
+
+async def test_create_or_get_active_creates_new_attempt(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement_uuid = uuid4()
+    attempt_id = uuid4()
+
+    async with session_maker() as db:
+        attempt, created = await VerificationAttemptRepository(db).create_or_get_active(
+            **_create_kwargs(
+                id=attempt_id,
+                requirement_uuid=requirement_uuid,
+                submitted_value=_submitted_value(),
+            )
+        )
+        await db.commit()
+
+    assert created is True
+    assert attempt.id == attempt_id
+    assert attempt.snapshot_source == "submitted"
+    assert attempt.legacy_job_id == attempt_id
+    assert attempt.submitted_value == "https://github.com/attemptrepo/repo"
+
+
+async def test_create_or_get_active_returns_existing_active_attempt(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement_uuid = uuid4()
+    first_id = uuid4()
+    second_id = uuid4()
+
+    async with session_maker() as db:
+        first, first_created = await VerificationAttemptRepository(
+            db
+        ).create_or_get_active(
+            **_create_kwargs(
+                id=first_id,
+                requirement_uuid=requirement_uuid,
+                submitted_value=_submitted_value(
+                    "https://github.com/attemptrepo/first"
+                ),
+            )
+        )
+        await db.commit()
+
+    async with session_maker() as db:
+        second, second_created = await VerificationAttemptRepository(
+            db
+        ).create_or_get_active(
+            **_create_kwargs(
+                id=second_id,
+                requirement_uuid=requirement_uuid,
+                submitted_value=_submitted_value(
+                    "https://github.com/attemptrepo/second"
+                ),
+            )
+        )
+        await db.commit()
+
+    assert first_created is True
+    assert second_created is False
+    assert second.id == first.id
+    assert second.submitted_value == "https://github.com/attemptrepo/first"
+
+    async with session_maker() as db:
+        count = await db.scalar(
+            select(func.count())
+            .select_from(VerificationAttempt)
+            .where(VerificationAttempt.requirement_uuid == requirement_uuid)
+        )
+    assert count == 1
+
+
+async def test_create_or_get_active_raises_for_succeeded_attempt(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement_uuid = uuid4()
+    await _insert_attempt(
+        session_maker, requirement_uuid=requirement_uuid, outcome="succeeded"
+    )
+
+    async with session_maker() as db:
+        with pytest.raises(AttemptAlreadyValidatedError):
+            await VerificationAttemptRepository(db).create_or_get_active(
+                **_create_kwargs(
+                    id=uuid4(),
+                    requirement_uuid=requirement_uuid,
+                    submitted_value=_submitted_value(),
+                )
+            )
+
+
+async def test_create_or_get_active_serializes_concurrent_submits(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    """Two concurrent submits for the same (user, requirement) must not
+    both create an active attempt. The transaction-scoped advisory lock in
+    ``create_or_get_active`` serializes them: the second caller blocks until
+    the first commits, then sees the first's row under the lock and reuses
+    it instead of creating a second active attempt."""
+    requirement_uuid = uuid4()
+
+    async def _submit(value: str) -> tuple[UUID, bool]:
+        async with session_maker() as db:
+            attempt, created = await VerificationAttemptRepository(
+                db
+            ).create_or_get_active(
+                **_create_kwargs(
+                    id=uuid4(),
+                    requirement_uuid=requirement_uuid,
+                    submitted_value=_submitted_value(
+                        f"https://github.com/attemptrepo/{value}"
+                    ),
+                )
+            )
+            await db.commit()
+        return attempt.id, created
+
+    results = await asyncio.gather(_submit("first"), _submit("second"))
+
+    created_flags = [created for _, created in results]
+    assert created_flags.count(True) == 1
+    assert created_flags.count(False) == 1
+    # Both callers must agree on which attempt won the race.
+    assert results[0][0] == results[1][0]
+
+    async with session_maker() as db:
+        count = await db.scalar(
+            select(func.count())
+            .select_from(VerificationAttempt)
+            .where(VerificationAttempt.requirement_uuid == requirement_uuid)
+        )
+    assert count == 1
+
+
+async def test_delete_active_removes_non_terminal_attempt(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    attempt_id = await _insert_attempt(session_maker)
+
+    async with session_maker() as db:
+        deleted = await VerificationAttemptRepository(db).delete_active(attempt_id)
+        await db.commit()
+    assert deleted is True
+
+    async with session_maker() as db:
+        status = await VerificationAttemptRepository(db).get_status(attempt_id)
+    assert status is None
+
+
+async def test_delete_active_refuses_terminal_attempt(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    attempt_id = await _insert_attempt(session_maker, outcome="succeeded")
+
+    async with session_maker() as db:
+        deleted = await VerificationAttemptRepository(db).delete_active(attempt_id)
+    assert deleted is False
+
+    async with session_maker() as db:
+        status = await VerificationAttemptRepository(db).get_status(attempt_id)
+    assert status is not None
+
+
+async def test_delete_active_refuses_claimed_attempt(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    attempt_id = await _insert_attempt(session_maker, started_at=utcnow())
+
+    async with session_maker() as db:
+        deleted = await VerificationAttemptRepository(db).delete_active(attempt_id)
+    assert deleted is False
+
+    async with session_maker() as db:
+        status = await VerificationAttemptRepository(db).get_status(attempt_id)
+    assert status is not None
+    assert status.started_at is not None

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_job_repository.py
@@ -103,6 +103,26 @@ class TestCreate:
         assert job.created_at is not None
         assert job.result_submission_id is None
 
+    async def test_creates_verification_job_with_explicit_id(
+        self,
+        db_session: AsyncSession,
+        user,
+        req_uuid: UUID,
+    ):
+        """The unified-attempt submission path shares one UUID between the
+        ``verification_attempts`` row and this compatibility job row."""
+        repo = VerificationJobRepository(db_session)
+        shared_id = uuid4()
+
+        job = await repo.create(
+            id=shared_id,
+            user_id=USER_ID,
+            requirement_uuid=req_uuid,
+            submitted_value=_github_value("https://github.com/testuser"),
+        )
+
+        assert job.id == shared_id
+
     async def test_create_or_get_active_returns_existing_active_job(
         self,
         db_session: AsyncSession,


### PR DESCRIPTION
## Why

Authoritative tables cannot become reliable readers until every new learner action writes them. This layer changes writes while preserving mixed-revision compatibility.

## What changed

- create an attempt and compatibility job with one UUID and one transaction
- snapshot artifact, requirement, username, submission value, provider, and trace context
- serialize concurrent submissions with a transaction-scoped advisory lock
- start Durable only after commit and preserve claimed attempts after ambiguous starts
- dual-write step checks and unchecks to both progress tables

## Stack position

Depends on #661. Legacy reads remain until #663.

## Validation

`uv run poe check`