### PR TITLE
Drain legacy learner-state writes

### DIFF
--- a/api/alembic/versions/0052_bridge_legacy_verification_drain.py
+++ b/api/alembic/versions/0052_bridge_legacy_verification_drain.py
@@ -1,0 +1,252 @@
+"""bridge legacy verification results during the drain window
+
+Why this change: legacy API replicas and already-running legacy Durable
+orchestrations can write ``verification_jobs`` after the original point-in-time
+backfill. Without a database bridge, those jobs can remain missing from
+``verification_attempts`` or leave an attempt active after a linked submission
+was persisted.
+
+Schema effect:
+- Backfills jobs missed after migration 0049.
+- Finalizes active attempts from linked legacy submissions.
+- Adds temporary insert/link triggers so rolling-deployment writes cannot open
+  another gap.
+- Uses a locked-down SECURITY DEFINER trigger because the Functions role has
+  intentionally narrow column grants on ``verification_attempts``.
+
+Rollback removes the temporary triggers and function but preserves repaired
+attempt rows and terminal outcomes.
+
+Revision ID: 0052_bridge_legacy_verification_drain
+Revises: 0051_narrow_functions_role_attempt_grants
+Create Date: 2026-07-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0052_bridge_legacy_verification_drain"
+down_revision: str | None = "0051_narrow_functions_role_attempt_grants"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_FUNCTION = "bridge_legacy_verification_job_to_attempt"
+_INSERT_TRIGGER = "trg_bridge_legacy_verification_job_insert"
+_LINK_TRIGGER = "trg_bridge_legacy_verification_job_link"
+
+_ATTEMPT_COLUMNS = """
+    id, user_id, requirement_uuid,
+    artifact_schema_version, curriculum_version, content_hash,
+    requirement_snapshot, requirement_snapshot_hash,
+    snapshot_source, payload_version,
+    github_username_snapshot, submission_value_kind, submitted_value,
+    cloud_provider, traceparent,
+    outcome, started_at, completed_at, feedback_json, validation_message,
+    error_code, terminal_source, legacy_job_id, legacy_submission_id,
+    created_at, updated_at
+"""
+
+_JOB_ATTEMPT_SELECT = """
+    vj.id,
+    vj.user_id,
+    vj.requirement_uuid,
+    NULL, NULL, NULL,
+    NULL, NULL,
+    'reconstructed',
+    NULL,
+    vj.extracted_username,
+    vj.submission_value_kind,
+    vj.submitted_value,
+    vj.cloud_provider,
+    vj.traceparent,
+    CASE
+        WHEN vj.result_submission_id IS NULL THEN NULL
+        WHEN s.is_validated THEN 'succeeded'
+        WHEN s.verification_completed THEN 'failed'
+        ELSE 'server_error'
+    END,
+    vj.created_at,
+    CASE
+        WHEN vj.result_submission_id IS NULL THEN NULL
+        ELSE COALESCE(
+            s.validated_at,
+            s.updated_at,
+            s.created_at,
+            vj.updated_at,
+            vj.created_at,
+            now()
+        )
+    END,
+    CASE
+        WHEN vj.result_submission_id IS NULL THEN NULL
+        ELSE s.feedback_json
+    END,
+    CASE
+        WHEN vj.result_submission_id IS NULL THEN NULL
+        ELSE s.validation_message
+    END,
+    CASE
+        WHEN vj.result_submission_id IS NULL THEN NULL
+        WHEN s.is_validated THEN 'verification_succeeded'
+        WHEN s.verification_completed THEN 'validation_failed'
+        ELSE 'verification_incomplete'
+    END,
+    CASE
+        WHEN vj.result_submission_id IS NULL THEN NULL
+        ELSE 'legacy_orchestrator'
+    END,
+    vj.id,
+    vj.result_submission_id,
+    COALESCE(vj.created_at, now()),
+    COALESCE(vj.updated_at, vj.created_at, now())
+"""
+
+
+def _backfill_and_finalize() -> None:
+    op.execute(
+        f"""
+        INSERT INTO verification_attempts ({_ATTEMPT_COLUMNS})
+        SELECT {_JOB_ATTEMPT_SELECT}
+        FROM verification_jobs vj
+        LEFT JOIN submissions s ON s.id = vj.result_submission_id
+        ON CONFLICT DO NOTHING
+        """
+    )
+    op.execute(
+        """
+        UPDATE verification_attempts AS a
+        SET outcome = CASE
+                WHEN s.is_validated THEN 'succeeded'
+                WHEN s.verification_completed THEN 'failed'
+                ELSE 'server_error'
+            END,
+            started_at = COALESCE(a.started_at, vj.created_at),
+            completed_at = COALESCE(
+                s.validated_at,
+                s.updated_at,
+                s.created_at,
+                vj.updated_at,
+                vj.created_at,
+                now()
+            ),
+            feedback_json = s.feedback_json,
+            validation_message = s.validation_message,
+            error_code = CASE
+                WHEN s.is_validated THEN 'verification_succeeded'
+                WHEN s.verification_completed THEN 'validation_failed'
+                ELSE 'verification_incomplete'
+            END,
+            terminal_source = 'legacy_orchestrator',
+            legacy_submission_id = s.id,
+            updated_at = COALESCE(
+                s.updated_at,
+                s.created_at,
+                vj.updated_at,
+                vj.created_at,
+                now()
+            )
+        FROM verification_jobs vj
+        JOIN submissions s ON s.id = vj.result_submission_id
+        WHERE a.legacy_job_id = vj.id
+          AND a.outcome IS NULL
+        """
+    )
+
+
+def _install_bridge() -> None:
+    op.execute(
+        f"""
+        CREATE OR REPLACE FUNCTION public.{_FUNCTION}()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = pg_catalog, pg_temp
+        AS $function$
+        BEGIN
+            INSERT INTO public.verification_attempts ({_ATTEMPT_COLUMNS})
+            SELECT {_JOB_ATTEMPT_SELECT}
+            FROM (SELECT NEW.*) AS vj
+            LEFT JOIN public.submissions s
+              ON s.id = vj.result_submission_id
+            ON CONFLICT DO NOTHING;
+
+            IF NEW.result_submission_id IS NOT NULL THEN
+                UPDATE public.verification_attempts AS a
+                SET outcome = CASE
+                        WHEN s.is_validated THEN 'succeeded'
+                        WHEN s.verification_completed THEN 'failed'
+                        ELSE 'server_error'
+                    END,
+                    started_at = COALESCE(a.started_at, NEW.created_at),
+                    completed_at = COALESCE(
+                        s.validated_at,
+                        s.updated_at,
+                        s.created_at,
+                        NEW.updated_at,
+                        NEW.created_at,
+                        now()
+                    ),
+                    feedback_json = s.feedback_json,
+                    validation_message = s.validation_message,
+                    error_code = CASE
+                        WHEN s.is_validated THEN 'verification_succeeded'
+                        WHEN s.verification_completed THEN 'validation_failed'
+                        ELSE 'verification_incomplete'
+                    END,
+                    terminal_source = 'legacy_orchestrator',
+                    legacy_submission_id = s.id,
+                    updated_at = COALESCE(
+                        s.updated_at,
+                        s.created_at,
+                        NEW.updated_at,
+                        NEW.created_at,
+                        now()
+                    )
+                FROM public.submissions s
+                WHERE a.legacy_job_id = NEW.id
+                  AND a.outcome IS NULL
+                  AND s.id = NEW.result_submission_id;
+            END IF;
+
+            RETURN NEW;
+        END;
+        $function$;
+        """
+    )
+    op.execute(f"REVOKE ALL ON FUNCTION public.{_FUNCTION}() FROM PUBLIC")
+    op.execute(
+        f"""
+        CREATE TRIGGER {_INSERT_TRIGGER}
+        AFTER INSERT ON verification_jobs
+        FOR EACH ROW EXECUTE FUNCTION public.{_FUNCTION}()
+        """
+    )
+    op.execute(
+        f"""
+        CREATE TRIGGER {_LINK_TRIGGER}
+        AFTER UPDATE OF result_submission_id ON verification_jobs
+        FOR EACH ROW
+        WHEN (NEW.result_submission_id IS DISTINCT FROM OLD.result_submission_id)
+        EXECUTE FUNCTION public.{_FUNCTION}()
+        """
+    )
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '5min'")
+
+    _install_bridge()
+    _backfill_and_finalize()
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    op.execute(f"DROP TRIGGER IF EXISTS {_LINK_TRIGGER} ON verification_jobs")
+    op.execute(f"DROP TRIGGER IF EXISTS {_INSERT_TRIGGER} ON verification_jobs")
+    op.execute(f"DROP FUNCTION IF EXISTS public.{_FUNCTION}()")

--- a/api/alembic/versions/0053_bridge_legacy_job_deletes.py
+++ b/api/alembic/versions/0053_bridge_legacy_job_deletes.py
@@ -1,0 +1,81 @@
+"""terminalize attempts when legacy jobs are deleted during drain
+
+Why this change: an older API replica can still delete a failed, unlinked
+``verification_jobs`` row during a rolling deployment. Migration 0052 bridges
+job inserts and result links, but without a delete bridge that old poller would
+leave its matching ``verification_attempts`` row active.
+
+Schema effect:
+- Adds a temporary SECURITY DEFINER delete trigger that compare-and-sets the
+  matching active attempt to ``server_error`` in the same transaction.
+
+Rollback removes the temporary trigger and function but preserves terminal
+attempt outcomes.
+
+Revision ID: 0053_bridge_legacy_job_deletes
+Revises: 0052_bridge_legacy_verification_drain
+Create Date: 2026-07-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0053_bridge_legacy_job_deletes"
+down_revision: str | None = "0052_bridge_legacy_verification_drain"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_FUNCTION = "terminalize_deleted_legacy_verification_job"
+_TRIGGER = "trg_terminalize_deleted_legacy_verification_job"
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    op.execute(
+        f"""
+        CREATE OR REPLACE FUNCTION public.{_FUNCTION}()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = pg_catalog, pg_temp
+        AS $function$
+        BEGIN
+            UPDATE public.verification_attempts
+            SET outcome = 'server_error',
+                started_at = COALESCE(started_at, OLD.created_at),
+                completed_at = now(),
+                validation_message =
+                    'Legacy verification ended before recording a result.',
+                error_code = 'server_error',
+                terminal_source = 'legacy_job_delete',
+                updated_at = now()
+            WHERE id = OLD.id
+              AND legacy_job_id = OLD.id
+              AND outcome IS NULL;
+
+            RETURN OLD;
+        END;
+        $function$;
+        """
+    )
+    op.execute(f"REVOKE ALL ON FUNCTION public.{_FUNCTION}() FROM PUBLIC")
+    op.execute(
+        f"""
+        CREATE TRIGGER {_TRIGGER}
+        AFTER DELETE ON verification_jobs
+        FOR EACH ROW EXECUTE FUNCTION public.{_FUNCTION}()
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    op.execute(f"DROP TRIGGER IF EXISTS {_TRIGGER} ON verification_jobs")
+    op.execute(f"DROP FUNCTION IF EXISTS public.{_FUNCTION}()")

--- a/api/alembic/versions/0054_repair_deleted_legacy_job_attempts.py
+++ b/api/alembic/versions/0054_repair_deleted_legacy_job_attempts.py
@@ -1,0 +1,58 @@
+"""repair active attempts whose legacy jobs were already deleted
+
+Why this change: migration 0053 protects future legacy job deletes, but an old
+poller may have deleted a job between the original backfill and installation of
+that trigger. Those attempts must not remain active and block retries.
+
+Data effect:
+- Compare-and-sets active legacy-provenance attempts with no remaining job to
+  ``server_error``.
+
+Rollback preserves repaired terminal outcomes.
+
+Revision ID: 0054_repair_deleted_legacy_job_attempts
+Revises: 0053_bridge_legacy_job_deletes
+Create Date: 2026-07-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0054_repair_deleted_legacy_job_attempts"
+down_revision: str | None = "0053_bridge_legacy_job_deletes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '5min'")
+
+    op.execute(
+        """
+        UPDATE verification_attempts AS a
+        SET outcome = 'server_error',
+            started_at = COALESCE(a.started_at, a.created_at),
+            completed_at = now(),
+            validation_message =
+                'Legacy verification ended before recording a result.',
+            error_code = 'server_error',
+            terminal_source = 'legacy_job_repair',
+            updated_at = now()
+        WHERE a.outcome IS NULL
+          AND a.legacy_job_id IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1
+            FROM verification_jobs vj
+            WHERE vj.id = a.legacy_job_id
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")

--- a/api/scripts/reconcile_verification_backfill.py
+++ b/api/scripts/reconcile_verification_backfill.py
@@ -11,8 +11,8 @@ Usage from the ``api/`` directory::
     uv run python scripts/reconcile_verification_backfill.py
 
 Exit codes:
-    0  Fully reconciled (no divergences).
-    1  Divergences found (see the printed report).
+    0  Fully reconciled and no legacy verification work remains.
+    1  Divergences or undrained legacy work found (see the printed report).
     2  Could not connect / query error.
 """
 
@@ -43,7 +43,7 @@ async def _main() -> int:
         await engine.dispose()
 
     print(format_report(report))
-    return 0 if report.ok else 1
+    return 0 if report.contract_ready else 1
 
 
 def main() -> int:

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -195,35 +195,80 @@ async def _render_processing_card(
     )
 
 
-async def _delete_terminal_job(
+async def _terminalize_failed_attempt(
     request: Request,
     token_data: VerificationStatusToken,
     status: str,
 ) -> bool:
-    """Drop the verification_jobs row after Durable reaches terminal failure.
-
-    Replaces the older ``mark_server_error`` / ``mark_cancelled`` writes:
-    the user-facing failure message comes from Durable's runtime status
-    in the poller, not from a Postgres re-read, so we don't need to copy
-    Durable's terminal state back into Postgres. Deleting frees the
-    partial unique index so the user can retry.
-
-    The delete is guarded — if the persist activity won a race and
-    attached a Submission first, ``delete_active`` returns False and we
-    leave the row alone.
-    """
+    """Persist a terminal Durable failure without orphaning legacy state."""
     session_maker = request.app.state.session_maker
+    attempt_id = UUID(token_data.job_id)
     async with session_maker() as session:
-        repository = VerificationJobRepository(session)
-        job_id = UUID(token_data.job_id)
-        deleted = await repository.delete_active(job_id)
-        await session.commit()
-    if not deleted:
-        logger.info(
-            "verification.poller.delete_skipped",
-            extra={"job_id": str(job_id), "runtime_status": status},
+        attempt_repo = VerificationAttemptRepository(session)
+        attempt = await attempt_repo.get_status(attempt_id)
+        if attempt is None:
+            # A job can predate the drain bridge or lose an active-row
+            # uniqueness race. With no attempt provenance to preserve, remove
+            # only that orphaned active job.
+            deleted = await VerificationJobRepository(session).delete_active(attempt_id)
+            await session.commit()
+            if deleted:
+                logger.warning(
+                    "verification.legacy_write_used",
+                    extra={
+                        "path": "orphaned_terminal_job_cleanup",
+                        "table": "verification_jobs",
+                        "job_id": str(attempt_id),
+                        "runtime_status": status,
+                    },
+                )
+            return deleted
+
+        cancelled = status in {"terminated", "canceled"}
+        result = await attempt_repo.finalize(
+            attempt_id,
+            outcome="cancelled" if cancelled else "server_error",
+            error_code="cancelled" if cancelled else "server_error",
+            validation_message=(
+                "Verification was cancelled."
+                if cancelled
+                else "Verification failed before recording a result."
+            ),
+            terminal_source="legacy_poller",
+            feedback_json=None,
         )
-    return deleted
+        if not result.won:
+            logger.info(
+                "verification.poller.finalize_skipped",
+                extra={
+                    "attempt_id": str(attempt_id),
+                    "runtime_status": status,
+                    "outcome": result.state.outcome,
+                },
+            )
+            return False
+        deleted_job = await VerificationJobRepository(session).delete_active(attempt_id)
+        await session.commit()
+        if deleted_job:
+            logger.warning(
+                "verification.legacy_write_used",
+                extra={
+                    "path": "terminal_job_cleanup",
+                    "table": "verification_jobs",
+                    "job_id": str(attempt_id),
+                    "runtime_status": status,
+                },
+            )
+        logger.info(
+            "verification.poller.attempt_terminalized",
+            extra={
+                "attempt_id": str(attempt_id),
+                "runtime_status": status,
+                "outcome": result.state.outcome,
+                "cas_won": result.won,
+            },
+        )
+    return True
 
 
 async def _render_step_toggle(
@@ -322,9 +367,8 @@ async def htmx_submit_verification(
 
     Every submission type runs through Durable Functions:
     :func:`create_verification_attempt` validates the request and creates a
-    ``VerificationAttempt`` (plus its compatibility ``VerificationJob``); we
-    start the versioned attempt orchestration and return a spinner card that
-    polls for status.
+    ``VerificationAttempt``; we start the versioned attempt orchestration and
+    return a spinner card that polls for status.
     """
     user_id = current_user.user_id
     github_username = current_user.github_username
@@ -443,11 +487,8 @@ async def _start_async_attempt_and_render(
 ) -> HTMLResponse:
     """Start the Durable attempt orchestration and render the spinner.
 
-    Posts no body -- the PR4 attempt starter loads identity, the
-    requirement snapshot, and the submitted value straight from the
-    ``verification_attempts`` row keyed by ``attempt_submission.attempt_id``,
-    which is shared with the compatibility ``verification_jobs`` row created
-    in the same transaction.
+    Posts no body -- the attempt starter loads identity, the requirement
+    snapshot, and the submitted value straight from ``verification_attempts``.
 
     On the rare concurrent-submit case (``created=False``) the original
     submit already kicked off Durable; we skip the start call and let
@@ -455,10 +496,8 @@ async def _start_async_attempt_and_render(
     original start never actually succeeded, the poller will see a 404
     from Durable and surface the error so the user can retry.
 
-    On a Durable start-call failure that never reached Functions (config
-    error, or a transport error before the request landed), deletes the
-    just-created attempt and legacy job rows so neither blocks the user's
-    retry -- nothing ran, so there is nothing worth retaining.
+    On a Durable start-call failure that never reached Functions, deletes the
+    just-created attempt so it does not block the learner's retry.
     """
     try:
         if attempt_submission.created:
@@ -501,15 +540,9 @@ async def _start_async_attempt_and_render(
         # after Functions has claimed and started it, in which case the row
         # must remain for the orchestration to finalize.
         async with session_maker() as write_session:
-            attempt_deleted = await VerificationAttemptRepository(
-                write_session
-            ).delete_active(
+            await VerificationAttemptRepository(write_session).delete_active(
                 attempt_submission.attempt_id,
             )
-            if attempt_deleted:
-                await VerificationJobRepository(write_session).delete_active(
-                    attempt_submission.attempt_id,
-                )
             await write_session.commit()
         # A config error means the verification service is misconfigured on our
         # side, so retrying will never help. A start error is usually a
@@ -586,8 +619,8 @@ async def htmx_verification_job_status(
         )
 
     if status in _DURABLE_FAILURE_STATUSES:
-        deleted = await _delete_terminal_job(request, token_data, status)
-        if not deleted:
+        terminalized = await _terminalize_failed_attempt(request, token_data, status)
+        if not terminalized:
             return HTMLResponse(_reload_verification_html())
 
         requirement = get_requirement_by_slug(token_data.requirement_slug)

--- a/api/src/learn_to_cloud/services/steps_service.py
+++ b/api/src/learn_to_cloud/services/steps_service.py
@@ -1,22 +1,12 @@
-"""Step progress service for learning step management.
+"""Learning-step completion service."""
 
-After the Phase E follow-up that dropped legacy id columns, the unit of
-identity for steps is ``step.uuid``. The HTMX endpoints take a step
-UUID directly; the topic context is recovered (when needed for
-rendering) by walking the loaded curriculum tree.
-
-Writes go to both the legacy ``step_progress`` table and the
-curriculum-decoupled ``learner_step_completions`` table (PR5 of the
-verification/progress refactor) so PR6 can cut progress reads over to the
-new table without a backfill race. Reads stay on ``step_progress`` until
-that cutover.
-"""
-
+import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
 from learn_to_cloud_shared.content_service import get_topic_containing_step
 from learn_to_cloud_shared.models import utcnow
+from learn_to_cloud_shared.progress_reads import resolve_completed_step_uuids
 from learn_to_cloud_shared.repositories import (
     LearnerStepCompletionRepository,
     StepProgressRepository,
@@ -27,6 +17,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 if TYPE_CHECKING:
     from learn_to_cloud_shared.schemas import Topic
+
+logger = logging.getLogger(__name__)
 
 
 class StepValidationError(Exception):
@@ -60,10 +52,10 @@ async def get_valid_completed_steps(
     topic: "Topic",
 ) -> set[UUID]:
     """Get completed step UUIDs filtered to steps that exist in this topic."""
-    step_repo = StepProgressRepository(db)
-    return await step_repo.get_completed_step_uuids(
-        user_id, (step.uuid for step in topic.learning_steps)
+    completed, _ = await resolve_completed_step_uuids(
+        db, user_id, (step.uuid for step in topic.learning_steps)
     )
+    return completed
 
 
 async def complete_step(
@@ -83,19 +75,7 @@ async def complete_step(
     topic, step = _find_step(step_uuid)
 
     completed_at = utcnow()
-    completion_repo = LearnerStepCompletionRepository(db)
-    step_repo = StepProgressRepository(db)
-
-    # Write the authoritative row first: the legacy step_progress insert's
-    # mirror trigger (migration 0049) then finds the row already present and
-    # no-ops. Both writes are ON CONFLICT DO NOTHING against the same
-    # (user_id, step_uuid) key, so this is idempotent regardless of order.
-    await completion_repo.create_if_not_exists(
-        user_id=user_id,
-        step_uuid=step.uuid,
-        completed_at=completed_at,
-    )
-    step_progress = await step_repo.create_if_not_exists(
+    completion = await LearnerStepCompletionRepository(db).create_if_not_exists(
         user_id=user_id,
         step_uuid=step.uuid,
         completed_at=completed_at,
@@ -109,7 +89,7 @@ async def complete_step(
 
     completed = await get_valid_completed_steps(db, user_id, topic)
 
-    if step_progress is None:
+    if completion is None:
         span.set_attribute("step.action", "already_completed")
         return (
             StepCompletionResult(
@@ -127,7 +107,7 @@ async def complete_step(
         StepCompletionResult(
             topic_slug=topic.slug,
             step_slug=step.slug,
-            completed_at=step_progress.completed_at,
+            completed_at=completion.completed_at,
         ),
         topic,
         completed,
@@ -148,15 +128,19 @@ async def uncomplete_step(
     """
     topic, step = _find_step(step_uuid)
 
-    completion_repo = LearnerStepCompletionRepository(db)
-    step_repo = StepProgressRepository(db)
-
-    # Delete the authoritative row first for the same reason as the insert
-    # order in complete_step: whichever delete (this one or the legacy
-    # step_progress mirror trigger) runs second finds nothing left to
-    # remove and is a harmless no-op.
-    await completion_repo.delete(user_id=user_id, step_uuid=step.uuid)
-    deleted = await step_repo.delete_step(user_id, step.uuid)
+    authoritative_deleted = await LearnerStepCompletionRepository(db).delete(
+        user_id=user_id, step_uuid=step.uuid
+    )
+    # Until the legacy fallback is removed, an old row would otherwise make
+    # this step appear complete again. This delete-through creates no new
+    # legacy state and is removed with the fallback in the contract layer.
+    legacy_deleted = await StepProgressRepository(db).delete_step(user_id, step.uuid)
+    if legacy_deleted:
+        logger.warning(
+            "step.legacy_delete_through_used",
+            extra={"user_id": user_id, "step_uuid": str(step.uuid)},
+        )
+    deleted = max(authoritative_deleted, legacy_deleted)
 
     span = trace.get_current_span()
     span.set_attribute("step.uuid", str(step.uuid))

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -23,9 +23,6 @@ from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     AttemptAlreadyValidatedError,
     VerificationAttemptRepository,
 )
-from learn_to_cloud_shared.repositories.verification_job_repository import (
-    VerificationJobRepository,
-)
 from learn_to_cloud_shared.requirements import (
     RequirementIndex,
     get_prerequisite_phase,
@@ -128,13 +125,14 @@ async def get_phase_submission_context(
     )
     legacy_only_uuids = set(requirements_by_uuid.keys()) - has_any_attempt
     if legacy_only_uuids:
-        logger.warning(
-            "submission_card.legacy_fallback_used",
-            extra={"user_id": user_id, "count": len(legacy_only_uuids)},
-        )
         legacy_submissions = await SubmissionRepository(db).get_latest_for_requirements(
             user_id, legacy_only_uuids
         )
+        if legacy_submissions:
+            logger.warning(
+                "submission_card.legacy_fallback_used",
+                extra={"user_id": user_id, "count": len(legacy_submissions)},
+            )
         for sub in legacy_submissions:
             requirement = requirements_by_uuid.get(sub.requirement_uuid)
             if requirement is None:
@@ -181,14 +179,7 @@ class _PreValidationContext:
 
 @dataclass(frozen=True, slots=True)
 class VerificationAttemptSubmission:
-    """Result of creating or reusing a verification attempt (async Durable path).
-
-    ``attempt_id`` is shared with the compatibility ``verification_jobs`` row
-    created in the same transaction, so the caller can key the Durable start
-    call, status polling, and any failure cleanup off one id -- Functions
-    loads everything else (identity, requirement snapshot, submitted value)
-    straight from the attempt row.
-    """
+    """Result of creating or reusing a verification attempt."""
 
     attempt_id: UUID
     created: bool
@@ -272,15 +263,13 @@ async def create_verification_attempt(
 
     Every submission type runs through Durable Functions. This validates the
     request, then -- inside one transaction, guarded by a transaction-scoped
-    Postgres advisory lock on ``(user_id, requirement_uuid)`` -- creates (or
-    reuses) the authoritative ``VerificationAttempt`` row plus its
-    compatibility ``VerificationJob`` row, sharing one UUID, so old API
-    readers stay valid while the attempt row becomes the source of truth.
+    Postgres advisory lock on ``(user_id, requirement_uuid)`` -- creates or
+    reuses the authoritative ``VerificationAttempt`` row.
 
     The advisory lock serializes concurrent submits for the same
-    requirement so two racing requests can never both pass the
-    active/succeeded checks and create two active attempts; it releases
-    automatically when the transaction commits below.
+    requirement so two racing requests can never both pass the active/succeeded
+    checks and create two active attempts. New attempts no longer create a
+    compatibility ``verification_jobs`` row.
     """
     ctx = await _check_submission_preconditions(
         session_maker,
@@ -316,22 +305,12 @@ async def create_verification_attempt(
                 submitted_value=typed_value,
                 cloud_provider=None,
                 traceparent=traceparent,
-                legacy_job_id=attempt_id,
+                legacy_job_id=None,
             )
         except AttemptAlreadyValidatedError as exc:
             raise AlreadyValidatedError(
                 "You have already completed this requirement."
             ) from exc
-
-        if created:
-            await VerificationJobRepository(write_session).create(
-                id=attempt.id,
-                user_id=user_id,
-                requirement_uuid=ctx.requirement.uuid,
-                submitted_value=typed_value,
-                extracted_username=github_username,
-                traceparent=traceparent,
-            )
 
         await write_session.commit()
 

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -272,11 +272,10 @@ class TestHtmxSubmitVerification:
         # Should render a server error card, not crash
         assert result is not None
 
-    async def test_durable_start_failure_deletes_attempt_and_job(self):
+    async def test_durable_start_failure_deletes_attempt(self):
         """When Durable's start_new call fails before reaching Functions, the
-        route deletes both the just-created attempt and legacy job rows
-        instead of marking either terminal. Frees the partial unique
-        indexes so the user can retry immediately."""
+        route deletes the just-created attempt instead of marking it terminal,
+        freeing the active slot so the user can retry immediately."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
         attempt_submission = _mock_attempt_submission(created=True)
@@ -286,8 +285,6 @@ class TestHtmxSubmitVerification:
         )
         attempt_repo = MagicMock()
         attempt_repo.delete_active = AsyncMock(return_value=True)
-        job_repo = MagicMock()
-        job_repo.delete_active = AsyncMock(return_value=True)
 
         with (
             patch(
@@ -314,10 +311,6 @@ class TestHtmxSubmitVerification:
                 "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
                 return_value=attempt_repo,
             ),
-            patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
-                return_value=job_repo,
-            ),
         ):
             result = await htmx_submit_verification(
                 request,
@@ -330,7 +323,6 @@ class TestHtmxSubmitVerification:
         attempt_repo.delete_active.assert_awaited_once_with(
             attempt_submission.attempt_id
         )
-        job_repo.delete_active.assert_awaited_once_with(attempt_submission.attempt_id)
         write_session.commit.assert_awaited_once()
 
     async def test_durable_config_error_does_not_invite_immediate_retry(
@@ -347,8 +339,6 @@ class TestHtmxSubmitVerification:
         )
         attempt_repo = MagicMock()
         attempt_repo.delete_active = AsyncMock(return_value=True)
-        job_repo = MagicMock()
-        job_repo.delete_active = AsyncMock(return_value=True)
 
         with (
             patch(
@@ -375,10 +365,6 @@ class TestHtmxSubmitVerification:
                 "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
                 return_value=attempt_repo,
             ),
-            patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
-                return_value=job_repo,
-            ),
         ):
             result = await htmx_submit_verification(
                 request,
@@ -392,7 +378,6 @@ class TestHtmxSubmitVerification:
         attempt_repo.delete_active.assert_awaited_once_with(
             attempt_submission.attempt_id
         )
-        job_repo.delete_active.assert_awaited_once_with(attempt_submission.attempt_id)
         _, _, context = _patch_templates.TemplateResponse.call_args.args
         assert context["server_error"] is True
         assert context["server_error_retryable"] is False
@@ -415,8 +400,6 @@ class TestHtmxSubmitVerification:
         )
         attempt_repo = MagicMock()
         attempt_repo.delete_active = AsyncMock(return_value=False)
-        job_repo = MagicMock()
-        job_repo.delete_active = AsyncMock(return_value=True)
 
         with (
             patch(
@@ -443,10 +426,6 @@ class TestHtmxSubmitVerification:
                 "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
                 return_value=attempt_repo,
             ),
-            patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
-                return_value=job_repo,
-            ),
         ):
             await htmx_submit_verification(
                 request,
@@ -461,7 +440,6 @@ class TestHtmxSubmitVerification:
         attempt_repo.delete_active.assert_awaited_once_with(
             attempt_submission.attempt_id
         )
-        job_repo.delete_active.assert_not_awaited()
 
     async def test_async_submit_still_returns_processing_card(self):
         """Regression: async submissions must keep using the
@@ -711,7 +689,7 @@ class TestHtmxVerificationJobStatus:
         assert isinstance(result, HTMLResponse)
         assert "location.reload()" in bytes(result.body).decode()
 
-    async def test_failed_status_deletes_active_job_and_renders_error(
+    async def test_failed_status_terminalizes_attempt_and_renders_error(
         self,
         _patch_templates,
     ):
@@ -742,16 +720,29 @@ class TestHtmxVerificationJobStatus:
                 return_value=DurableStatusResult(runtime_status="Failed"),
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
                 autospec=True,
             ) as mock_repository_class,
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                autospec=True,
+            ) as mock_job_repository_class,
             patch(
                 "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
                 return_value=MagicMock(),
             ),
         ):
             mock_repository = mock_repository_class.return_value
-            mock_repository.delete_active = AsyncMock(return_value=True)
+            mock_repository.get_status = AsyncMock(return_value=MagicMock())
+            mock_repository.finalize = AsyncMock(
+                return_value=MagicMock(
+                    won=True,
+                    state=MagicMock(outcome="server_error"),
+                )
+            )
+            mock_job_repository_class.return_value.delete_active = AsyncMock(
+                return_value=True
+            )
 
             result = await htmx_verification_job_status(
                 request,
@@ -760,7 +751,17 @@ class TestHtmxVerificationJobStatus:
             )
 
         assert isinstance(result, HTMLResponse)
-        mock_repository.delete_active.assert_awaited_once_with(job_id)
+        mock_repository.finalize.assert_awaited_once_with(
+            job_id,
+            outcome="server_error",
+            error_code="server_error",
+            validation_message="Verification failed before recording a result.",
+            terminal_source="legacy_poller",
+            feedback_json=None,
+        )
+        mock_job_repository_class.return_value.delete_active.assert_awaited_once_with(
+            job_id
+        )
         mock_session.commit.assert_awaited_once()
         _, _, context = _patch_templates.TemplateResponse.call_args.args
         assert context["server_error"] is True
@@ -772,9 +773,7 @@ class TestHtmxVerificationJobStatus:
             "issue at https://github.com/learntocloud/learn-to-cloud-app/issues."
         )
 
-    async def test_canceled_status_also_deletes_active_job(self):
-        """``Canceled`` and ``Terminated`` are handled the same way as
-        ``Failed`` — delete the row, let the user retry."""
+    async def test_canceled_status_terminalizes_attempt_as_cancelled(self):
         request = _mock_request()
         mock_session = AsyncMock()
         request.app.state.session_maker.return_value.__aenter__.return_value = (
@@ -800,16 +799,29 @@ class TestHtmxVerificationJobStatus:
                 return_value=DurableStatusResult(runtime_status="Canceled"),
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
                 autospec=True,
             ) as mock_repository_class,
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                autospec=True,
+            ) as mock_job_repository_class,
             patch(
                 "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
                 return_value=MagicMock(),
             ),
         ):
             mock_repository = mock_repository_class.return_value
-            mock_repository.delete_active = AsyncMock(return_value=True)
+            mock_repository.get_status = AsyncMock(return_value=MagicMock())
+            mock_repository.finalize = AsyncMock(
+                return_value=MagicMock(
+                    won=True,
+                    state=MagicMock(outcome="cancelled"),
+                )
+            )
+            mock_job_repository_class.return_value.delete_active = AsyncMock(
+                return_value=True
+            )
 
             result = await htmx_verification_job_status(
                 request,
@@ -818,12 +830,72 @@ class TestHtmxVerificationJobStatus:
             )
 
         assert isinstance(result, HTMLResponse)
-        mock_repository.delete_active.assert_awaited_once_with(job_id)
+        mock_repository.finalize.assert_awaited_once_with(
+            job_id,
+            outcome="cancelled",
+            error_code="cancelled",
+            validation_message="Verification was cancelled.",
+            terminal_source="legacy_poller",
+            feedback_json=None,
+        )
+        mock_job_repository_class.return_value.delete_active.assert_awaited_once_with(
+            job_id
+        )
 
-    async def test_failed_status_delete_skipped_when_persist_won_race(self):
-        """If ``delete_active`` returns False (persist linked a
-        Submission first) the poller still responds with a reload — it
-        just logs and moves on."""
+    async def test_failed_status_reloads_when_attempt_was_already_finalized(self):
+        request = _mock_request()
+        mock_session = AsyncMock()
+        request.app.state.session_maker.return_value.__aenter__.return_value = (
+            mock_session
+        )
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        job_id = uuid4()
+        token_data = VerificationStatusToken(
+            user_id=1,
+            job_id=str(job_id),
+            instance_id=str(uuid4()),
+            requirement_slug="req-1",
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.load_verification_status_token",
+                return_value=token_data,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_verification_orchestration_status",
+                new_callable=AsyncMock,
+                return_value=DurableStatusResult(runtime_status="Failed"),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
+                autospec=True,
+            ) as mock_attempt_repository_class,
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
+                autospec=True,
+            ) as mock_job_repository_class,
+        ):
+            attempt_repo = mock_attempt_repository_class.return_value
+            attempt_repo.get_status = AsyncMock(return_value=MagicMock())
+            attempt_repo.finalize = AsyncMock(
+                return_value=MagicMock(
+                    won=False,
+                    state=MagicMock(outcome="succeeded"),
+                )
+            )
+
+            result = await htmx_verification_job_status(
+                request,
+                token="signed-token",
+                current_user=current_user,
+            )
+
+        assert "location.reload()" in bytes(result.body).decode()
+        mock_job_repository_class.return_value.delete_active.assert_not_called()
+        mock_session.commit.assert_not_awaited()
+
+    async def test_failed_status_reload_when_attempt_and_job_are_missing(self):
         request = _mock_request()
         mock_session = AsyncMock()
         request.app.state.session_maker.return_value.__aenter__.return_value = (
@@ -848,12 +920,20 @@ class TestHtmxVerificationJobStatus:
                 return_value=DurableStatusResult(runtime_status="Failed"),
             ),
             patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
