### PR TITLE
refactor: drop legacy curriculum schema

### DIFF
--- a/api/alembic/versions/0055_drop_legacy_curriculum_contract.py
+++ b/api/alembic/versions/0055_drop_legacy_curriculum_contract.py
@@ -1,0 +1,278 @@
+"""drop legacy learner-state and database curriculum contract
+
+Why this change: learner state now lives exclusively in
+``verification_attempts`` and ``learner_step_completions`` while curriculum
+content is served from the packaged artifact. The legacy verification,
+submission, step-progress, and curriculum tables are no longer runtime
+dependencies.
+
+Schema effect:
+- Refuses to run until legacy verification and step state is fully reconciled.
+- Removes temporary drain triggers and their SECURITY DEFINER functions.
+- Drops migration-provenance columns from ``verification_attempts``.
+- Drops ``verification_jobs``, ``submissions``, ``step_progress``, and all five
+  database curriculum tables.
+- Reapplies least-privilege Functions grants without the provenance column.
+
+This contract migration is intentionally irreversible. A downgrade could
+recreate empty legacy tables but cannot recover the dropped learner history,
+curriculum shadow, or provenance. Failing loudly is safer than presenting a
+false rollback path.
+
+Revision ID: 0055_drop_legacy_curriculum_contract
+Revises: 0054_repair_deleted_legacy_job_attempts
+Create Date: 2026-07-15
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import context, op
+
+revision: str = "0055_drop_legacy_curriculum_contract"
+down_revision: str | None = "0054_repair_deleted_legacy_job_attempts"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SELECT_COLUMNS: tuple[str, ...] = (
+    "id",
+    "user_id",
+    "requirement_uuid",
+    "snapshot_source",
+    "payload_version",
+    "requirement_snapshot",
+    "requirement_snapshot_hash",
+    "submission_value_kind",
+    "submitted_value",
+    "github_username_snapshot",
+    "cloud_provider",
+    "traceparent",
+    "outcome",
+    "started_at",
+    "created_at",
+    "completed_at",
+    "error_code",
+    "validation_message",
+    "terminal_source",
+    "feedback_json",
+)
+
+_UPDATE_COLUMNS: tuple[str, ...] = (
+    "outcome",
+    "error_code",
+    "validation_message",
+    "terminal_source",
+    "feedback_json",
+    "started_at",
+    "completed_at",
+    "updated_at",
+)
+
+_DRAIN_CHECKS: tuple[tuple[str, str], ...] = (
+    (
+        "unlinked verification jobs",
+        """
+        SELECT count(*)
+        FROM verification_jobs
+        WHERE result_submission_id IS NULL
+        """,
+    ),
+    (
+        "verification jobs without matching attempts",
+        """
+        SELECT count(*)
+        FROM verification_jobs AS j
+        LEFT JOIN verification_attempts AS a
+          ON a.legacy_job_id = j.id
+        WHERE a.id IS NULL
+        """,
+    ),
+    (
+        "active attempts linked to legacy jobs",
+        """
+        SELECT count(*)
+        FROM verification_attempts
+        WHERE legacy_job_id IS NOT NULL
+          AND outcome IS NULL
+        """,
+    ),
+    (
+        "legacy submissions without matching attempts",
+        """
+        SELECT count(*)
+        FROM submissions AS s
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM verification_attempts AS a
+            WHERE a.legacy_submission_id = s.id
+        )
+        """,
+    ),
+    (
+        "legacy step completions without authoritative rows",
+        """
+        SELECT count(*)
+        FROM step_progress AS p
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM learner_step_completions AS c
+            WHERE c.user_id = p.user_id
+              AND c.step_uuid = p.step_uuid
+        )
+        """,
+    ),
+    (
+        "legacy outcomes that differ from authoritative attempts",
+        """
+        SELECT count(*)
+        FROM verification_jobs AS j
+        JOIN submissions AS s
+          ON s.id = j.result_submission_id
+        JOIN verification_attempts AS a
+          ON a.legacy_job_id = j.id
+        WHERE a.outcome IS DISTINCT FROM CASE
+            WHEN s.is_validated THEN 'succeeded'
+            WHEN s.verification_completed THEN 'failed'
+            ELSE 'server_error'
+        END
+        """,
+    ),
+)
+
+
+def _verification_functions_role() -> str | None:
+    role = os.environ.get("POSTGRES_VERIFICATION_FUNCTIONS_ROLE")
+    if not role:
+        return None
+    if not (role[0].isalpha() or role[0] == "_") or not all(
+        char.isalnum() or char == "_" for char in role
+    ):
+        raise RuntimeError(
+            f"POSTGRES_VERIFICATION_FUNCTIONS_ROLE is not a valid identifier: {role!r}"
+        )
+    return role
+
+
+def _assert_drain_complete() -> None:
+    if context.is_offline_mode():
+        return
+
+    bind = op.get_bind()
+    failures: list[str] = []
+    for label, query in _DRAIN_CHECKS:
+        count = bind.execute(sa.text(query)).scalar_one()
+        if count:
+            failures.append(f"{label}: {count}")
+    if failures:
+        detail = "; ".join(failures)
+        raise RuntimeError(f"Legacy contract drain is incomplete ({detail})")
+
+
+def _drop_temporary_bridges() -> None:
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS trg_terminalize_deleted_legacy_verification_job
+        ON verification_jobs
+        """
+    )
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS trg_bridge_legacy_verification_job_link
+        ON verification_jobs
+        """
+    )
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS trg_bridge_legacy_verification_job_insert
+        ON verification_jobs
+        """
+    )
+    op.execute(
+        """
+        DROP FUNCTION IF EXISTS
+            public.terminalize_deleted_legacy_verification_job()
+        """
+    )
+    op.execute(
+        """
+        DROP FUNCTION IF EXISTS
+            public.bridge_legacy_verification_job_to_attempt()
+        """
+    )
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS trg_mirror_step_progress_to_completions
+        ON step_progress
+        """
+    )
+    op.execute("DROP FUNCTION IF EXISTS mirror_step_progress_to_completions()")
+
+
+def _narrow_functions_grants() -> None:
+    role = _verification_functions_role()
+    if not role:
+        return
+
+    select_columns = ", ".join(_SELECT_COLUMNS)
+    update_columns = ", ".join(_UPDATE_COLUMNS)
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                REVOKE ALL ON verification_attempts FROM "{role}";
+                GRANT SELECT ({select_columns})
+                    ON verification_attempts TO "{role}";
+                GRANT UPDATE ({update_columns})
+                    ON verification_attempts TO "{role}";
+                REVOKE SELECT (uuid, submission_value_kind)
+                    ON requirements FROM "{role}";
+            END IF;
+        END $$;
+        """
+    )
+
+
+def _drop_retired_tables() -> None:
+    # PR 9 removes every client before this contract migration can deploy.
+    for table_name in (
+        "verification_jobs",
+        "step_progress",
+        "submissions",
+        "requirements",
+        "learning_objectives",
+        "steps",
+        "topics",
+        "phases",
+    ):
+        op.execute(
+            f"""
+            -- squawk-ignore ban-drop-table
+            DROP TABLE {table_name}
+            """
+        )
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '5min'")
+
+    _assert_drain_complete()
+    _drop_temporary_bridges()
+    _narrow_functions_grants()
+
+    op.drop_column("verification_attempts", "legacy_job_id")
+    op.drop_column("verification_attempts", "legacy_submission_id")
+
+    _drop_retired_tables()
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "0055 drops legacy learner history and curriculum data; downgrade is "
+        "intentionally unsupported"
+    )

