### PR TITLE
fix: make dog-food Playwright browser work on x86_64 and ARM64

### DIFF
--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -45,9 +45,11 @@ npm install -g @playwright/mcp@latest
 # server then reports the browser as "not installed" even though one is in the
 # cache. Going through playwright-mcp keeps the revisions in lockstep.
 #
-# Chromium (rather than the `chrome` channel) is the only option that works on
-# both architectures: Google Chrome has no ARM64 Linux build, while Playwright
-# ships Chromium builds for both x64 and ARM64. This matches the
+# Chromium (rather than the `chrome` channel) is the only Chromium-engine
+# option available on both architectures: Google Chrome has no ARM64 Linux
+# build, while Playwright ships Chromium builds for both x64 and ARM64.
+# Firefox and WebKit also run on both, but they would test a different engine
+# than the Chromium-based browsers most users are on. This matches the
 # `--browser chromium` arg in `.mcp.json` and `.vscode/mcp.json`.
 #
 # `--with-deps` installs the OS libraries (libatk, libnss, etc.) the browser

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -37,21 +37,23 @@ echo "🐍 Setting up the Python workspace environment..."
 uv sync --all-packages --locked
 
 # Install Playwright MCP server + browser for dogfooding.
-# Install `playwright` globally alongside the MCP package so the subsequent
-# `playwright install` call doesn't emit the "install your project's
-# dependencies first" warning (npx looks for playwright in the cwd's
-# package.json, and the repo root has none).
 echo "🎭 Installing Playwright MCP + browser..."
-npm install -g playwright @playwright/mcp@latest
+npm install -g @playwright/mcp@latest
+# Install the browser through `playwright-mcp` rather than a standalone
+# `playwright` CLI. The MCP server bundles its own playwright-core, and a
+# separately installed CLI can resolve a different browser revision — the MCP
+# server then reports the browser as "not installed" even though one is in the
+# cache. Going through playwright-mcp keeps the revisions in lockstep.
+#
+# Chromium (rather than the `chrome` channel) is the only option that works on
+# both architectures: Google Chrome has no ARM64 Linux build, while Playwright
+# ships Chromium builds for both x64 and ARM64. This matches the
+# `--browser chromium` arg in `.mcp.json` and `.vscode/mcp.json`.
+#
 # `--with-deps` installs the OS libraries (libatk, libnss, etc.) the browser
-# needs to actually launch; without them Chromium/Chrome fail with
+# needs to actually launch; without them Chromium fails with
 # "error while loading shared libraries". The flag uses sudo internally.
-if [ "$(uname -m)" = "aarch64" ]; then
-    # Google Chrome has no ARM64 Linux build; use Playwright's bundled Chromium instead
-    playwright install --with-deps chromium
-else
-    playwright install --with-deps chrome
-fi
+playwright-mcp install-browser chromium --with-deps
 
 # Install Aspire CLI for the MCP server (aspire agent mcp).
 # Installed via the standalone script so we don't need .NET SDK or the VS Code

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -76,7 +76,7 @@ or invoke the agent directly with `@dog-food`. The agent will:
 
 Everything is pre-installed by the devcontainer (`on-create.sh`):
 - Playwright MCP server + Chromium (configured in `.mcp.json` for the Copilot CLI and `.vscode/mcp.json` for VS Code)
-- System libraries for headless Chromium (installed by `playwright-mcp install-browser --with-deps`)
+- System libraries for headless Chromium (installed by `playwright-mcp install-browser chromium --with-deps`)
 - Database seeded with at least one user (via `scripts/dogfood_session.py`)
 
 ### Cross-architecture support

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -64,7 +64,7 @@ test our app
 or invoke the agent directly with `@dog-food`. The agent will:
 
 1. **Start the API** on port 8000 and verify `/health` + `/ready`
-2. **Install Chrome** if needed (headless, `--no-sandbox` for devcontainers)
+2. **Install Chromium** if needed (headless, `--no-sandbox` for devcontainers)
 3. **Test all public pages** — Home, Curriculum, FAQ, Privacy, Terms, Status
 4. **Toggle dark mode** and verify it works
 5. **Authenticate** via a signed session cookie (no real GitHub OAuth needed)