+                autospec=True,
+            ) as mock_attempt_repository_class,
+            patch(
                 "learn_to_cloud.routes.htmx_routes.VerificationJobRepository",
                 autospec=True,
-            ) as mock_repository_class,
+            ) as mock_job_repository_class,
         ):
-            mock_repository = mock_repository_class.return_value
-            mock_repository.delete_active = AsyncMock(return_value=False)
+            mock_attempt_repository_class.return_value.get_status = AsyncMock(
+                return_value=None
+            )
+            mock_job_repository_class.return_value.delete_active = AsyncMock(
+                return_value=False
+            )
 
             result = await htmx_verification_job_status(
                 request,

--- a/api/tests/services/test_steps_service.py
+++ b/api/tests/services/test_steps_service.py
@@ -48,20 +48,16 @@ class TestCompleteStep:
                 return_value=(topic, step),
             ),
             patch(
-                "learn_to_cloud.services.steps_service.StepProgressRepository",
-                autospec=True,
-            ) as MockRepo,
-            patch(
                 "learn_to_cloud.services.steps_service.LearnerStepCompletionRepository",
                 autospec=True,
             ) as MockCompletionRepo,
+            patch(
+                "learn_to_cloud.services.steps_service.resolve_completed_step_uuids",
+                new=AsyncMock(return_value=({step.uuid}, set())),
+            ),
         ):