--- a/api/tests/test_migration_chain.py
+++ b/api/tests/test_migration_chain.py
@@ -85,7 +85,6 @@ def alembic_engine():
         conn.execute(text(f"DROP DATABASE IF EXISTS {MIGRATION_DB}"))
         conn.execute(text(f"CREATE DATABASE {MIGRATION_DB}"))
     admin_eng.dispose()
-
     mig_url = _sync_url().rsplit("/", 1)[0] + f"/{MIGRATION_DB}"
     engine = create_engine(mig_url)
     yield engine
@@ -103,3 +102,64 @@ def alembic_engine():
         )
         conn.execute(text(f"DROP DATABASE IF EXISTS {MIGRATION_DB}"))
     admin_eng.dispose()
+
+
+def test_contract_removes_legacy_database_objects(
+    alembic_runner, alembic_engine
+) -> None:
+    alembic_runner.migrate_up_to("0055_drop_legacy_curriculum_contract")
+
+    dropped_tables = {
+        "verification_jobs",
+        "submissions",
+        "step_progress",
+        "requirements",
+        "learning_objectives",
+        "steps",
+        "topics",
+        "phases",
+    }
+    with alembic_engine.connect() as conn:
+        remaining_tables = set(
+            conn.execute(
+                text(
+                    """
+                    SELECT table_name
+                    FROM information_schema.tables
+                    WHERE table_schema = 'public'
+                    """
+                )
+            ).scalars()
+        )
+        attempt_columns = set(
+            conn.execute(
+                text(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'verification_attempts'
+                    """
+                )
+            ).scalars()
+        )
+        temporary_functions = set(
+            conn.execute(
+                text(
+                    """
+                    SELECT proname
+                    FROM pg_proc
+                    WHERE proname IN (
+                        'mirror_step_progress_to_completions',
+                        'bridge_legacy_verification_job_to_attempt',
+                        'terminalize_deleted_legacy_verification_job'
+                    )
+                    """
+                )
+            ).scalars()
+        )
+
+    assert dropped_tables.isdisjoint(remaining_tables)
+    assert "legacy_job_id" not in attempt_columns
+    assert "legacy_submission_id" not in attempt_columns
+    assert temporary_functions == set()

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -1,4 +1,4 @@
-"""SQLAlchemy models for Learn to Cloud progress tracking."""
+"""SQLAlchemy models for learner accounts and progress."""
 
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -10,31 +10,25 @@ from sqlalchemy import (
     CheckConstraint,
     DateTime,
     ForeignKey,
-    ForeignKeyConstraint,
     Index,
-    Integer,
     String,
     Text,
-    UniqueConstraint,
     Uuid,
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column
 
 from learn_to_cloud_shared.core.database import Base
 
 
 def utcnow() -> datetime:
-    """Return current UTC time (timezone-aware)."""
+    """Return the current timezone-aware UTC time."""
     return datetime.now(UTC)
 
 
 class TimestampMixin:
-    """Mixin that adds created_at and updated_at timestamp columns.
-
-    Use this for any model that needs audit timestamps.
-    """
+    """Add creation and update timestamps."""
 
     @declared_attr
     def created_at(cls) -> Mapped[datetime]:
@@ -46,7 +40,7 @@ class TimestampMixin:
 
 
 class User(TimestampMixin, Base):
-    """User model - authenticated via GitHub OAuth."""
+    """GitHub-authenticated learner."""
 
     __tablename__ = "users"
     __table_args__ = (Index("ix_users_github_username", "github_username"),)
@@ -55,69 +49,22 @@ class User(TimestampMixin, Base):
     first_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     last_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
-    github_username: Mapped[str] = mapped_column(
-        String(255),
-        nullable=False,
-    )
+    github_username: Mapped[str] = mapped_column(String(255), nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
-
-    submissions: Mapped[list["Submission"]] = relationship(
-        back_populates="user",
-        cascade="all, delete-orphan",
-    )
-    verification_jobs: Mapped[list["VerificationJob"]] = relationship(
-        back_populates="user",
-        cascade="all, delete-orphan",
-    )
-    step_progress: Mapped[list["StepProgress"]] = relationship(
-        back_populates="user",
-        cascade="all, delete-orphan",
-    )
 
 
 class SubmissionType(StrEnum):
-    """Type of submission for hands-on verification.
+    """Supported hands-on verification types."""
 
-    Currently supports Phase 0, Phase 1, and Phase 2 verification types.
-
-    To add a new verification type:
-    1. Add the enum value here
-    2. Add a validator function in the appropriate module under
-       ``verification/`` (or create a new module for complex types)
-    3. Register a :class:`VerificationProfile` for it in
-       ``verification/engine.py``: declare its ordered steps (each a
-       registered check plus typed params) and whether it needs a GitHub
-       username. A registry-exhaustiveness test enforces that every type has
-       a profile.
-    4. Add optional fields to HandsOnRequirement schema if needed
-    """
-
-    # Phase 0: Profile README
     PROFILE_README = "profile_readme"
-
-    # Phase 1: repo fork and CTF completion
     REPO_FORK = "repo_fork"
     CTF_TOKEN = "ctf_token"
-
-    # Phase 2: Networking lab verification
     NETWORKING_TOKEN = "networking_token"
-
-    # Phase 3: Journal API implementation
     JOURNAL_API_VERIFIER = "journal_api_verifier"
-
-    # Phase 4: Cloud deployment validation
     DEPLOYED_API = "deployed_api"
-
-    # Phase 4: Capstone architecture alignment (deploy.sh vs description)
     DEPLOYMENT_ARCHITECTURE = "deployment_architecture"
-
-    # Phase 5: DevOps analysis
     DEVOPS_ANALYSIS = "devops_analysis"
-
-    # Phase 6: Security posture
     SECURITY_SCANNING = "security_scanning"
-
-    # Phase 7: Interview & job prep reflection
     CAREER_REFLECTION = "career_reflection"
 
 
@@ -131,11 +78,7 @@ class SubmissionValueKind(StrEnum):
 
 
 class VerificationAttemptOutcome(StrEnum):
-    """Terminal result of a verification attempt.
-
-    ``NULL`` (absent) marks an active, in-flight attempt; the values here
-    are only ever set once the attempt reaches a terminal state.
-    """
+    """Terminal result of a verification attempt."""
 
     SUCCEEDED = "succeeded"
     FAILED = "failed"
@@ -144,341 +87,10 @@ class VerificationAttemptOutcome(StrEnum):
 
 
 class VerificationSnapshotSource(StrEnum):
-    """Provenance of an attempt's requirement snapshot.
-
-    ``submitted`` attempts carry the requirement definition captured at
-    submission time; ``reconstructed`` attempts were built by a backfill
-    from legacy rows and may honestly lack the original artifact metadata.
-    """
+    """Source of an attempt's requirement snapshot."""
 
     SUBMITTED = "submitted"
     RECONSTRUCTED = "reconstructed"
-
-
-class Submission(TimestampMixin, Base):
-    """Tracks validated submissions for hands-on verification.
-
-    References curriculum via ``requirement_uuid`` (FK to
-    ``requirements.uuid``). Phase D.2 of #461 / #465 dropped the legacy
-    denormalized ``requirement_id`` / ``submission_type`` / ``phase_id``
-    columns and the ``attempt_number`` counter (per #460) -- callers
-    derive those values from the joined ``Requirement`` row when
-    needed.
-    """
-
-    __tablename__ = "submissions"
-    __table_args__ = (
-        CheckConstraint(
-            "is_validated IS FALSE OR validated_at IS NOT NULL",
-            name="ck_submissions_validated_at_when_validated",
-        ),
-        CheckConstraint(
-            "is_validated IS FALSE OR verification_completed IS TRUE",
-            name="ck_submissions_completed_when_validated",
-        ),
-        CheckConstraint(
-            """
-            (
-                submission_value_kind = 'github_url'
-                AND github_url IS NOT NULL
-                AND token_value IS NULL
-                AND deployed_url IS NULL
-                AND text_value IS NULL
-                AND submitted_value = github_url
-            )
-            OR (
-                submission_value_kind = 'token'
-                AND token_value IS NOT NULL
-                AND github_url IS NULL
-                AND deployed_url IS NULL
-                AND text_value IS NULL
-                AND submitted_value = token_value
-            )
-            OR (
-                submission_value_kind = 'deployed_url'
-                AND deployed_url IS NOT NULL
-                AND github_url IS NULL
-                AND token_value IS NULL
-                AND text_value IS NULL
-                AND submitted_value = deployed_url
-            )
-            OR (
-                submission_value_kind = 'text'
-                AND text_value IS NOT NULL
-                AND github_url IS NULL
-                AND token_value IS NULL
-                AND deployed_url IS NULL
-                AND submitted_value = text_value
-            )
-            """,
-            name="ck_submissions_typed_value_shape",
-        ),
-        CheckConstraint(
-            """
-            (
-                github_url IS NULL
-                OR length(btrim(github_url)) > 0
-            )
-            AND (
-                deployed_url IS NULL
-                OR length(btrim(deployed_url)) > 0
-            )
-            AND (
-                token_value IS NULL
-                OR length(btrim(token_value)) > 0
-            )
-            AND (
-                text_value IS NULL
-                OR length(btrim(text_value)) > 0
-            )
-            """,
-            name="ck_submissions_typed_value_format",
-        ),
-        ForeignKeyConstraint(
-            ["requirement_uuid", "submission_value_kind"],
-            ["requirements.uuid", "requirements.submission_value_kind"],
-            name="fk_submissions_requirement_value_kind",
-            ondelete="RESTRICT",
-        ),
-        Index(
-            "ix_submissions_user_verified_updated",
-            "user_id",
-            "verification_completed",
-            "updated_at",
-        ),
-        Index(
-            "ix_submissions_user_req_uuid_latest",
-            "user_id",
-            "requirement_uuid",
-            text("created_at DESC"),
-        ),
-    )
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(
-        BigInteger,
-        ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
-    )
-    requirement_uuid: Mapped[UUID] = mapped_column(
-        Uuid(as_uuid=True),
-        ForeignKey(
-            "requirements.uuid",
-            ondelete="RESTRICT",
-            name="fk_submissions_requirement_uuid",
-        ),
-        nullable=False,
-    )
-    submitted_value: Mapped[str] = mapped_column(
-        Text,
-        nullable=False,
-    )
-    submission_value_kind: Mapped[str] = mapped_column(Text, nullable=False)
-    github_url: Mapped[str | None] = mapped_column(Text, nullable=True)
-    token_value: Mapped[str | None] = mapped_column(Text, nullable=True)
-    deployed_url: Mapped[str | None] = mapped_column(Text, nullable=True)
-    text_value: Mapped[str | None] = mapped_column(Text, nullable=True)
-    extracted_username: Mapped[str | None] = mapped_column(
-        String(255),
-        nullable=True,
-    )
-    is_validated: Mapped[bool] = mapped_column(Boolean, default=False)
-    validated_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True),
-        nullable=True,
-    )
-    # True when verification logic actually ran (not blocked by server error).
-    # Only count completed verification attempts.
-    verification_completed: Mapped[bool] = mapped_column(Boolean, default=False)
-    # Structured per-task feedback for multi-task verification
-    # submissions, stored as JSONB. Each element is a TaskResult shape
-    # (``task_name``, ``passed``, ``feedback``, ``next_steps``). Now that
-    # we surface rubric feedback for passing submissions too (#425),
-    # every multi-task verification persists a payload.
-    feedback_json: Mapped[list[dict] | None] = mapped_column(JSONB, nullable=True)
-    # User-facing validation error message (persists across page reloads)
-    validation_message: Mapped[str | None] = mapped_column(String(1024), nullable=True)
-    # Cloud provider for multi-cloud labs ("aws", "azure", "gcp", or None)
-    cloud_provider: Mapped[str | None] = mapped_column(
-        String(16),
-        nullable=True,
-    )
-
-    user: Mapped["User"] = relationship(back_populates="submissions")
-    verification_jobs: Mapped[list["VerificationJob"]] = relationship(
-        back_populates="result_submission"
-    )
-
-
-class VerificationJob(TimestampMixin, Base):
-    """Work-queue marker for asynchronous verification execution.
-
-    A row exists during in-flight Durable orchestration. The persist
-    activity links a ``Submission`` via ``result_submission_id`` when
-    work completes; the poller deletes the row if Durable reports
-    terminal failure. PR4 dropped the legacy ``status`` enum, the
-    ``mark_*`` lifecycle methods, and the Postgres-side error /
-    timestamp columns — Durable owns runtime state, ``Submission``
-    owns the outcome.
-    """
-
-    __tablename__ = "verification_jobs"
-    __table_args__ = (
-        CheckConstraint(
-            """
-            (
-                submission_value_kind = 'github_url'
-                AND github_url IS NOT NULL
-                AND token_value IS NULL
-                AND deployed_url IS NULL
-                AND text_value IS NULL
-                AND submitted_value = github_url
-            )
-            OR (
-                submission_value_kind = 'token'
-                AND token_value IS NOT NULL
-                AND github_url IS NULL
-                AND deployed_url IS NULL
-                AND text_value IS NULL
-                AND submitted_value = token_value
-            )
-            OR (
-                submission_value_kind = 'deployed_url'
-                AND deployed_url IS NOT NULL
-                AND github_url IS NULL
-                AND token_value IS NULL
-                AND text_value IS NULL
-                AND submitted_value = deployed_url
-            )
-            OR (
-                submission_value_kind = 'text'
-                AND text_value IS NOT NULL
-                AND github_url IS NULL
-                AND token_value IS NULL
-                AND deployed_url IS NULL
-                AND submitted_value = text_value
-            )
-            """,
-            name="ck_verification_jobs_typed_value_shape",
-        ),
-        CheckConstraint(
-            """
-            (
-                github_url IS NULL
-                OR length(btrim(github_url)) > 0
-            )
-            AND (
-                deployed_url IS NULL
-                OR length(btrim(deployed_url)) > 0
-            )
-            AND (
-                token_value IS NULL
-                OR length(btrim(token_value)) > 0
-            )
-            AND (
-                text_value IS NULL
-                OR length(btrim(text_value)) > 0
-            )
-            """,
-            name="ck_verification_jobs_typed_value_format",
-        ),
-        ForeignKeyConstraint(
-            ["requirement_uuid", "submission_value_kind"],
-            ["requirements.uuid", "requirements.submission_value_kind"],
-            name="fk_verification_jobs_requirement_value_kind",
-            ondelete="RESTRICT",
-        ),
-        Index(
-            "ix_verification_jobs_user_req_uuid_created",
-            "user_id",
-            "requirement_uuid",
-            "created_at",
-        ),
-        Index(
-            "uq_verification_jobs_active_user_req_uuid",
-            "user_id",
-            "requirement_uuid",
-            unique=True,
-            postgresql_where=text("result_submission_id IS NULL"),
-        ),
-    )
-
-    id: Mapped[UUID] = mapped_column(
-        Uuid(as_uuid=True),
-        primary_key=True,
-        default=uuid4,
-    )
-    user_id: Mapped[int] = mapped_column(
-        BigInteger,
-        ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
-    )
-    requirement_uuid: Mapped[UUID] = mapped_column(
-        Uuid(as_uuid=True),
-        ForeignKey(
-            "requirements.uuid",
-            ondelete="RESTRICT",
-            name="fk_verification_jobs_requirement_uuid",
-        ),
-        nullable=False,
-    )
-    submitted_value: Mapped[str] = mapped_column(Text, nullable=False)
-    submission_value_kind: Mapped[str] = mapped_column(Text, nullable=False)
-    github_url: Mapped[str | None] = mapped_column(Text, nullable=True)
-    token_value: Mapped[str | None] = mapped_column(Text, nullable=True)
-    deployed_url: Mapped[str | None] = mapped_column(Text, nullable=True)
-    text_value: Mapped[str | None] = mapped_column(Text, nullable=True)
-    extracted_username: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    cloud_provider: Mapped[str | None] = mapped_column(String(16), nullable=True)
-    result_submission_id: Mapped[int | None] = mapped_column(
-        Integer,
-        ForeignKey("submissions.id", name="fk_verification_jobs_result_submission_id"),
-        nullable=True,
-    )
-    traceparent: Mapped[str | None] = mapped_column(String(255), nullable=True)
-
-    user: Mapped["User"] = relationship(back_populates="verification_jobs")
-    result_submission: Mapped["Submission | None"] = relationship(
-        back_populates="verification_jobs"
-    )
-
-
-class StepProgress(Base):
-    """Tracks completion of learning steps within topics.
-
-    References the curriculum via ``step_uuid`` (FK to ``steps.uuid``).
-    Phase D.1c (#465) dropped the legacy ``topic_id`` / ``step_id`` /
-    ``phase_id`` / ``step_order`` denormalized columns; that data is now
-    derived from the FK join when needed.
-    """
-
-    __tablename__ = "step_progress"
-    __table_args__ = (
-        UniqueConstraint("user_id", "step_uuid", name="uq_step_progress_user_step"),
-        Index("ix_step_progress_step_uuid", "step_uuid"),
-    )
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[int] = mapped_column(
-        BigInteger,
-        ForeignKey("users.id", ondelete="CASCADE"),
-        nullable=False,
-    )
-    step_uuid: Mapped[UUID] = mapped_column(
-        Uuid(as_uuid=True),
-        ForeignKey(
-            "steps.uuid",
-            ondelete="RESTRICT",
-            name="fk_step_progress_step_uuid",
-        ),
-        nullable=False,
-    )
-    completed_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        default=utcnow,
-    )
-
-    user: Mapped["User"] = relationship(back_populates="step_progress")
 
 
 class LearnerStepCompletion(Base):
