### PR TITLE
docs: restore reliable Pages publishing

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,63 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'scripts/check_docs.py'
+      - '.github/workflows/pages.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'scripts/check_docs.py'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate documentation links
+        run: |
+          python -m unittest discover -s scripts/tests
+          python scripts/check_docs.py
+
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,12 @@ repos:
         language: system
         files: ^api/alembic/versions/.*\.py$
         pass_filenames: false
+      - id: docs-links
+        name: documentation links
+        entry: bash -c 'python -m unittest discover -s scripts/tests && python scripts/check_docs.py'
+        language: system
+        files: ^(docs/|scripts/check_docs\.py$|scripts/tests/test_check_docs\.py$)
+        pass_filenames: false
 
   # General file hygiene + check-yaml
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Or use VS Code's **"API + Verification"** compound launch configuration.
 ## Contributing
 
 See the [Contributing Guide](docs/contributing.md) for linting, testing, the dog-food QA agent, Copilot skills, and architecture conventions.
+Published architecture and operations docs are available on
+[GitHub Pages](https://learntocloud.github.io/learn-to-cloud-app/).
 
 ## Deployment
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,9 @@
 
 ## Development Setup
 
-The devcontainer handles everything automatically — see the [README](../README.md) for Quick Start instructions.
+The devcontainer handles everything automatically. See the
+[README Quick Start](https://github.com/learntocloud/learn-to-cloud-app#quick-start)
+for setup instructions.
 
 ## Quality Gates
 
@@ -102,6 +104,11 @@ The project ships several Copilot agent skills in `.github/skills/`:
 | `check-prod` | "check prod" | Check Azure health, errors, latency |
 | `debug-deploy` | "debug deploy" | Diagnose CI/CD and Terraform failures |
 | `query-prod-db` | "query prod db" | Run ad-hoc queries against production DB |
+| `reset-local-submissions` | "reset local submissions" | Reset local verification state |
+| `reset-prod-submissions` | "reset prod submissions" | Reset production verification state |
+| `review-pr-comments` | "review PR comments" | Triage and address PR feedback |
+| `review-terraform` | "review terraform" | Validate Terraform changes |
+| `write-migration` | "write migration" | Create safe Alembic migrations |
 
 ## Architecture
 
@@ -143,7 +150,7 @@ It's fine to bundle them in one PR when the code change is purely
 additive and the old code path doesn't break without the new schema
 (e.g., adding a nullable column that nothing reads yet).
 
-See [docs/migrations.md](migrations.md) for more on how migrations work.
+See [Database Migrations](migrations.html) for more on how migrations work.
 
 ## Editing curriculum content
 
@@ -160,5 +167,23 @@ To change it:
    ```
 3. Open a PR. CI runs the same validators.
 
-See [`docs/curriculum.md`](curriculum.md) for the full packaged-artifact
+See [Curriculum Architecture](curriculum.html) for the full packaged-artifact
 architecture.
+
+## GitHub Pages
+
+Repository documentation is published from `docs/` at
+`https://learntocloud.github.io/learn-to-cloud-app/`. The Pages workflow:
+
+1. Runs `python scripts/check_docs.py`.
+2. Builds the Markdown and static HTML with Jekyll.
+3. Deploys the generated site to the `github-pages` environment.
+
+Pull requests build the site without deploying it. Merges to `main` that touch
+the docs, validator, or Pages workflow publish automatically. Maintainers can
+also use the workflow's **Run workflow** action for a manual publish.
+
+Repository settings must keep **Pages > Build and deployment > Source** set to
+**GitHub Actions**. After publishing, verify the
+[documentation root](https://learntocloud.github.io/learn-to-cloud-app/) and
+[presentation](https://learntocloud.github.io/learn-to-cloud-app/scaling-with-github/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,18 @@
+---
+title: Learn to Cloud App Documentation
+---
+
+# Learn to Cloud App Documentation
+
+Architecture, contributor, and operations documentation for the
+[Learn to Cloud app](https://github.com/learntocloud/learn-to-cloud-app).
+
+## Guides
+
+- [Curriculum architecture](curriculum.html)
+- [Progression system](progression-system.html)
+- [Database migrations](migrations.html)
+- [Contributing](contributing.html)
+- [GitHub Powering Your AI SDLC presentation](scaling-with-github/)
+
+Application users should start at [learntocloud.guide](https://learntocloud.guide).

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -151,7 +151,8 @@ docker compose run --rm api-multiworker python -m alembic upgrade head
 docker compose up api-multiworker
 ```
 
-Alternatively, create a one-off migration service in `docker-compose.yml` (see below).
+`api-multiworker` is a diagnostic Compose service rather than the normal local
+development path. For day-to-day work, run Alembic directly from `api/`.
 
 ## Tips
 

--- a/docs/progression-system.md
+++ b/docs/progression-system.md
@@ -3,36 +3,42 @@
 ## Core Concept
 
 A **Phase is Complete** when ALL requirements are met:
-1. ✅ All **Learning Steps** completed
-2. ✅ All **Hands-on Requirements** validated
+1. All **Learning Steps** are completed.
+2. All **Hands-on Requirements** are verified successfully.
 
 This drives: profile stats and dashboard progress.
 
 ## Content Access
 
-All phases, topics, and steps are **fully unlocked** - users can access any content in any order. There is no gating based on completion status.
+All phases, topics, and learning steps are unlocked, so learners can read the
+curriculum in any order. Hands-on verification is sequential from Phase 4
+through Phase 7: each phase's requirements must be verified before submissions
+for the next phase unlock.
 
 ## Progress Calculation
 
 **Topic:** `Steps Completed / Total Steps`
 
-**Phase:** `(Steps + Hands-on) / Total`
+**Phase:** two separate measures:
+
+- Learning progress: `Completed Steps / Current Catalog Steps`
+- Verification progress: `Succeeded Requirements / Current Catalog Requirements`
+
+A phase is complete only when both measures are complete. A measure with no
+requirements is complete by definition.
 
 ## Key Files
 
 | Purpose | File |
 |---------|------|
-| Progress | `services/progress_service.py` |
-| Hands-on | `packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/requirements.py` |
+| Progress | `api/src/learn_to_cloud/services/progress_service.py` |
+| Hands-on | `packages/learn-to-cloud-shared/src/learn_to_cloud_shared/requirements.py` |
+| Catalog reads | `packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py` |
 
 ## Important
 
 Step/topic counts are **dynamically derived** from content YAML—do NOT hardcode.
 
-Step completion identity is based on stable `step_id` values (not positional order), and
-progress is reconciled against currently loaded content to avoid drift after curriculum edits.
-
----
-
-## Feedback
-If you encounter a pattern, convention, or edge case that should be added to these instructions, let me know so we can consider including it.
+Step and requirement completion identity uses stable UUIDs, not positional
+order. Progress intersects stored UUIDs with the current catalog so retired
+content no longer counts without deleting learner history.

--- a/docs/scaling-with-github/index.html
+++ b/docs/scaling-with-github/index.html
@@ -77,23 +77,23 @@
   </div>
   <div class="feature-grid" style="margin-top: 16px; text-align: center; grid-template-columns: 1fr 1fr 1fr 1fr;">
     <div class="feature-card" style="text-align: center;">
-      <p class="big-number">1</p>
-      <p class="big-number-label">Engineer (sometimes 2)</p>
+      <p class="big-number">8</p>
+      <p class="big-number-label">Curriculum phases</p>
     </div>
     <div class="feature-card" style="text-align: center;">
-      <p class="big-number">~3,000</p>
-      <p class="big-number-label">Active users</p>
+      <p class="big-number">3</p>
+      <p class="big-number-label">Python workspace packages</p>
     </div>
     <div class="feature-card" style="text-align: center;">
-      <p class="big-number">18ms</p>
-      <p class="big-number-label">P95 latency</p>
+      <p class="big-number">10</p>
+      <p class="big-number-label">Repository skills</p>
     </div>
     <div class="feature-card" style="text-align: center;">
-      <p class="big-number">0</p>
-      <p class="big-number-label">5xx errors (24h)</p>
+      <p class="big-number">6</p>
+      <p class="big-number-label">Custom agents</p>
     </div>
   </div>
-  <p style="margin-top: 20px; font-size: 0.75em; text-align: center;">Team of 1. This is how it gets done.</p>
+  <p style="margin-top: 20px; font-size: 0.75em; text-align: center;">A small team, backed by repeatable automation.</p>
 </section>
 
 <!-- ============================================================ -->
@@ -204,7 +204,7 @@
   <pre><code class="language-markdown"># Project Instructions
 
 ## Tech Stack
-- Backend: FastAPI 0.115 + Python 3.13, async throughout
+- Backend: FastAPI 0.139+ + Python 3.13, async throughout
 - Database: PostgreSQL 16 via async SQLAlchemy 2.0
 - Frontend: Jinja2 templates + HTMX + Tailwind CSS v4
 - Auth: GitHub OAuth via Authlib
@@ -329,7 +329,7 @@ Routes (HTTP) → Services (Business Logic) → Repositories (DB)
 <section>
   <h3 class="section-title">Phase 3</h3>
   <h2>🔨 Build</h2>
-  <p>Continuous integration: every push is validated automatically</p>
+  <p>Continuous integration: relevant changes are validated automatically</p>
   <p class="dim" style="font-size: 0.6em; margin-top: 24px; letter-spacing: 2px;">↓ DEMO</p>
 </section>
 
@@ -341,22 +341,23 @@ Routes (HTTP) → Services (Business Logic) → Repositories (DB)
         <tr><th>Job</th><th>Trigger</th><th>What It Does</th></tr>
       </thead>
       <tbody>
-        <tr><td class="blue">changes</td><td>Every push</td><td>Detect which folders changed (skip unnecessary work)</td></tr>
+        <tr><td class="blue">changes</td><td>Push + PR</td><td>Detect code and infrastructure changes</td></tr>
         <tr><td class="blue">dependency-review</td><td>PRs only</td><td>Block PRs with vulnerable dependencies</td></tr>
-        <tr><td class="blue">ci</td><td>Every push + PR</td><td>Lint → format → type-check → test with coverage</td></tr>
-        <tr><td class="blue">terraform</td><td>Main only</td><td>Plan + apply infrastructure changes</td></tr>
-        <tr><td class="blue">deploy</td><td>Main only</td><td>Build Docker → push to ACR → update Container App</td></tr>
+        <tr><td class="blue">ci</td><td>Code changes</td><td>Static checks, content validation, migrations, and tests</td></tr>
+        <tr><td class="blue">terraform-ci</td><td>Infra changes</td><td>Format, initialize, validate, and test Terraform</td></tr>
+        <tr><td class="blue">terraform</td><td>Main + manual</td><td>Plan infrastructure; apply only on main</td></tr>
+        <tr><td class="blue">deploy</td><td>Main + manual</td><td>Build images, migrate, and update Azure services</td></tr>
       </tbody>
     </table>
   </div>
   <div class="feature-grid" style="margin-top: 16px;">
     <div class="feature-card">
       <h4>Path Filtering</h4>
-      <p>Only deploy when api/, content/, or infra/ files change</p>
+      <p>Application deploys run only for code, package, or infrastructure changes</p>
     </div>
     <div class="feature-card">
       <h4>Concurrency Control</h4>
-      <p>New push cancels in-progress deploys, no wasted builds</p>
+      <p>PR runs cancel when superseded; active production deploys finish safely</p>
     </div>
   </div>
 </section>
@@ -365,6 +366,8 @@ Routes (HTTP) → Services (Business Logic) → Repositories (DB)
   <h2>The CI Job</h2>
   <p class="file-path">.github/workflows/deploy.yml</p>
   <pre><code class="language-yaml">  ci:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -374,25 +377,20 @@ Routes (HTTP) → Services (Business Logic) → Repositories (DB)
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: learntocloud
         ports: ["5432:5432"]
+<!--
     env:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud
-    defaults:
-      run:
-        working-directory: api
+-->
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version-file: "api/pyproject.toml"
-      - uses: astral-sh/setup-uv@v7
-      - run: uv sync --locked
-      - uses: astral-sh/ruff-action@v3
-        with: { src: "./api", args: "check" }
-      - uses: astral-sh/ruff-action@v3
-        with: { src: "./api", args: "format --check" }
-      - run: uv run ty check --python .venv/bin/python
-      - run: uv run pytest tests/ -v --tb=short --cov=. --cov-report=xml</code></pre>
-  <p class="dim" style="font-size: 0.65em; margin-top: 8px;">Every push triggers lint, format, type-check, and tests against a real PostgreSQL instance.</p>
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+      - uses: astral-sh/setup-uv@v8
+      - run: uv sync --all-packages --locked
+      - run: uv run poe static
+      - run: uv run poe package-smoke
+      - run: cd api &amp;&amp; uv run alembic upgrade head
+      - run: uv run poe test</code></pre>
+  <p class="dim" style="font-size: 0.65em; margin-top: 8px;">Relevant pushes and pull requests run one workspace-wide quality gate against PostgreSQL.</p>
 </section>
 
 <!-- ============================================================ -->
@@ -410,15 +408,16 @@ Routes (HTTP) → Services (Business Logic) → Repositories (DB)
   <p class="file-path">.github/skills/validate/SKILL.md</p>
   <pre><code class="language-markdown"># Validate Python Changes
 
-## Step 0: Kill any existing API processes
-## Step 1: Run Ruff Lint
-## Step 2: Run Ruff Format Check
-## Step 3: Run ty Type Check
-## Step 4: Start the API
-## Step 5: Smoke Test Endpoints
+## Step 1: Run the workspace static checks
+  uv run poe static
+## Step 2: Start the API
+## Step 3: Smoke test endpoints
   curl -s http://localhost:8000/health
   curl -s http://localhost:8000/ready
-## Step 6: Kill the API</code></pre>
+  curl -s http://localhost:8000/openapi.json
+## Step 4: Stop the API
+## Step 5: Run workspace tests when logic changed
+  uv run poe test</code></pre>
   <p class="dim" style="font-size: 0.65em; margin-top: 12px;">Static analysis catches lint errors. Starting the API catches import errors, circular imports, and route registration bugs.</p>
 </section>
 
@@ -488,14 +487,12 @@ End-to-end workflow: run prek checks, fix failures, commit,
 push, and monitor the GitHub Actions deploy pipeline through
 to a healthy production readiness check.
 
-## Step 0: Match User's Energy
-Reply with "LFG 🚀 I'll ship it"
-
-## Step 1: Run Prek (all pre-commit hooks)
-## Step 2: Fix Any Failures (auto-fix + re-run)
-## Step 3: Stage All Changes + Commit
-## Step 4: Push + Monitor Deploy Workflow
-## Step 5: Verify Production Health</code></pre>
+## Step 1: Confirm branch and GitHub authentication
+## Step 2: Run uv run poe check
+## Step 3: Stage and commit with the required trailer
+## Step 4: Push and open a pull request
+## Step 5: Monitor deployment after merge
+## Step 6: Verify production health</code></pre>
   <p class="dim" style="font-size: 0.65em; margin-top: 8px;">Say "ship it": Copilot runs lint, commits, pushes, monitors the deploy, and checks prod health.</p>
 </section>
 
@@ -514,7 +511,7 @@ Reply with "LFG 🚀 I'll ship it"
   <div class="feature-grid">
     <div class="feature-card">
       <h4>🔍 CodeQL</h4>
-      <p>Semantic static analysis on every push, PR, and weekly schedule. Covers OWASP Top 10.</p>
+      <p>Semantic static analysis on relevant pushes, pull requests, and a weekly schedule. Covers OWASP Top 10.</p>
     </div>
     <div class="feature-card">
       <h4>🔐 Secret Scanning</h4>
@@ -568,19 +565,19 @@ Reply with "LFG 🚀 I'll ship it"
   <p class="file-path">.github/skills/check-prod/SKILL.md</p>
   <pre><code class="language-markdown"># Production Health Check
 
-10 checks. One verdict. All read-only. Uses Azure CLI.
+14 checks. One verdict. All read-only. Uses Azure CLI.
 
 ## Verdict Logic
 🔴 Critical - Non-200 readiness, 5xx errors, DB CPU > 80%
 ⚠️  Warning  - P95 > 500ms, DB CPU 50-80%, failed availability
 ✅ Healthy  - None of the above
 
-## The 10 Checks
- 1. Container App status       6. DB CPU, memory, storage
- 2. Availability tests (24h)   7. Active DB connections
- 3. Request latency P95        8. Fired alerts (24h)
- 4. Error rates 4xx/5xx        9. Container restarts
- 5. Unhandled exceptions      10. Dependency health</code></pre>
+## Coverage
+- Readiness and Azure resource health
+- Availability, request health, and error trends
+- Exceptions, dependencies, and database metrics
+- Container metrics, stability, alerts, and console errors
+- Authentication and verification business signals</code></pre>
 </section>
 
 <section>
@@ -591,7 +588,7 @@ Reply with "LFG 🚀 I'll ship it"
         <tr><th>You Say</th><th>Copilot Does</th></tr>
       </thead>
       <tbody>
-        <tr><td class="green">"check prod"</td><td>10-point health check: errors, latency, DB, alerts</td></tr>
+        <tr><td class="green">"check prod"</td><td>14-point health check: errors, latency, DB, alerts</td></tr>
         <tr><td class="green">"debug deploy"</td><td>Diagnose CI/CD failures: state locks, auth, quotas</td></tr>
         <tr><td class="green">"query db"</td><td>Production PostgreSQL queries with Entra ID auth</td></tr>
         <tr><td class="green">"validate changes"</td><td>Lint → format → type-check → start API → smoke test</td></tr>
@@ -630,19 +627,14 @@ Reply with "LFG 🚀 I'll ship it"
           <td>Scans content YAML for broken external URLs</td>
         </tr>
         <tr>
-          <td class="blue">Cross-Repo Overview</td>
-          <td>Daily (5am)</td>
-          <td>Issue/PR dashboard across 4 repos</td>
+          <td class="blue">Agentic Maintenance</td>
+          <td>Daily</td>
+          <td>Cleans up expiring workflow outputs and maintenance state</td>
         </tr>
         <tr>
-          <td class="blue">Community Thanks</td>
-          <td>Weekly (Sun)</td>
-          <td>Aggregates issue reporters for shoutouts</td>
-        </tr>
-        <tr>
-          <td class="blue">Deck Updater</td>
-          <td>Every push</td>
-          <td>Keeps this presentation in sync with the repo</td>
+          <td class="blue">Pages</td>
+          <td>Docs changes</td>
+          <td>Validates, builds, and publishes this documentation site</td>
         </tr>
       </tbody>
     </table>
@@ -677,14 +669,16 @@ Reply with "LFG 🚀 I'll ship it"
 │   ├── check-prod/SKILL.md          # ⚙️ Operate: health check
 │   ├── debug-deploy/SKILL.md        # ⚙️ Operate: diagnose failures
 │   ├── query-prod-db/SKILL.md       # ⚙️ Operate: production queries
-│   └── reset-local-submissions/SKILL.md  # 🧪 Test: reset verification state
+│   ├── reset-local-submissions/SKILL.md  # 🧪 Test: reset verification state
+│   ├── reset-prod-submissions/SKILL.md   # ⚙️ Operate: reset production state
+│   ├── review-pr-comments/SKILL.md       # ⌨️ Code: address review feedback
+│   ├── review-terraform/SKILL.md         # 🔒 Secure: validate infrastructure
+│   └── write-migration/SKILL.md          # ⌨️ Code: safe schema changes
 └── workflows/
     ├── deploy.yml                   # 🔨 Build + 🚀 Deploy: CI/CD
     ├── codeql.yml                   # 🔒 Secure: static analysis
     ├── content-link-auditor.md      # 📡 Monitor: broken link scan
-    ├── cross-repo-issues-overview.md # 📡 Monitor: issue dashboard
-    ├── discussion-answer-thanks.md  # 📡 Monitor: community recognition
-    └── update-deck.md               # 📡 Monitor: keep deck current</code></pre>
+    └── pages.yml                    # 📡 Monitor: publish documentation</code></pre>
 </section>
 
 <section class="center-slide">
@@ -695,16 +689,16 @@ Reply with "LFG 🚀 I'll ship it"
       <p class="big-number-label">SDLC phases with AI</p>
     </div>
     <div class="feature-card" style="text-align: center;">
-      <p class="big-number">0</p>
-      <p class="big-number-label">Manual deploys</p>
+      <p class="big-number">2</p>
+      <p class="big-number-label">Deployment pipelines</p>
     </div>
     <div class="feature-card" style="text-align: center;">
-      <p class="big-number">6</p>
+      <p class="big-number">10</p>
       <p class="big-number-label">Copilot skills</p>
     </div>
     <div class="feature-card" style="text-align: center;">
-      <p class="big-number">100%</p>
-      <p class="big-number-label">Markdown config</p>
+      <p class="big-number">5</p>
+      <p class="big-number-label">Reusable prompt files</p>
     </div>
   </div>
   <p style="margin-top: 32px; font-size: 0.9em;">
@@ -713,13 +707,13 @@ Reply with "LFG 🚀 I'll ship it"
 </section>
 
 <section class="center-slide" data-background-gradient="radial-gradient(circle at 80% 50%, #0d2137 0%, #0d1117 70%)">
-  <h2>This Deck Updates Itself</h2>
+  <h2>Keep the Deck Current</h2>
   <div class="highlight-box" style="text-align: left; display: inline-block;">
-    <p style="font-size: 0.8em;">Pushes to <code>main</code> that change repo config trigger a Copilot Workflow that:</p>
+    <p style="font-size: 0.8em;">Changes to repository automation should update this presentation in the same pull request:</p>
     <ol style="list-style: decimal; padding-left: 1.5em; font-size: 0.75em; margin-top: 12px;">
-      <li style="margin: 0.4em 0;">Scans the repo for skills, agents, prompts, and workflows</li>
-      <li style="margin: 0.4em 0;">Compares what exists against what's in the deck</li>
-      <li style="margin: 0.4em 0;">Opens a PR if anything is out of date</li>
+      <li style="margin: 0.4em 0;">Compare skills, agents, prompts, and workflows</li>
+      <li style="margin: 0.4em 0;">Update examples and durable repository counts</li>
+      <li style="margin: 0.4em 0;">Let the Pages workflow validate and publish the result</li>
     </ol>
   </div>
   <p style="margin-top: 32px;" class="dim">

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,0 +1,133 @@
+"""Validate local links and GitHub Pages entrypoints under docs/."""
+
+from __future__ import annotations
+
+import re
+import sys
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_ROOT = REPO_ROOT / "docs"
+PAGES_PREFIX = "/learn-to-cloud-app/"
+REQUIRED_ENTRYPOINTS = (
+    DOCS_ROOT / "index.md",
+    DOCS_ROOT / "scaling-with-github" / "index.html",
+)
+MARKDOWN_LINK = re.compile(r"!?\[[^\]]*]\(([^)\s]+)(?:\s+[^)]*)?\)")
+MARKDOWN_HEADING = re.compile(r"^#{1,6}\s+(.+?)\s*#*\s*$", re.MULTILINE)
+
+
+class LinkParser(HTMLParser):
+    """Collect links and anchors from an HTML document."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: list[str] = []
+        self.anchors: set[str] = set()
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        for name in ("id", "name"):
+            if value := attributes.get(name):
+                self.anchors.add(value)
+        for name in ("href", "src"):
+            if value := attributes.get(name):
+                self.links.append(value)
+
+
+def markdown_anchors(content: str) -> set[str]:
+    """Return GitHub-style heading anchors for Markdown content."""
+    anchors: set[str] = set()
+    for heading in MARKDOWN_HEADING.findall(content):
+        anchor = re.sub(r"[^\w\- ]", "", heading.lower(), flags=re.UNICODE)
+        anchors.add(re.sub(r"[\s\-]+", "-", anchor).strip("-"))
+    return anchors
+
+
+def links_and_anchors(path: Path) -> tuple[list[str], set[str]]:
+    content = path.read_text(encoding="utf-8")
+    if path.suffix == ".html":
+        parser = LinkParser()
+        parser.feed(content)
+        return parser.links, parser.anchors
+    return MARKDOWN_LINK.findall(content), markdown_anchors(content)
+
+
+def resolve_target(source: Path, link_path: str) -> Path:
+    decoded_path = unquote(link_path)
+    if decoded_path.startswith(PAGES_PREFIX):
+        target = DOCS_ROOT / decoded_path.removeprefix(PAGES_PREFIX)
+    elif decoded_path.startswith("/"):
+        target = DOCS_ROOT / decoded_path.removeprefix("/")
+    else:
+        target = source.parent / decoded_path
+
+    target = target.resolve()
+    if target.suffix == ".html" and not target.exists():
+        markdown_target = target.with_suffix(".md")
+        if markdown_target.exists():
+            target = markdown_target
+    if target.is_dir():
+        for index_name in ("index.md", "index.html"):
+            index = target / index_name
+            if index.exists():
+                return index
+    return target
+
+
+def validate_docs() -> list[str]:
+    """Return validation errors for the documentation tree."""
+    errors: list[str] = []
+    for entrypoint in REQUIRED_ENTRYPOINTS:
+        if not entrypoint.is_file():
+            errors.append(f"missing required Pages entrypoint: {entrypoint}")
+
+    documents = sorted((*DOCS_ROOT.rglob("*.md"), *DOCS_ROOT.rglob("*.html")))
+    for source in documents:
+        links, _ = links_and_anchors(source)
+        for link in links:
+            parsed = urlsplit(link)
+            if parsed.scheme or parsed.netloc:
+                continue
+            if not parsed.path:
+                target = source
+            else:
+                target = resolve_target(source, parsed.path)
+
+            try:
+                target.relative_to(REPO_ROOT)
+            except ValueError:
+                errors.append(
+                    f"{source.relative_to(REPO_ROOT)}: link escapes repo: {link}"
+                )
+                continue
+
+            if not target.is_file():
+                errors.append(
+                    f"{source.relative_to(REPO_ROOT)}: missing target for {link}"
+                )
+                continue
+
+            if parsed.fragment and target.suffix in {".md", ".html"}:
+                _, anchors = links_and_anchors(target)
+                if unquote(parsed.fragment) not in anchors:
+                    errors.append(
+                        f"{source.relative_to(REPO_ROOT)}: missing fragment for {link}"
+                    )
+    return errors
+
+
+def main() -> int:
+    errors = validate_docs()
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    document_count = sum(1 for _ in DOCS_ROOT.rglob("*") if _.is_file())
+    print(f"Documentation links valid across {document_count} files.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_check_docs.py
+++ b/scripts/tests/test_check_docs.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import check_docs
+
+
+class CheckDocsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.repo_root = Path(self.temporary_directory.name)
+        self.docs_root = self.repo_root / "docs"
+        self.scaling_index = self.docs_root / "scaling-with-github" / "index.html"
+        self.scaling_index.parent.mkdir(parents=True)
+        self.scaling_index.write_text("<h1 id='slides'>Slides</h1>", encoding="utf-8")
+
+        patcher = patch.multiple(
+            check_docs,
+            REPO_ROOT=self.repo_root,
+            DOCS_ROOT=self.docs_root,
+            REQUIRED_ENTRYPOINTS=(self.docs_root / "index.md", self.scaling_index),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_accepts_valid_pages_links_and_fragments(self) -> None:
+        (self.docs_root / "index.md").write_text(
+            "# Home\n\n[Guide](guide.html#details)\n[Slides](scaling-with-github/)\n",
+            encoding="utf-8",
+        )
+        (self.docs_root / "guide.md").write_text(
+            "# Guide\n\n## Details\n", encoding="utf-8"
+        )
+
+        self.assertEqual(check_docs.validate_docs(), [])
+
+    def test_reports_missing_local_target(self) -> None:
+        (self.docs_root / "index.md").write_text(
+            "# Home\n\n[Missing](missing.html)\n", encoding="utf-8"
+        )
+
+        errors = check_docs.validate_docs()
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("missing target", errors[0])
+
+    def test_reports_missing_fragment(self) -> None:
+        (self.docs_root / "index.md").write_text(
+            "# Home\n\n[Guide](guide.html#missing)\n", encoding="utf-8"
+        )
+        (self.docs_root / "guide.md").write_text("# Guide\n", encoding="utf-8")
+
+        errors = check_docs.validate_docs()
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("missing fragment", errors[0])
+
+    def test_reports_links_that_escape_repository(self) -> None:
+        (self.docs_root / "index.md").write_text(
+            "# Home\n\n[Outside](../../outside.md)\n", encoding="utf-8"
+        )
+
+        errors = check_docs.validate_docs()
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("link escapes repo", errors[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #649

## Summary
- audit and refresh all documentation, including the GitHub SDLC presentation
- add a GitHub Pages landing page and publishing guidance
- add deterministic docs link validation with focused tests
- replace the stale implicit Pages deployment with an explicit Jekyll build and deploy workflow

## Validation
- uv run poe check
- external documentation links audited
- live Pages URLs remain expected 404s until this PR merges and deploys