-            repo = MockRepo.return_value
-            repo.create_if_not_exists = AsyncMock(return_value=mock_progress)
-            repo.get_completed_step_uuids = AsyncMock(return_value={step.uuid})
-
             completion_repo = MockCompletionRepo.return_value
-            completion_repo.create_if_not_exists = AsyncMock(return_value=MagicMock())
+            completion_repo.create_if_not_exists = AsyncMock(return_value=mock_progress)
 
             result, returned_topic, completed = await complete_step(
                 AsyncMock(), user_id=1, step_uuid=step.uuid
@@ -70,19 +66,12 @@ class TestCompleteStep:
         assert result.step_slug == step.slug
         assert returned_topic.uuid == topic.uuid
         assert step.uuid in completed
-        # Both the authoritative and legacy tables get the dual write, with
-        # one shared completed_at timestamp.
         completion_repo.create_if_not_exists.assert_awaited_once()
-        repo.create_if_not_exists.assert_awaited_once()
         completion_await_args = completion_repo.create_if_not_exists.await_args
-        legacy_await_args = repo.create_if_not_exists.await_args
         assert completion_await_args is not None
-        assert legacy_await_args is not None
         completion_kwargs = completion_await_args.kwargs
-        legacy_kwargs = legacy_await_args.kwargs
         assert completion_kwargs["user_id"] == 1
         assert completion_kwargs["step_uuid"] == step.uuid
-        assert completion_kwargs["completed_at"] == legacy_kwargs["completed_at"]
 
     @pytest.mark.asyncio
     async def test_unknown_step_raises(self):
@@ -114,10 +103,13 @@ class TestUncompleteStep:
                 "learn_to_cloud.services.steps_service.LearnerStepCompletionRepository",
                 autospec=True,
             ) as MockCompletionRepo,
