### PR TITLE
chore: drop GitHub.copilot from devcontainer extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,7 +47,6 @@
         "ms-azuretools.vscode-docker",
         "dbaeumer.vscode-eslint",
         "bradlc.vscode-tailwindcss",
-        "GitHub.copilot",
         "ms-azuretools.vscode-azure-mcp-server"
       ]
     }


### PR DESCRIPTION
VS Code ships Copilot and Copilot Chat as built-in extensions. Listing GitHub.copilot made container setup try to install the older marketplace copilot-chat (0.48.1) over the built-in 0.59.0, which fails with a downgrade error during every rebuild.

## Summary

<!-- What does this PR do and why? -->

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.
