### PR TITLE
Improve Git and GitHub resources in Phase 1 and Phase 3

### DIFF
--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
@@ -1,6 +1,6 @@
 {
   "artifact_schema_version": 1,
-  "content_hash": "c88e33e551d9d6682d38fe1e2c8c80a864a7ebfcbca1d2fd6b4755075168eca4",
+  "content_hash": "e99735afb6c84f87dab1e9da790eccf0c6add8b20c8f8caa0cedee2f9244f1db",
   "curriculum_version": 3,
   "phases": [
     {
@@ -832,13 +832,13 @@
               "action": "practice",
               "checklist": [],
               "code": null,
-              "description": "Required. Complete one introductory GitHub Learn path (for example, Intro to Git) before moving to the local Git workflow.",
+              "description": "Required. Complete one introductory GitHub Skills course (for example, Intro to Git) before moving to the local Git workflow.",
               "done_when": null,
               "options": [],
               "order": 8,
               "slug": "phase1-topic1-practice-complete-a-github-skills-path",
               "tips": [],
-              "title": "Complete an introductory GitHub Learn path",
+              "title": "Complete an introductory GitHub Skills course",
               "url": "https://learn.github.com/skills",
               "uuid": "d2184bd4-a077-4de8-8f88-0f1a640a6806"
             },
@@ -2559,7 +2559,7 @@
               "action": "practice",
               "checklist": [],
               "code": null,
-              "description": "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. If you need a quick refresher on GitHub workflows, complete a GitHub Skills path at https://learn.github.com/skills and use Git command references at https://github.com/git-guides/git-overview. Important: Follow the development workflow \u2014 create a feature branch for each task, run the tests, then open a Pull Request to merge into main. You'll need to submit each merged PR link for verification.",
+              "description": "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. If you need a quick refresher on GitHub workflows, complete a GitHub Skills course at https://learn.github.com/skills and use Git command references at https://github.com/git-guides/git-overview. Important: Follow the development workflow \u2014 create a feature branch for each task, run the tests, then open a Pull Request to merge into main. You'll need to submit each merged PR link for verification.",
               "done_when": null,
               "options": [],
               "order": 1,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
@@ -1,6 +1,6 @@
 {
   "artifact_schema_version": 1,
-  "content_hash": "e99735afb6c84f87dab1e9da790eccf0c6add8b20c8f8caa0cedee2f9244f1db",
+  "content_hash": "20e4df2d67da7f6c2948b4cbd3c9226683c4d29ff33208adb39dedc69819718f",
   "curriculum_version": 3,
   "phases": [
     {
@@ -832,7 +832,7 @@
               "action": "practice",
               "checklist": [],
               "code": null,
-              "description": "Required. Complete one introductory GitHub Skills course (for example, Intro to Git) before moving to the local Git workflow.",
+              "description": "Required. Complete one introductory GitHub Skills course (for example, Introduction to Git) before moving to the local Git workflow.",
               "done_when": null,
               "options": [],
               "order": 8,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
@@ -1,7 +1,7 @@
 {
   "artifact_schema_version": 1,
-  "content_hash": "4123a7ef3474c99f07d446cd70964906355daf2cb0ba89782be0452b4a49b8b9",
-  "curriculum_version": 2,
+  "content_hash": "c88e33e551d9d6682d38fe1e2c8c80a864a7ebfcbca1d2fd6b4755075168eca4",
+  "curriculum_version": 3,
   "phases": [
     {
       "capstone": null,
@@ -815,17 +815,45 @@
               "uuid": "21e322f4-9fae-4609-af79-13fb33f828a0"
             },
             {
-              "action": "practice",
+              "action": "read",
               "checklist": [],
               "code": null,
-              "description": "Clone your README repo to your local machine. Use VS Code to edit it and push changes back to GitHub from the terminal. Don't feel like you have to make a very fancy README\u2014write a brief description on who you are and add links to your socials.",
+              "description": "Install Git and verify it works in your terminal so you are ready for local-to-remote workflow steps.",
               "done_when": null,
               "options": [],
               "order": 7,
+              "slug": "phase1-topic1-read-install-git",
+              "tips": [],
+              "title": "Install Git",
+              "url": "https://github.com/git-guides/install-git",
+              "uuid": "9b574f74-bef8-4f8c-b87a-c7d24753def9"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Required. Complete one introductory GitHub Learn path (for example, Intro to Git) before moving to the local Git workflow.",
+              "done_when": null,
+              "options": [],
+              "order": 8,
+              "slug": "phase1-topic1-practice-complete-a-github-skills-path",
+              "tips": [],
+              "title": "Complete an introductory GitHub Learn path",
+              "url": "https://learn.github.com/skills",
+              "uuid": "d2184bd4-a077-4de8-8f88-0f1a640a6806"
+            },
+            {
+              "action": "practice",
+              "checklist": [],
+              "code": null,
+              "description": "Clone your README repo to your local machine. Use VS Code to edit it and push changes back to GitHub from the terminal. Use Git Guides as your command reference for clone, status, add, commit, and push while you work. Don't feel like you have to make a very fancy README\u2014write a brief description on who you are and add links to your socials.",
+              "done_when": null,
+              "options": [],
+              "order": 9,
               "slug": "phase1-topic1-practice-practice-git-workflow",
               "tips": [],
               "title": "Practice Git workflow",
-              "url": null,
+              "url": "https://github.com/git-guides/git-overview",
               "uuid": "4a41c7e9-a0aa-4ab4-b47d-8760d92c6ffc"
             },
             {
@@ -835,7 +863,7 @@
               "description": "Open the Learn to Cloud discussions page and bookmark it. If you ever have questions while working through the curriculum, this is the primary place to ask, share progress, and get support.",
               "done_when": null,
               "options": [],
-              "order": 8,
+              "order": 10,
               "slug": "phase1-topic1-practice-join-the-learn-to",
               "tips": [],
               "title": "Join the Learn to Cloud community",
@@ -2531,7 +2559,7 @@
               "action": "practice",
               "checklist": [],
               "code": null,
-              "description": "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. Important: Follow the development workflow \u2014 create a feature branch for each task, run the tests, then open a Pull Request to merge into main. You'll need to submit each merged PR link for verification.",
+              "description": "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. If you need a quick refresher on GitHub workflows, complete a GitHub Skills path at https://learn.github.com/skills and use Git command references at https://github.com/git-guides/git-overview. Important: Follow the development workflow \u2014 create a feature branch for each task, run the tests, then open a Pull Request to merge into main. You'll need to submit each merged PR link for verification.",
               "done_when": null,
               "options": [],
               "order": 1,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
@@ -5,4 +5,4 @@
 # steps, objectives, or requirements). The compiler enforces that this
 # value strictly increases relative to the previously committed
 # curriculum.json artifact -- it will refuse to compile otherwise.
-curriculum_version: 2
+curriculum_version: 3

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/developer-setup.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/developer-setup.yaml
@@ -80,7 +80,7 @@ learning_steps:
   action: 'Practice:'
   title: Complete an introductory GitHub Skills course
   url: https://learn.github.com/skills
-  description: Required. Complete one introductory GitHub Skills course (for example, Intro to Git) before moving to the local Git workflow.
+  description: Required. Complete one introductory GitHub Skills course (for example, Introduction to Git) before moving to the local Git workflow.
   slug: phase1-topic1-practice-complete-a-github-skills-path
 - uuid: 4a41c7e9-a0aa-4ab4-b47d-8760d92c6ffc
   order: 9

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/developer-setup.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/developer-setup.yaml
@@ -78,16 +78,16 @@ learning_steps:
 - uuid: d2184bd4-a077-4de8-8f88-0f1a640a6806
   order: 8
   action: 'Practice:'
-  title: Complete an introductory GitHub Learn path
+  title: Complete an introductory GitHub Skills course
   url: https://learn.github.com/skills
-  description: Required. Complete one introductory GitHub Learn path (for example, Intro to Git) before moving to the local Git workflow.
+  description: Required. Complete one introductory GitHub Skills course (for example, Intro to Git) before moving to the local Git workflow.
   slug: phase1-topic1-practice-complete-a-github-skills-path
 - uuid: 4a41c7e9-a0aa-4ab4-b47d-8760d92c6ffc
   order: 9
   action: 'Practice:'
+  title: Practice Git workflow
   url: https://github.com/git-guides/git-overview
   description: Clone your README repo to your local machine. Use VS Code to edit it and push changes back to GitHub from the terminal. Use Git Guides as your command reference for clone, status, add, commit, and push while you work. Don't feel like you have to make a very fancy README—write a brief description on who you are and add links to your socials.
-  title: Practice Git workflow
   slug: phase1-topic1-practice-practice-git-workflow
 - uuid: e2b87158-c3d4-4aae-b6ee-b38d48fce103
   order: 10

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/developer-setup.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/developer-setup.yaml
@@ -68,14 +68,29 @@ learning_steps:
   url: https://docs.github.com/account-and-profile/how-tos/profile-customization/managing-your-profile-readme
   description: In Phase 0 you created your profile README repository on GitHub. Open it and review the README that powers your profile before you start editing it locally.
   slug: phase1-topic1-practice-adding-a-profile-readme
-- uuid: 4a41c7e9-a0aa-4ab4-b47d-8760d92c6ffc
+- uuid: 9b574f74-bef8-4f8c-b87a-c7d24753def9
   order: 7
+  action: 'Read:'
+  title: Install Git
+  url: https://github.com/git-guides/install-git
+  description: Install Git and verify it works in your terminal so you are ready for local-to-remote workflow steps.
+  slug: phase1-topic1-read-install-git
+- uuid: d2184bd4-a077-4de8-8f88-0f1a640a6806
+  order: 8
   action: 'Practice:'
-  description: Clone your README repo to your local machine. Use VS Code to edit it and push changes back to GitHub from the terminal. Don't feel like you have to make a very fancy README—write a brief description on who you are and add links to your socials.
+  title: Complete an introductory GitHub Learn path
+  url: https://learn.github.com/skills
+  description: Required. Complete one introductory GitHub Learn path (for example, Intro to Git) before moving to the local Git workflow.
+  slug: phase1-topic1-practice-complete-a-github-skills-path
+- uuid: 4a41c7e9-a0aa-4ab4-b47d-8760d92c6ffc
+  order: 9
+  action: 'Practice:'
+  url: https://github.com/git-guides/git-overview
+  description: Clone your README repo to your local machine. Use VS Code to edit it and push changes back to GitHub from the terminal. Use Git Guides as your command reference for clone, status, add, commit, and push while you work. Don't feel like you have to make a very fancy README—write a brief description on who you are and add links to your socials.
   title: Practice Git workflow
   slug: phase1-topic1-practice-practice-git-workflow
 - uuid: e2b87158-c3d4-4aae-b6ee-b38d48fce103
-  order: 8
+  order: 10
   action: 'Practice:'
   title: Join the Learn to Cloud community
   description: Open the Learn to Cloud discussions page and bookmark it. If you ever have questions while working through the curriculum, this is the primary place to ask, share progress, and get support.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase3/build-the-app.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase3/build-the-app.yaml
@@ -23,7 +23,7 @@ learning_steps:
   action: 'Practice:'
   title: Journal Starter Repository
   url: https://github.com/learntocloud/journal-starter
-  description: "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. Important: Follow the development workflow — create a feature branch for each task, run the tests, then open a Pull Request to merge into main. You'll need to submit each merged PR link for verification."
+  description: "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. If you need a quick refresher on GitHub workflows, complete a GitHub Skills path at https://learn.github.com/skills and use Git command references at https://github.com/git-guides/git-overview. Important: Follow the development workflow — create a feature branch for each task, run the tests, then open a Pull Request to merge into main. You'll need to submit each merged PR link for verification."
   slug: phase3-topic5-practice-journal-starter-repository
 - uuid: 0f5b41ca-70f1-43f3-a1d2-f6396f00f1c3
   order: 2

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase3/build-the-app.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase3/build-the-app.yaml
@@ -23,7 +23,7 @@ learning_steps:
   action: 'Practice:'
   title: Journal Starter Repository
   url: https://github.com/learntocloud/journal-starter
-  description: "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. If you need a quick refresher on GitHub workflows, complete a GitHub Skills path at https://learn.github.com/skills and use Git command references at https://github.com/git-guides/git-overview. Important: Follow the development workflow — create a feature branch for each task, run the tests, then open a Pull Request to merge into main. You'll need to submit each merged PR link for verification."
+  description: "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. If you need a quick refresher on GitHub workflows, complete a GitHub Skills course at https://learn.github.com/skills and use Git command references at https://github.com/git-guides/git-overview. Important: Follow the development workflow — create a feature branch for each task, run the tests, then open a Pull Request to merge into main. You'll need to submit each merged PR link for verification."
   slug: phase3-topic5-practice-journal-starter-repository
 - uuid: 0f5b41ca-70f1-43f3-a1d2-f6396f00f1c3
   order: 2


### PR DESCRIPTION
This updates curriculum guidance so early learners get Git fundamentals first, while still having GitHub workflow support at the right time.

## What changed
- Added a new Phase 1 **Install Git** step using Git Guides (`install-git`).
- Added a new required Phase 1 step for an **introductory GitHub Learn path** (for example, Intro to Git), without emphasizing PR-heavy paths in week one.
- Updated the Phase 1 **Practice Git workflow** step to include `git-overview` and explicit command guidance (clone, status, add, commit, push).
- Updated the Phase 3 capstone practice description with a brief refresher note linking to GitHub Learn and Git Guides, while keeping the Journal Starter repo as the primary source of truth.

## Notes for reviewers
- Scope is limited to content YAML in Phase 1 and Phase 3.
- No verification requirement files were changed.

Fixes: #677