+            patch(
+                "learn_to_cloud.services.steps_service.resolve_completed_step_uuids",
+                new=AsyncMock(return_value=(set(), set())),
+            ),
         ):
             repo = MockRepo.return_value
             repo.delete_step = AsyncMock(return_value=1)
-            repo.get_completed_step_uuids = AsyncMock(return_value=set())
 
             completion_repo = MockCompletionRepo.return_value
             completion_repo.delete = AsyncMock(return_value=1)
@@ -142,14 +134,12 @@ class TestGetValidCompletedSteps:
         topic = _make_topic([s1, s2])
 
         with patch(
-            "learn_to_cloud.services.steps_service.StepProgressRepository",
-            autospec=True,
-        ) as MockRepo:
-            repo = MockRepo.return_value
-            repo.get_completed_step_uuids = AsyncMock(return_value={s1.uuid})
-
+            "learn_to_cloud.services.steps_service.resolve_completed_step_uuids",
+            new=AsyncMock(return_value=({s1.uuid}, set())),
+        ) as resolve:
             result = await get_valid_completed_steps(
                 AsyncMock(), user_id=1, topic=topic
             )
 
         assert result == {s1.uuid}
+        resolve.assert_awaited_once()

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -287,10 +287,6 @@ class TestAlreadyValidatedShortCircuit:
                 "VerificationAttemptRepository",
                 autospec=True,
             ) as mock_attempt_repo_class,