@@ -491,20 +103,15 @@ class LearnerStepCompletion(Base):
         ForeignKey("users.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    step_uuid: Mapped[UUID] = mapped_column(
-        Uuid(as_uuid=True),
-        primary_key=True,
-    )
+    step_uuid: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
     completed_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=utcnow,
     )
 
-    user: Mapped["User"] = relationship()
-
 
 class VerificationAttempt(TimestampMixin, Base):
-    """Persist a verification attempt using its UUID as the Durable instance ID."""
+    """One verification attempt, keyed by its Durable instance UUID."""
 
     __tablename__ = "verification_attempts"
     __table_args__ = (
@@ -529,9 +136,6 @@ class VerificationAttempt(TimestampMixin, Base):
             "snapshot_source IN ('submitted', 'reconstructed')",
             name="ck_verification_attempts_snapshot_source",
         ),
-        # New ``submitted`` attempts must carry a real requirement snapshot
-        # and its hash. ``reconstructed`` migrated history may honestly
-        # leave the artifact metadata NULL.
         CheckConstraint(
             "snapshot_source = 'reconstructed' OR ("
             "requirement_snapshot IS NOT NULL "
@@ -569,14 +173,8 @@ class VerificationAttempt(TimestampMixin, Base):
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
     )
-    requirement_uuid: Mapped[UUID] = mapped_column(
-        Uuid(as_uuid=True),
-        nullable=False,
-    )
+    requirement_uuid: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), nullable=False)
 
