### PR TITLE
fix: log verification attempt lifecycle from the API

### DIFF
--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -32,6 +32,7 @@ from learn_to_cloud_shared.submission_derivation import (
     derive_submission_value,
     is_derivable,
 )
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 if TYPE_CHECKING:
@@ -242,6 +243,54 @@ async def _terminalize_failed_attempt(
     return True
 
 
+async def _log_attempt_completion(
+    request: Request,
+    token_data: VerificationStatusToken,
+    user_id: int,
+    status: str,
+) -> None:
+    """Log the terminal state of an attempt the orchestration finalized.
+
+    The poller is the API's only view of an attempt that Functions finished on
+    its own, so without this a whole submission — success or ``server_error`` —
+    leaves no server-side trace on the API (#700).
+    """
+    attempt_id = UUID(token_data.job_id)
+    session_maker = request.app.state.session_maker
+    try:
+        async with session_maker() as session:
+            state = await VerificationAttemptRepository(session).get_terminal_state(
+                attempt_id
+            )
+    except SQLAlchemyError as exc:
+        # The learner's result is already persisted and the page is about to
+        # reload; a logging read must never turn that into a visible failure.
+        logger.warning(
+            "verification.attempt.completed_read_failed",
+            extra={
+                "user_id": user_id,
+                "requirement_slug": token_data.requirement_slug,
+                "attempt_id": str(attempt_id),
+                "error_type": type(exc).__name__,
+            },
+        )
+        return
+
+    extra = {
+        "user_id": user_id,
+        "requirement_slug": token_data.requirement_slug,
+        "attempt_id": str(attempt_id),
+        "runtime_status": status,
+        "outcome": state.outcome if state else None,
+        "error_code": state.error_code if state else None,
+        "terminal_source": state.terminal_source if state else None,
+    }
+    if state is None or state.outcome == "server_error":
+        logger.warning("verification.attempt.completed", extra=extra)
+    else:
+        logger.info("verification.attempt.completed", extra=extra)
+
+
 async def _render_step_toggle(
     request: Request,
     user_id: int,
@@ -439,6 +488,16 @@ async def htmx_submit_verification(
             ),
         )
 
+    logger.info(
+        "verification.attempt.created",
+        extra={
+            "user_id": user_id,
+            "requirement_slug": requirement_slug,
+            "attempt_id": str(attempt_submission.attempt_id),
+            "attempt_created": attempt_submission.created,
+        },
+    )
+
     return await _start_async_attempt_and_render(
         session_maker=session_maker,
         user_id=user_id,
@@ -609,6 +668,7 @@ async def htmx_verification_attempt_status(
         )
 
     if status in _TERMINAL_DURABLE_STATUSES:
+        await _log_attempt_completion(request, token_data, user_id, status)
         return HTMLResponse(_reload_verification_html())
 
     logger.warning(

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -12,12 +12,14 @@ Testing approach:
 - HTMX-specific behavior: HX-Refresh, HX-Redirect headers
 """
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from fastapi.responses import HTMLResponse
+from sqlalchemy.exc import SQLAlchemyError
 
 from learn_to_cloud.core.auth import AuthenticatedUser
 from learn_to_cloud.routes.htmx_routes import (
@@ -240,6 +242,52 @@ class TestHtmxSubmitVerification:
         assert result is not None
         mock_create_attempt.assert_awaited_once()
         mock_start.assert_awaited_once_with(attempt_submission.attempt_id)
+
+    async def test_submit_logs_attempt_created(self, caplog):
+        """A successful submission leaves an application log line (#700)."""
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        attempt_submission = _mock_attempt_submission(created=True)
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.derive_submission_value",
+                autospec=True,
+                return_value="https://github.com/user/repo",
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.create_verification_attempt",
+                new_callable=AsyncMock,
+                return_value=attempt_submission,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes."
+                "start_verification_attempt_orchestration",
+                new_callable=AsyncMock,
+                return_value=SimpleNamespace(
+                    instance_id=str(attempt_submission.attempt_id)
+                ),
+            ),
+            caplog.at_level(logging.INFO, logger="learn_to_cloud.routes.htmx_routes"),
+        ):
+            await htmx_submit_verification(
+                request,
+                current_user,
+                requirement_slug="req-1",
+                submitted_value="https://github.com/user/repo",
+            )
+
+        record = next(
+            r for r in caplog.records if r.message == "verification.attempt.created"
+        )
+        assert record.attempt_id == str(attempt_submission.attempt_id)
+        assert record.attempt_created is True
+        assert record.requirement_slug == "req-1"
+        assert record.user_id == 1
 
     async def test_submit_unexpected_error_renders_server_error(self):
         """Unexpected exceptions render a server error card."""
@@ -679,7 +727,110 @@ class TestHtmxVerificationAttemptStatus:
                 new_callable=AsyncMock,
                 return_value=DurableStatusResult(runtime_status="Completed"),
             ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
+                autospec=True,
+            ) as mock_repository_class,
         ):