-            patch(
-                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
-                autospec=True,
-            ) as mock_job_repo_class,
         ):
             mock_attempt = _mock_attempt()
             mock_attempt_repo = MagicMock()
@@ -298,10 +294,6 @@ class TestAlreadyValidatedShortCircuit:
                 return_value=(mock_attempt, True)
             )
             mock_attempt_repo_class.return_value = mock_attempt_repo
-
-            mock_job_repo = MagicMock()
-            mock_job_repo.create = AsyncMock(return_value=MagicMock())
-            mock_job_repo_class.return_value = mock_job_repo
 
             result = await create_verification_attempt(
                 session_maker=mock_session_maker,
@@ -314,7 +306,6 @@ class TestAlreadyValidatedShortCircuit:
             assert isinstance(result, VerificationAttemptSubmission)
             assert result.attempt_id == mock_attempt.id
             assert result.created is True
-            mock_job_repo.create.assert_awaited_once()
 
 
 @pytest.mark.unit
@@ -387,10 +378,6 @@ class TestSequentialPhaseGating:
                 "VerificationAttemptRepository",
                 autospec=True,
             ) as mock_attempt_repo_class,
-            patch(
-                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
-                autospec=True,
-            ) as mock_job_repo_class,
         ):
             mock_attempt = _mock_attempt()
             mock_attempt_repo = MagicMock()
@@ -398,10 +385,6 @@ class TestSequentialPhaseGating:
                 return_value=(mock_attempt, True)
             )
             mock_attempt_repo_class.return_value = mock_attempt_repo
-
-            mock_job_repo = MagicMock()
-            mock_job_repo.create = AsyncMock(return_value=MagicMock())
-            mock_job_repo_class.return_value = mock_job_repo
 
             result = await create_verification_attempt(
                 session_maker=mock_session_maker,
@@ -443,10 +426,6 @@ class TestCreateVerificationAttempt:
                 autospec=True,
             ) as mock_attempt_repo_class,
             patch(
-                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
-                autospec=True,
-            ) as mock_job_repo_class,
-            patch(
                 "learn_to_cloud.services.submissions_service._current_traceparent",
                 return_value=(
                     "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
@@ -458,10 +437,6 @@ class TestCreateVerificationAttempt:
                 return_value=(mock_attempt, True)
             )
             mock_attempt_repo_class.return_value = mock_attempt_repo
-
-            mock_job_repo = MagicMock()
-            mock_job_repo.create = AsyncMock(return_value=MagicMock())
-            mock_job_repo_class.return_value = mock_job_repo
 
             result = await create_verification_attempt(
                 session_maker=mock_session_maker,
@@ -475,15 +450,11 @@ class TestCreateVerificationAttempt:
         assert result.attempt_id == mock_attempt.id
         assert result.created is True
         mock_attempt_repo.create_or_get_active.assert_awaited_once()
-        mock_job_repo.create.assert_awaited_once()
-        job_create_await_args = mock_job_repo.create.await_args
-        assert job_create_await_args is not None
-        assert job_create_await_args.kwargs["id"] == mock_attempt.id
         expected_traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
         attempt_create_await_args = mock_attempt_repo.create_or_get_active.await_args
         assert attempt_create_await_args is not None
         assert attempt_create_await_args.kwargs["traceparent"] == expected_traceparent
-        assert job_create_await_args.kwargs["traceparent"] == expected_traceparent
+        assert attempt_create_await_args.kwargs["legacy_job_id"] is None
 
     @pytest.mark.asyncio
     async def test_returns_verification_attempt_submission(self):
@@ -507,20 +478,12 @@ class TestCreateVerificationAttempt:
                 "VerificationAttemptRepository",
                 autospec=True,
             ) as mock_attempt_repo_class,
-            patch(
-                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
-                autospec=True,
-            ) as mock_job_repo_class,
         ):
             mock_attempt_repo = MagicMock()
             mock_attempt_repo.create_or_get_active = AsyncMock(
                 return_value=(mock_attempt, True)
             )
             mock_attempt_repo_class.return_value = mock_attempt_repo
-
-            mock_job_repo = MagicMock()
-            mock_job_repo.create = AsyncMock(return_value=MagicMock())
-            mock_job_repo_class.return_value = mock_job_repo
 
             result = await create_verification_attempt(
                 session_maker=mock_session_maker,
@@ -536,9 +499,7 @@ class TestCreateVerificationAttempt:
         mock_attempt_repo.create_or_get_active.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_concurrent_submit_reuses_active_attempt_without_new_job(self):
-        """When the attempt repo reports ``created=False`` (an active attempt
-        already exists), no second compatibility job row is created."""
+    async def test_concurrent_submit_reuses_active_attempt(self):
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement(
             submission_type=SubmissionType.JOURNAL_API_VERIFIER,
@@ -559,20 +520,12 @@ class TestCreateVerificationAttempt:
                 "VerificationAttemptRepository",
                 autospec=True,
             ) as mock_attempt_repo_class,
-            patch(
-                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
-                autospec=True,
-            ) as mock_job_repo_class,
         ):
             mock_attempt_repo = MagicMock()
             mock_attempt_repo.create_or_get_active = AsyncMock(
                 return_value=(mock_attempt, False)
             )
             mock_attempt_repo_class.return_value = mock_attempt_repo
-
-            mock_job_repo = MagicMock()
-            mock_job_repo.create = AsyncMock()
-            mock_job_repo_class.return_value = mock_job_repo
 
             result = await create_verification_attempt(
                 session_maker=mock_session_maker,
@@ -584,7 +537,6 @@ class TestCreateVerificationAttempt:
 
         assert result.attempt_id == mock_attempt.id
         assert result.created is False
-        mock_job_repo.create.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_preconditions_still_enforced(self):
@@ -973,18 +925,12 @@ class TestRunSubmitSmokeCheck:
                 "learn_to_cloud.services.submissions_service.are_all_requirements_succeeded",
                 new=_gating_mock(mock_requirement.uuid, already_validated=False),
             ) as mock_gate,
-            patch(
-                "learn_to_cloud.services.submissions_service.VerificationJobRepository",
-                autospec=True,
-            ) as mock_job_repo_class,
         ):
             result = await run_submit_smoke_check(mock_session_maker)
 
         assert result["requirement_slug"] == mock_requirement.slug
         # Reads use the synthetic, non-existent user id.
         mock_gate.assert_awaited_once_with(ANY, SMOKE_USER_ID, [mock_requirement.uuid])
-        # The canary never creates a verification job (no writes).
-        mock_job_repo_class.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_smoke_check_propagates_read_errors(self):

--- a/api/tests/test_verification_backfill_migration.py
+++ b/api/tests/test_verification_backfill_migration.py
@@ -22,6 +22,9 @@ MIGRATION_DB = "test_verification_backfill_migrations"
 _BEFORE = "0048_validate_deployment_architecture_type"
 _TABLES = "0049_add_verification_attempts_and_step_completions"
 _INDEXES = "0050_verification_attempts_concurrent_indexes"
+_GRANTS = "0051_narrow_functions_role_attempt_grants"
+_DELETE_BRIDGE = "0053_bridge_legacy_job_deletes"
+_DELETE_REPAIR = "0054_repair_deleted_legacy_job_attempts"
 
 os.environ.setdefault(
     "POSTGRES_VERIFICATION_FUNCTIONS_ROLE",
@@ -413,6 +416,110 @@ def test_concurrent_indexes_created_by_0050(alembic_runner, alembic_engine):
     ):
         assert index_name in by_name, f"{index_name} missing"
         assert by_name[index_name] is True, f"{index_name} is INVALID"