-    # Identity / snapshot of the curriculum artifact and requirement.
-    # Text/BigInteger throughout to satisfy squawk's prefer-text-field and
-    # prefer-bigint-over-int safety rules for new columns.
     artifact_schema_version: Mapped[int | None] = mapped_column(
         BigInteger, nullable=True
     )
@@ -587,14 +185,12 @@ class VerificationAttempt(TimestampMixin, Base):
     snapshot_source: Mapped[str] = mapped_column(Text, nullable=False)
     payload_version: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
 
-    # Submitted identity / value.
     github_username_snapshot: Mapped[str | None] = mapped_column(Text, nullable=True)
     submission_value_kind: Mapped[str] = mapped_column(Text, nullable=False)
     submitted_value: Mapped[str] = mapped_column(Text, nullable=False)
     cloud_provider: Mapped[str | None] = mapped_column(Text, nullable=True)
     traceparent: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    # Lifecycle / result.
     outcome: Mapped[str | None] = mapped_column(Text, nullable=True)
     started_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
@@ -606,255 +202,3 @@ class VerificationAttempt(TimestampMixin, Base):
     validation_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
     terminal_source: Mapped[str | None] = mapped_column(Text, nullable=True)
-
-    legacy_job_id: Mapped[UUID | None] = mapped_column(
-        Uuid(as_uuid=True), nullable=True
-    )
-    legacy_submission_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
-
-    user: Mapped["User"] = relationship()
-
-
-# ---------------------------------------------------------------------------
-# Curriculum tables (issue #463 / Phase B of #461)
-#
-# These tables hold the curriculum content authored in YAML. The sync
-# function writes to them on deploy; the app reads from them at runtime
-# via content_db_loader (Phase C).
-#
-# All curriculum entities:
-#   * use UUID primary keys (issue #462)
-#   * support soft-delete via ``deleted_at`` (Q3 of #461)
-#   * use ON DELETE RESTRICT on FKs (Q4 of #461)
-# Topics, steps, and requirements carry a ``slug`` -- the kebab-case
-# human-readable id from YAML (matches the YAML filename or the inline
-# slug field). Phases use ``slug`` (e.g. "phase0") + ``order`` (int 0-6)
-# as the human keys; learning_objectives are identified solely by uuid.
-# ---------------------------------------------------------------------------
-
-
-class CurriculumPhase(TimestampMixin, Base):
-    """A curriculum phase (stored copy of YAML _phase.yaml metadata)."""
-
-    __tablename__ = "phases"
-    __table_args__ = (
-        Index(
-            "uq_phases_slug_active",
-            "slug",
-            unique=True,
-            postgresql_where=text("deleted_at IS NULL"),
-        ),
-    )
-
-    uuid: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
-    slug: Mapped[str] = mapped_column(Text, nullable=False)
-    name: Mapped[str] = mapped_column(Text, nullable=False)
-    description: Mapped[str] = mapped_column(Text, nullable=False)
-    short_description: Mapped[str] = mapped_column(Text, nullable=False)
-    order: Mapped[int] = mapped_column(BigInteger, nullable=False)
-    deleted_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-
-
-class CurriculumTopic(TimestampMixin, Base):
-    """A topic within a curriculum phase."""
-
-    __tablename__ = "topics"
-    __table_args__ = (
-        Index(
-            "uq_topics_phase_slug_active",
-            "phase_uuid",
-            "slug",
-            unique=True,
-            postgresql_where=text("deleted_at IS NULL"),
-        ),
-    )
-
-    uuid: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
-    phase_uuid: Mapped[UUID] = mapped_column(
-        Uuid(as_uuid=True),
-        ForeignKey("phases.uuid", ondelete="RESTRICT", name="fk_topics_phase_uuid"),
-        nullable=False,
-    )
-    slug: Mapped[str] = mapped_column(Text, nullable=False)
-    name: Mapped[str] = mapped_column(Text, nullable=False)
-    description: Mapped[str] = mapped_column(Text, nullable=False)
-    order: Mapped[int] = mapped_column(BigInteger, nullable=False)
-    deleted_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-
-
-class CurriculumStep(TimestampMixin, Base):
-    """A learning step within a curriculum topic."""
-
-    __tablename__ = "steps"
-    __table_args__ = (
-        Index(
-            "uq_steps_topic_order_active",
-            "topic_uuid",
-            "order",
-            unique=True,
-            postgresql_where=text("deleted_at IS NULL"),
-        ),
-    )
-
-    uuid: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
-    topic_uuid: Mapped[UUID] = mapped_column(
-        Uuid(as_uuid=True),
-        ForeignKey("topics.uuid", ondelete="RESTRICT", name="fk_steps_topic_uuid"),
-        nullable=False,
-    )
-    slug: Mapped[str] = mapped_column(Text, nullable=False)
-    order: Mapped[int] = mapped_column(BigInteger, nullable=False)
-    action: Mapped[str | None] = mapped_column(Text, nullable=True)
-    title: Mapped[str | None] = mapped_column(Text, nullable=True)
-    url: Mapped[str | None] = mapped_column(Text, nullable=True)
-    description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    code: Mapped[str | None] = mapped_column(Text, nullable=True)
-    # Bundled per-step extras (options, checklist, tips, done_when).
-    # Bundled rather than split out because Phase B doesn't need to query
-    # these individually; split later if Phase C-and-beyond needs it.
-    extra_config: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    deleted_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-
-
-class CurriculumLearningObjective(TimestampMixin, Base):
-    """A learning objective for a curriculum topic."""
-
-    __tablename__ = "learning_objectives"
-    __table_args__ = (
-        Index(
-            "uq_learning_objectives_topic_order_active",
-            "topic_uuid",
-            "order",
-            unique=True,
-            postgresql_where=text("deleted_at IS NULL"),
-        ),
-    )
-
-    uuid: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
-    topic_uuid: Mapped[UUID] = mapped_column(
-        Uuid(as_uuid=True),
-        ForeignKey(
-            "topics.uuid",
-            ondelete="RESTRICT",
-            name="fk_learning_objectives_topic_uuid",
-        ),
-        nullable=False,
-    )
-    text_: Mapped[str] = mapped_column("text", Text, nullable=False)
-    order: Mapped[int] = mapped_column(BigInteger, nullable=False)
-    deleted_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-
-
-class CurriculumRequirement(TimestampMixin, Base):
-    """A hands-on requirement for a curriculum phase.
-
-    The ``submission_type`` is stored as plain text rather than the
-    SubmissionType enum because the canonical type-discrimination
-    lives in the Pydantic discriminated union (#470), which keeps
-    type_config aligned. The DB just stores whatever string the sync
-    wrote.
-    """
-
-    __tablename__ = "requirements"
-    __table_args__ = (
-        # 'github_profile' is a retired submission type kept in this list on
-        # purpose: soft-deleted historical rows still carry it, so tightening the
-        # constraint would require deleting data. The type is gone from the
-        # SubmissionType enum and the tolerant content loader skips it.
-        CheckConstraint(
-            """
-            (
-                submission_type IN (
-                    'github_profile',
-                    'profile_readme',
-                    'repo_fork',
-                    'journal_api_verifier',
-                    'devops_analysis',
-                    'security_scanning',
-                    'ci_status'
-                )
-                AND submission_value_kind = 'github_url'
-            )
-            OR (
-                submission_type IN (
-                    'ctf_token',
-                    'networking_token',
-                    'iac_token'
-                )
-                AND submission_value_kind = 'token'
-            )
-            OR (
-                submission_type = 'deployed_api'
-                AND submission_value_kind = 'deployed_url'
-            )
-            OR (
-                submission_type IN (
-                    'career_reflection',
-                    'deployment_architecture'
-                )
-                AND submission_value_kind = 'text'
-            )
-            """,
-            name="ck_requirements_submission_value_kind_matches_type",
-        ),
-        Index(
-            "uq_requirements_phase_slug_active",
-            "phase_uuid",
-            "slug",
-            unique=True,
-            postgresql_where=text("deleted_at IS NULL"),
-        ),
-        # Requirement slugs are globally unique: they show up in URLs,
-        # log lines, and ad-hoc queries, so two requirements sharing a
-        # slug in different phases would be too easy to confuse. The
-        # FK from submissions/verification_jobs targets uuid, so this
-        # invariant is for humans, not the schema.
-        Index(
-            "uq_requirements_slug_active",
-            "slug",
-            unique=True,
-            postgresql_where=text("deleted_at IS NULL"),
-        ),
-        UniqueConstraint(
-            "uuid",
-            "submission_value_kind",
-            name="uq_requirements_uuid_value_kind",
-        ),
-    )
-
-    uuid: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True)
-    phase_uuid: Mapped[UUID] = mapped_column(
-        Uuid(as_uuid=True),
-        ForeignKey(
-            "phases.uuid",
-            ondelete="RESTRICT",
-            name="fk_requirements_phase_uuid",
-        ),
-        nullable=False,
-    )
-    slug: Mapped[str] = mapped_column(Text, nullable=False)
-    name: Mapped[str] = mapped_column(Text, nullable=False)
-    description: Mapped[str] = mapped_column(Text, nullable=False)
-    submission_type: Mapped[str] = mapped_column(Text, nullable=False)
-    submission_value_kind: Mapped[str] = mapped_column(Text, nullable=False)
-    order: Mapped[int] = mapped_column(
-        BigInteger,
-        nullable=False,
-        server_default=text("0"),
-    )
-    type_config: Mapped[dict] = mapped_column(
-        JSONB,
-        nullable=False,
-        server_default=text("'{}'::jsonb"),
-    )
-    deleted_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )


### PR DESCRIPTION
## Why

After #666 removes every caller and is fully deployed, the drained compatibility schema can be contracted without a rolling-deployment race. ORM definitions must be removed in this same layer to preserve Alembic model/DDL parity.

## What changed

- fail before contraction if legacy jobs, submissions, outcomes, or checked steps are not fully reconciled
- drop temporary bridge triggers and security-definer functions
- drop attempt provenance columns and legacy learner-state tables
- drop all database curriculum tables
- remove the matching unused ORM definitions and assert the final schema
- keep downgrade intentionally unsupported because dropped history cannot be recreated honestly

## Stack position

Final layer. Merge and deploy only after #666 API and Functions revisions are fully active.

## Validation

`uv run poe check`, including migration-chain, model/DDL parity, and Squawk checks