### PR TITLE
Recover packaged curriculum deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -215,6 +215,9 @@ jobs:
             exit 1
           fi
 
+      - name: Validate installed shared runtime package
+        run: uv run poe package-smoke
+
       - name: Verify single migration head (no branches)
         working-directory: api
         run: |
@@ -463,24 +466,17 @@ jobs:
             -t ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:${{ github.sha }} \
             -t ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:latest .
 
-          docker run --rm -i ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }} python - <<'PY'
-          from importlib.resources import files
-          from pathlib import Path
-
-          phases_path = Path(
-              str(files("learn_to_cloud_shared").joinpath("content", "phases"))
-          )
-          assert not phases_path.exists(), f"API image contains YAML at {phases_path}"
-          PY
+          docker run --rm \
+            ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }} \
+            python -m learn_to_cloud_shared.runtime_package_check
 
           docker run --rm -i \
             -e DATABASE__URL="postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud" \
             ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:${{ github.sha }} \
             python - <<'PY'
-          from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
+          from learn_to_cloud_shared.runtime_package_check import main
 
-          catalog = get_curriculum_catalog()
-          assert catalog.phases, "Migration image did not load the curriculum artifact"
+          main()
           PY
 
           docker push ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -430,13 +430,6 @@ jobs:
           import function_app
           PY
 
-      - name: Deploy verification Functions
-        uses: Azure/functions-action@bc63708cc6539760eea18d8a7de4ce8ef5fdf593 # v1
-        with:
-          app-name: ${{ needs.terraform.outputs.verification_functions_name }}
-          package: apps/verification-functions
-          remote-build: false
-
       - name: Log in to ACR
         run: az acr login --name ${{ needs.terraform.outputs.container_registry_name }}
 
@@ -484,10 +477,10 @@ jobs:
             -e DATABASE__URL="postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud" \
             ${{ needs.terraform.outputs.container_registry_endpoint }}/migrations:${{ github.sha }} \
             python - <<'PY'
-          from learn_to_cloud_shared.content_yaml_loader import get_all_phases_from_yaml
+          from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
 
-          phases = get_all_phases_from_yaml()
-          assert phases, "Migration image did not load curriculum phases"
+          catalog = get_curriculum_catalog()
+          assert catalog.phases, "Migration image did not load the curriculum artifact"
           PY
 
           docker push ${{ needs.terraform.outputs.container_registry_endpoint }}/api:${{ github.sha }}
@@ -566,6 +559,13 @@ jobs:
             --tail 100 \
             --format text || true
           exit 1
+
+      - name: Deploy verification Functions
+        uses: Azure/functions-action@bc63708cc6539760eea18d8a7de4ce8ef5fdf593 # v1
+        with:
+          app-name: ${{ needs.terraform.outputs.verification_functions_name }}
+          package: apps/verification-functions
+          remote-build: false
 
       - name: Deploy to Container App
         run: |

--- a/build-out-notes.md
+++ b/build-out-notes.md
@@ -55,12 +55,21 @@ its tests are removed.
 ## PR 9/10: Deployment-safe contract split
 
 The plan combined removal of every legacy caller with the table-drop migration
-in PR 9. The deployment workflow runs migrations before deploying new API and
-Functions revisions, so that ordering could drop tables while PR 8 replicas
-were still serving traffic.
+in PR 9. The deployment workflow runs migrations before updating the API, so
+that ordering could drop tables while PR 8 replicas were still serving traffic.
 
 The contract is therefore split into two deployments. PR 9 removes runtime and
 pipeline callers while leaving the drained tables and their unused ORM
 definitions in place. PR 10 removes those definitions alongside the final
 schema drop and its migration assertions, and must deploy after the PR 9 API
 and Functions revisions are fully active.
+
+## Post-merge deploy recovery
+
+The PR 9 deployment failed before migrations because an image smoke check still
+loaded authored curriculum YAML. Runtime images now intentionally omit that
+source content, so the check now loads the packaged curriculum artifact.
+
+The failure also exposed that Functions deployed before image validation and
+database migrations. Functions deployment now follows successful migrations,
+preventing new Function code from running against an older schema.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/runtime_package_check.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/runtime_package_check.py
@@ -1,0 +1,23 @@
+"""Validate the installed shared package's runtime curriculum contract."""
+
+from importlib.resources import files
+from pathlib import Path
+
+from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
+
+
+def main() -> None:
+    """Verify the compiled curriculum exists and authored YAML does not."""
+    catalog = get_curriculum_catalog()
+    if not catalog.phases:
+        raise RuntimeError("Runtime package did not load the curriculum artifact.")
+
+    phases_path = Path(
+        str(files("learn_to_cloud_shared").joinpath("content", "phases"))
+    )
+    if phases_path.exists():
+        raise RuntimeError(f"Runtime package contains authored YAML at {phases_path}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,19 @@ set -e
 (cd apps/verification-functions && uv run pytest tests/)
 """
 
+[tool.poe.tasks.package-smoke]
+help = "Build and validate the installed shared runtime package"
+shell = """
+set -euo pipefail
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+uv build --package learn-to-cloud-shared --wheel --out-dir "$tmpdir"
+wheel=$(find "$tmpdir" -maxdepth 1 -name '*.whl' -print -quit)
+uv venv "$tmpdir/venv"
+uv pip install --python "$tmpdir/venv/bin/python" "$wheel"
+"$tmpdir/venv/bin/python" -m learn_to_cloud_shared.runtime_package_check
+"""
+
 [tool.poe.tasks.check]
-help = "Run the full quality gate: static checks then tests"
-sequence = ["static", "test"]
+help = "Run the full quality gate: static checks, package smoke, then tests"
+sequence = ["static", "package-smoke", "test"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ set -e
 [tool.poe.tasks.package-smoke]
 help = "Build and validate the installed shared runtime package"
 shell = """
-set -euo pipefail
+set -eu
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 uv build --package learn-to-cloud-shared --wheel --out-dir "$tmpdir"


### PR DESCRIPTION
## Why

The #666 production deploy failed while validating the migration image because the check still loaded authored curriculum YAML. Runtime images intentionally exclude YAML after the packaged curriculum cutover. Verification Functions had already deployed before the failure, while migrations and the API rollout were skipped.

Failed run: https://github.com/learntocloud/learn-to-cloud-app/actions/runs/29430077454

## What changed

- validate the packaged `curriculum.json` catalog instead of unavailable YAML
- deploy verification Functions only after image validation and successful migrations
- add one reusable installed-package checker for local, PR CI, and container smoke validation
- build and install the shared wheel in isolation during `uv run poe check`
- record the recovery deviation in `build-out-notes.md`

## Validation

- `uv run poe check`
- isolated wheel smoke confirms `curriculum.json` loads and authored phase YAML is excluded
- DevOps review found no actionable rollout issues

## Recovery

Merge this PR before #667. Its `main` deployment will apply migrations 0049-0054, redeploy Functions against the migrated schema, and roll out the #666 API revision.