+
+
+@pytest.mark.migration_chain
+def test_legacy_drain_backfill_and_triggers(alembic_runner, alembic_engine):
+    from learn_to_cloud_shared.models import Submission, User, VerificationJob
+
+    alembic_runner.migrate_up_to(_GRANTS)
+    with Session(alembic_engine) as session:
+        session.add(User(id=1001, github_username="octocat"))
+        session.flush()
+        cur = _seed_curriculum(session)
+
+        linked_submission = _make_submission(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            is_validated=True,
+            verification_completed=True,
+        )
+        linked_job = _make_job(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_github"],
+            result_submission_id=linked_submission,
+        )
+        active_job = _make_job(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_token"],
+            value_kind="token",
+        )
+        session.commit()
+
+    alembic_runner.migrate_up_to(_DELETE_BRIDGE)
+
+    assert _fetch_attempt(alembic_engine, linked_job)["outcome"] == "succeeded"
+    assert _fetch_attempt(alembic_engine, active_job)["outcome"] is None
+
+    with Session(alembic_engine) as session:
+        active = session.get(VerificationJob, active_job)
+        assert active is not None
+        result = Submission(
+            user_id=1001,
+            requirement_uuid=cur["req_token"],
+            submitted_value="tok-123",
+            submission_value_kind="token",
+            token_value="tok-123",
+            is_validated=False,
+            verification_completed=True,
+        )
+        session.add(result)
+        session.flush()
+        active.result_submission_id = result.id
+        session.commit()
+
+    finalized = _fetch_attempt(alembic_engine, active_job)
+    assert finalized["outcome"] == "failed"
+    assert finalized["terminal_source"] == "legacy_orchestrator"
+
+    with Session(alembic_engine) as session:
+        triggered_job = _make_job(
+            session,
+            user_id=1001,
+            requirement_uuid=cur["req_token"],
+            value_kind="token",
+        )
+        session.commit()
+
+    triggered = _fetch_attempt(alembic_engine, triggered_job)
+    assert triggered["outcome"] is None
+    assert triggered["legacy_job_id"] == triggered_job
+
+    with Session(alembic_engine) as session:
+        job = session.get(VerificationJob, triggered_job)
+        assert job is not None
+        session.delete(job)
+        session.commit()
+
+    deleted = _fetch_attempt(alembic_engine, triggered_job)
+    assert deleted["outcome"] == "server_error"
+    assert deleted["terminal_source"] == "legacy_job_delete"
+
+    missing_job_id = uuid.uuid4()
+    with Session(alembic_engine) as session:
+        from learn_to_cloud_shared.models import VerificationAttempt
+
+        session.add(
+            VerificationAttempt(
+                id=missing_job_id,
+                user_id=1001,
+                requirement_uuid=cur["req_token"],
+                snapshot_source="reconstructed",
+                submission_value_kind="token",
+                submitted_value="tok-missing",
+                legacy_job_id=missing_job_id,
+            )
+        )
+        session.commit()
+
+    alembic_runner.migrate_up_to(_DELETE_REPAIR)
+
+    repaired = _fetch_attempt(alembic_engine, missing_job_id)
+    assert repaired["outcome"] == "server_error"
+    assert repaired["terminal_source"] == "legacy_job_repair"
 
 
 def _index_is_valid(engine, index_name: str) -> bool | None:

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -963,7 +963,7 @@ async def finalize_verification_attempt(
     run_payload,
     context: func.Context,
 ) -> dict[str, object]:
-    """Compare-and-set the attempt's real outcome and mirror the legacy row."""
+    """Compare-and-set the attempt's real outcome."""
     with _attached_invocation_context(context):
         run_result = VerificationRunResult.from_payload(_activity_payload(run_payload))
         _set_prepared_job_span_attributes(run_result.job)
@@ -983,7 +983,7 @@ async def terminalize_verification_attempt(
     input_payload,
     context: func.Context,
 ) -> dict[str, object]:
-    """Compare-and-set a failure/cancellation outcome + mirror the legacy row."""
+    """Compare-and-set a failure/cancellation outcome."""
     with _attached_invocation_context(context):
         data = _activity_payload(input_payload)
         attempt_id = UUID(str(data["attempt_id"]))

--- a/build-out-notes.md
+++ b/build-out-notes.md
@@ -10,3 +10,33 @@ claim winner calls `start_new`; retries inspect the existing instance and never
 restart it.
 
 The fixed instance ID, attempt lifecycle, and final schema remain unchanged.
+
+## PR 8: Legacy drain compatibility
+
+The plan said to stop all `step_progress` writes while retaining the legacy
+read fallback for a drain deployment. Those two actions conflict when a learner
+unchecks a previously mirrored step: deleting only
+`learner_step_completions` would let the stale `step_progress` row make the
+step appear complete again.
+
+PR 8 therefore stops legacy inserts immediately but temporarily deletes the
+matching `step_progress` row when a learner unchecks a step. This delete-through
+is observable and is removed with the fallback and mirror trigger in the
+contract layer.
+
+The plan also did not account for an old Durable orchestration completing after
+attempt reads became authoritative. Its legacy submission could be persisted
+while the matching `verification_attempts` row stayed active, then be
+reconciled incorrectly as a server error. PR 8 bridges legacy-orchestrator
+results into the matching attempt with the same compare-and-set finalization
+used by the new path. A temporary database trigger and idempotent repair
+migration also cover jobs written after the original point-in-time backfill or
+during a rolling deployment. The old orchestration remains registered only for
+the drain cohort. A terminally failed legacy job is deleted only after its
+matching attempt is terminalized in the same transaction, so an old API replica
+can retry without leaving authoritative state active. The attempt retains the
+historical job UUID until the contract layer removes provenance columns.
+Temporary insert, result-link, and delete triggers make those guarantees hold
+for older replicas throughout the rolling deployment, not only for the new
+application revision. A final idempotent repair terminalizes any active attempt
+whose legacy job was deleted before the delete trigger became available.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
@@ -15,9 +16,10 @@ from sqlalchemy import (
     delete,
     exists,
     func,
+    literal,
     select,
     text,
-    union,
+    union_all,
     update,
     values,
 )
@@ -31,6 +33,8 @@ from learn_to_cloud_shared.models import (
     utcnow,
 )
 from learn_to_cloud_shared.submission_values import SubmittedValue
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -175,7 +179,7 @@ class VerificationAttemptRepository:
         submitted_value: SubmittedValue,
         cloud_provider: str | None,
         traceparent: str | None,
-        legacy_job_id: UUID,
+        legacy_job_id: UUID | None,
     ) -> tuple[VerificationAttempt, bool]:
         """Create a new attempt, or return the active one, under an advisory lock.
 
@@ -743,12 +747,16 @@ class VerificationAttemptRepository:
         ).data(requirement_phase_rows)
 
         succeeded_attempts = select(
-            VerificationAttempt.user_id, VerificationAttempt.requirement_uuid
+            VerificationAttempt.user_id,
+            VerificationAttempt.requirement_uuid,
+            literal(0).label("legacy_rows"),
         ).where(
             VerificationAttempt.outcome == VerificationAttemptOutcome.SUCCEEDED.value
         )
         validated_legacy = select(
-            Submission.user_id, Submission.requirement_uuid
+            Submission.user_id,
+            Submission.requirement_uuid,
+            literal(1).label("legacy_rows"),
         ).where(
             Submission.is_validated.is_(True),
             ~exists().where(
@@ -756,7 +764,9 @@ class VerificationAttemptRepository:
                 VerificationAttempt.requirement_uuid == Submission.requirement_uuid,
             ),
         )
-        succeeded = union(succeeded_attempts, validated_legacy).subquery("succeeded")
+        succeeded = union_all(succeeded_attempts, validated_legacy).subquery(
+            "succeeded"
+        )
 
         result = await self.db.execute(
             select(
@@ -765,6 +775,7 @@ class VerificationAttemptRepository:
                 func.count(func.distinct(succeeded.c.requirement_uuid)).label(
                     "validated"
                 ),
+                func.sum(succeeded.c.legacy_rows).label("legacy_rows"),
             )
             .select_from(succeeded)
             .join(
@@ -774,8 +785,15 @@ class VerificationAttemptRepository:
             )
             .group_by(requirement_phase_map.c.phase_order, succeeded.c.user_id)
         )
+        rows = result.all()
+        legacy_rows = sum(row.legacy_rows or 0 for row in rows)
+        if legacy_rows:
+            logger.warning(
+                "stats.legacy_fallback_used",
+                extra={"count": legacy_rows},
+            )
         return [
-            (order, user_id)
-            for order, user_id, validated in result.all()
-            if validated >= completable[order]
+            (row.phase_order, row.user_id)
+            for row in rows
+            if row.validated >= completable[row.phase_order]
         ]

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
@@ -15,17 +15,17 @@ Trust boundary and idempotency:
    unchanged.
 2. :func:`finalize_verification_attempt` writes the terminal outcome with a
    compare-and-set (``UPDATE ... WHERE outcome IS NULL RETURNING``) so replays
-   and competing finalizers never overwrite a result, then mirrors the legacy
-   ``submissions`` row for a linked legacy ``verification_jobs`` so old API
-   readers stay correct.
+   and competing finalizers never overwrite a result. Attempts from before the
+   writer cutover still mirror their linked legacy job during the drain.
 3. :func:`terminalize_verification_attempt` is the authoritative failure path
    (orchestrator/activity exception, or the stale-attempt reconciler): it
-   compare-and-sets a ``server_error`` / ``cancelled`` outcome and mirrors the
-   legacy submission the same idempotent way.
+   compare-and-sets a ``server_error`` / ``cancelled`` outcome and applies the
+   same conditional drain mirror.
 """
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -65,6 +65,7 @@ from learn_to_cloud_shared.verification_job_executor import (
 )
 
 tracer = trace.get_tracer(__name__)
+logger = logging.getLogger(__name__)
 
 _SNAPSHOT_SOURCE_SUBMITTED = "submitted"
 _ORCHESTRATOR_TERMINAL_SOURCE = "orchestrator"
@@ -186,7 +187,7 @@ async def finalize_verification_attempt(
     *,
     session_maker: async_sessionmaker[AsyncSession],
 ) -> AttemptTerminalState:
-    """Persist an attempt's real verification outcome (CAS) + legacy mirror."""
+    """Persist an attempt's real verification outcome via compare-and-set."""
     run_result = run_result.without_evidence()
     job = run_result.job
     validation_result = run_result.validation_result
@@ -223,7 +224,7 @@ async def terminalize_verification_attempt(
     terminal_source: str,
     session_maker: async_sessionmaker[AsyncSession],
 ) -> AttemptTerminalState:
