### PR TITLE
fix: keep verification evidence visible after a pass

### DIFF
--- a/api/src/learn_to_cloud/rendering/context.py
+++ b/api/src/learn_to_cloud/rendering/context.py
@@ -318,6 +318,22 @@ def feedback_tasks_and_passed(
     return tasks, passed
 
 
+_URL_SCHEMES = ("https://", "http://")
+
+
+def _graded_url(submission: Any) -> str | None:
+    """Return the graded value when it is a URL worth showing back.
+
+    Token and free-text submissions are deliberately excluded: a career
+    reflection can run to 20,000 characters and a completion token is noise,
+    so neither belongs in the verified summary.
+    """
+    if submission is None:
+        return None
+    value = getattr(submission, "submitted_value", "") or ""
+    return value if value.startswith(_URL_SCHEMES) else None
+
+
 def build_requirement_card_context(
     *,
     requirement: Any,
@@ -407,6 +423,7 @@ def build_requirement_card_context(
         "verification_status_token": verification_status_token,
         "verification_status_delay_seconds": verification_status_delay_seconds,
         "derived_url": derived_url,
+        "graded_url": _graded_url(submission),
     }
 
 

--- a/api/src/learn_to_cloud/templates/partials/requirement_card.html
+++ b/api/src/learn_to_cloud/templates/partials/requirement_card.html
@@ -164,6 +164,16 @@
             Checking...
         </span>
     </form>
+    {% if derived_url %}
+    {# The read-only field above is derived server-side, which is invisible to a
+       learner whose fork is named differently or lives under an org (#701). #}
+    <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+        This URL is built from your signed-in GitHub username and the repository this
+        requirement expects, so it can't be edited. If your fork has a different name
+        or lives under an organization, rename it or fork it to your own account
+        before verifying.
+    </p>
+    {% endif %}
     {% endif %}
 
     {% if card_state == 'unavailable' %}

--- a/api/src/learn_to_cloud/templates/partials/verified_requirement_row.html
+++ b/api/src/learn_to_cloud/templates/partials/verified_requirement_row.html
@@ -1,15 +1,57 @@
-{# Compact "already verified" requirement row with optional expandable
-   feedback explaining why it passed. Shared by the locked and unlocked
-   branches of pages/phase.html so there's exactly one verified-row markup.
+{# "Already verified" requirement summary with optional expandable feedback
+   explaining why it passed. Shared by the locked and unlocked branches of
+   pages/phase.html so there's exactly one verified-row markup.
+
+   Keeps the evidence of the grade visible (#701): what the requirement asked
+   for, which value was graded, and when. Without it a passed requirement
+   collapsed to a name and a checkmark, leaving the learner no record of what
+   was evaluated and no way to contest it.
 
    Required context:
      card  – a build_requirement_card_context() dict with card_state == 'passed'
 #}
 <div id="requirement-{{ card.requirement.slug }}">
-    <div class="flex items-center gap-3 rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 px-4 py-2.5">
-        <span class="text-green-600 dark:text-green-400" aria-hidden="true">✓</span>
-        <span class="text-sm font-medium text-green-800 dark:text-green-200">{{ card.requirement.name }}</span>
-        <span class="sr-only">— Verified</span>
+    <div class="rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 px-4 py-2.5">
+        <div class="flex items-center gap-3 flex-wrap">
+            <span class="text-green-600 dark:text-green-400" aria-hidden="true">✓</span>
+            <span class="text-sm font-medium text-green-800 dark:text-green-200">{{ card.requirement.name }}</span>
+            <span class="sr-only">— Verified</span>
+            {% if card.submission and card.submission.validated_at %}
+            <span class="ml-auto text-xs text-green-700 dark:text-green-300">
+                Verified {{ card.submission.validated_at.strftime('%b %d, %Y') }}
+            </span>
+            {% endif %}
+        </div>
+
+        {% if card.requirement.description %}
+        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">{{ card.requirement.description }}</p>
+        {% endif %}
+
+        {% if card.graded_url %}
+        <p class="mt-2 text-xs text-gray-600 dark:text-gray-400 break-all">
+            Graded:
+            <a
+                href="{{ card.graded_url }}"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="underline hover:no-underline"
+            >{{ card.graded_url }}</a>
+        </p>
+        {% endif %}
+
+        <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            A verified requirement can't be resubmitted. If this result looks wrong,
+            <a
+                href="https://github.com/learntocloud/learn-to-cloud-app/issues/new"
+                data-report-issue
+                data-issue-title="Verification result looks wrong: {{ card.requirement.name }}"
+                data-issue-labels="bug"
+                data-issue-context="requirement={{ card.requirement.slug }}"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="underline hover:no-underline"
+            >report it</a>.
+        </p>
     </div>
     {% if card.feedback_tasks %}
     {% with feedback_tasks=card.feedback_tasks, feedback_passed=card.feedback_passed, requirement_slug=card.requirement.slug %}

--- a/api/tests/rendering/test_context.py
+++ b/api/tests/rendering/test_context.py
@@ -240,6 +240,35 @@ class TestBuildRequirementCardContext:
         )
         assert ctx["derived_url"] is None
 
+    def test_graded_url_exposes_the_url_that_was_verified(self):
+        """The verified card shows which value was graded (#701)."""
+        req = _make_requirement(SubmissionType.JOURNAL_API_VERIFIER)
+        ctx = build_requirement_card_context(
+            requirement=req,
+            github_username="alice",
+            submission=_make_submission(is_validated=True, verification_completed=True),
+        )
+        assert ctx["graded_url"] == "https://github.com/alice/repo"
+
+    def test_graded_url_omits_non_url_submissions(self):
+        """Tokens and free text are not echoed back into the verified card."""
+        req = _make_requirement(SubmissionType.CTF_TOKEN)
+        ctx = build_requirement_card_context(
+            requirement=req,
+            github_username="alice",
+            submission=_make_submission(
+                is_validated=True,
+                verification_completed=True,
+                submitted_value="ctf-token-abc123",
+            ),
+        )
+        assert ctx["graded_url"] is None
+
+    def test_graded_url_is_none_without_a_submission(self):
+        req = _make_requirement(SubmissionType.CTF_TOKEN)
+        ctx = build_requirement_card_context(requirement=req, github_username="alice")
+        assert ctx["graded_url"] is None
+
     def test_misconfigured_required_repo_falls_back_to_none(self):
         """JOURNAL_API_VERIFIER without required_repo is now impossible (#470).
 
@@ -277,6 +306,7 @@ def _make_submission(
     is_validated: bool,
     verification_completed: bool = False,
     validation_message: str | None = None,
+    submitted_value: str = "https://github.com/alice/repo",
 ):
     from datetime import UTC, datetime
 
@@ -284,7 +314,7 @@ def _make_submission(
 
     return SubmissionData(
         id=uuid4(),
-        submitted_value="https://github.com/alice/repo",
+        submitted_value=submitted_value,
         is_validated=is_validated,
         verification_completed=verification_completed,
         validation_message=validation_message,

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -50,12 +50,15 @@ def _submission(
     is_validated: bool,
     verification_completed: bool = False,
     validation_message: str | None = None,
+    submitted_value: str = "",
+    validated_at: datetime | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         is_validated=is_validated,
         verification_completed=verification_completed,
         validation_message=validation_message,
-        submitted_value="",
+        submitted_value=submitted_value,
+        validated_at=validated_at,
     )
 
 
@@ -210,11 +213,58 @@ class TestPhaseVerificationCardStates:
         req = _requirement("ci-status", "CI Status")
         submission = _submission(is_validated=True, verification_completed=True)
         html = self._render_phase([req], {"ci-status": submission})
-        # A passed requirement renders via the compact verified row, not the
+        # A passed requirement renders via the verified row, not the
         # full interactive card -- see partials/verified_requirement_row.html.
         assert 'id="requirement-ci-status"' in html
         assert "text-green-800 dark:text-green-200" in html
         assert "Verified" in html
+
+    def test_passed_keeps_requirement_context_visible(self):
+        """A verified requirement keeps its evidence on screen (#701)."""
+        req = _requirement("ci-status", "CI Status")
+        req.description = "Submit your Journal API fork URL"
+        submission = _submission(
+            is_validated=True,
+            verification_completed=True,
+            submitted_value="https://github.com/tester/journal-api",
+            validated_at=datetime(2026, 7, 29, 12, 0),
+        )
+        html = self._render_phase([req], {"ci-status": submission})
+
+        assert "Submit your Journal API fork URL" in html
+        assert "https://github.com/tester/journal-api" in html
+        assert "Verified Jul 29, 2026" in html
+        assert "report it" in html
+
+    def test_passed_does_not_echo_non_url_submissions(self):
+        """Tokens and long free text are not dumped back into the summary."""
+        req = _requirement("career-reflection", "Career Reflection")
+        submission = _submission(
+            is_validated=True,
+            verification_completed=True,
+            submitted_value="a very long written reflection " * 50,
+            validated_at=datetime(2026, 7, 29, 12, 0),
+        )
+        html = self._render_phase([req], {"career-reflection": submission})
+
+        assert "Graded:" not in html
+        assert "a very long written reflection" not in html
+        assert "Verified Jul 29, 2026" in html
+
+    def test_readonly_derived_url_is_explained(self):
+        """The auto-derived, read-only field says why it can't be edited (#701)."""
+        from learn_to_cloud_shared.models import SubmissionType
+
+        req = _requirement("journal-api", "Journal API")
+        req.submission_type = SubmissionType.JOURNAL_API_VERIFIER
+        req.type_config = SimpleNamespace(
+            placeholder=None, required_repo="learntocloud/journal-api"
+        )
+        html = self._render_phase([req], {})
+
+        assert "readonly" in html
+        assert "can't be edited" in html
+        assert "under an organization" in html
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #701. **Layer 1 of a 2-PR stack** — #699 builds on this branch.

## Problem

Once a requirement reached `Verified`, `partials/verified_requirement_row.html` replaced the whole card with a name and a checkmark. The learner could no longer see which value was graded, when it was graded, what the requirement asked for, or how to contest a wrong result.

## Change

The verified row keeps the evidence of the grade:

- **Requirement description** — what was actually being asked.
- **Graded value** — rendered as a link, from a new `graded_url` context key.
- **Verification date**, from `submission.validated_at`.
- **A report link**, using the existing `data-report-issue` decoration.

One judgement call worth reviewing: **only `http(s)` values are echoed back.** A completion token is noise, and a career reflection can run to 20,000 characters — neither belongs in a summary card, so `_graded_url()` returns `None` for them and the row simply omits the line. Tested in both directions.

The report link says *"A verified requirement can't be resubmitted"* rather than offering a re-run. That matches current server behaviour (`AttemptAlreadyValidatedError` blocks resubmission of a succeeded requirement); making passed requirements re-runnable would be a product decision, not a bug fix, so it is deliberately out of scope here.

## Also

Explains the read-only derived URL next to the input. The `journal-api-implementation` description tells the learner to "Submit your Journal API fork URL" while the field is `readOnly` and auto-derived from the signed-in account — a learner whose fork is named differently or lives under an org had no way to tell what would be submitted.

## Testing

- 3 context tests for `graded_url` (URL, non-URL, no submission).
- 3 rendering tests: verified row keeps context, does not echo non-URL submissions, read-only field is explained.
- `uv run poe check` green.