### PR TITLE
Remove retired compatibility paths

### DIFF
--- a/.github/agents/dog-food.agent.md
+++ b/.github/agents/dog-food.agent.md
@@ -30,12 +30,11 @@ Run Steps 1–3, then Step 5 (Submission Test), then Step 6.
 
 | Phase | Requirement ID | Submission Type | Needs Functions? | Value source |
 |-------|---------------|-----------------|-----------------|--------------|
-| 0 | `github-profile` | `github_profile` | No | Auto-derived from username |
-| 1 | `profile-readme` | `profile_readme` | No | Auto-derived from username |
-| 1 | `linux-ctfs-fork` | `repo_fork` | No | Auto-derived from username |
-| 1 | `linux-ctfs-token` | `ctf_token` | No | Token — user must provide |
-| 2 | `networking-lab-fork` | `repo_fork` | No | Auto-derived from username |
-| 2 | `networking-lab-token` | `networking_token` | No | Token — user must provide |
+| 1 | `profile-readme` | `profile_readme` | **Yes** | Auto-derived from username |
+| 1 | `linux-ctfs-fork` | `repo_fork` | **Yes** | Auto-derived from username |
+| 1 | `linux-ctfs-token` | `ctf_token` | **Yes** | Token — user must provide |
+| 2 | `networking-lab-fork` | `repo_fork` | **Yes** | Auto-derived from username |
+| 2 | `networking-lab-token` | `networking_token` | **Yes** | Token — user must provide |
 | 3 | `journal-api-implementation` | `journal_api_verifier` | **Yes** | Auto-derived from username |
 | 4 | `deployed-journal-api` | `deployed_api` | **Yes** | URL — user must provide |
 | 5 | `devops-implementation` | `devops_analysis` | **Yes** | Auto-derived from username |

--- a/README.md
+++ b/README.md
@@ -136,8 +136,6 @@ Or use VS Code's **"API + Verification"** compound launch configuration.
 │   ├── src/
 │   │   └── learn_to_cloud/
 │   │       ├── main.py       # App entry point
