### PR TITLE
fix: harden verification engine contracts

### DIFF
--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -191,6 +191,7 @@ def _set_verification_span_attributes(
     requirement_slug: str | None = None,
     submission_type: str | None = None,
     status: str | None = None,
+    grading_disposition: str | None = None,
 ) -> None:
     """Add verification identity to the current span when telemetry is enabled."""
     span = otel_trace.get_current_span()
@@ -206,6 +207,8 @@ def _set_verification_span_attributes(
         span.set_attribute("verification.submission_type", submission_type)
     if status:
         span.set_attribute("verification.status", status)
+    if grading_disposition:
+        span.set_attribute("verification.grading_disposition", grading_disposition)
     if user_id is not None:
         user_id_text = str(user_id)
         span.set_attribute("enduser.id", user_id_text)
@@ -234,6 +237,11 @@ def _set_result_span_attributes(result: VerificationRunResult) -> None:
         requirement_slug=attempt.requirement.slug,
         submission_type=attempt.requirement.submission_type.value,
         status=outcome_for_validation(result.validation_result),
+        grading_disposition=(
+            result.grading_disposition.value
+            if result.grading_disposition is not None
+            else None
+        ),
     )
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -2,14 +2,15 @@
 
 Plain shared-package code (no Durable imports) that the Durable activities
 call. A submission type maps to a :class:`VerificationProfile`: an ordered
-list of :class:`Step`s, each naming a registered **check** (code) plus typed
-**params** (data). :func:`run_profile` looks up the profile, runs its steps in
-order, short-circuits on a failed gate, accumulates
+list of :class:`Step`s whose typed params select a registered **check**.
+:func:`run_profile` looks up the profile, runs its steps in order,
+short-circuits on a failed gate, accumulates
 :class:`EvidenceBundle`s, and produces one aggregate ``ValidationResult``.
 
-Checks are registered by name in ``_CHECK_REGISTRY`` via
-:func:`register_check`. Adding a verification behavior becomes "register a
-check, declare a profile," not "touch an orchestrator and a validator."
+Checks are registered by params type in ``_CHECK_REGISTRY`` via
+:func:`register_check`. The params type is the single dispatch key, so adding a
+verification behavior cannot drift across a separate union, registry name, and
+profile step name.
 
 Every submission type resolves to a :class:`VerificationProfile`; a
 registry-exhaustiveness test guarantees no type is left unmapped.
@@ -19,7 +20,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
-from typing import Annotated, Literal
+from typing import ClassVar
 
 from opentelemetry import trace
 from pydantic import Field
@@ -76,6 +77,7 @@ from learn_to_cloud_shared.verification.token_base import (
     verify_networking_token,
 )
 from learn_to_cloud_shared.verification_workflow import (
+    GradingDisposition,
     PreparedVerificationAttempt,
     VerificationRunResult,
 )