-    """Compare-and-set a failure/cancellation outcome + legacy mirror.
+    """Compare-and-set a failure/cancellation outcome.
 
     Used by the orchestrator's exception path and the stale-attempt
     reconciler. Never overwrites an already-terminal attempt.
@@ -306,6 +307,14 @@ async def _ensure_legacy_mirror(
         if job is None or job.result_submission_id is not None:
             return
 
+        logger.warning(
+            "verification.legacy_write_used",
+            extra={
+                "path": "attempt_terminal_mirror",
+                "table": "submissions",
+                "attempt_id": str(attempt_id),
+            },
+        )
         submission = await _create_mirror_submission(db, state)
         link = await job_repo.link_submission(job.id, submission.id)
         if link is LinkResult.LINKED:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_job_executor.py
@@ -10,8 +10,8 @@ A verification job is identified by the presence of its row in
    prior run), returns the same execution result without doing more
    work.
 2. ``run_profile`` runs the engine (no DB writes).
-3. ``persist_verification_result`` writes the ``Submission`` and links
-   it to the job via ``VerificationJobRepository.link_submission``.
+3. ``persist_verification_result`` writes the ``Submission``, links it to the
+   job, and compare-and-sets the matching unified attempt for the drain cohort.
    Idempotent against retries via the ``ALREADY_LINKED`` short-circuit.
 
 The requirement definition and ``github_username`` snapshot travel with
@@ -23,6 +23,7 @@ snapshot.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from uuid import UUID
@@ -33,7 +34,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from learn_to_cloud_shared.github_target import GitHubTarget
 from learn_to_cloud_shared.models import (
     Submission,
+    VerificationAttemptOutcome,
     VerificationJob,
+)
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    VerificationAttemptRepository,
 )
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     LinkResult,
@@ -56,6 +61,7 @@ from learn_to_cloud_shared.verification.grading_requests import LLMGradingReques
 from learn_to_cloud_shared.verification.tasks.base import EvidenceBundle
 
 tracer = trace.get_tracer(__name__)
+logger = logging.getLogger(__name__)
 
 VALIDATION_FAILED_ERROR_CODE = "validation_failed"
 VERIFICATION_INCOMPLETE_ERROR_CODE = "verification_incomplete"
@@ -334,6 +340,51 @@ def _code_for_outcome(outcome: str, fallback: str | None = None) -> str:
     return fallback or VERIFICATION_INCOMPLETE_ERROR_CODE
 
 
+def _outcome_for_submission(submission: Submission) -> VerificationAttemptOutcome:
+    if submission.is_validated:
+        return VerificationAttemptOutcome.SUCCEEDED
+    if submission.verification_completed:
+        return VerificationAttemptOutcome.FAILED
+    return VerificationAttemptOutcome.SERVER_ERROR
+
+
+async def _sync_legacy_submission_to_attempt(
+    db: AsyncSession,
+    *,
+    job_id: UUID,
+    submission: Submission,
+) -> bool:
+    """Finalize the matching attempt when an old orchestration drains."""
+    repo = VerificationAttemptRepository(db)
+    status = await repo.get_status(job_id)
+    if status is None:
+        logger.warning(
+            "verification.legacy_attempt_missing",
+            extra={"job_id": str(job_id), "submission_id": submission.id},
+        )
+        return False
+
+    outcome = _outcome_for_submission(submission)
+    result = await repo.finalize(
+        job_id,
+        outcome=outcome,
+        error_code=_code_for_outcome(outcome.value),
+        validation_message=submission.validation_message,
+        terminal_source="legacy_orchestrator",
+        feedback_json=submission.feedback_json,
+    )
+    logger.warning(
+        "verification.legacy_result_bridged",
+        extra={
+            "job_id": str(job_id),
+            "submission_id": submission.id,
+            "outcome": result.state.outcome,
+            "cas_won": result.won,
+        },
+    )
+    return True
+
+
 def _outcome_from_submission(submission: Submission) -> str:
     if submission.is_validated:
         return _OUTCOME_SUCCEEDED