-│   │       ├── models.py     # Compatibility imports for shared models
-│   │       ├── schemas.py    # Compatibility imports for shared schemas
 │   │       ├── routes/       # API + page endpoints
 │   │       ├── services/     # Business logic
 │   │       ├── repositories/ # Database queries

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -227,8 +227,7 @@ async def create_verification_attempt(
 
     The advisory lock serializes concurrent submits for the same
     requirement so two racing requests can never both pass the active/succeeded
-    checks and create two active attempts. New attempts no longer create a
-    compatibility ``verification_jobs`` row.
+    checks and create two active attempts.
     """
     ctx = await _check_submission_preconditions(
         session_maker,

--- a/api/src/learn_to_cloud/templates/partials/requirement_card.html
+++ b/api/src/learn_to_cloud/templates/partials/requirement_card.html
@@ -107,7 +107,7 @@
             id="input-{{ requirement.slug }}"
             type="text"
             name="submitted_value"
-            placeholder="{{ requirement.placeholder | default('Paste your completion token here') }}"
+            placeholder="{{ requirement.type_config.placeholder | default('Paste your completion token here') }}"
             value=""
             class="flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             required
@@ -119,7 +119,7 @@
             id="input-{{ requirement.slug }}"
             type="url"
             name="submitted_value"
-            placeholder="{{ requirement.placeholder | default('https://your-api.example.com') }}"
+            placeholder="{{ requirement.type_config.placeholder | default('https://your-api.example.com') }}"
             value="{% if submission %}{{ submission.submitted_value }}{% endif %}"
             class="flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             required

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -38,6 +38,7 @@ def _requirement(slug: str, name: str) -> SimpleNamespace:
         name=name,
         description="",
         submission_type=SubmissionType.CTF_TOKEN,
+        type_config=SimpleNamespace(placeholder=None),
     )
 
 

--- a/api/tests/services/test_progress_service.py
+++ b/api/tests/services/test_progress_service.py
@@ -3,7 +3,7 @@
 Tests cover:
 - compute_topic_progress status derivation and stale-step filtering
 - phase_progress_to_data status mapping
-- fetch_user_progress DB assembly (authoritative + narrow legacy fallback)
+- fetch_user_progress DB assembly from authoritative learner state
 - fetch_phase_progress per-topic breakdown, including zero-requirement phases
 - both-measures phase completion (learning AND verification)
 - find_first_incomplete_step / resolve_continue_destination

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -191,8 +191,7 @@ class TestSubmissionValidationErrors:
 class TestAlreadyValidatedShortCircuit:
     @pytest.mark.asyncio
     async def test_already_validated_raises_error(self):
-        """Authoritative-or-legacy succeeded (via ``are_all_requirements_succeeded``)
-        short-circuits before any attempt is created."""
+        """A succeeded attempt short-circuits before another attempt is created."""
         mock_session_maker = _mock_session_maker()
         mock_requirement = _make_mock_requirement()
 

--- a/apps/verification-functions/tests/test_attempt_orchestrations.py
+++ b/apps/verification-functions/tests/test_attempt_orchestrations.py
@@ -20,6 +20,7 @@ from learn_to_cloud_shared.models import VerificationAttemptOutcome
 from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     AttemptStatusRow,
 )
+from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.testing.requirement_factories import (
     journal_api_verifier_requirement,
     repo_fork_requirement,
@@ -29,7 +30,7 @@ from learn_to_cloud_shared.verification_workflow import PreparedVerificationAtte
 
 
 # --------------------------------------------------------------------------- #
-# Orchestration driver (mirrors the legacy orchestration test harness)
+# Orchestration driver
 # --------------------------------------------------------------------------- #
 
 
@@ -97,7 +98,7 @@ def _prepared_payload(requirement: Any, value: str) -> dict[str, object]:
         user_id=1,
         github_username="alice",
         requirement=requirement,
-        submitted_value=value,
+        submitted_value=SubmittedValue.from_raw(requirement, value),
     )
     return job.to_payload()
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -310,12 +310,6 @@ class _RequirementBase(StrictFrozenModel):
     name: str
     description: str
 
-    @property
-    def placeholder(self) -> str | None:
-        """Backwards-compat shim: read ``type_config.placeholder`` if any."""
-        cfg = getattr(self, "type_config", None)
-        return getattr(cfg, "placeholder", None) if cfg is not None else None
-
 
 class ProfileReadmeRequirement(_RequirementBase):
     submission_type: Literal[SubmissionType.PROFILE_README]

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Protocol
 from urllib.parse import urlparse
 
 from learn_to_cloud_shared.models import SubmissionType, SubmissionValueKind
@@ -16,12 +15,10 @@ _GITHUB_URL_TYPES = {
     SubmissionType.JOURNAL_API_VERIFIER.value,
     SubmissionType.DEVOPS_ANALYSIS.value,
     SubmissionType.SECURITY_SCANNING.value,
-    "ci_status",
 }
 _TOKEN_TYPES = {
     SubmissionType.CTF_TOKEN.value,
     SubmissionType.NETWORKING_TOKEN.value,
-    "iac_token",
 }
 _DEPLOYED_URL_TYPES = {SubmissionType.DEPLOYED_API.value}
 _TEXT_TYPES = {
@@ -34,18 +31,9 @@ _TEXT_TYPES = {
 _MAX_TEXT_LENGTH = 20_000
 
 
-class SubmittedValueColumns(Protocol):
-    submission_value_kind: str
-    github_url: str | None
-    token_value: str | None
-    deployed_url: str | None
-    text_value: str | None
-    submitted_value: str
-
-
 @dataclass(frozen=True, slots=True)
 class SubmittedValue:
-    """A submitted value normalized into its database storage shape."""
+    """A submitted value normalized into its typed representation."""
 
     kind: SubmissionValueKind
     github_url: str | None = None
@@ -68,9 +56,9 @@ class SubmittedValue:
             raise ValueError(f"Missing value for {self.kind.value}")
         return value
 
-    def to_columns(self) -> dict[str, str | None]:
+    def to_payload(self) -> dict[str, str | None]:
+        """Serialize the typed value for Durable workflow transport."""
         return {
-            "submitted_value": self.as_text,
             "submission_value_kind": self.kind.value,
             "github_url": self.github_url,
             "token_value": self.token_value,
@@ -78,11 +66,9 @@ class SubmittedValue:
             "text_value": self.text_value,
         }
 
-    def to_payload(self) -> dict[str, str | None]:
-        return self.to_columns()
-
     @classmethod
     def from_payload(cls, payload: object) -> SubmittedValue:
+        """Deserialize a typed Durable workflow value."""
         if not isinstance(payload, Mapping):
             raise TypeError("Expected submission_value payload object")
         payload_map: dict[str, object] = {}
@@ -93,19 +79,27 @@ class SubmittedValue:
         kind = payload_map.get("submission_value_kind")
         if not isinstance(kind, str):
             raise TypeError("Expected submission_value_kind payload field")
-        return cls.from_columns(
-            kind=kind,
-            github_url=_optional_str(payload_map.get("github_url"), "github_url"),
-            token_value=_optional_str(payload_map.get("token_value"), "token_value"),
-            deployed_url=_optional_str(
-                payload_map.get("deployed_url"),
-                "deployed_url",
-            ),
-            text_value=_optional_str(payload_map.get("text_value"), "text_value"),
-            legacy_value=_optional_str(
-                payload_map.get("submitted_value"),
-                "submitted_value",
-            ),
+        normalized_kind = SubmissionValueKind(kind)
+        github_url = _optional_str(payload_map.get("github_url"), "github_url")
+        token_value = _optional_str(payload_map.get("token_value"), "token_value")
+        deployed_url = _optional_str(
+            payload_map.get("deployed_url"),
+            "deployed_url",
+        )
+        text_value = _optional_str(payload_map.get("text_value"), "text_value")
+        _single_value_for_kind(
+            normalized_kind,
+            github_url=github_url,
+            token_value=token_value,
+            deployed_url=deployed_url,
+            text_value=text_value,
+        )
+        return cls(
+            kind=normalized_kind,
+            github_url=github_url,
+            token_value=token_value,
+            deployed_url=deployed_url,
+            text_value=text_value,
         )
 
     @classmethod
@@ -157,37 +151,6 @@ class SubmittedValue:
             case SubmissionValueKind.TEXT:
                 return cls(kind=normalized_kind, text_value=value)
 
-    @classmethod
-    def from_columns(
-        cls,
-        *,
-        kind: str | SubmissionValueKind,
-        github_url: str | None,
-        token_value: str | None,
-        deployed_url: str | None,
-        text_value: str | None = None,
-        legacy_value: str | None = None,
-    ) -> SubmittedValue:
-        normalized_kind = (
-            kind if isinstance(kind, SubmissionValueKind) else SubmissionValueKind(kind)
-        )
-        value = _single_value_for_kind(
-            normalized_kind,
-            github_url=github_url,
-            token_value=token_value,
-            deployed_url=deployed_url,
-            text_value=text_value,
-        )
-        if legacy_value is not None and legacy_value != value:
-            raise ValueError("Legacy submitted_value does not match typed value")
-        return cls(
-            kind=normalized_kind,
-            github_url=github_url,
-            token_value=token_value,
-            deployed_url=deployed_url,
-            text_value=text_value,
-        )
-
 
 def value_kind_for_submission_type(
     submission_type: SubmissionType | str,
@@ -206,17 +169,6 @@ def value_kind_for_submission_type(
     if raw_type in _TEXT_TYPES:
         return SubmissionValueKind.TEXT
     raise ValueError(f"Unknown submission_type for submitted value: {raw_type!r}")
-
-
-def submission_value_from_columns(row: SubmittedValueColumns) -> SubmittedValue:
-    return SubmittedValue.from_columns(
-        kind=row.submission_value_kind,
-        github_url=row.github_url,
-        token_value=row.token_value,
-        deployed_url=row.deployed_url,
-        text_value=row.text_value,
-        legacy_value=row.submitted_value,
-    )
 
 
 def _optional_str(value: object, field_name: str) -> str | None:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ci_status.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ci_status.py
@@ -27,9 +27,9 @@ import httpx
 from opentelemetry import trace
 
 from learn_to_cloud_shared.schemas import ValidationResult
+from learn_to_cloud_shared.verification.errors import github_error_to_result
 from learn_to_cloud_shared.verification.github_http import (
     RETRIABLE_EXCEPTIONS,
-    github_error_to_validation_result,
 )
 from learn_to_cloud_shared.verification.workflow_runs import (
     WorkflowRuns,
@@ -89,7 +89,7 @@ async def verify_ci_status(
                     ),
                 )
             span.record_exception(e)
-            return github_error_to_validation_result(
+            return github_error_to_result(
                 e,
                 event="ci_status.api_error",
                 context={"owner": owner, "repo": repo},

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/codeql_status.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/codeql_status.py
@@ -35,9 +35,9 @@ import httpx
 from opentelemetry import trace
 
 from learn_to_cloud_shared.schemas import ValidationResult
+from learn_to_cloud_shared.verification.errors import github_error_to_result
 from learn_to_cloud_shared.verification.github_http import (
     RETRIABLE_EXCEPTIONS,
-    github_error_to_validation_result,
 )
 from learn_to_cloud_shared.verification.repo_ref import RepoRef, default_repo_ref
 from learn_to_cloud_shared.verification.workflow_runs import (
@@ -96,7 +96,7 @@ async def verify_codeql_status(
                     ),
                 )
             span.record_exception(e)
-            return github_error_to_validation_result(
+            return github_error_to_result(
                 e,
                 event="codeql_status.api_error",
                 context={"owner": owner, "repo": repo},
@@ -165,7 +165,7 @@ async def verify_codeql_status(
                     ),
                 )
             span.record_exception(e)
-            return github_error_to_validation_result(
+            return github_error_to_result(
                 e,
                 event="codeql_status.api_error",
                 context={"owner": owner, "repo": repo},

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/devops_analysis.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/devops_analysis.py
@@ -10,10 +10,10 @@ import httpx
 from opentelemetry import trace
 
 from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
+from learn_to_cloud_shared.verification.errors import github_error_to_result
 from learn_to_cloud_shared.verification.evidence import truncate_to_bytes
 from learn_to_cloud_shared.verification.github_http import (
     RETRIABLE_EXCEPTIONS,
-    github_error_to_validation_result,
 )
 from learn_to_cloud_shared.verification.graders import grade_indicator_task
 from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
@@ -253,7 +253,7 @@ async def run_devops_workflow(
                     ),
                 )
             span.record_exception(e)
-            return github_error_to_validation_result(
+            return github_error_to_result(
                 e,
                 event="devops_analysis.repo_tree_error",
                 context={"owner": owner, "repo": repo},

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -997,7 +997,7 @@ async def run_profile(
     context = StepContext(
         job=job,
         repository=job.target,
-        submitted_value=job.typed_submitted_value.as_text,
+        submitted_value=job.submitted_value.as_text,
         repo_files=repo_files,
     )
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_http.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_http.py
@@ -27,17 +27,10 @@ from learn_to_cloud_shared.core.config import get_worker_settings
 from learn_to_cloud_shared.core.github_client import (
     get_github_client as _get_github_client,
 )
-from learn_to_cloud_shared.verification.errors import (
-    GitHubServerError,
-    github_error_to_result,
-    make_retriable,
-)
+from learn_to_cloud_shared.verification.errors import GitHubServerError, make_retriable
 
 # Exceptions that should trigger retry.
 RETRIABLE_EXCEPTIONS: tuple[type[Exception], ...] = make_retriable(GitHubServerError)
-
-# Re-export under the historical name used across verification modules.
-github_error_to_validation_result = github_error_to_result
 
 
 def _parse_retry_after(header_value: str | None) -> float | None:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
@@ -17,9 +17,9 @@ from opentelemetry import trace
 
 from learn_to_cloud_shared.github_target import GitHubTarget
 from learn_to_cloud_shared.schemas import ValidationResult
+from learn_to_cloud_shared.verification.errors import github_error_to_result
 from learn_to_cloud_shared.verification.github_http import (
     RETRIABLE_EXCEPTIONS,
-    github_error_to_validation_result,
 )
 from learn_to_cloud_shared.verification.github_metadata import (
     GitHubMetadata,
@@ -32,7 +32,6 @@ __all__ = [
     "check_github_url_exists",
     "check_repo_is_fork_of",
     "default_github_metadata",
-    "github_error_to_validation_result",
     "validate_profile_readme",
     "validate_repo_fork",
 ]
@@ -130,7 +129,7 @@ async def check_repo_is_fork_of(
     except httpx.HTTPStatusError as e:
         span = trace.get_current_span()
         span.record_exception(e)
-        return github_error_to_validation_result(
+        return github_error_to_result(
             e,
             event="fork_check.api_error",
             context={"username": username, "repo": repo_name},

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/grading_requests.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/grading_requests.py
@@ -4,8 +4,7 @@ Kept dependency-light on purpose: it imports only schemas and task
 definitions, never ``verification_workflow``. That lets the workflow transport
 carry :class:`LLMGradingRequest`s on ``VerificationRunResult`` (so the engine
 can record grading requests on the verify result) without an import cycle,
-and lets both the engine and the legacy grading probe build the LLM prompt
-from one place.
+and keeps prompt construction shared with the grading activity.
 """
 
 from __future__ import annotations

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_workflow.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_workflow.py
@@ -34,15 +34,7 @@ class PreparedVerificationAttempt:
     user_id: int
     github_username: str | None
     requirement: HandsOnRequirement
-    submitted_value: SubmittedValue | str
-
-    def __post_init__(self) -> None:
-        if isinstance(self.submitted_value, str):
-            object.__setattr__(
-                self,
-                "submitted_value",
-                SubmittedValue.from_raw(self.requirement, self.submitted_value),
-            )
+    submitted_value: SubmittedValue
 
     def to_payload(self) -> dict[str, object]:
         return {
@@ -50,15 +42,8 @@ class PreparedVerificationAttempt:
             "user_id": self.user_id,
             "github_username": self.github_username,
             "requirement": self.requirement.model_dump(mode="json"),
-            "submitted_value": self.typed_submitted_value.as_text,
-            "submission_value": self.typed_submitted_value.to_payload(),
+            "submission_value": self.submitted_value.to_payload(),
         }
-
-    @property
-    def typed_submitted_value(self) -> SubmittedValue:
-        if isinstance(self.submitted_value, str):
-            return SubmittedValue.from_raw(self.requirement, self.submitted_value)
-        return self.submitted_value
 
     @property
     def target(self) -> GitHubTarget | None:
@@ -77,14 +62,7 @@ class PreparedVerificationAttempt:
                 else None
             ),
             requirement=requirement,