@@ -83,17 +85,23 @@ from learn_to_cloud_shared.verification_workflow import (
 _tracer = trace.get_tracer(__name__)
 
 # ---------------------------------------------------------------------------
-# Step params: per-check models in a discriminated union keyed by ``check``.
+# Step params: each model type selects exactly one registered check.
 # ---------------------------------------------------------------------------
 
 
-class CIStatusParams(FrozenModel):
+class CheckParams(FrozenModel):
+    """Base for typed check configuration and its stable diagnostic name."""
+
+    check_name: ClassVar[str]
+
+
+class CIStatusParams(CheckParams):
     """Params for the ``github_ci_passing`` gate (workflow file is fixed)."""
 
-    check: Literal["github_ci_passing"] = "github_ci_passing"
+    check_name = "github_ci_passing"
 
 
-class LLMRubricReviewParams(FrozenModel):
+class LLMRubricReviewParams(CheckParams):
     """Params for the terminal ``llm_rubric_review`` step.
 
     Carries the rubric ``task`` (criteria + grader) and the exact repository
@@ -101,53 +109,53 @@ class LLMRubricReviewParams(FrozenModel):
     keeps evidence deterministic and matches the prescribed capstone files.
     """
 
-    check: Literal["llm_rubric_review"] = "llm_rubric_review"
+    check_name = "llm_rubric_review"
     task: VerificationTask
     evidence_paths: tuple[str, ...]
 
 
-class DeploymentArchitectureGateParams(FrozenModel):
+class DeploymentArchitectureGateParams(CheckParams):
     """Params for the Phase 4 ``deployment_architecture_gate`` (no config).
 
     The gate reads the description length and deploy-script path from the
     requirement's ``type_config`` at runtime, so it carries no data.
     """
 
-    check: Literal["deployment_architecture_gate"] = "deployment_architecture_gate"
+    check_name = "deployment_architecture_gate"
 
 
-class DeploymentArchitectureReviewParams(FrozenModel):
+class DeploymentArchitectureReviewParams(CheckParams):
     """Params for the Phase 4 ``deployment_architecture_review`` rubric step.
 
     Bundles the learner's forked ``deploy.sh`` with their architecture
     description for the LLM rubric grader.
     """
 
-    check: Literal["deployment_architecture_review"] = "deployment_architecture_review"
+    check_name = "deployment_architecture_review"
     task: VerificationTask
 
 
-class DeployedApiCheckParams(FrozenModel):
+class DeployedApiCheckParams(CheckParams):
     """Params for the deterministic ``deployed_api_check`` (no config).
 
     The check probes the submitted base URL's health surface; the target URL
     is the submitted value, so it carries no data.
     """
 
-    check: Literal["deployed_api_check"] = "deployed_api_check"
+    check_name = "deployed_api_check"
 
 
-class DevopsAnalysisCheckParams(FrozenModel):
+class DevopsAnalysisCheckParams(CheckParams):
     """Params for the deterministic ``devops_analysis_check`` (no config).
 
     The check runs the Phase 5 DevOps workflow against the fork resolved from
     the requirement plus the learner's username, so it carries no data.
     """
 
-    check: Literal["devops_analysis_check"] = "devops_analysis_check"
+    check_name = "devops_analysis_check"
 
 
-class CodeQLStatusParams(FrozenModel):
+class CodeQLStatusParams(CheckParams):
     """Params for the Phase 6 ``codeql_status`` gate (no config).
 
     The gate verifies the fork's CodeQL workflow ran green on the current
@@ -155,95 +163,76 @@ class CodeQLStatusParams(FrozenModel):
     so it carries no data.
     """
 
-    check: Literal["codeql_status"] = "codeql_status"
+    check_name = "codeql_status"
 
 
-class SecurityScanningReviewParams(FrozenModel):
+class SecurityScanningReviewParams(CheckParams):
     """Params for the Phase 6 ``security_scanning_review`` rubric step.
 
     Bundles the fork's security-scanning config files for the LLM rubric
     grader; carries the rubric ``task``.
     """
 
-    check: Literal["security_scanning_review"] = "security_scanning_review"
+    check_name = "security_scanning_review"
     task: VerificationTask
 
 
-class CareerReflectionGateParams(FrozenModel):
+class CareerReflectionGateParams(CheckParams):
     """Params for the Phase 7 ``career_reflection_gate`` (no config).
 
     The gate only rejects empty submissions; the rubric does the real grading.
     """
 
-    check: Literal["career_reflection_gate"] = "career_reflection_gate"
+    check_name = "career_reflection_gate"
 
 
-class CareerReflectionReviewParams(FrozenModel):
+class CareerReflectionReviewParams(CheckParams):
     """Params for the Phase 7 ``career_reflection_review`` text rubric step.
 
     Bundles the learner's free-text reflection as evidence; carries the rubric
     ``task``. Text-only, so the grading request uses the no-repo prompt.
     """
 
-    check: Literal["career_reflection_review"] = "career_reflection_review"
+    check_name = "career_reflection_review"
     task: VerificationTask
 
 
-class ProfileReadmeCheckParams(FrozenModel):
+class ProfileReadmeCheckParams(CheckParams):
     """Params for the deterministic Phase 0 ``profile_readme_check`` (no config).
 
     The check confirms the learner's ``<username>/<username>`` profile README
     repo resolves; the target is built from the username, so it carries no data.
     """
 
-    check: Literal["profile_readme_check"] = "profile_readme_check"
+    check_name = "profile_readme_check"
 
 
-class RepoForkCheckParams(FrozenModel):
+class RepoForkCheckParams(CheckParams):
     """Params for the deterministic Phase 1/2 ``repo_fork_check`` (no config).
 
     The check confirms the learner's repo is a fork of the required upstream;
     fork identity and upstream come from the target, so it carries no data.
     """
 
-    check: Literal["repo_fork_check"] = "repo_fork_check"
+    check_name = "repo_fork_check"
 
 
-class CtfTokenCheckParams(FrozenModel):
+class CtfTokenCheckParams(CheckParams):
     """Params for the deterministic Phase 1 ``ctf_token_check`` (no config).
 
     The check verifies the submitted CTF token against the learner's username.
     """
 
-    check: Literal["ctf_token_check"] = "ctf_token_check"
+    check_name = "ctf_token_check"
 
 
-class NetworkingTokenCheckParams(FrozenModel):
+class NetworkingTokenCheckParams(CheckParams):
     """Params for the deterministic Phase 2 ``networking_token_check`` (no config).
 
     The check verifies the submitted networking token against the username.
     """
 
-    check: Literal["networking_token_check"] = "networking_token_check"
-
-
-StepParams = Annotated[
-    CIStatusParams
-    | LLMRubricReviewParams
-    | DeploymentArchitectureGateParams
-    | DeploymentArchitectureReviewParams
-    | DeployedApiCheckParams
-    | DevopsAnalysisCheckParams
-    | CodeQLStatusParams
-    | SecurityScanningReviewParams
-    | CareerReflectionGateParams
-    | CareerReflectionReviewParams
-    | ProfileReadmeCheckParams
-    | RepoForkCheckParams
-    | CtfTokenCheckParams
-    | NetworkingTokenCheckParams,
-    Field(discriminator="check"),
-]
+    check_name = "networking_token_check"
 
 
 # ---------------------------------------------------------------------------
@@ -251,16 +240,11 @@ StepParams = Annotated[
 # ---------------------------------------------------------------------------
 
 
-class Step(FrozenModel):
-    """One ordered gate in a profile: a registered check plus its params.
+@dataclass(frozen=True, slots=True)
+class Step:
+    """One ordered profile step selected by its typed params."""
 
-    ``check`` is the registry key (which code runs); ``params`` is the typed
-    per-check config. They are kept separate, per the engine sketch, so the
-    dispatch key and the param schema evolve independently.
-    """
-
-    check: str
-    params: StepParams
+    params: CheckParams
     task_id: str
 
 
@@ -311,29 +295,31 @@ class VerificationProfile:
     rubric: LLMRubricGraderConfig | None = None
 
 
-CheckFn = Callable[[StepContext, StepParams], Awaitable[StepResult]]
+CheckFn = Callable[[StepContext, CheckParams], Awaitable[StepResult]]
 
-_CHECK_REGISTRY: dict[str, CheckFn] = {}
+_CHECK_REGISTRY: dict[type[CheckParams], CheckFn] = {}
 
 
-def register_check(name: str) -> Callable[[CheckFn], CheckFn]:
-    """Register a check under ``name``. Raises if the name is already taken."""
+def register_check(
+    params_type: type[CheckParams],
+) -> Callable[[CheckFn], CheckFn]:
+    """Register the check selected by ``params_type``."""
 
     def decorator(fn: CheckFn) -> CheckFn:
-        if name in _CHECK_REGISTRY:
-            raise ValueError(f"Check already registered: {name}")
-        _CHECK_REGISTRY[name] = fn
+        if params_type in _CHECK_REGISTRY:
+            raise ValueError(f"Check already registered: {params_type.check_name}")
+        _CHECK_REGISTRY[params_type] = fn
         return fn
 
     return decorator
 
 
-def check_for(name: str) -> CheckFn:
-    """Return the check registered under ``name`` or raise ``KeyError``."""
+def check_for(params: CheckParams) -> CheckFn:
+    """Return the check registered for ``params`` or raise ``KeyError``."""
     try:
-        return _CHECK_REGISTRY[name]
+        return _CHECK_REGISTRY[type(params)]
     except KeyError:
-        raise KeyError(f"No check registered for {name!r}") from None
+        raise KeyError(f"No check registered for {params.check_name!r}") from None
 
 
 # ---------------------------------------------------------------------------
@@ -341,10 +327,10 @@ def check_for(name: str) -> CheckFn:
 # ---------------------------------------------------------------------------
 
 
-@register_check("github_ci_passing")
+@register_check(CIStatusParams)
 async def _check_github_ci_passing(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Gate on a green CI run on the fork's ``main`` branch."""
     target = context.repository
@@ -367,10 +353,10 @@ async def _check_github_ci_passing(
     )
 
 
-@register_check("llm_rubric_review")
+@register_check(LLMRubricReviewParams)
 async def _check_llm_rubric_review(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Fetch exact-path evidence for a terminal LLM rubric review.
 
@@ -398,10 +384,10 @@ async def _check_llm_rubric_review(
     )
 
 
-@register_check("deployed_api_check")
+@register_check(DeployedApiCheckParams)
 async def _check_deployed_api(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Deterministic Phase 4 gate: probe the submitted API base URL."""
     result = await validate_deployed_api(context.submitted_value)
@@ -412,10 +398,10 @@ async def _check_deployed_api(
     )
 
 
-@register_check("devops_analysis_check")
+@register_check(DevopsAnalysisCheckParams)
 async def _check_devops_analysis(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Deterministic Phase 5 gate: run the DevOps workflow on the fork."""
     target = context.repository
@@ -438,10 +424,10 @@ async def _check_devops_analysis(
     )
 
 
-@register_check("codeql_status")
+@register_check(CodeQLStatusParams)
 async def _check_codeql_status(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Deterministic Phase 6 gate: CodeQL green on the fork's current main HEAD."""
     target = context.repository
@@ -464,10 +450,10 @@ async def _check_codeql_status(
     )
 
 
-@register_check("security_scanning_review")
+@register_check(SecurityScanningReviewParams)
 async def _check_security_scanning_review(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Bundle the fork's security-scanning config files for rubric grading."""
     assert isinstance(params, SecurityScanningReviewParams)
@@ -489,10 +475,10 @@ async def _check_security_scanning_review(
     )
 
 
-@register_check("career_reflection_gate")
+@register_check(CareerReflectionGateParams)
 async def _check_career_reflection_gate(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Deterministic Phase 7 gate: reject empty reflection submissions."""
     result = validate_career_reflection(context.submitted_value)
@@ -503,10 +489,10 @@ async def _check_career_reflection_gate(
     )
 
 
-@register_check("career_reflection_review")
+@register_check(CareerReflectionReviewParams)
 async def _check_career_reflection_review(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Bundle the learner's free-text reflection for text rubric grading."""
     assert isinstance(params, CareerReflectionReviewParams)
@@ -519,10 +505,10 @@ async def _check_career_reflection_review(
     )
 
 
-@register_check("profile_readme_check")
+@register_check(ProfileReadmeCheckParams)
 async def _check_profile_readme(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Deterministic Phase 0 gate: the profile README repo resolves."""
     target = context.repository
@@ -547,10 +533,10 @@ async def _check_profile_readme(
     )
 
 
-@register_check("repo_fork_check")
+@register_check(RepoForkCheckParams)
 async def _check_repo_fork(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Deterministic Phase 1/2 gate: the learner's repo forks the upstream."""
     target = context.repository
@@ -575,10 +561,10 @@ async def _check_repo_fork(
     )
 
 
-@register_check("ctf_token_check")
+@register_check(CtfTokenCheckParams)
 async def _check_ctf_token(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Deterministic Phase 1 gate: verify the submitted CTF token."""
     result = verify_ctf_token(
@@ -591,10 +577,10 @@ async def _check_ctf_token(
     )
 
 
-@register_check("networking_token_check")
+@register_check(NetworkingTokenCheckParams)
 async def _check_networking_token(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Deterministic Phase 2 gate: verify the submitted networking token."""
     result = verify_networking_token(
@@ -607,10 +593,10 @@ async def _check_networking_token(
     )
 
 
-@register_check("deployment_architecture_gate")
+@register_check(DeploymentArchitectureGateParams)
 async def _check_deployment_architecture_gate(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Phase 4 gate: description meets min length and ``deploy.sh`` exists."""
     result = await validate_deployment_architecture(
@@ -626,10 +612,10 @@ async def _check_deployment_architecture_gate(
     )
 
 
-@register_check("deployment_architecture_review")
+@register_check(DeploymentArchitectureReviewParams)
 async def _check_deployment_architecture_review(
     context: StepContext,
-    params: StepParams,
+    params: CheckParams,
 ) -> StepResult:
     """Bundle the fork's ``deploy.sh`` and the architecture description.
 
@@ -688,12 +674,10 @@ _JOURNAL_API_PROFILE = VerificationProfile(
     requires_username=True,
     steps=(
         Step(
-            check="github_ci_passing",
             params=CIStatusParams(),
             task_id="journal-api-implementation-ci",
         ),
         Step(
-            check="llm_rubric_review",
             params=LLMRubricReviewParams(
                 task=JOURNAL_API_FINAL_RUBRIC_TASK,
                 evidence_paths=JOURNAL_API_IMPORTANT_PATHS,
@@ -714,12 +698,10 @@ _DEPLOYMENT_ARCHITECTURE_PROFILE = VerificationProfile(
     requires_username=True,
     steps=(
         Step(
-            check="deployment_architecture_gate",
             params=DeploymentArchitectureGateParams(),
             task_id="deployment-architecture-gate",
         ),
         Step(
-            check="deployment_architecture_review",
             params=DeploymentArchitectureReviewParams(
                 task=DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK,
             ),
@@ -738,7 +720,6 @@ _DEPLOYED_API_PROFILE = VerificationProfile(
     requires_username=False,
     steps=(
         Step(
-            check="deployed_api_check",
             params=DeployedApiCheckParams(),
             task_id="deployed-api-check",
         ),
@@ -752,7 +733,6 @@ _DEVOPS_ANALYSIS_PROFILE = VerificationProfile(
     requires_username=True,
     steps=(
         Step(
-            check="devops_analysis_check",
             params=DevopsAnalysisCheckParams(),
             task_id="devops-analysis-check",
         ),
@@ -769,12 +749,10 @@ _SECURITY_SCANNING_PROFILE = VerificationProfile(
     requires_username=True,
     steps=(
         Step(
-            check="codeql_status",
             params=CodeQLStatusParams(),
             task_id="codeql-status-gate",
         ),
         Step(
-            check="security_scanning_review",
             params=SecurityScanningReviewParams(task=SECURITY_SCANNING_RUBRIC_TASK),
             task_id=SECURITY_SCANNING_RUBRIC_TASK.id,
         ),
@@ -792,12 +770,10 @@ _CAREER_REFLECTION_PROFILE = VerificationProfile(
     requires_username=False,
     steps=(
         Step(
-            check="career_reflection_gate",
             params=CareerReflectionGateParams(),
             task_id="career-reflection-gate",
         ),
         Step(
-            check="career_reflection_review",
             params=CareerReflectionReviewParams(task=CAREER_REFLECTION_RUBRIC_TASK),
             task_id=CAREER_REFLECTION_RUBRIC_TASK.id,
         ),
@@ -812,7 +788,6 @@ _PROFILE_README_PROFILE = VerificationProfile(
     requires_username=True,
     steps=(
         Step(
-            check="profile_readme_check",
             params=ProfileReadmeCheckParams(),
             task_id="profile-readme-check",
         ),
@@ -826,7 +801,6 @@ _REPO_FORK_PROFILE = VerificationProfile(
     requires_username=True,
     steps=(
         Step(
-            check="repo_fork_check",
             params=RepoForkCheckParams(),
             task_id="repo-fork-check",
         ),
@@ -840,7 +814,6 @@ _CTF_TOKEN_PROFILE = VerificationProfile(
     requires_username=True,
     steps=(
         Step(
-            check="ctf_token_check",
             params=CtfTokenCheckParams(),
             task_id="ctf-token-check",
         ),
@@ -854,7 +827,6 @@ _NETWORKING_TOKEN_PROFILE = VerificationProfile(
     requires_username=True,
     steps=(
         Step(
-            check="networking_token_check",
             params=NetworkingTokenCheckParams(),
             task_id="networking-token-check",
         ),
@@ -877,13 +849,44 @@ def _steps_for(profile: VerificationProfile) -> tuple[Step, ...]:
 def _aggregate(step_results: list[StepResult]) -> ValidationResult:
     """Fold step results into one ``ValidationResult``.
 
-    A ``validation_result`` passthrough (a deterministic gate) is authoritative
-    and returned unchanged. Rubric profiles aggregate from per-step task
-    results.
+    One deterministic gate is returned unchanged. Multiple gates fold in
+    declaration order: the last gate supplies the decisive message while all
+    gate outcomes and task feedback contribute to the aggregate.
     """
-    for result in step_results:
-        if result.validation_result is not None:
-            return result.validation_result
+    authoritative_results = [
+        result.validation_result
+        for result in step_results
+        if result.validation_result is not None
+    ]
+    if len(authoritative_results) == 1:
+        return authoritative_results[0]
+    if authoritative_results:
+        decisive_result = authoritative_results[-1]
+        task_results = [
+            task_result
+            for validation_result in authoritative_results
+            for task_result in (validation_result.task_results or [])
+        ]
+
+        def latest_value(field: str) -> bool | str | None:
+            for validation_result in reversed(authoritative_results):
+                value = getattr(validation_result, field)
+                if value is not None:
+                    return value
+            return None
+
+        return decisive_result.model_copy(
+            update={
+                "is_valid": all(result.is_valid for result in authoritative_results),
+                "username_match": latest_value("username_match"),
+                "repo_exists": latest_value("repo_exists"),
+                "task_results": task_results or None,
+                "verification_completed": all(
+                    result.verification_completed for result in authoritative_results
+                ),
+                "cloud_provider": latest_value("cloud_provider"),
+            }
+        )
 
     task_results = [r.task_result for r in step_results if r.task_result is not None]
     passed = all(r.passed for r in step_results)
@@ -912,8 +915,7 @@ def _grading_requests_for(
     a migrated profile signals "no grading needed" to the orchestrator.
 
     A task whose evidence source is ``submitted_text`` grades free text with no
-    repository (Phase 7); every other task grades repository evidence and is
-    skipped when the job has no GitHub target.
+    repository (Phase 7); every other task requires a repository target.
     """
     target = job.target
     requests: list[LLMGradingRequest] = []
@@ -932,7 +934,9 @@ def _grading_requests_for(
             )
         else:
             if target is None or not target.repo:
-                continue
+                raise ValueError(
+                    f"Rubric task {task.id!r} requires a GitHub repository target"
+                )
             message = build_repo_rubric_message(
                 requirement_slug=job.requirement.slug,
                 requirement_name=job.requirement.name,
@@ -952,6 +956,23 @@ def _grading_requests_for(
     return requests
 
 
+def _grading_disposition_for(
+    profile: VerificationProfile,
+    step_results: list[StepResult],
+    grading_requests: list[LLMGradingRequest],
+) -> GradingDisposition:
+    """Explain why this run will or will not enter LLM grading."""
+    if profile.rubric is None:
+        if grading_requests:
+            raise ValueError("Non-rubric profile produced grading requests")
+        return GradingDisposition.NOT_REQUIRED
+    if grading_requests:
+        return GradingDisposition.REQUESTED
+    if any(not result.passed and result.stop_on_fail for result in step_results):
+        return GradingDisposition.SKIPPED_GATE_FAILED
+    raise ValueError("Rubric profile completed without a grading request")
+
+
 async def run_profile(
     job: PreparedVerificationAttempt,
     *,
@@ -963,9 +984,10 @@ async def run_profile(
     rest. Evidence bundles accumulate across steps, are visible to later steps
     via ``evidence_so_far``, and are carried on the returned run result.
 
-    Every registered profile records its LLM grading requests on the result
-    (``grading_requests`` is a list, possibly empty). An unregistered type
-    (which the exhaustiveness test forbids) returns a clean error result.
+    Every result records both its LLM grading requests and a
+    ``grading_disposition`` explaining why grading was requested or skipped.
+    An unregistered type (which the exhaustiveness test forbids) returns a
+    clean error result.
     """
     profile = _resolve_profile(job)
     if profile is None:
@@ -979,6 +1001,7 @@ async def run_profile(
             ),
             evidence=None,
             grading_requests=[],
+            grading_disposition=(GradingDisposition.SKIPPED_UNKNOWN_SUBMISSION_TYPE),
         )
 
     if profile.requires_username and not job.github_username:
@@ -991,6 +1014,7 @@ async def run_profile(
             ),
             evidence=None,
             grading_requests=[],
+            grading_disposition=GradingDisposition.SKIPPED_MISSING_USERNAME,
         )
 
     steps = _steps_for(profile)
@@ -1004,7 +1028,7 @@ async def run_profile(
     step_results: list[StepResult] = []
     bundles: list[EvidenceBundle] = []
     for step in steps:
-        result = await check_for(step.check)(context, step.params)
+        result = await check_for(step.params)(context, step.params)
         step_results.append(result)
         if result.evidence:
             bundles.extend(result.evidence)
@@ -1017,10 +1041,14 @@ async def run_profile(
 
     deterministic_result = _aggregate(step_results)
     grading_requests = _grading_requests_for(job, deterministic_result, step_results)
+    grading_disposition = _grading_disposition_for(
+        profile, step_results, grading_requests
+    )
 
     return VerificationRunResult(
         attempt=job,
         validation_result=deterministic_result,
         evidence=bundles or None,
         grading_requests=grading_requests,
+        grading_disposition=grading_disposition,
     )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -63,6 +63,7 @@ def apply_llm_grading_decisions(
     return VerificationRunResult(
         attempt=run_result.attempt,
         validation_result=validation_result,
+        grading_disposition=run_result.grading_disposition,
     )
 
 
@@ -88,6 +89,7 @@ def llm_grading_unavailable_result(
     return VerificationRunResult(
         attempt=run_result.attempt,
         validation_result=validation_result,
+        grading_disposition=run_result.grading_disposition,
     )
 
 
@@ -118,6 +120,7 @@ def llm_grading_content_filtered_result(
     return VerificationRunResult(
         attempt=run_result.attempt,
         validation_result=validation_result,
+        grading_disposition=run_result.grading_disposition,
     )
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_workflow.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_workflow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
+from enum import StrEnum
 from uuid import UUID
 
 from learn_to_cloud_shared.github_target import GitHubTarget
@@ -24,6 +25,16 @@ VERIFICATION_SUCCEEDED_CODE = "verification_succeeded"
 OUTCOME_SUCCEEDED = "succeeded"
 OUTCOME_FAILED = "failed"
 OUTCOME_SERVER_ERROR = "server_error"
+
+
+class GradingDisposition(StrEnum):
+    """Why LLM grading was requested or skipped for a verification run."""
+
+    REQUESTED = "requested"
+    NOT_REQUIRED = "not_required"
+    SKIPPED_GATE_FAILED = "skipped_gate_failed"
+    SKIPPED_MISSING_USERNAME = "skipped_missing_username"
+    SKIPPED_UNKNOWN_SUBMISSION_TYPE = "skipped_unknown_submission_type"
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,6 +85,7 @@ class VerificationRunResult:
     validation_result: ValidationResult
     evidence: list[EvidenceBundle] | None = None
     grading_requests: list[LLMGradingRequest] | None = None
+    grading_disposition: GradingDisposition | None = None
 
     def to_payload(self) -> dict[str, object]:
         return {
@@ -87,6 +99,11 @@ class VerificationRunResult:
             "grading_requests": (
                 [request.model_dump(mode="json") for request in self.grading_requests]
                 if self.grading_requests is not None
+                else None
+            ),
+            "grading_disposition": (
+                self.grading_disposition.value
+                if self.grading_disposition is not None
                 else None
             ),
         }
@@ -105,6 +122,12 @@ class VerificationRunResult:
             if isinstance(raw_requests, list)
             else None
         )
+        raw_disposition = payload.get("grading_disposition")
+        grading_disposition = (
+            GradingDisposition(_expect_str(raw_disposition, "grading_disposition"))
+            if raw_disposition is not None
+            else None
+        )
         return cls(
             attempt=PreparedVerificationAttempt.from_payload(
                 _expect_mapping(payload["attempt"])
@@ -114,6 +137,7 @@ class VerificationRunResult:
             ),
             evidence=evidence,
             grading_requests=grading_requests,
+            grading_disposition=grading_disposition,
         )
 
     def without_transport_data(self) -> VerificationRunResult:

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_run_result_evidence.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_run_result_evidence.py
@@ -16,6 +16,7 @@ from learn_to_cloud_shared.verification.tasks.base import (
     EvidenceItem,
 )
 from learn_to_cloud_shared.verification_workflow import (
+    GradingDisposition,
     PreparedVerificationAttempt,
     VerificationRunResult,
 )
@@ -111,15 +112,19 @@ class TestVerificationRunResultGradingRequests:
             attempt=_run_result(None).attempt,
             validation_result=ValidationResult(is_valid=False, message="gate failed"),
             grading_requests=[],
+            grading_disposition=GradingDisposition.SKIPPED_GATE_FAILED,
         )
         restored = VerificationRunResult.from_payload(result.to_payload())
         assert restored.grading_requests == []
+        assert restored.grading_disposition == GradingDisposition.SKIPPED_GATE_FAILED
 
     def test_without_transport_data_strips_grading_requests(self) -> None:
         result = VerificationRunResult(
             attempt=_run_result(None).attempt,
             validation_result=ValidationResult(is_valid=True, message="ok"),
             grading_requests=[_grading_request()],
+            grading_disposition=GradingDisposition.REQUESTED,
         )
         stripped = result.without_transport_data()
         assert stripped.grading_requests is None
+        assert stripped.grading_disposition == GradingDisposition.REQUESTED

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -11,6 +11,7 @@ from learn_to_cloud_shared.testing.requirement_factories import (
 )
 from learn_to_cloud_shared.verification import engine as engine_module
 from learn_to_cloud_shared.verification.engine import (
+    CheckParams,
     CIStatusParams,
     Step,
     StepContext,
@@ -24,7 +25,42 @@ from learn_to_cloud_shared.verification.tasks.base import (
     EvidenceBundle,
     EvidenceItem,
 )
-from learn_to_cloud_shared.verification_workflow import PreparedVerificationAttempt
+from learn_to_cloud_shared.verification_workflow import (
+    GradingDisposition,
+    PreparedVerificationAttempt,
+)
+
+
+class PassingCheckParams(CheckParams):
+    check_name = "test_gate_pass"
+
+
+class HardFailParams(CheckParams):
+    check_name = "hard_fail"
+
+
+class NeverRunsParams(CheckParams):
+    check_name = "never_runs"
+
+
+class SoftFailParams(CheckParams):
+    check_name = "soft_fail"
+
+
+class AfterSoftParams(CheckParams):
+    check_name = "after_soft"
+
+
+class EmitEvidenceParams(CheckParams):
+    check_name = "emit_evidence"
+
+
+class ReadEvidenceParams(CheckParams):
+    check_name = "read_evidence"
+
+
+class UnknownCheckParams(CheckParams):
+    check_name = "does-not-exist"
 
 
 def _job(requirement=None) -> PreparedVerificationAttempt:
@@ -40,8 +76,8 @@ def _job(requirement=None) -> PreparedVerificationAttempt:
     )
 
 
-def _step(check: str, task_id: str) -> Step:
-    return Step(check=check, params=CIStatusParams(), task_id=task_id)
+def _step(params: CheckParams, task_id: str) -> Step:
+    return Step(params=params, task_id=task_id)
 
 
 def _profile(*steps: Step) -> VerificationProfile:
@@ -56,7 +92,7 @@ async def test_run_profile_uses_declared_steps(monkeypatch):
         items=[EvidenceItem(path="a.txt", content="x")],
     )
 
-    @register_check("test_gate_pass")
+    @register_check(PassingCheckParams)
     async def _gate(context: StepContext, params) -> StepResult:
         return StepResult(
             passed=True,
@@ -67,7 +103,7 @@ async def test_run_profile_uses_declared_steps(monkeypatch):
     monkeypatch.setattr(
         engine_module,
         "profile_for",
-        lambda _t: _profile(_step("test_gate_pass", "gate")),
+        lambda _t: _profile(_step(PassingCheckParams(), "gate")),
     )
 
     result = await run_profile(_job())
@@ -83,12 +119,12 @@ async def test_run_profile_uses_declared_steps(monkeypatch):
 async def test_failed_gate_short_circuits(monkeypatch):
     ran: list[str] = []
 
-    @register_check("hard_fail")
+    @register_check(HardFailParams)
     async def _first(context: StepContext, params) -> StepResult:
         ran.append("first")
         return StepResult(passed=False, stop_on_fail=True)
 
-    @register_check("never_runs")
+    @register_check(NeverRunsParams)
     async def _second(context: StepContext, params) -> StepResult:
         ran.append("second")
         return StepResult(passed=True)
@@ -96,7 +132,10 @@ async def test_failed_gate_short_circuits(monkeypatch):
     monkeypatch.setattr(
         engine_module,
         "profile_for",
-        lambda _t: _profile(_step("hard_fail", "a"), _step("never_runs", "b")),
+        lambda _t: _profile(
+            _step(HardFailParams(), "a"),
+            _step(NeverRunsParams(), "b"),
+        ),
     )
 
     result = await run_profile(_job())
@@ -109,12 +148,12 @@ async def test_failed_gate_short_circuits(monkeypatch):
 async def test_stop_on_fail_false_continues(monkeypatch):
     ran: list[str] = []
 
-    @register_check("soft_fail")
+    @register_check(SoftFailParams)
     async def _soft(context: StepContext, params) -> StepResult:
         ran.append("soft")
         return StepResult(passed=False, stop_on_fail=False)
 
-    @register_check("after_soft")
+    @register_check(AfterSoftParams)
     async def _after(context: StepContext, params) -> StepResult:
         ran.append("after")
         return StepResult(passed=True)
@@ -122,7 +161,10 @@ async def test_stop_on_fail_false_continues(monkeypatch):
     monkeypatch.setattr(
         engine_module,
         "profile_for",
-        lambda _t: _profile(_step("soft_fail", "a"), _step("after_soft", "b")),
+        lambda _t: _profile(
+            _step(SoftFailParams(), "a"),
+            _step(AfterSoftParams(), "b"),
+        ),
     )
 
     result = await run_profile(_job())
@@ -131,16 +173,74 @@ async def test_stop_on_fail_false_continues(monkeypatch):
     assert result.validation_result.is_valid is False
 
 
+def test_multiple_authoritative_results_keep_latest_message_and_all_feedback():
+    first_task = TaskResult(task_name="Files", passed=True, feedback="present")
+    second_task = TaskResult(task_name="Image", passed=True, feedback="pullable")
+
+    result = engine_module._aggregate(
+        [
+            StepResult(
+                passed=True,
+                validation_result=ValidationResult(
+                    is_valid=True,
+                    message="Required files exist",
+                    username_match=True,
+                    task_results=[first_task],
+                ),
+            ),
+            StepResult(
+                passed=True,
+                validation_result=ValidationResult(
+                    is_valid=True,
+                    message="Container image is pullable",
+                    repo_exists=True,
+                    task_results=[second_task],
+                ),
+            ),
+        ]
+    )
+
+    assert result.is_valid is True
+    assert result.message == "Container image is pullable"
+    assert result.username_match is True
+    assert result.repo_exists is True
+    assert result.task_results == [first_task, second_task]
+
+
+def test_later_authoritative_failure_is_not_hidden_by_an_earlier_pass():
+    result = engine_module._aggregate(
+        [
+            StepResult(
+                passed=True,
+                validation_result=ValidationResult(
+                    is_valid=True,
+                    message="Required files exist",
+                ),
+            ),
+            StepResult(
+                passed=False,
+                validation_result=ValidationResult(
+                    is_valid=False,
+                    message="Container image is not pullable",
+                ),
+            ),
+        ]
+    )
+
+    assert result.is_valid is False
+    assert result.message == "Container image is not pullable"
+
+
 @pytest.mark.asyncio
 async def test_later_step_sees_prior_evidence(monkeypatch):
     seen: list[int] = []
     bundle = EvidenceBundle(task_id="a", source="repo_files")
 
-    @register_check("emit_evidence")
+    @register_check(EmitEvidenceParams)
     async def _emit(context: StepContext, params) -> StepResult:
         return StepResult(passed=True, evidence=[bundle])
 
-    @register_check("read_evidence")
+    @register_check(ReadEvidenceParams)
     async def _read(context: StepContext, params) -> StepResult:
         seen.append(len(context.evidence_so_far))
         return StepResult(passed=True)
@@ -148,7 +248,10 @@ async def test_later_step_sees_prior_evidence(monkeypatch):
     monkeypatch.setattr(
         engine_module,
         "profile_for",
-        lambda _t: _profile(_step("emit_evidence", "a"), _step("read_evidence", "b")),
+        lambda _t: _profile(
+            _step(EmitEvidenceParams(), "a"),
+            _step(ReadEvidenceParams(), "b"),
+        ),
     )
 
     await run_profile(_job())
@@ -165,19 +268,22 @@ async def test_unregistered_type_returns_unknown_result(monkeypatch):
     assert result.validation_result.is_valid is False
     assert "Unknown submission type" in result.validation_result.message
     assert result.grading_requests == []
+    assert (
+        result.grading_disposition == GradingDisposition.SKIPPED_UNKNOWN_SUBMISSION_TYPE
+    )
 
 
 def test_register_check_rejects_duplicates():
     with pytest.raises(ValueError, match="already registered"):
 
-        @register_check("github_ci_passing")
+        @register_check(CIStatusParams)
         async def _dupe(context, params):  # pragma: no cover - registration fails
             return StepResult(passed=True)
 
 
 def test_check_for_unknown_raises():
     with pytest.raises(KeyError):
-        check_for("does-not-exist")
+        check_for(UnknownCheckParams())
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +334,7 @@ async def test_journal_profile_records_grading_requests_when_ci_passes(monkeypat
     assert result.evidence is not None and len(result.evidence) == 1
     assert result.grading_requests is not None
     assert len(result.grading_requests) == 1
+    assert result.grading_disposition == GradingDisposition.REQUESTED
     request = result.grading_requests[0]
     assert request.task.id == JOURNAL_API_FINAL_RUBRIC_TASK.id
     assert "journal-api-implementation" in request.message
@@ -247,6 +354,7 @@ async def test_journal_profile_skips_grading_when_ci_fails(monkeypatch):
     assert result.validation_result.is_valid is False
     assert result.validation_result.message == "CI is red"
     assert result.grading_requests == []
+    assert result.grading_disposition == GradingDisposition.SKIPPED_GATE_FAILED
     assert result.evidence is None
 
 
@@ -385,6 +493,7 @@ async def test_deployed_api_profile_passes_through_deterministic_result(monkeypa
     assert result.validation_result.is_valid is True
     assert result.validation_result.message == "API is healthy"
     assert result.grading_requests == []
+    assert result.grading_disposition == GradingDisposition.NOT_REQUIRED
     assert result.evidence is None
 
 
@@ -657,6 +766,7 @@ async def test_profile_requiring_username_short_circuits_when_missing():
     assert result.validation_result.username_match is False
     assert "GitHub username is required" in result.validation_result.message
     assert result.grading_requests == []
+    assert result.grading_disposition == GradingDisposition.SKIPPED_MISSING_USERNAME
 
 
 # ---------------------------------------------------------------------------
@@ -675,10 +785,7 @@ def test_every_submission_type_has_a_registered_profile():
 
 
 # ---------------------------------------------------------------------------
-# Every registered profile step must round-trip through the StepParams
-# discriminated union and reference a registered check. This fails in CI (not
-# only in the Functions host) if a new check is added without a StepParams
-# union arm, e.g. the Phase 6 ``codeql_status`` gate.
+# Every profile step's params type must own a registered check.
 # ---------------------------------------------------------------------------
 
 
@@ -690,10 +797,7 @@ def test_every_registered_profile_step_is_valid():
 
     for submission_type, profile in _PROFILE_REGISTRY.items():
         for step in profile.steps:
-            assert step.check in _CHECK_REGISTRY, (
-                f"{submission_type}: step check '{step.check}' is not registered"
+            params_type = type(step.params)
+            assert params_type in _CHECK_REGISTRY, (
+                f"{submission_type}: check '{params_type.check_name}' is not registered"
             )
-            # Re-validating the dumped step forces the discriminated union to
-            # resolve the params type; a missing union arm raises here.
-            rebuilt = Step.model_validate(step.model_dump())
-            assert rebuilt.params.check == step.check


### PR DESCRIPTION
Closes #648.

## What changed
- make each check params type the single dispatch key, removing the manual `StepParams` union and duplicate `Step.check` name
- fold multiple deterministic gate results so later failures are not hidden and earlier task feedback is retained
- record an explicit grading disposition for requested, unnecessary, and skipped grading, including telemetry

## Resolution notes
- token checks intentionally remain on the unified Durable pipeline; a second execution path is not justified
- the incomplete `execute_verification_job` helper was already removed in #666

## Validation
- `uv run poe check`
- API health, readiness, and OpenAPI smoke tests