@@ -75,9 +75,25 @@ or invoke the agent directly with `@dog-food`. The agent will:
 ### Prerequisites
 
 Everything is pre-installed by the devcontainer (`on-create.sh`):
-- Playwright MCP server + Chrome (configured in `.vscode/mcp.json`)
-- System libraries for headless Chrome (installed in the `Dockerfile`)
+- Playwright MCP server + Chromium (configured in `.mcp.json` for the Copilot CLI and `.vscode/mcp.json` for VS Code)
+- System libraries for headless Chromium (installed by `playwright-mcp install-browser --with-deps`)
 - Database seeded with at least one user (via `scripts/dogfood_session.py`)
+
+### Cross-architecture support
+
+The agent runs on both x86_64 and ARM64 (Apple Silicon) devcontainers because it
+uses **Chromium**, not the `chrome` channel — Google Chrome has no ARM64 Linux
+build, and pointing the MCP server at it there fails at launch.
+
+Two things must stay in sync, so change them together:
+
+- The `--browser chromium` arg in `.mcp.json` and `.vscode/mcp.json`.
+- The `playwright-mcp install-browser chromium` call in `on-create.sh`.
+
+Install the browser through `playwright-mcp`, not a separately installed
+`playwright` CLI. The MCP server bundles its own playwright-core and resolves a
+specific browser revision; a standalone CLI may install a different one, and the
+MCP server then reports the browser as not installed.
 
 ### Artifacts
 
@@ -88,10 +104,9 @@ Screenshots are saved to `.dogfood/` (gitignored). No artifacts pollute the repo
 | Component | File |
 |-----------|------|
 | Agent instructions | `.github/agents/dog-food.agent.md` |
-| MCP server config | `.vscode/mcp.json` |
+| MCP server config | `.mcp.json`, `.vscode/mcp.json` |
 | Session cookie generator | `scripts/dogfood_session.py` |
-| Chrome system deps | `.devcontainer/Dockerfile` |
-| Chrome + MCP install | `.devcontainer/on-create.sh` |
+| Chromium + MCP install | `.devcontainer/on-create.sh` |
 
 ## Copilot Skills
 


### PR DESCRIPTION
Closes #468

## Problem

The dog-food agent couldn't launch a browser. Two bugs, one on each arch:

- **x86_64 (currently broken on `main`)**: `.mcp.json` / `.vscode/mcp.json` pass `--browser chromium`, but `on-create.sh` installed the `chrome` *channel*. The MCP server resolves `chromium` to Chrome for Testing, which was never installed:
  `Error: Browser "chrome-for-testing" is not installed`
- **ARM64 (the original issue)**: Google Chrome has no ARM64 Linux build. `on-create.sh` installed Chromium via a globally installed `playwright` CLI — but that CLI resolves a *different* browser revision (1234) than the playwright-core bundled in `@playwright/mcp` (1232), so the MCP server still reports the browser as not installed.

## Fix

Install the browser through `playwright-mcp install-browser chromium --with-deps` on every architecture:

- Same package installs and launches the browser, so revisions can never skew.
- Chromium ships for both x64 (`builds/cft/.../linux64`) and ARM64 (`builds/chromium/.../chromium-linux-arm64.zip`), so the arch branch is gone.
- MCP configs already say `--browser chromium` — no config change needed.

Note: the issue claims `--browser` doesn't accept `chromium`. The `--help` text is stale; it does.

## Verification (x86_64 devcontainer)

Cleared `~/.cache/ms-playwright/chromium-*`, ran the new install command, then drove the MCP server with the exact args from `.mcp.json`:

- `browser_navigate` → `https://example.com` returned a page snapshot ✅
- `browser_console_messages` → `Total messages: 0 (Errors: 0, Warnings: 0)` ✅
- Same test against `main`'s config beforehand → `chrome-for-testing is not installed` ❌

ARM64 was verified as far as possible from x86_64: confirmed the ARM64 Chromium build URL for the pinned revision returns 206, and that the registry maps `debian*-arm64` to it. A manual dog-food run on ARM64 is still worth doing.

## Docs

`docs/contributing.md` gains a cross-architecture section and fixes two stale references (Chrome→Chromium, and Chrome system deps attributed to the `Dockerfile`, which has none — they come from `--with-deps`).