@@ -401,6 +452,14 @@ async def prepare_verification_job(
     ``submissions`` here -- no curriculum or users reads.
     """
     normalized_job_id = _coerce_job_id(job_id)
+    logger.warning(
+        "verification.legacy_read_used",
+        extra={
+            "path": "legacy_orchestrator_prepare",
+            "table": "verification_jobs",
+            "job_id": str(normalized_job_id),
+        },
+    )
 
     with tracer.start_as_current_span(
         "prepare_verification_job",
@@ -433,6 +492,12 @@ async def prepare_verification_job(
                     submission=submission,
                     requirement=requirement,
                 )
+                await _sync_legacy_submission_to_attempt(
+                    db,
+                    job_id=normalized_job_id,
+                    submission=submission,
+                )
+                await db.commit()
                 span.set_attribute("verification.status", result.status)
                 span.set_attribute("verification.replay", True)
                 return VerificationJobPreparation(terminal_result=result)
@@ -510,10 +575,24 @@ async def persist_verification_result(
                     submission=submission,
                     requirement=job.requirement,
                 )
+                await _sync_legacy_submission_to_attempt(
+                    db,
+                    job_id=job.id,
+                    submission=submission,
+                )
+                await db.commit()
                 span.set_attribute("verification.status", result.status)
                 span.set_attribute("verification.replay", True)
                 return result
 
+            logger.warning(
+                "verification.legacy_write_used",
+                extra={
+                    "path": "legacy_orchestrator",
+                    "table": "submissions",
+                    "job_id": str(job.id),
+                },
+            )
             submission = await persist_validation_result(
                 db,
                 user_id=job.user_id,
@@ -551,10 +630,21 @@ async def persist_verification_result(
                         submission=canonical_submission,
                         requirement=job.requirement,
                     )
+                    await _sync_legacy_submission_to_attempt(
+                        fresh_db,
+                        job_id=job.id,
+                        submission=canonical_submission,
+                    )
+                    await fresh_db.commit()
                 span.set_attribute("verification.status", result.status)
                 span.set_attribute("verification.replay", True)
                 return result
 
+            await _sync_legacy_submission_to_attempt(
+                db,
+                job_id=job.id,
+                submission=submission,
+            )
             await db.commit()
 
         outcome = _outcome_for(validation_result)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_reconciliation.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_reconciliation.py
@@ -56,10 +56,12 @@ class ReconciliationReport:
     attempts_without_provenance: list[UUID] = field(default_factory=list)
     step_completions_missing: list[tuple[int, UUID]] = field(default_factory=list)
     step_completions_extra: list[tuple[int, UUID]] = field(default_factory=list)
+    active_legacy_attempts: list[UUID] = field(default_factory=list)
+    unlinked_legacy_jobs: list[UUID] = field(default_factory=list)
 
     @property
     def divergences(self) -> dict[str, int]:
-        """Named divergence categories mapped to their row counts."""
+        """State that must agree across authoritative and legacy records."""
         return {
             "linked_outcome_mismatches": len(self.linked_outcome_mismatches),
             "orphan_outcome_mismatches": len(self.orphan_outcome_mismatches),
@@ -70,13 +72,30 @@ class ReconciliationReport:
             "dangling_submission_provenance": len(self.dangling_submission_provenance),
             "attempts_without_provenance": len(self.attempts_without_provenance),
             "step_completions_missing": len(self.step_completions_missing),
-            "step_completions_extra": len(self.step_completions_extra),
+        }
+
+    @property
+    def drain_observations(self) -> dict[str, int]:
+        """Expected one-way-cutover state retained for operator visibility."""
+        return {
+            "authoritative_only_step_completions": len(self.step_completions_extra),
+            "active_legacy_attempts": len(self.active_legacy_attempts),
+            "unlinked_legacy_jobs": len(self.unlinked_legacy_jobs),
         }
 
     @property
     def ok(self) -> bool:
         """True when every divergence category is empty."""
         return not any(self.divergences.values())
+
+    @property
+    def contract_ready(self) -> bool:
+        """True when data agrees and no legacy verification work remains."""
+        return (
+            self.ok
+            and not self.active_legacy_attempts
+            and not self.unlinked_legacy_jobs
+        )
 
 
 async def _scalar_count(session: AsyncSession, table: str) -> int:
@@ -200,8 +219,12 @@ async def run_reconciliation(session: AsyncSession) -> ReconciliationReport:
                     SELECT s.id
                     FROM submissions s
                     WHERE NOT EXISTS (
-                        SELECT 1 FROM verification_attempts a
+                        SELECT 1
+                        FROM verification_attempts a
+                        LEFT JOIN verification_jobs vj
+                          ON vj.id = a.legacy_job_id
                         WHERE a.legacy_submission_id = s.id
+                           OR vj.result_submission_id = s.id
                     )
                     ORDER BY s.id
                     """
@@ -219,6 +242,7 @@ async def run_reconciliation(session: AsyncSession) -> ReconciliationReport:
                     SELECT a.id
                     FROM verification_attempts a
                     WHERE a.legacy_job_id IS NOT NULL
+                      AND a.outcome IS NULL
                       AND NOT EXISTS (
                         SELECT 1 FROM verification_jobs vj
                         WHERE vj.id = a.legacy_job_id
@@ -264,6 +288,48 @@ async def run_reconciliation(session: AsyncSession) -> ReconciliationReport:
                     WHERE legacy_job_id IS NULL
                       AND legacy_submission_id IS NULL
                       AND snapshot_source = 'reconstructed'
+                    ORDER BY id
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    active_legacy_attempts = [
+        r.id
+        for r in (
+            await session.execute(
+                text(
+                    """
+                    SELECT id
+                    FROM verification_attempts
+                    WHERE outcome IS NULL
+                      AND (
+                        legacy_job_id IS NOT NULL
+                        OR legacy_submission_id IS NOT NULL
+                      )
+                    ORDER BY id
+                    """
+                )
+            )
+        ).all()
+    ]
+
+    unlinked_legacy_jobs = [
+        r.id
+        for r in (
+            await session.execute(
+                text(
+                    """
+                    SELECT id
+                    FROM verification_jobs vj
+                    WHERE vj.result_submission_id IS NULL
+                      AND NOT EXISTS (
+                        SELECT 1
+                        FROM verification_attempts a
+                        WHERE a.legacy_job_id = vj.id
+                          AND a.outcome IS NOT NULL
+                      )
                     ORDER BY id
                     """
                 )
@@ -323,6 +389,8 @@ async def run_reconciliation(session: AsyncSession) -> ReconciliationReport:
         attempts_without_provenance=attempts_without_provenance,
         step_completions_missing=step_completions_missing,
         step_completions_extra=step_completions_extra,
+        active_legacy_attempts=active_legacy_attempts,
+        unlinked_legacy_jobs=unlinked_legacy_jobs,
     )
 
 
@@ -338,5 +406,10 @@ def format_report(report: ReconciliationReport) -> str:
         marker = "ok" if count == 0 else "!!"
         lines.append(f"  [{marker}] {name:<32} {count}")
     lines.append("")
+    lines.append("Drain observations:")
+    for name, count in report.drain_observations.items():
+        lines.append(f"  [--] {name:<32} {count}")
+    lines.append("")
     lines.append("RESULT: " + ("OK -- fully reconciled" if report.ok else "DIVERGENT"))
+    lines.append("CONTRACT READY: " + ("yes" if report.contract_ready else "no"))
     return "\n".join(lines)

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
@@ -323,6 +323,7 @@ async def test_finalize_maps_outcomes(
 ) -> None:
     requirement = repo_fork_requirement(slug="fork", required_repo="owner/repo")
     attempt_id = await _insert_submitted_attempt(session_maker, requirement)
+    submissions_before = await _count_submissions(session_maker)
     state = await finalize_verification_attempt(
         _run_result(
             attempt_id,
@@ -338,6 +339,7 @@ async def test_finalize_maps_outcomes(
         stored = await VerificationAttemptRepository(db).get_status(attempt_id)
     assert stored is not None
     assert stored.outcome == expected
+    assert await _count_submissions(session_maker) == submissions_before
 
 
 async def test_finalize_replay_does_not_overwrite(

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_job_executor.py
@@ -15,9 +15,13 @@ from learn_to_cloud_shared.models import (
     Submission,
     SubmissionType,
     SubmissionValueKind,
+    VerificationAttempt,
     VerificationJob,
 )
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    VerificationAttemptRepository,
+)
 from learn_to_cloud_shared.repositories.verification_job_repository import (
     VerificationJobRepository,
 )
@@ -159,6 +163,27 @@ async def _count_submissions(
 ) -> int:
     async with session_maker() as db:
         return await db.scalar(select(func.count()).select_from(Submission)) or 0
+
+
+async def _attach_active_attempt(
+    session_maker: async_sessionmaker[AsyncSession],
+    *,
+    job_id: UUID,
+    requirement: HandsOnRequirement,
+) -> None:
+    async with session_maker() as db:
+        db.add(
+            VerificationAttempt(
+                id=job_id,
+                user_id=USER_ID,
+                requirement_uuid=requirement.uuid,
+                snapshot_source="reconstructed",
+                submission_value_kind=SubmissionValueKind.GITHUB_URL.value,
+                submitted_value="https://github.com/executoruser/repo",
+                legacy_job_id=job_id,
+            )
+        )
+        await db.commit()
 
 
 async def _get_submission(
@@ -467,6 +492,58 @@ async def test_persist_is_idempotent_via_result_submission_id_guard(
     assert second.status == "succeeded"
     assert second.submission_id == first.submission_id
     assert await _count_submissions(session_maker) == 1
+
+
+async def test_legacy_persist_finalizes_matching_attempt(
+    session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
+):
+    job_id = await _create_job(session_maker, synced_requirement)
+    await _attach_active_attempt(
+        session_maker,
+        job_id=job_id,
+        requirement=synced_requirement,
+    )
+    run_result = VerificationRunResult(
+        job=_prepared(job_id, synced_requirement),
+        validation_result=ValidationResult(is_valid=True, message="Verified"),
+    )
+
+    await persist_verification_result(run_result, session_maker=session_maker)
+
+    async with session_maker() as db:
+        status = await VerificationAttemptRepository(db).get_status(job_id)
+    assert status is not None
+    assert status.outcome == "succeeded"
+
+
+async def test_legacy_prepare_replay_repairs_active_attempt(
+    session_maker: async_sessionmaker[AsyncSession],
+    synced_requirement: HandsOnRequirement,
+):
+    job_id = await _create_job(session_maker, synced_requirement)
+    run_result = VerificationRunResult(
+        job=_prepared(job_id, synced_requirement),
+        validation_result=ValidationResult(is_valid=False, message="Needs work"),
+    )
+    await persist_verification_result(run_result, session_maker=session_maker)
+    await _attach_active_attempt(
+        session_maker,
+        job_id=job_id,
+        requirement=synced_requirement,
+    )
+
+    preparation = await prepare_verification_job(
+        job_id,
+        session_maker=session_maker,
+        prepared_input=_prepared(job_id, synced_requirement),
+    )
+
+    assert preparation.terminal_result is not None
+    async with session_maker() as db:
+        status = await VerificationAttemptRepository(db).get_status(job_id)
+    assert status is not None
+    assert status.outcome == "failed"
 
 
 async def test_persist_raises_when_job_row_was_deleted(

--- a/packages/learn-to-cloud-shared/tests/test_verification_reconciliation.py
+++ b/packages/learn-to-cloud-shared/tests/test_verification_reconciliation.py
@@ -198,6 +198,8 @@ class TestDivergences:
 
         assert len(report.active_uniqueness_violations) == 1
         assert report.active_uniqueness_violations[0].active_count == 2
+        assert len(report.active_legacy_attempts) == 2
+        assert not report.contract_ready
 
     async def test_legacy_only_job_and_submission(self, db_session: AsyncSession):
         await _make_user(db_session)
@@ -209,6 +211,47 @@ class TestDivergences:
 
         assert job_id in report.legacy_only_jobs
         assert submission_id in report.legacy_only_submissions
+        assert job_id not in report.unlinked_legacy_jobs
+
+    async def test_job_linked_submission_is_not_legacy_only(
+        self, db_session: AsyncSession
+    ):
+        await _make_user(db_session)
+        req = await _make_requirement(db_session)
+        submission_id = await _make_submission(db_session, req)
+        job_id = await _make_job(db_session, req, result_submission_id=submission_id)
+        db_session.add(
+            _attempt(
+                req,
+                attempt_id=job_id,
+                legacy_job_id=job_id,
+                legacy_submission_id=None,
+            )
+        )
+        await db_session.flush()
+
+        report = await run_reconciliation(db_session)
+
+        assert submission_id not in report.legacy_only_submissions
+
+    async def test_terminal_unlinked_job_is_drained(self, db_session: AsyncSession):
+        await _make_user(db_session)
+        req = await _make_requirement(db_session)
+        job_id = await _make_job(db_session, req, result_submission_id=None)
+        db_session.add(
+            _attempt(
+                req,
+                attempt_id=job_id,
+                outcome="server_error",
+                legacy_job_id=job_id,
+            )
+        )
+        await db_session.flush()
+
+        report = await run_reconciliation(db_session)
+
+        assert job_id not in report.unlinked_legacy_jobs
+        assert report.contract_ready
 
     async def test_dangling_provenance(self, db_session: AsyncSession):
         await _make_user(db_session)
@@ -218,6 +261,7 @@ class TestDivergences:
             _attempt(
                 req,
                 attempt_id=attempt_id,
+                outcome=None,
                 legacy_job_id=uuid.uuid4(),  # points at a non-existent job
             )
         )
@@ -226,6 +270,27 @@ class TestDivergences:
         report = await run_reconciliation(db_session)
 
         assert attempt_id in report.dangling_job_provenance
+
+    async def test_terminal_attempt_may_retain_deleted_job_id(
+        self, db_session: AsyncSession
+    ):
+        await _make_user(db_session)
+        req = await _make_requirement(db_session)
+        attempt_id = uuid.uuid4()
+        db_session.add(
+            _attempt(
+                req,
+                attempt_id=attempt_id,
+                outcome="server_error",
+                legacy_job_id=uuid.uuid4(),
+            )
+        )
+        await db_session.flush()
+
+        report = await run_reconciliation(db_session)
+
+        assert attempt_id not in report.dangling_job_provenance
+        assert report.ok
 
     async def test_reconstructed_attempt_without_provenance_is_flagged(
         self, db_session: AsyncSession
@@ -287,6 +352,8 @@ class TestDivergences:
         report = await run_reconciliation(db_session)
 
         assert (USER_ID, extra_step) in report.step_completions_extra
+        assert report.ok
+        assert report.drain_observations["authoritative_only_step_completions"] == 1
 
 
 class TestFormatReport:
@@ -295,6 +362,8 @@ class TestFormatReport:
         rendered = format_report(report)
         assert "OK -- fully reconciled" in rendered
         assert "verification_attempts" in rendered
+        assert "Drain observations" in rendered
+        assert "CONTRACT READY: yes" in rendered
 
     def test_divergent_report_flags_result(self):
         report = ReconciliationReport(


### PR DESCRIPTION
## Why

Before legacy tables can be removed, new traffic must stop writing them and old replicas/orchestrations must be unable to create divergence during the drain window.

## What changed

- stop creating new compatibility jobs and submissions
- stop inserting legacy step progress while preserving safe uncheck behavior during fallback
- bridge old Durable results into authoritative attempts
- install temporary insert, result-link, and delete triggers for rolling-deployment races
- repair gaps after the original point-in-time backfill
- add observable reconciliation and contract-readiness gates

## Stack position

Depends on #664. Legacy tables, fallbacks, and the old orchestrator remain only for this deployment/drain cohort; #666 removes callers after the gate is clean. Material deviations are in `build-out-notes.md`.

## Validation

`uv run poe check`