-            submitted_value=(
-                SubmittedValue.from_payload(payload["submission_value"])
-                if "submission_value" in payload
-                else SubmittedValue.from_raw(
-                    requirement,
-                    _expect_str(payload["submitted_value"], "submitted_value"),
-                )
-            ),
+            submitted_value=SubmittedValue.from_payload(payload["submission_value"]),
         )
 
 

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_payload_roundtrip.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_payload_roundtrip.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 
+from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.testing.requirement_factories import (
     deployed_api_requirement,
     profile_readme_requirement,
@@ -17,28 +18,34 @@ from learn_to_cloud_shared.verification_workflow import PreparedVerificationAtte
 @pytest.mark.unit
 class TestPreparedVerificationAttemptRoundTrip:
     def test_repo_fork_requirement_round_trip(self) -> None:
+        requirement = repo_fork_requirement(slug="my-fork", required_repo="owner/repo")
         attempt = PreparedVerificationAttempt(
             id=uuid4(),
             user_id=42,
             github_username="alice",
-            requirement=repo_fork_requirement(
-                slug="my-fork", required_repo="owner/repo"
+            requirement=requirement,
+            submitted_value=SubmittedValue.from_raw(
+                requirement, "https://github.com/alice/repo"
             ),
-            submitted_value="https://github.com/alice/repo",
         )
         payload = attempt.to_payload()
+        assert "submitted_value" not in payload
+        assert "submitted_value" not in payload["submission_value"]
         restored = PreparedVerificationAttempt.from_payload(payload)
         assert restored.requirement.slug == attempt.requirement.slug
         assert restored.requirement.type_config.required_repo == "owner/repo"
         assert type(restored.requirement) is type(attempt.requirement)
 
     def test_profile_readme_requirement_round_trip(self) -> None:
+        requirement = profile_readme_requirement(slug="profile")
         attempt = PreparedVerificationAttempt(
             id=uuid4(),
             user_id=1,
             github_username="bob",
-            requirement=profile_readme_requirement(slug="profile"),
-            submitted_value="https://github.com/bob/bob",
+            requirement=requirement,
+            submitted_value=SubmittedValue.from_raw(
+                requirement, "https://github.com/bob/bob"
+            ),
         )
         payload = attempt.to_payload()
         restored = PreparedVerificationAttempt.from_payload(payload)
@@ -46,16 +53,22 @@ class TestPreparedVerificationAttemptRoundTrip:
         assert type(restored.requirement) is type(attempt.requirement)
 
     def test_deployed_api_requirement_round_trip(self) -> None:
+        requirement = deployed_api_requirement(
+            slug="deployed", placeholder="https://your-api.example.com"
+        )
         attempt = PreparedVerificationAttempt(
             id=uuid4(),
             user_id=99,
             github_username=None,
-            requirement=deployed_api_requirement(
-                slug="deployed", placeholder="https://your-api.example.com"
+            requirement=requirement,
+            submitted_value=SubmittedValue.from_raw(
+                requirement, "https://api.example.com"
             ),
-            submitted_value="https://api.example.com",
         )
         payload = attempt.to_payload()
         restored = PreparedVerificationAttempt.from_payload(payload)
         assert restored.github_username is None
-        assert restored.requirement.placeholder == "https://your-api.example.com"
+        assert (
+            restored.requirement.type_config.placeholder
+            == "https://your-api.example.com"
+        )

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_run_result_evidence.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_run_result_evidence.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 
 from learn_to_cloud_shared.schemas import ValidationResult
+from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.testing.requirement_factories import (
     repo_fork_requirement,
 )
@@ -21,13 +22,16 @@ from learn_to_cloud_shared.verification_workflow import (
 
 
 def _run_result(evidence) -> VerificationRunResult:
+    requirement = repo_fork_requirement(required_repo="owner/repo")
     return VerificationRunResult(
         attempt=PreparedVerificationAttempt(
             id=uuid4(),
             user_id=1,
             github_username="alice",
-            requirement=repo_fork_requirement(required_repo="owner/repo"),
-            submitted_value="https://github.com/alice/repo",
+            requirement=requirement,
+            submitted_value=SubmittedValue.from_raw(
+                requirement, "https://github.com/alice/repo"
+            ),
         ),
         validation_result=ValidationResult(is_valid=True, message="ok"),
         evidence=evidence,

--- a/packages/learn-to-cloud-shared/tests/test_submission_values.py
+++ b/packages/learn-to-cloud-shared/tests/test_submission_values.py
@@ -25,8 +25,6 @@ from learn_to_cloud_shared.testing.requirement_factories import (
         (SubmissionType.DEPLOYED_API, SubmissionValueKind.DEPLOYED_URL),
         (SubmissionType.CAREER_REFLECTION, SubmissionValueKind.TEXT),
         (SubmissionType.DEPLOYMENT_ARCHITECTURE, SubmissionValueKind.TEXT),
-        ("ci_status", SubmissionValueKind.GITHUB_URL),
-        ("iac_token", SubmissionValueKind.TOKEN),
     ],
 )
 def test_value_kind_for_submission_type(
@@ -37,7 +35,7 @@ def test_value_kind_for_submission_type(
 
 
 @pytest.mark.unit
-def test_github_url_value_uses_github_column() -> None:
+def test_github_url_value_uses_typed_payload() -> None:
     value = SubmittedValue.from_raw(
         profile_readme_requirement(),
         " https://github.com/user ",
@@ -45,8 +43,7 @@ def test_github_url_value_uses_github_column() -> None:
 
     assert value.kind is SubmissionValueKind.GITHUB_URL
     assert value.github_url == "https://github.com/user"
-    assert value.to_columns() == {
-        "submitted_value": "https://github.com/user",
+    assert value.to_payload() == {
         "submission_value_kind": "github_url",
         "github_url": "https://github.com/user",
         "token_value": None,
@@ -56,7 +53,7 @@ def test_github_url_value_uses_github_column() -> None:
 
 
 @pytest.mark.unit
-def test_text_value_uses_text_column() -> None:
+def test_text_value_uses_typed_payload() -> None:
     value = SubmittedValue.from_raw(
         career_reflection_requirement(),
         "  ## Question 0?\n\nA thoughtful answer.  ",
@@ -65,8 +62,7 @@ def test_text_value_uses_text_column() -> None:
     assert value.kind is SubmissionValueKind.TEXT
     assert value.text_value == "## Question 0?\n\nA thoughtful answer."
     assert value.as_text == "## Question 0?\n\nA thoughtful answer."
-    assert value.to_columns() == {
-        "submitted_value": "## Question 0?\n\nA thoughtful answer.",
+    assert value.to_payload() == {
         "submission_value_kind": "text",
         "github_url": None,
         "token_value": None,
@@ -76,20 +72,13 @@ def test_text_value_uses_text_column() -> None:
 
 
 @pytest.mark.unit
-def test_text_value_round_trips_through_columns() -> None:
+def test_text_value_round_trips_through_payload() -> None:
     original = SubmittedValue.from_raw(
         career_reflection_requirement(),
         "Reflection body text.",
     )
 
-    restored = SubmittedValue.from_columns(
-        kind=original.kind.value,
-        github_url=None,
-        token_value=None,
-        deployed_url=None,
-        text_value=original.text_value,
-        legacy_value=original.as_text,
-    )
+    restored = SubmittedValue.from_payload(original.to_payload())
 
     assert restored.kind is SubmissionValueKind.TEXT
     assert restored.text_value == "Reflection body text."
@@ -135,14 +124,14 @@ def test_deployed_url_rejects_whitespace() -> None:
 
 
 @pytest.mark.unit
-def test_payload_round_trip_rejects_legacy_mismatch() -> None:
+def test_payload_rejects_multiple_typed_values() -> None:
     payload = {
         "submission_value_kind": "github_url",
         "github_url": "https://github.com/user",
-        "token_value": None,
+        "token_value": "unexpected-token",
         "deployed_url": None,
-        "submitted_value": "https://github.com/other",
+        "text_value": None,
     }
 
-    with pytest.raises(ValueError, match="Legacy submitted_value"):
+    with pytest.raises(ValueError, match="Invalid typed value"):
         SubmittedValue.from_payload(payload)

--- a/packages/learn-to-cloud-shared/tests/test_verification_attempt_snapshot.py
+++ b/packages/learn-to-cloud-shared/tests/test_verification_attempt_snapshot.py
@@ -72,8 +72,8 @@ def test_reconstructed_snapshot_is_not_runnable() -> None:
     # runnable typed requirement, so it must be rejected.
     reconstructed = {
         "uuid": "11111111-1111-1111-1111-111111111111",
-        "slug": "legacy",
-        "name": "Legacy",
+        "slug": "historical",
+        "name": "Historical",
         "submission_type": "repo_fork",
         "submission_value_kind": "github_url",
         "reconstructed": True,

--- a/packages/learn-to-cloud-shared/tests/verification/test_deployment_architecture.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_deployment_architecture.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 from learn_to_cloud_shared.github_target import GitHubTarget
+from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.testing.requirement_factories import (
     deployment_architecture_requirement,
 )
@@ -160,7 +161,9 @@ class TestJobTarget:
             user_id=1,
             github_username="alice",
             requirement=req,
-            submitted_value="my long architecture description",
+            submitted_value=SubmittedValue.from_raw(
+                req, "my long architecture description"
+            ),
         )
 
         target = job.target
@@ -184,7 +187,9 @@ class TestJobTarget:
             user_id=1,
             github_username="",
             requirement=req,
-            submitted_value="my long architecture description",
+            submitted_value=SubmittedValue.from_raw(
+                req, "my long architecture description"
+            ),
         )
 
         assert job.target is None

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 import pytest
 
 from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
+from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.testing.requirement_factories import (
     repo_fork_requirement,
 )
@@ -27,12 +28,15 @@ from learn_to_cloud_shared.verification_workflow import PreparedVerificationAtte
 
 
 def _job(requirement=None) -> PreparedVerificationAttempt:
+    requirement = requirement or repo_fork_requirement()
     return PreparedVerificationAttempt(
         id=uuid4(),
         user_id=1,
         github_username="learner",
-        requirement=requirement or repo_fork_requirement(),
-        submitted_value="https://github.com/learner/test-repo",
+        requirement=requirement,
+        submitted_value=SubmittedValue.from_raw(
+            requirement, "https://github.com/learner/test-repo"
+        ),
     )
 
 
@@ -186,16 +190,19 @@ def _journal_job() -> PreparedVerificationAttempt:
         journal_api_verifier_requirement,
     )
 
+    requirement = journal_api_verifier_requirement(
+        slug="journal-api-implementation",
+        name="Journal API Implementation",
+        required_repo="owner/journal-starter",
+    )
     return PreparedVerificationAttempt(
         id=uuid4(),
         user_id=1,
         github_username="learner",
-        requirement=journal_api_verifier_requirement(
-            slug="journal-api-implementation",
-            name="Journal API Implementation",
-            required_repo="owner/journal-starter",
+        requirement=requirement,
+        submitted_value=SubmittedValue.from_raw(
+            requirement, "https://github.com/learner/journal-starter"
         ),
-        submitted_value="https://github.com/learner/journal-starter",
     )
 
 
@@ -253,15 +260,16 @@ def _deployment_job(description: str) -> PreparedVerificationAttempt:
         deployment_architecture_requirement,
     )
 
+    requirement = deployment_architecture_requirement(
+        slug="deployment-architecture",
+        required_repo="owner/journal-starter",
+    )
     return PreparedVerificationAttempt(
         id=uuid4(),
         user_id=1,
         github_username="learner",
-        requirement=deployment_architecture_requirement(
-            slug="deployment-architecture",
-            required_repo="owner/journal-starter",
-        ),
-        submitted_value=description,
+        requirement=requirement,
+        submitted_value=SubmittedValue.from_raw(requirement, description),
     )
 
 
@@ -334,12 +342,13 @@ def _deployed_api_job() -> PreparedVerificationAttempt:
         deployed_api_requirement,
     )
 
+    requirement = deployed_api_requirement(slug="deployed-api")
     return PreparedVerificationAttempt(
         id=uuid4(),
         user_id=1,
         github_username=None,
-        requirement=deployed_api_requirement(slug="deployed-api"),
-        submitted_value="https://api.example.com",
+        requirement=requirement,
+        submitted_value=SubmittedValue.from_raw(requirement, "https://api.example.com"),
     )
 
 
@@ -348,15 +357,18 @@ def _devops_job() -> PreparedVerificationAttempt:
         devops_analysis_requirement,
     )
 
+    requirement = devops_analysis_requirement(
+        slug="devops-analysis",
+        required_repo="owner/devops-repo",
+    )
     return PreparedVerificationAttempt(
         id=uuid4(),
         user_id=1,
         github_username="learner",
-        requirement=devops_analysis_requirement(
-            slug="devops-analysis",
-            required_repo="owner/devops-repo",
+        requirement=requirement,
+        submitted_value=SubmittedValue.from_raw(
+            requirement, "https://github.com/learner/devops-repo"
         ),
-        submitted_value="https://github.com/learner/devops-repo",
     )
 
 
@@ -430,15 +442,18 @@ def _security_job() -> PreparedVerificationAttempt:
         security_scanning_requirement,
     )
 
+    requirement = security_scanning_requirement(
+        slug="security-scanning",
+        required_repo="owner/sec-repo",
+    )
     return PreparedVerificationAttempt(
         id=uuid4(),
         user_id=1,
         github_username="learner",
-        requirement=security_scanning_requirement(
-            slug="security-scanning",
-            required_repo="owner/sec-repo",
+        requirement=requirement,
+        submitted_value=SubmittedValue.from_raw(
+            requirement, "https://github.com/learner/sec-repo"
         ),
-        submitted_value="https://github.com/learner/sec-repo",
     )
 
 
@@ -447,12 +462,13 @@ def _career_job(text: str) -> PreparedVerificationAttempt:
         career_reflection_requirement,
     )
 
+    requirement = career_reflection_requirement(slug="career-reflection")
     return PreparedVerificationAttempt(
         id=uuid4(),
         user_id=1,
         github_username=None,
-        requirement=career_reflection_requirement(slug="career-reflection"),
-        submitted_value=text,
+        requirement=requirement,
+        submitted_value=SubmittedValue.from_raw(requirement, text),
     )
 
 
@@ -540,7 +556,7 @@ def _phase02_job(requirement, submitted_value, github_username="learner"):
         user_id=1,
         github_username=github_username,
         requirement=requirement,
-        submitted_value=submitted_value,
+        submitted_value=SubmittedValue.from_raw(requirement, submitted_value),
     )
 
 

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -8,6 +8,7 @@ from learn_to_cloud_shared.schemas import (
     TaskResult,
     ValidationResult,
 )
+from learn_to_cloud_shared.submission_values import SubmittedValue
 from learn_to_cloud_shared.verification.llm_grading import (
     LLMGradingDecisionPayload,
     apply_llm_grading_decisions,
@@ -43,7 +44,9 @@ def _run_result(is_valid: bool = True) -> VerificationRunResult:
             user_id=1,
             github_username="learner",
             requirement=requirement,
-            submitted_value="https://github.com/learner/journal",
+            submitted_value=SubmittedValue.from_raw(
+                requirement, "https://github.com/learner/journal"
+            ),
         ),
         validation_result=ValidationResult(
             is_valid=is_valid,
@@ -76,7 +79,9 @@ def _phase3_run_result(is_valid: bool = True) -> VerificationRunResult:
             user_id=1,
             github_username="learner",
             requirement=requirement,
-            submitted_value="https://github.com/learner/journal-starter",
+            submitted_value=SubmittedValue.from_raw(
+                requirement, "https://github.com/learner/journal-starter"
+            ),
         ),
         validation_result=ValidationResult(
             is_valid=is_valid,
@@ -210,7 +215,7 @@ def _phase7_run_result(
             user_id=1,
             github_username="learner",
             requirement=requirement,
-            submitted_value=submitted_text,
+            submitted_value=SubmittedValue.from_raw(requirement, submitted_text),
         ),
         validation_result=ValidationResult(
             is_valid=is_valid,


### PR DESCRIPTION
## Why

The curriculum and learner-state contraction removed the legacy database contract, but several active compatibility shims remained. The current design no longer needs them.

## What changed

- make typed submission values the only Durable payload contract
- remove duplicate scalar payload fields, scalar fallback parsing, and deleted-table column helpers
- remove obsolete `ci_status` and `iac_token` submission mappings
- replace the historical GitHub error alias with the canonical helper
- read placeholders directly from typed requirement configuration
- remove stale compatibility documentation and tests

Required Alembic revisions and the helper imported by revision 0049 remain because fresh databases still execute that migration chain; they are migration infrastructure, not runtime compatibility paths.

## Rollout safety

Current attempt payloads already contain the typed `submission_value` object. In-flight payloads may contain extra scalar fields, which the typed parser naturally ignores. The drained legacy orchestrator is no longer registered.

## Validation

- `uv run poe check`
- focused diff review found no correctness or rollout issues

Closes #652
Closes #653