+            mock_repository_class.return_value.get_terminal_state = AsyncMock(
+                return_value=None
+            )
+            result = await htmx_verification_attempt_status(
+                request,
+                token="signed-token",
+                current_user=current_user,
+            )
+
+        assert isinstance(result, HTMLResponse)
+        assert "location.reload()" in bytes(result.body).decode()
+
+    async def test_completed_status_logs_terminal_outcome(self, caplog):
+        """The poller records the attempt's terminal outcome (#700)."""
+        request = _mock_request()
+        request.app.state.session_maker.return_value.__aenter__.return_value = (
+            AsyncMock()
+        )
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        job_id = uuid4()
+        token_data = VerificationStatusToken(
+            user_id=1,
+            job_id=str(job_id),
+            instance_id=str(uuid4()),
+            requirement_slug="journal-api-implementation",
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.load_verification_status_token",
+                return_value=token_data,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_verification_attempt_status",
+                new_callable=AsyncMock,
+                return_value=DurableStatusResult(runtime_status="Completed"),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
+                autospec=True,
+            ) as mock_repository_class,
+            caplog.at_level(logging.INFO, logger="learn_to_cloud.routes.htmx_routes"),
+        ):
+            mock_repository_class.return_value.get_terminal_state = AsyncMock(
+                return_value=SimpleNamespace(
+                    id=job_id,
+                    outcome="server_error",
+                    error_code="verification_incomplete",
+                    validation_message="boom",
+                    terminal_source="orchestrator",
+                    completed_at=None,
+                )
+            )
+            await htmx_verification_attempt_status(
+                request,
+                token="signed-token",
+                current_user=current_user,
+            )
+
+        record = next(
+            r for r in caplog.records if r.message == "verification.attempt.completed"
+        )
+        # A server_error is the case an operator most needs to find, so it must
+        # not be buried at INFO.
+        assert record.levelno == logging.WARNING
+        assert record.outcome == "server_error"
+        assert record.error_code == "verification_incomplete"
+        assert record.attempt_id == str(job_id)
+        assert record.requirement_slug == "journal-api-implementation"
+
+    async def test_completed_status_survives_log_read_failure(self):
+        """A logging read failure must not break the learner's page reload."""
+        request = _mock_request()
+        current_user = AuthenticatedUser(user_id=1, github_username="user")
+        token_data = VerificationStatusToken(
+            user_id=1,
+            job_id=str(uuid4()),
+            instance_id=str(uuid4()),
+            requirement_slug="req-1",
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.load_verification_status_token",
+                return_value=token_data,
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_verification_attempt_status",
+                new_callable=AsyncMock,
+                return_value=DurableStatusResult(runtime_status="Completed"),
+            ),
+            patch(
+                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
+                autospec=True,
+            ) as mock_repository_class,
+        ):
+            mock_repository_class.return_value.get_terminal_state = AsyncMock(
+                side_effect=SQLAlchemyError("connection lost")
+            )
             result = await htmx_verification_attempt_status(
                 request,
                 token="signed-token",


### PR DESCRIPTION
Closes #700.

## Problem

An entire submission flow — `POST /htmx/github/submit`, attempt creation, and every status poll — produced **no application log line** on the API. The existing logging only fires on paths where the API itself fails (`durable_start_failed`, `unexpected_error`, poller-side terminalization). An attempt that Functions finalized on its own left all its evidence in the Functions log, in both directions:

- **Failed run**: learner saw "Service unavailable", attempt persisted as `outcome=server_error / error_code=verification_incomplete`, API log had nothing.
- **Successful run**: same silence.

## Change

Two lifecycle log points, matching the issue's suggested minimum:

| Event | Where | Fields |
|---|---|---|
| `verification.attempt.created` | after `create_verification_attempt` | `user_id`, `requirement_slug`, `attempt_id`, `attempt_created` |
| `verification.attempt.completed` | poller, on terminal Durable status | `user_id`, `requirement_slug`, `attempt_id`, `runtime_status`, `outcome`, `error_code`, `terminal_source` |

Two deliberate decisions worth reviewing:

- **`server_error` logs at WARNING**, everything else at INFO. That is the outcome an operator most needs to find, and it should not sit at the same level as a routine pass.
- **The terminal-state read is guarded** against `SQLAlchemyError`. The learner's result is already persisted and the page is about to reload, so a read that exists only for logging must never turn into a visible failure. The guard logs `verification.attempt.completed_read_failed` rather than swallowing silently.

Note `attempt_created` is not named `created` because that key collides with a stdlib `LogRecord` attribute and raises `KeyError` at log time — caught by the new test.

## Testing

- 3 new tests: created-log fields, terminal-outcome log level/fields, and reload survives a log-path DB error.
- Updated `test_completed_status_returns_reload_trigger` for the new repository call.
- `uv run poe check` green.