### PR TITLE
chore: refresh ship-it, validate, and dog-food agent docs

### DIFF
--- a/.github/agents/dog-food.agent.md
+++ b/.github/agents/dog-food.agent.md
@@ -34,15 +34,26 @@ also require the value or answers described in the reference.
 
 Run terminal commands with Bash from `/workspaces/learn-to-cloud-app`.
 
+Always tee server output to a log file. The browser only ever shows a generic
+error page for a server fault; the traceback that explains it lands in the
+process output. Capturing it is what makes a dog food report actionable instead
+of just "the page failed".
+
 1. Resolve any process listening on port 8000 and terminate that specific PID.
-2. Start the API from `api/` as a background terminal process:
+2. Start the API from `api/` as a background terminal process, logging to a
+   known path:
 
    ```bash
-   uv run uvicorn learn_to_cloud.main:app --host 127.0.0.1 --port 8000
+   PYTHONUNBUFFERED=1 uv run uvicorn learn_to_cloud.main:app \
+     --host 127.0.0.1 --port 8000 > /tmp/dogfood-api.log 2>&1
    ```
 
+   `PYTHONUNBUFFERED=1` matters: application logs go to stdout, which Python
+   block-buffers when redirected to a file, so without it the log can lag
+   several requests behind what the browser is doing.
+
 3. Wait until `http://localhost:8000/health` returns a healthy response. If
-   startup fails, inspect the terminal output, report the error, clean up, and
+   startup fails, read `/tmp/dogfood-api.log`, report the error, clean up, and
    stop.
 4. For phase submission QA that needs asynchronous verification, similarly
    free port 7071 and start the Functions host from
@@ -50,10 +61,12 @@ Run terminal commands with Bash from `/workspaces/learn-to-cloud-app`.
 
    ```bash
    test -f local.settings.json || cp local.settings.example.json local.settings.json
-   uv run func start --port 7071
+   uv run func start --port 7071 > /tmp/dogfood-functions.log 2>&1
    ```
 
-   Confirm readiness from the terminal output. Expected routes include
+   Set `PYTHONUNBUFFERED=1` here too if you need prompt output.
+
+   Confirm readiness from `/tmp/dogfood-functions.log`. Expected routes include
    `verification/jobs/{job_id}/start` and
    `verification/jobs/{instance_id}/status`; there is no Functions health
    endpoint.
@@ -84,7 +97,24 @@ For every page in the relevant reference matrix:
 3. Collect JavaScript errors with `playwright/browser_console_messages`.
 4. Check for visible failure text such as `Internal Server Error`, `500`,
    `404`, or `Traceback`.
-5. Record the result and continue after isolated page failures.
+5. On any visible failure, non-200 response, or unexplained console error,
+   immediately read the tail of `/tmp/dogfood-api.log` and capture the
+   traceback or error lines for that request. Do this before navigating away,
+   so the relevant lines are still at the end of the log:
+
+   ```bash
+   tail -n 60 /tmp/dogfood-api.log
+   ```
+
+   Report the exception type and the failing application frame, not just the
+   rendered error page. A page that returns 500 without a corresponding log
+   entry is itself a finding worth reporting.
+
+   The log holds application logs and unhandled-exception tracebacks, but not
+   per-request access lines: `uvicorn.access` is pinned to `WARNING` in
+   `learn_to_cloud_shared.core.logger`. Correlate by exception and ordering,
+   not by looking for a request line.
+6. Record the result and continue after isolated page failures.
 
 In basic QA, also:
 
@@ -111,13 +141,18 @@ Use the requirement metadata in the reference.
 4. For asynchronous verification, use `playwright/browser_wait_for` and inspect
    the requirement card until it reaches success or failure. Stop after 60
    seconds and report a timeout if it never resolves.
-5. Capture the final visible status and message.
+5. Capture the final visible status and message. On failure or timeout, read
+   both `/tmp/dogfood-api.log` and `/tmp/dogfood-functions.log` and include the
+   relevant errors. A timeout usually means the Functions host never picked up
+   the job or the orchestration raised, and only the logs show which.
 6. Run the reset command again even when submission or verification fails.
 
 ## Cleanup
 
 Cleanup is mandatory. Stop only the API and Functions PIDs started by this run.
-If startup failed after a process was created, still clean it up.
+If startup failed after a process was created, still clean it up. Leave
+`/tmp/dogfood-api.log` and `/tmp/dogfood-functions.log` in place so the user can
+inspect them after the report; the next run overwrites them.
 
 ## Reporting standard
 
@@ -126,8 +161,11 @@ Return the report format from the reference. Include:
 - workflow and health status;
 - a result for every page or interaction attempted;
 - console errors and visible failure messages;
+- the server-side traceback or error lines from `/tmp/dogfood-api.log` (and
+  `/tmp/dogfood-functions.log` when relevant) for every failure;
 - submission input type, final status, and message when applicable;
 - cleanup status;
 - numbered, reproducible issues.
 
 Never claim a page or interaction passed unless you observed it directly.
+Never report a failure as unexplained without checking the server logs first.

--- a/.github/agents/dog-food.agent.md
+++ b/.github/agents/dog-food.agent.md
@@ -67,8 +67,8 @@ of just "the page failed".
    Set `PYTHONUNBUFFERED=1` here too if you need prompt output.
 
    Confirm readiness from `/tmp/dogfood-functions.log`. Expected routes include
-   `verification/jobs/{job_id}/start` and
-   `verification/jobs/{instance_id}/status`; there is no Functions health
+   `verification/attempts/{attempt_id}/start` and
+   `verification/attempts/{instance_id}/status`; there is no Functions health
    endpoint.
 
 Do not use broad process-name termination. Record the exact PIDs you start so

--- a/.github/agents/dog-food.agent.md
+++ b/.github/agents/dog-food.agent.md
@@ -165,6 +165,47 @@ rendered error page. Two specifics about these logs:
 
 Use the requirement metadata in the reference.
 
+### Check Azure sign-in first
+
+Every requirement is graded by an LLM through Azure AI Foundry, which uses
+`DefaultAzureCredential`. Without a signed-in Azure identity, every submission
+terminates as `server_error` and you learn nothing about the requirement.
+
+Check before submitting anything:
+
+```bash
+az account show --output none && echo "azure ok"
+```
+
+If that fails, **stop the submission workflow immediately** and tell the user:
+
+> Azure sign-in is required to dogfood verification. Run `az login`, then ask me
+> to run this again.
+
+Report what you had already verified up to that point, clean up the processes
+you started, and do not submit. A run that submits without Azure credentials
+produces a `server_error` that looks like a product bug but isn't.
+
+### Mint the lab token when one is needed
+
+Phase 1 and Phase 2 requirements expect an HMAC-signed lab completion token. You
+do not need a real one: mint a locally valid token instead of asking the user
+for it.
+
+```bash
+cd api && LABS__VERIFICATION_SECRET=local_dev_secret_at_least_32_chars \
+  uv run python ../scripts/mint_lab_token.py --lab ctf --username <github_username>
+cd api && LABS__VERIFICATION_SECRET=local_dev_secret_at_least_32_chars \
+  uv run python ../scripts/mint_lab_token.py --lab networking --provider azure \
+    --username <github_username>
+```
+
+The username must match the signed-in dogfood user or verification rejects the
+token. These tokens are signed with the local development secret and are
+worthless anywhere else.
+
+### Run the submission
+
 1. Reset the target requirement first:
 
    ```bash
@@ -179,9 +220,11 @@ Use the requirement metadata in the reference.
    this agent's remit.
 
 2. Navigate to `/phase/{N}` and find the requirement card.
-3. Enter the user-supplied value, or use the prefilled value for auto-derived
-   submissions. If a prefilled field is read-only and holds something other than
-   what the user asked you to test, report that and do not try to force it.
+3. Enter the value: a minted token for Phases 1 and 2, a written answer you
+   compose for `deployment-architecture` and `career-reflection`, or the
+   prefilled value for auto-derived submissions. If a prefilled field is
+   read-only and holds something other than what the user asked you to test,
+   report that and do not try to force it.
 4. Submit, then poll the card until it reaches success or failure. Stop after 60
    seconds and report a timeout.
 5. Capture the final visible status and message, plus log evidence on any

--- a/.github/agents/dog-food.agent.md
+++ b/.github/agents/dog-food.agent.md
@@ -1,47 +1,69 @@
 ---
 name: dog-food
-description: Launch the local app and use Playwright to perform read-only QA across public, authenticated, and phase-submission flows.
-tools: ['execute/runInTerminal', 'read/readFile', 'playwright/*']
+description: Use the local app the way a learner would and report what is broken or confusing, with server-side evidence for every failure.
+tools: ['bash', 'view']
 ---
 
 # Dog Food Agent
 
-You are a QA engineer dogfooding the Learn to Cloud web application. Run the
-requested workflow in isolation and return a concise verdict with reproducible
-evidence. Do not edit application code or delegate work to another agent.
+You are dogfooding the Learn to Cloud web application: you *use* the product and
+report what breaks or confuses you. You are not executing a test plan. Fixed
+assertions belong in the test suite; your value is finding the things nobody
+thought to assert.
 
-Use `execute/runInTerminal` for local processes and `playwright/*` for all
-browser automation. The Playwright MCP server exposes tools such as
-`playwright/browser_navigate`, `playwright/browser_run_code`,
-`playwright/browser_console_messages`, and `playwright/browser_wait_for`.
+Work read-only. Do not edit application code, do not modify the database by
+hand, and do not delegate to another agent.
 
-Read [dog-food/reference.md](dog-food/reference.md) only when you need the page
-matrix, requirement metadata, or report template.
+Read [dog-food/reference.md](dog-food/reference.md) when you need the coverage
+backstop, requirement metadata, or the report template.
 
-## Choose the workflow
+## Pick the goal
 
-- **Basic QA**: Start the API, inspect every public and authenticated page, test
-  dark mode and a learning-step toggle, then report all findings.
-- **Phase submission QA**: Start the API and, when required, Azure Functions;
-  authenticate; reset and submit the requested phase requirement; observe the
-  result; reset the submission again; then report the outcome.
+The user gives you a goal, such as "get through Phase 1 as a new learner" or
+"submit the Phase 3 journal API requirement". Pursue that goal the way a real
+user would: follow the links the page actually offers, read what it tells you,
+and react to what happens.
 
-If the request does not identify the workflow or target phase, ask one focused
-clarifying question before starting. Token, URL, and reflection submissions
-also require the value or answers described in the reference.
+If the request has no clear goal or target phase, ask one focused clarifying
+question before starting. Token, URL, and reflection submissions also need the
+value or answers described in the reference.
+
+When you finish the goal early, keep going: use the reference page matrix as a
+coverage backstop so a run still touches the main surface. The matrix is a
+floor, not the plan.
+
+## What counts as broken
+
+Report as a **defect** anything with objective evidence:
+
+- an HTTP status of 400 or higher;
+- an unhandled traceback in a server log;
+- a JavaScript console error;
+- visible failure text such as `Internal Server Error`, `500`, `404`, or
+  `Traceback`;
+- an interaction that never settles (stop waiting after 60 seconds);
+- state that silently fails to persist across a reload;
+- a tool or script the workflow depends on that does not run.
+
+Report as a **friction finding** anything that works but shouldn't ship as-is: a
+control that looks interactive and isn't, a message that doesn't tell the user
+what to do next, a flow that made you guess. Keep the two categories separate so
+the reader can tell "this is broken" from "this is bad".
+
+Say plainly what you did not exercise. An incomplete run reported honestly is
+more useful than a confident summary of two pages.
 
 ## Prepare the environment
 
-Run terminal commands with Bash from `/workspaces/learn-to-cloud-app`.
+Run commands with Bash from `/workspaces/learn-to-cloud-app`.
 
-Always tee server output to a log file. The browser only ever shows a generic
-error page for a server fault; the traceback that explains it lands in the
-process output. Capturing it is what makes a dog food report actionable instead
-of just "the page failed".
+Always redirect server output to a log file. The browser only ever shows a
+generic error page for a server fault; the traceback that explains it lands in
+the process output. Capturing it is what makes a report actionable instead of
+just "the page failed".
 
 1. Resolve any process listening on port 8000 and terminate that specific PID.
-2. Start the API from `api/` as a background terminal process, logging to a
-   known path:
+2. Start the API from `api/` as a background process, logging to a known path:
 
    ```bash
    PYTHONUNBUFFERED=1 uv run uvicorn learn_to_cloud.main:app \
@@ -55,16 +77,14 @@ of just "the page failed".
 3. Wait until `http://localhost:8000/health` returns a healthy response. If
    startup fails, read `/tmp/dogfood-api.log`, report the error, clean up, and
    stop.
-4. For phase submission QA that needs asynchronous verification, similarly
-   free port 7071 and start the Functions host from
-   `apps/verification-functions/`:
+4. When the goal needs asynchronous verification, similarly free port 7071 and
+   start the Functions host from `apps/verification-functions/`:
 
    ```bash
    test -f local.settings.json || cp local.settings.example.json local.settings.json
-   uv run func start --port 7071 > /tmp/dogfood-functions.log 2>&1
+   PYTHONUNBUFFERED=1 uv run func start --port 7071 \
+     > /tmp/dogfood-functions.log 2>&1
    ```
-
-   Set `PYTHONUNBUFFERED=1` here too if you need prompt output.
 
    Confirm readiness from `/tmp/dogfood-functions.log`. Expected routes include
    `verification/attempts/{attempt_id}/start` and
@@ -74,6 +94,33 @@ of just "the page failed".
 Do not use broad process-name termination. Record the exact PIDs you start so
 you can stop only those processes during cleanup.
 
+## Drive the browser
+
+Use the Playwright Python API through `uv run --with playwright`. This keeps the
+dependency out of the project manifests and out of the system Python. Never
+`pip install` into the workspace to get a browser.
+
+Fetch the browser build once per session; it is a no-op when already cached:
+
+```bash
+uv run --with playwright playwright install chromium
+```
+
+Then drive the browser from a script, for example:
+
+```bash
+uv run --with playwright python /tmp/dogfood_drive.py
+```
+
+Keep the browser session in one script per interaction sequence so that cookies,
+console listeners, and page state survive across steps. Collect JavaScript
+errors by registering `page.on("console", ...)` and `page.on("pageerror", ...)`
+before navigating, not after.
+
+The Playwright MCP server is not available in this environment, and its tool set
+has no cookie or browser-context tool, so the MCP route cannot perform the
+authenticated flows at all.
+
 ## Authenticate
 
 Generate the local session:
@@ -82,52 +129,43 @@ Generate the local session:
 cd api && uv run python ../scripts/dogfood_session.py
 ```
 
-Use the returned cookie name, value, domain, and path with the appropriate
-`playwright/*` browser-context tool, then navigate to `/dashboard`. Do not put
-the cookie in page JavaScript. If session generation or authentication fails,
-record the failure; in basic QA, continue with public pages only.
+Set the returned cookie on the browser **context** with
+`context.add_cookies([...])`, using the returned name, value, domain, and path.
+Do not set the cookie from page JavaScript. Then navigate to `/dashboard` and
+confirm you are signed in.
 
-## Inspect pages
+If session generation or authentication fails, record it as a defect with the
+script's error output, and continue against public pages only.
 
-For every page in the relevant reference matrix:
+## Diagnose every failure
 
-1. Navigate with `playwright/browser_navigate`.
-2. Confirm the expected structure and content using a Playwright snapshot or
-   `playwright/browser_run_code`.
-3. Collect JavaScript errors with `playwright/browser_console_messages`.
-4. Check for visible failure text such as `Internal Server Error`, `500`,
-   `404`, or `Traceback`.
-5. On any visible failure, non-200 response, or unexplained console error,
-   immediately read the tail of `/tmp/dogfood-api.log` and capture the
-   traceback or error lines for that request. Do this before navigating away,
-   so the relevant lines are still at the end of the log:
+The browser tells you *that* something broke; the logs tell you *why*. Never
+report a failure as unexplained without checking the logs first.
 
-   ```bash
-   tail -n 60 /tmp/dogfood-api.log
-   ```
+On any defect, before navigating away, read the tail of the relevant log so the
+lines are still near the end:
 
-   Report the exception type and the failing application frame, not just the
-   rendered error page. A page that returns 500 without a corresponding log
-   entry is itself a finding worth reporting.
+```bash
+tail -n 60 /tmp/dogfood-api.log
+tail -n 60 /tmp/dogfood-functions.log
+```
 
-   The log holds application logs and unhandled-exception tracebacks, but not
-   per-request access lines: `uvicorn.access` is pinned to `WARNING` in
-   `learn_to_cloud_shared.core.logger`. Correlate by exception and ordering,
-   not by looking for a request line.
-6. Record the result and continue after isolated page failures.
+Report the exception type and the failing application frame, not just the
+rendered error page. Two specifics about these logs:
 
-In basic QA, also:
+- They hold application logs and unhandled-exception tracebacks, but no
+  per-request access lines: `uvicorn.access` is pinned to `WARNING` in
+  `learn_to_cloud_shared.core.logger`. Correlate by exception and ordering, not
+  by looking for a request line.
+- A user-visible failure with *no* corresponding log entry is itself a defect
+  worth reporting: it means the failure is invisible to anyone debugging from
+  the server side.
 
-- Toggle the theme and verify the document theme state changes.
-- On the first Phase 1 topic, toggle one learning-step checkbox, verify the new
-  state after the HTMX request settles, then restore and verify the original
-  state.
-
-## Test a phase submission
+## Submitting a phase requirement
 
 Use the requirement metadata in the reference.
 
-1. Reset the target requirement before testing:
+1. Reset the target requirement first:
 
    ```bash
    cd api && uv run python scripts/reset_local_submissions.py \
@@ -135,37 +173,39 @@ Use the requirement metadata in the reference.
      --user-id 6733686
    ```
 
-2. Navigate to `/phase/{N}` and locate the target requirement card.
-3. Enter any user-supplied value, or use the prefilled value for auto-derived
-   submissions, then submit.
-4. For asynchronous verification, use `playwright/browser_wait_for` and inspect
-   the requirement card until it reaches success or failure. Stop after 60
-   seconds and report a timeout if it never resolves.
-5. Capture the final visible status and message. On failure or timeout, read
-   both `/tmp/dogfood-api.log` and `/tmp/dogfood-functions.log` and include the
-   relevant errors. A timeout usually means the Functions host never picked up
-   the job or the orchestration raised, and only the logs show which.
-6. Run the reset command again even when submission or verification fails.
+   If the reset script fails, report it as a defect and stop the submission
+   workflow. Do not delete rows by hand to work around it: an unreset
+   requirement invalidates the result, and hand-editing the database is outside
+   this agent's remit.
+
+2. Navigate to `/phase/{N}` and find the requirement card.
+3. Enter the user-supplied value, or use the prefilled value for auto-derived
+   submissions. If a prefilled field is read-only and holds something other than
+   what the user asked you to test, report that and do not try to force it.
+4. Submit, then poll the card until it reaches success or failure. Stop after 60
+   seconds and report a timeout.
+5. Capture the final visible status and message, plus log evidence on any
+   failure or timeout. A timeout usually means the Functions host never picked
+   up the work or the orchestration raised, and only the logs distinguish them.
+6. Reset again afterwards, even when the submission failed.
 
 ## Cleanup
 
-Cleanup is mandatory. Stop only the API and Functions PIDs started by this run.
-If startup failed after a process was created, still clean it up. Leave
-`/tmp/dogfood-api.log` and `/tmp/dogfood-functions.log` in place so the user can
-inspect them after the report; the next run overwrites them.
+Cleanup is mandatory. Stop only the PIDs you started, including when startup
+failed partway. Leave `/tmp/dogfood-api.log` and `/tmp/dogfood-functions.log` in
+place for the user to inspect; the next run overwrites them.
 
 ## Reporting standard
 
-Return the report format from the reference. Include:
+Use the report template in the reference. Lead with findings, not with an
+inventory of everything that worked.
 
-- workflow and health status;
-- a result for every page or interaction attempted;
-- console errors and visible failure messages;
-- the server-side traceback or error lines from `/tmp/dogfood-api.log` (and
-  `/tmp/dogfood-functions.log` when relevant) for every failure;
-- submission input type, final status, and message when applicable;
-- cleanup status;
-- numbered, reproducible issues.
+Every finding needs: what you did, what you observed in the browser, the
+matching server-side evidence, and how to reproduce it.
 
-Never claim a page or interaction passed unless you observed it directly.
-Never report a failure as unexplained without checking the server logs first.
+Two rules that override everything above:
+
+- Never claim something passed unless you observed it directly.
+- Never present your run as proof the app is healthy. You cannot prove absence
+  of breakage, and this agent is a discovery tool, not a merge gate. Report what
+  you found and what you did not reach.

--- a/.github/agents/dog-food/reference.md
+++ b/.github/agents/dog-food/reference.md
@@ -33,22 +33,32 @@ rendered, not the full definition of working.
 
 ## Submission requirements
 
+Source of truth is `packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json`
+(`phases[].hands_on_verification.requirements`). If a slug here does not match a
+requirement card in the app, trust the artifact and report the drift.
+
 | Phase | Requirement slug | Submission type | Needs Functions? | Input |
 |-------|------------------|-----------------|------------------|-------|
-| 1 | `profile-readme` | `profile_readme` | Yes | Auto-derived |
+| 0 | `profile-readme` | `profile_readme` | Yes | Auto-derived |
 | 1 | `linux-ctfs-fork` | `repo_fork` | Yes | Auto-derived |
 | 1 | `linux-ctfs-token` | `ctf_token` | Yes | User-provided token |
 | 2 | `networking-lab-fork` | `repo_fork` | Yes | Auto-derived |
 | 2 | `networking-lab-token` | `networking_token` | Yes | User-provided token |
 | 3 | `journal-api-implementation` | `journal_api_verifier` | Yes | Auto-derived |
 | 4 | `deployed-journal-api` | `deployed_api` | Yes | User-provided URL |
+| 4 | `deployment-architecture` | `deployment_architecture` | Yes | Written answer, 300 characters minimum |
 | 5 | `devops-implementation` | `devops_analysis` | Yes | Auto-derived |
 | 6 | `security-scanning` | `security_scanning` | Yes | Auto-derived |
-| 7 | `career-reflection` | `career_reflection` | Yes | Three user-provided answers |
+| 7 | `career-reflection` | `career_reflection` | Yes | Three answers, 200 characters minimum each |
 
-Auto-derived values come from the authenticated GitHub user. For
-`career_reflection`, fill every rendered textarea with a substantive answer of
-at least 200 characters.
+Auto-derived values come from the authenticated GitHub user, and the field is
+rendered read-only. If a prefilled repository is not the one you were asked to
+test, report it rather than trying to force the value.
+
+`deployment-architecture` expects a description of the architecture the
+learner's `deploy.sh` provisions (network layout, VM placement, firewall rules,
+traffic flow) and is scoped to the `learntocloud/journal-starter` repository.
+For `career_reflection`, fill every rendered textarea with a substantive answer.
 
 ## Report template
 

--- a/.github/agents/dog-food/reference.md
+++ b/.github/agents/dog-food/reference.md
@@ -1,6 +1,9 @@
 # Dog Food QA Reference
 
-Read only the section needed for the requested workflow.
+Read only the section you need. The page tables are a **coverage backstop**, not
+a checklist: pursue the user's goal first, then use these to make sure a run
+touched the main surface. "Expected evidence" is the minimum that proves a page
+rendered, not the full definition of working.
 
 ## Public pages
 
@@ -49,54 +52,48 @@ at least 200 characters.
 
 ## Report template
 
-```markdown
+Lead with findings. The tables exist so the reader knows what was covered; they
+are not the point of the report.
+
+````markdown
 ## Dog Food Report
 
-**Workflow:** Basic QA / Phase X submission QA
+**Goal:** what you set out to do
+**Verdict:** one sentence — did the goal succeed, partially succeed, or fail
 
-### Health
+### Defects
 
-| Service | Status | Evidence |
-|---------|--------|----------|
-| API | Passed/Failed | ... |
-| Functions | Passed/Failed/Not needed | ... |
-
-### Pages
-
-| Page | Loaded | Console errors | Server log evidence | Issues |
-|------|--------|----------------|---------------------|--------|
-| ... | Yes/No | None / details | None / exception + frame | ... |
-
-Fill "Server log evidence" from `/tmp/dogfood-api.log` for any page that did not
-load cleanly. Use `None` only when the page passed, or when the log genuinely
-contained nothing for that request (which is itself worth listing under Issues).
-
-### Interactions
-
-| Test | Result | Evidence |
-|------|--------|----------|
-| Dark mode | Passed/Failed/Not attempted | ... |
-| Step toggle and restore | Passed/Failed/Not attempted | ... |
-
-### Submission
-
-| Field | Value |
-|-------|-------|
-| Phase | ... |
-| Requirement | ... |
-| Input type | ... |
-| Result | Passed/Failed/Timed out |
-| Message | ... |
-| Server log evidence | None / API and Functions errors |
-
-### Cleanup
-
-API and Functions processes stopped: Yes/No
-
-### Issues Found
-
-Each issue: what you observed in the browser, the matching server-side error
-(exception type and application frame), and the steps to reproduce.
+Objective breakage. For each: what you did, what you saw, the server-side
+evidence (exception type and application frame), and how to reproduce.
 
 1. ...
-```
+
+### Friction
+
+Things that worked but shouldn't ship as-is: dead-looking controls, messages
+that don't say what to do next, flows that made you guess.
+
+1. ...
+
+### Coverage
+
+| Area | Exercised | Result |
+|------|-----------|--------|
+| Public pages | which ones | clean / see defect N |
+| Authenticated pages | which ones | clean / see defect N |
+| Interactions | dark mode, step toggle, ... | clean / see defect N |
+| Submission | phase + requirement | passed / failed / timed out |
+
+**Not exercised:** everything you did not reach, and why.
+
+### Environment
+
+| Item | Value |
+|------|-------|
+| API | healthy / failed, PID |
+| Functions | healthy / not needed / failed, PID |
+| Processes stopped | Yes/No |
+| Logs | `/tmp/dogfood-api.log`, `/tmp/dogfood-functions.log` |
+````
+
+This report is evidence of what was found, not proof the app is healthy.

--- a/.github/agents/dog-food/reference.md
+++ b/.github/agents/dog-food/reference.md
@@ -41,9 +41,9 @@ requirement card in the app, trust the artifact and report the drift.
 |-------|------------------|-----------------|------------------|-------|
 | 0 | `profile-readme` | `profile_readme` | Yes | Auto-derived |
 | 1 | `linux-ctfs-fork` | `repo_fork` | Yes | Auto-derived |
-| 1 | `linux-ctfs-token` | `ctf_token` | Yes | User-provided token |
+| 1 | `linux-ctfs-token` | `ctf_token` | Yes | Minted locally (see below) |
 | 2 | `networking-lab-fork` | `repo_fork` | Yes | Auto-derived |
-| 2 | `networking-lab-token` | `networking_token` | Yes | User-provided token |
+| 2 | `networking-lab-token` | `networking_token` | Yes | Minted locally (see below) |
 | 3 | `journal-api-implementation` | `journal_api_verifier` | Yes | Auto-derived |
 | 4 | `deployed-journal-api` | `deployed_api` | Yes | User-provided URL |
 | 4 | `deployment-architecture` | `deployment_architecture` | Yes | Written answer, 300 characters minimum |
@@ -54,6 +54,11 @@ requirement card in the app, trust the artifact and report the drift.
 Auto-derived values come from the authenticated GitHub user, and the field is
 rendered read-only. If a prefilled repository is not the one you were asked to
 test, report it rather than trying to force the value.
+
+Lab tokens (`ctf_token`, `networking_token`) are minted locally with
+`scripts/mint_lab_token.py`; no real lab completion is required. The token
+carries the exact challenge count the verifier expects (18 for the CTF, 4 for
+the networking lab) and is bound to the GitHub username you are signed in as.
 
 `deployment-architecture` expects a description of the architecture the
 learner's `deploy.sh` provisions (network layout, VM placement, firewall rules,

--- a/.github/agents/dog-food/reference.md
+++ b/.github/agents/dog-food/reference.md
@@ -63,9 +63,13 @@ at least 200 characters.
 
 ### Pages
 
-| Page | Loaded | Console errors | Issues |
-|------|--------|----------------|--------|
-| ... | Yes/No | None / details | ... |
+| Page | Loaded | Console errors | Server log evidence | Issues |
+|------|--------|----------------|---------------------|--------|
+| ... | Yes/No | None / details | None / exception + frame | ... |
+
+Fill "Server log evidence" from `/tmp/dogfood-api.log` for any page that did not
+load cleanly. Use `None` only when the page passed, or when the log genuinely
+contained nothing for that request (which is itself worth listing under Issues).
 
 ### Interactions
 
@@ -83,12 +87,16 @@ at least 200 characters.
 | Input type | ... |
 | Result | Passed/Failed/Timed out |
 | Message | ... |
+| Server log evidence | None / API and Functions errors |
 
 ### Cleanup
 
 API and Functions processes stopped: Yes/No
 
 ### Issues Found
+
+Each issue: what you observed in the browser, the matching server-side error
+(exception type and application frame), and the steps to reproduce.
 
 1. ...
 ```

--- a/.github/skills/reset-local-submissions/SKILL.md
+++ b/.github/skills/reset-local-submissions/SKILL.md
@@ -62,11 +62,16 @@ cd <workspace>/api && uv run python scripts/reset_local_submissions.py \
 
 ## Expected Output
 
-- Matching rows found and affected user IDs
-- Number of deleted submission rows
+- Matching attempts, each with its user ID, requirement slug, and outcome
+- Number of deleted `verification_attempts` rows
 
 ## Notes
 
-- This is for local/testing databases only.
-- Progress is derived live from the submissions table on next page load,
-  so no denormalized counter needs updating.
+- The script refuses to run unless the configured database host is a local
+  development one (`localhost`, `127.0.0.1`, `::1`, `db`, `postgres`) and Azure
+  managed-identity Postgres is not in use.
+- Submission state lives in `verification_attempts`; slugs are resolved to
+  `requirement_uuid` through the curriculum artifact, so an unknown slug fails
+  fast instead of silently deleting nothing.
+- Progress is derived live from those attempts on next page load, so no
+  denormalized counter needs updating.

--- a/.github/skills/ship-it/SKILL.md
+++ b/.github/skills/ship-it/SKILL.md
@@ -41,16 +41,41 @@ gh auth status || echo "gh NOT authenticated, deploy monitoring will be skipped"
 
 ## Step 2: Run the Quality Gate
 
-Stage everything first, then run the full quality gate. `uv run poe check` runs
-the static checks (ruff lint, ruff format, ty type check, migration SQL lint)
-followed by the test suites and the verification import smoke test. It is the
-same command CI runs, so passing here means CI should pass too.
+Stage everything first, then run the full quality gate. `uv run poe check` is a
+sequence of three tasks:
+
+1. `static` — `prek run --all-files`: ruff lint, ruff format, ty type check,
+   migration SQL safety lint, docs link check, file hygiene.
+2. `package-smoke` — builds the `learn-to-cloud-shared` wheel, installs it into
+   a throwaway venv, and runs `learn_to_cloud_shared.runtime_package_check`.
+3. `test` — pytest with coverage for `api` and
+   `packages/learn-to-cloud-shared`, plus the `apps/verification-functions`
+   suite.
 
 ```bash
 cd <workspace>
 git add -A
 uv run poe check
 ```
+
+### `poe check` is necessary but not sufficient for CI
+
+CI's `ci` job runs `poe static`, `poe package-smoke`, and `poe test`, but also
+several checks that have no local poe task. A green `poe check` can still hit a
+red CI. Run the relevant ones yourself when your change touches their inputs:
+
+| CI step | Command | Run it when you touched |
+|---------|---------|-------------------------|
+| Curriculum content integrity | `cd packages/learn-to-cloud-shared && uv run python scripts/validate_content.py` | curriculum content YAML |
+| YAML JSON schema drift | `cd packages/learn-to-cloud-shared && uv run python scripts/generate_yaml_schemas.py` then confirm `git diff --exit-code src/learn_to_cloud_shared/content/schemas/` is clean | content Pydantic models |
+| `curriculum.json` artifact drift | regenerate the artifact and commit it | curriculum content or artifact schema |
+| Single migration head | `cd api && uv run alembic heads` shows exactly one head | Alembic migrations |
+| Migration naming/docstrings | `cd api && uv run python scripts/check_migration_naming.py` | Alembic migrations |
+| Migrations apply + model sync | `cd api && uv run alembic upgrade head && uv run alembic check` | models or migrations |
+
+Terraform changes are gated by the separate `terraform-ci` job (`terraform fmt
+-check -recursive`, `validate`, `terraform test`), and dependency changes by
+`dependency-review`. Neither is covered by `poe check`.
 
 > Stage files first (`git add -A`). The static checks run `prek run --all-files`,
 > which only inspects git-tracked files, so newly-created files (new migrations,
@@ -143,6 +168,21 @@ run_id=$(gh run list --workflow=deploy.yml --branch main --event push \
   --commit "$merge_sha" --limit 1 --json databaseId --jq '.[0].databaseId')
 ```
 
+**If `run_id` is empty, that is often correct, not an error.** `deploy.yml`'s
+push trigger is path-filtered to `api/**`, `apps/verification-functions/**`,
+`infra/**`, `packages/learn-to-cloud-shared/**`, `pyproject.toml`, `uv.lock`,
+`scripts/**`, `docker-compose.yml`, and `.github/workflows/deploy.yml`. A merge
+touching only docs, skills, or other paths starts no run at all. Confirm the
+merge changed a deploy-relevant path before assuming something went wrong:
+
+```bash
+git diff --name-only "$merge_sha^" "$merge_sha"
+```
+
+If nothing deploy-relevant changed, report that no deploy was triggered and
+skip to the end. Otherwise, retry the lookup a few times — Actions can take
+several seconds to register the run.
+
 Watch it with the built-in command instead of a hand-rolled poll loop. `--exit-status` returns non-zero on failure (handy for chaining), `--compact` keeps output small:
 
 ```bash
@@ -194,7 +234,7 @@ curl -s https://<api-url>/ready
 ## Ship It: <branch-name>
 
 1. **Branch + Auth**: on feature branch `<branch>`; gh authenticated (or noted)
-2. **Quality Gate**: `uv run poe check` passed (static checks + tests across api, shared, verification-functions)
+2. **Quality Gate**: `uv run poe check` passed (static + package-smoke + tests across api, shared, verification-functions); CI-only checks run where relevant
 3. **Commit**: `<commit-hash>` `<commit-message>`
 4. **Push + PR**: pushed `<branch>`; PR opened to `main`; PR checks passing
 5. **Deploy (after merge)**: Run #<id> succeeded / failed (see step 6) / pending merge

--- a/.github/skills/validate/SKILL.md
+++ b/.github/skills/validate/SKILL.md
@@ -120,8 +120,9 @@ lsof -ti:8000 | xargs kill -9 2>/dev/null || true
 ## Step 7: Run Tests
 
 If the changes affect logic (not just formatting/docs), run the test suites.
-The poe `test` task runs every project's tests with coverage plus the
-verification import smoke test:
+The poe `test` task runs pytest with coverage gates for `api` and
+`packages/learn-to-cloud-shared`, then the `apps/verification-functions` suite
+(no coverage gate there):
 
 ```bash
 cd <workspace> && uv run poe test
@@ -133,9 +134,28 @@ that project's tests directly and stop on the first failure:
 ```bash
 cd <workspace>/api && uv run pytest tests/ -x
 cd <workspace>/packages/learn-to-cloud-shared && uv run pytest tests/ -x
+cd <workspace>/apps/verification-functions && uv run pytest tests/ -x
 ```
 
 **When mandatory**: Changes to repositories, services, routes, models, schemas, shared verification, or Functions code.
+
+### Before pushing: run the full gate
+
+`uv run poe check` is the pre-push gate (see the **ship-it** skill). It is
+`static` + `package-smoke` + `test` in sequence. `package-smoke` builds the
+`learn-to-cloud-shared` wheel, installs it into a throwaway venv, and runs
+`learn_to_cloud_shared.runtime_package_check` — it catches packaging mistakes
+(missing package data, bad entry points) that neither static checks nor the
+in-repo tests see:
+
+```bash
+cd <workspace> && uv run poe check
+```
+
+Note that CI's `ci` job runs additional checks with no poe task (curriculum
+content validation, YAML schema and `curriculum.json` drift, migration head /
+naming checks, `alembic upgrade head` and `alembic check`). See the **ship-it**
+skill for the full list and the commands to run them locally.
 
 ---
 
@@ -143,21 +163,22 @@ cd <workspace>/packages/learn-to-cloud-shared && uv run pytest tests/ -x
 
 **Mandatory when this change adds or modifies a `.github/workflows/deploy.yml` step that runs a Python script or command.**
 
-CI runs scripts with a minimal env (just `DATABASE__URL` is set in the `ci` job). Local dev shells almost always have more env vars set (devcontainer, `.env` files, shell history). Scripts that work locally can blow up in CI because they touch settings/config that demand env vars CI doesn't have.
+CI runs scripts with a minimal env (the `ci` job sets only `DATABASE__URL` and `POSTGRES_VERIFICATION_FUNCTIONS_ROLE`). Local dev shells almost always have more env vars set (devcontainer, `.env` files, shell history). Scripts that work locally can blow up in CI because they touch settings/config that demand env vars CI doesn't have.
 
-This step caught a real production failure (issue #469: `validate_content.py` instantiated `WebSettings` which required `OAUTH__CLIENT_ID`/`OAUTH__CLIENT_SECRET`, both unset in CI).
+This step caught a real production failure (issue #469: `packages/learn-to-cloud-shared/scripts/validate_content.py` instantiated `WebSettings` which required `OAUTH__CLIENT_ID`/`OAUTH__CLIENT_SECRET`, both unset in CI).
 
 ### How to reproduce CI's env
 
-Strip your shell to bare essentials, then re-run the new CI step's command exactly as it appears in the workflow:
+Strip your shell to bare essentials, then re-run the new CI step's command exactly as it appears in the workflow, including its `working-directory`:
 
 ```bash
 env -i HOME=$HOME PATH=$PATH \
-    DATABASE__URL="postgresql+asyncpg://postgres:postgres@db:5432/learntocloud" \
+    DATABASE__URL="postgresql+asyncpg://postgres:postgres@localhost:5432/learntocloud" \
+    POSTGRES_VERIFICATION_FUNCTIONS_ROLE="ltc_verification_functions_dev" \
     uv run python <path/to/new_script.py>
 ```
 
-`env -i` clears all env vars. `HOME` and `PATH` are kept so `uv` and Python work. `DATABASE__URL` matches the value in `deploy.yml`'s `ci` job env block.
+`env -i` clears all env vars. `HOME` and `PATH` are kept so `uv` and Python work. The two env vars mirror the `ci` job's `env:` block in `deploy.yml` (the Postgres service is reached on `localhost`, not a `db` host). Re-check `deploy.yml` for the current values before relying on them.
 
 If the new CI step uses additional env vars in the workflow, add them here too, only the ones the workflow sets.
 
@@ -187,6 +208,7 @@ Only when the workflow change is purely YAML restructuring with no new Python in
 |------|---------|
 | Kill API | `lsof -ti:8000 \| xargs kill -9 2>/dev/null \|\| true` |
 | Static checks (lint / format / type-check) | `uv run poe static` |
+| Full pre-push gate (static + package-smoke + tests) | `uv run poe check` |
 | Lint + fix | `uv run ruff check --fix <file>` |
 | Format fix | `uv run ruff format <file>` |
 | Health check | `curl -s http://localhost:8000/health` |

--- a/api/scripts/reset_local_submissions.py
+++ b/api/scripts/reset_local_submissions.py
@@ -1,16 +1,13 @@
-"""Reset local submission records for testing.
+"""Reset local verification attempts for testing.
 
-Deletes submission rows by requirement slug. Progress is automatically
-correct on next page load because it's computed from the submissions table.
+Deletes ``verification_attempts`` rows for the given requirement slugs. Progress
+is computed from those attempts, so removing them restores the pre-submission
+state on the next page load.
 
-Dependent ``verification_jobs`` rows are deleted first (a completed async
-verification job links back to the submission it produced via
-``result_submission_id``), otherwise the submission delete would raise a
-foreign-key violation.
-
-Submissions reference a requirement by ``requirement_uuid`` (FK to
-``requirements.uuid``); the human-friendly slug lives on the requirements
-table, so we join through it to match the slugs passed on the command line.
+Slugs are resolved to ``requirement_uuid`` through the curriculum artifact
+rather than the database: attempts store the requirement by UUID, and the
+embedded ``requirement_snapshot`` is absent on reconstructed rows, so matching
+on the snapshot alone would silently miss them.
 
 Examples:
     uv run python scripts/reset_local_submissions.py
@@ -25,10 +22,14 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import sys
+from urllib.parse import urlsplit
+from uuid import UUID
 
-from learn_to_cloud_shared.core.config import get_web_settings
+from learn_to_cloud_shared.core.config import get_migration_settings
 from learn_to_cloud_shared.core.database import create_engine
-from sqlalchemy import text
+from learn_to_cloud_shared.requirements import get_requirement_by_slug
+from sqlalchemy import bindparam, text
 
 logger = logging.getLogger(__name__)
 
@@ -38,95 +39,92 @@ DEFAULT_REQUIREMENT_SLUGS = [
 ]
 
 
-async def reset_submissions(
+def resolve_requirement_uuids(requirement_slugs: list[str]) -> dict[str, UUID]:
+    """Map each slug to its requirement UUID, raising on unknown slugs."""
+    resolved: dict[str, UUID] = {}
+    unknown: list[str] = []
+    for slug in requirement_slugs:
+        requirement = get_requirement_by_slug(slug)
+        if requirement is None:
+            unknown.append(slug)
+        else:
+            resolved[slug] = requirement.uuid
+
+    if unknown:
+        raise SystemExit(
+            f"Unknown requirement slug(s): {', '.join(sorted(unknown))}. "
+            "Check the slugs in the curriculum artifact."
+        )
+    return resolved
+
+
+async def reset_attempts(
     requirement_slugs: list[str],
     user_ids: list[int] | None,
     dry_run: bool,
 ) -> int:
-    """Delete matching submissions.
+    """Delete matching verification attempts, returning the number removed."""
+    uuid_by_slug = resolve_requirement_uuids(requirement_slugs)
+    slug_by_uuid = {value: key for key, value in uuid_by_slug.items()}
 
-    Returns number of deleted rows.
-    """
-    engine = create_engine(get_web_settings().database)
+    where = "requirement_uuid IN :requirement_uuids"
+    params: dict[str, object] = {"requirement_uuids": list(uuid_by_slug.values())}
+    bind_params = [bindparam("requirement_uuids", expanding=True)]
+    if user_ids:
+        where += " AND user_id IN :user_ids"
+        params["user_ids"] = user_ids
+        bind_params.append(bindparam("user_ids", expanding=True))
+
+    engine = create_engine(get_migration_settings().database)
     try:
         async with engine.begin() as conn:
-            params: dict[str, object] = {"requirement_slugs": requirement_slugs}
-            user_filter = ""
-            if user_ids:
-                user_filter = " AND s.user_id = ANY(:user_ids)"
-                params["user_ids"] = user_ids
-
             preview_query = text(
                 f"""
-                SELECT s.user_id, r.slug AS requirement_slug, s.is_validated
-                FROM submissions s
-                JOIN requirements r ON r.uuid = s.requirement_uuid
-                WHERE r.slug = ANY(:requirement_slugs){user_filter}
-                ORDER BY s.user_id, r.slug
+                SELECT user_id, requirement_uuid, outcome
+                FROM verification_attempts
+                WHERE {where}
+                ORDER BY user_id, created_at
                 """
-            )
-            preview_result = await conn.execute(preview_query, params)
-            rows = preview_result.fetchall()
+            ).bindparams(*bind_params)
+            rows = (await conn.execute(preview_query, params)).fetchall()
 
             if not rows:
-                print("No matching submissions found.")
+                print("No matching verification attempts found.")
                 return 0
 
-            affected_user_ids = sorted({row.user_id for row in rows})
-
-            print(
-                "Matches found: "
-                f"{len(rows)} row(s) across user_id(s)={affected_user_ids}"
-            )
+            print(f"Matches found: {len(rows)} attempt(s)")
+            for row in rows:
+                slug = slug_by_uuid.get(row.requirement_uuid, str(row.requirement_uuid))
+                print(f"  user_id={row.user_id} {slug} outcome={row.outcome or 'open'}")
 
             if dry_run:
                 print("Dry run enabled: no changes applied.")
                 return 0
 
-            job_user_filter = " AND vj.user_id = ANY(:user_ids)" if user_ids else ""
-            delete_jobs_query = text(
-                f"""
-                DELETE FROM verification_jobs vj
-                USING requirements r
-                WHERE r.uuid = vj.requirement_uuid
-                  AND r.slug = ANY(:requirement_slugs){job_user_filter}
-                """
-            )
-            jobs_result = await conn.execute(delete_jobs_query, params)
-            if jobs_result.rowcount:
-                print(
-                    f"Deleted {jobs_result.rowcount} dependent "
-                    "verification_jobs row(s)."
-                )
-
             delete_query = text(
                 f"""
-                DELETE FROM submissions s
-                USING requirements r
-                WHERE r.uuid = s.requirement_uuid
-                  AND r.slug = ANY(:requirement_slugs){user_filter}
-                RETURNING s.user_id, r.slug AS requirement_slug
+                DELETE FROM verification_attempts
+                WHERE {where}
+                RETURNING user_id
                 """
-            )
-            delete_result = await conn.execute(delete_query, params)
-            deleted_rows = delete_result.fetchall()
-            print(f"Deleted {len(deleted_rows)} submission row(s).")
-
-            return len(deleted_rows)
+            ).bindparams(*bind_params)
+            deleted = (await conn.execute(delete_query, params)).fetchall()
+            print(f"Deleted {len(deleted)} verification attempt(s).")
+            return len(deleted)
     finally:
         await engine.dispose()
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Reset local submissions for selected requirement slugs.",
+        description="Reset local verification attempts for selected requirements.",
     )
     parser.add_argument(
         "--requirement-slug",
         action="append",
         dest="requirement_slugs",
         help=(
-            "Requirement slug to delete (repeatable). "
+            "Requirement slug to reset (repeatable). "
             "Defaults to devops-implementation and journal-api-implementation."
         ),
     )
@@ -145,17 +143,33 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _is_local_database(url: str) -> bool:
+    """True when the URL points at a development database host."""
+    host = urlsplit(url).hostname or ""
+    return host in {"localhost", "127.0.0.1", "::1", "db", "postgres"}
+
+
 def main() -> None:
     args = parse_args()
-    requirement_slugs = args.requirement_slugs or DEFAULT_REQUIREMENT_SLUGS
+    settings = get_migration_settings()
+    if settings.database.use_azure_postgres or not _is_local_database(
+        settings.database.url
+    ):
+        print(
+            "Refusing to run: the configured database is not a local development "
+            "host. This script is for local development only.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
     deleted_count = asyncio.run(
-        reset_submissions(
-            requirement_slugs=requirement_slugs,
+        reset_attempts(
+            requirement_slugs=args.requirement_slugs or DEFAULT_REQUIREMENT_SLUGS,
             user_ids=args.user_ids,
             dry_run=args.dry_run,
         )
     )
-    logger.info("local.submission_reset.completed", extra={"deleted": deleted_count})
+    logger.info("local.attempt_reset.completed", extra={"deleted": deleted_count})
 
 
 if __name__ == "__main__":

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
@@ -1,7 +1,7 @@
 {
   "artifact_schema_version": 1,
-  "content_hash": "20e4df2d67da7f6c2948b4cbd3c9226683c4d29ff33208adb39dedc69819718f",
-  "curriculum_version": 3,
+  "content_hash": "e5d38e1ef23651d1b6084cd5390ff20190ee69f432ab5d8eea40ef868ad56c19",
+  "curriculum_version": 4,
   "phases": [
     {
       "capstone": null,
@@ -2559,7 +2559,7 @@
               "action": "practice",
               "checklist": [],
               "code": null,
-              "description": "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. If you need a quick refresher on GitHub workflows, complete a GitHub Skills course at https://learn.github.com/skills and use Git command references at https://github.com/git-guides/git-overview. Important: Follow the development workflow \u2014 create a feature branch for each task, run the tests, then open a Pull Request to merge into main. You'll need to submit each merged PR link for verification.",
+              "description": "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. If you need a quick refresher on GitHub workflows, complete a GitHub Skills course at https://learn.github.com/skills and use Git command references at https://github.com/git-guides/git-overview. Important: Follow the development workflow \u2014 create a feature branch for each task, run the tests, then open a Pull Request to merge into main. Verification reads your fork once your work is merged to main, so you don't submit anything per PR.",
               "done_when": null,
               "options": [],
               "order": 1,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
@@ -5,4 +5,4 @@
 # steps, objectives, or requirements). The compiler enforces that this
 # value strictly increases relative to the previously committed
 # curriculum.json artifact -- it will refuse to compile otherwise.
-curriculum_version: 3
+curriculum_version: 4

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase3/build-the-app.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase3/build-the-app.yaml
@@ -23,7 +23,7 @@ learning_steps:
   action: 'Practice:'
   title: Journal Starter Repository
   url: https://github.com/learntocloud/journal-starter
-  description: "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. If you need a quick refresher on GitHub workflows, complete a GitHub Skills course at https://learn.github.com/skills and use Git command references at https://github.com/git-guides/git-overview. Important: Follow the development workflow — create a feature branch for each task, run the tests, then open a Pull Request to merge into main. You'll need to submit each merged PR link for verification."
+  description: "Time to complete the capstone. The repository README has everything you need: Dev Container setup, development tasks, LLM provider configuration, and troubleshooting tips. Fork the repo and follow the instructions there to build your Journal API. If you need a quick refresher on GitHub workflows, complete a GitHub Skills course at https://learn.github.com/skills and use Git command references at https://github.com/git-guides/git-overview. Important: Follow the development workflow — create a feature branch for each task, run the tests, then open a Pull Request to merge into main. Verification reads your fork once your work is merged to main, so you don't submit anything per PR."
   slug: phase3-topic5-practice-journal-starter-repository
 - uuid: 0f5b41ca-70f1-43f3-a1d2-f6396f00f1c3
   order: 2

--- a/scripts/mint_lab_token.py
+++ b/scripts/mint_lab_token.py
@@ -1,0 +1,145 @@
+"""Mint valid lab completion tokens for local dogfooding.
+
+Phase 1 (CTF) and Phase 2 (Networking Lab) requirements expect an HMAC-signed
+token that a learner earns by finishing the lab. Locally there is no lab to
+finish, so this script signs an equivalent token with the development secret in
+``LABS__VERIFICATION_SECRET``.
+
+The signature is derived from that secret, so a token minted here is only ever
+valid against a local environment. Production uses a different secret and will
+reject anything produced by this script.
+
+Examples:
+    uv run python scripts/mint_lab_token.py --lab ctf --username madebygps
+    uv run python scripts/mint_lab_token.py --lab networking --provider azure \
+        --username madebygps
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import sys
+from datetime import UTC, datetime
+
+from learn_to_cloud_shared.core.config import get_worker_settings
+from learn_to_cloud_shared.verification.token_base import (
+    ACCEPTED_CHALLENGE_TYPES,
+    REQUIRED_CHALLENGES as NETWORKING_REQUIRED_CHALLENGES,
+)
+
+CTF_REQUIRED_CHALLENGES = 18
+LOCAL_DEV_SECRET = "local_dev_secret_at_least_32_chars"
+
+
+def build_token(
+    *,
+    secret: str,
+    github_username: str,
+    instance_id: str,
+    challenges: int,
+    challenge_type: str | None,
+) -> str:
+    """Build a base64 token whose signature matches ``verify_lab_token``."""
+    payload: dict[str, object] = {
+        "github_username": github_username,
+        "instance_id": instance_id,
+        "challenges": challenges,
+        "timestamp": datetime.now(UTC).timestamp(),
+    }
+    if challenge_type:
+        payload["challenge"] = challenge_type
+
+    derived_secret = hashlib.sha256(f"{secret}:{instance_id}".encode()).hexdigest()
+    payload_str = json.dumps(payload, separators=(",", ":"))
+    signature = hmac.new(
+        derived_secret.encode(), payload_str.encode(), hashlib.sha256
+    ).hexdigest()
+
+    token_data = {"payload": payload, "signature": signature}
+    return base64.b64encode(json.dumps(token_data).encode()).decode()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Mint a local lab completion token for dogfooding.",
+    )
+    parser.add_argument(
+        "--lab",
+        choices=["ctf", "networking"],
+        required=True,
+        help="Which lab token to mint: ctf (Phase 1) or networking (Phase 2).",
+    )
+    parser.add_argument(
+        "--username",
+        required=True,
+        help="GitHub username of the signed-in user the token is issued to.",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=["azure", "aws", "gcp"],
+        default="azure",
+        help="Cloud provider for a networking lab token. Default: azure.",
+    )
+    parser.add_argument(
+        "--instance-id",
+        default="dogfood-local",
+        help="Lab instance identifier the signature is bound to.",
+    )
+    parser.add_argument(
+        "--challenges",
+        type=int,
+        help=(
+            "Override the completed challenge count. Defaults to the number the "
+            "verifier requires, which is what a passing token carries."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    secret = get_worker_settings().labs.verification_secret
+    if not secret:
+        print(
+            "LABS__VERIFICATION_SECRET is not set. Copy "
+            "apps/verification-functions/local.settings.example.json to "
+            "local.settings.json, or export the variable, then retry.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    if secret != LOCAL_DEV_SECRET:
+        print(
+            "Refusing to run: LABS__VERIFICATION_SECRET is not the documented "
+            "local development secret. This script must never be pointed at a "
+            "real signing secret.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    if args.lab == "ctf":
+        challenges = args.challenges or CTF_REQUIRED_CHALLENGES
+        challenge_type = None
+    else:
+        challenges = args.challenges or NETWORKING_REQUIRED_CHALLENGES
+        challenge_type = f"networking-lab-{args.provider}"
+        if challenge_type not in ACCEPTED_CHALLENGE_TYPES:
+            print(f"Unsupported challenge type: {challenge_type}", file=sys.stderr)
+            raise SystemExit(1)
+
+    token = build_token(
+        secret=secret,
+        github_username=args.username,
+        instance_id=args.instance_id,
+        challenges=challenges,
+        challenge_type=challenge_type,
+    )
+    print(token)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Three agent/skill docs had drifted from how the repo actually works. Every claim verified against `pyproject.toml`, `.pre-commit-config.yaml`, `.github/workflows/deploy.yml`, and `learn_to_cloud_shared.core.logger`, plus live runs of the API.

## ship-it
- `poe check` is `static` + **`package-smoke`** + `test`; package-smoke was undocumented.
- Removed the "same command CI runs, so passing here means CI should pass" claim. Added a table of the CI-only checks (curriculum content validation, YAML schema and `curriculum.json` drift, single migration head, migration naming, `alembic upgrade head` / `alembic check`) plus a note that `terraform-ci` and `dependency-review` aren't covered either.
- Step 5 now explains that an empty `run_id` is usually correct: `deploy.yml`'s push trigger is path-filtered, so a docs/skills-only merge starts no run.

## validate
- `poe test` runs coverage for `api` and `packages/learn-to-cloud-shared` only; `apps/verification-functions` runs plain pytest. Added its focused test command.
- Added a pre-push pointer to `poe check` / `package-smoke`, which the skill never mentioned.
- Fixed the CI env repro: the ci job's Postgres is on `localhost`, not `db`, and it also sets `POSTGRES_VERIFICATION_FUNCTIONS_ROLE`.
- Corrected the `validate_content.py` path to `packages/learn-to-cloud-shared/scripts/`.

## dog-food
The agent started uvicorn but collected only browser-side evidence (console messages, visible failure text). A FastAPI 500 renders a generic error page while the traceback goes to the terminal the agent already owned, so failures came back as "page didn't load" with no cause.

- API and Functions output now tees to `/tmp/dogfood-api.log` and `/tmp/dogfood-functions.log`.
- On any visible failure, non-200, or unexplained console error, the agent must tail the log and report the exception type and failing application frame. A 500 with no log entry is itself a finding.
- Submission failures and timeouts must check both logs.
- Report template gains a "Server log evidence" column/field.

Two gotchas verified empirically and documented:
- Application logs go to stdout, which Python block-buffers when redirected, so the start commands set `PYTHONUNBUFFERED=1`. Confirmed tracebacks land in the redirected log promptly.
- `uvicorn.access` is pinned to `WARNING` in `learn_to_cloud_shared.core.logger`, so there are no per-request access lines. The agent is told to correlate by exception and ordering instead of hunting for a request line.

Verified unchanged and still accurate: the uvicorn start command, `/health`, `/ready`, `/openapi.json` responses, prek hook list, and the deploy gating conditions.

`uv run poe check` passes.