### PR TITLE
fix: open rubric feedback by default on a failed grade

### DIFF
--- a/api/src/learn_to_cloud/templates/partials/verification_feedback.html
+++ b/api/src/learn_to_cloud/templates/partials/verification_feedback.html
@@ -2,6 +2,11 @@
      Used by all submission types that return task-level feedback
      (DEVOPS_ANALYSIS, SECURITY_SCANNING, etc.)
 
+     A failing grade opens expanded (#699): the per-dimension rationale is the
+     only thing that tells a learner which rubric dimension failed and why, and
+     hiding it behind a click pushes them toward guess-and-resubmit. A passing
+     grade stays collapsed — there is nothing to act on.
+
      Required context:
        feedback_tasks   – list of dicts with keys: name, passed, message
        feedback_passed  – int count of passed tasks
@@ -17,7 +22,7 @@
     class="mt-3 rounded-lg border
            {% if all_passed %}border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20
            {% else %}border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20{% endif %}"
-    x-data="{ expanded: false }"
+    x-data="{ expanded: {{ 'false' if all_passed else 'true' }} }"
 >
     <button
         type="button"
@@ -34,7 +39,7 @@
             All checks passed
             {% else %}
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-            {{ feedback_passed }}/{{ total }} checks passed
+            {{ feedback_passed }}/{{ total }} checks passed — what to fix
             {% endif %}
         </span>
         <svg

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -103,6 +103,44 @@ def test_phase5_holistic_feedback_renders_in_shared_panel():
 
 
 @pytest.mark.unit
+def test_failing_feedback_panel_opens_by_default():
+    """A failed grade shows its per-dimension rationale without a click (#699)."""
+    html = _render(
+        "partials/verification_feedback.html",
+        feedback_tasks=[
+            {
+                "name": "Logging",
+                "passed": False,
+                "message": "No structured logging found.",
+                "next_steps": "Add a logger to the create endpoint.",
+            },
+            {"name": "Validation", "passed": True, "message": "Looks good."},
+        ],
+        feedback_passed=1,
+        requirement_slug="journal-api-implementation",
+    )
+
+    assert 'x-data="{ expanded: true }"' in html
+    assert "1/2 checks passed — what to fix" in html
+    assert "No structured logging found." in html
+    assert "Add a logger to the create endpoint." in html
+
+
+@pytest.mark.unit
+def test_passing_feedback_panel_stays_collapsed():
+    """A passing grade has nothing to act on, so it stays a summary."""
+    html = _render(
+        "partials/verification_feedback.html",
+        feedback_tasks=[{"name": "Logging", "passed": True, "message": "Good."}],
+        feedback_passed=1,
+        requirement_slug="journal-api-implementation",
+    )
+
+    assert 'x-data="{ expanded: false }"' in html
+    assert "All checks passed" in html
+
+
+@pytest.mark.unit
 class TestPhaseVerificationLocked:
     """The gated (`verification_locked`) branch of pages/phase.html."""
 


### PR DESCRIPTION
Closes #699. **Layer 2 of a 2-PR stack** — targets `fix/verified-requirement-context` (#704), not `main`. Review that one first.

## Correction to the issue

The rubric output is **not discarded**. `finalize_verification_attempt` persists `validation_result.task_results` into `verification_attempts.feedback_json`, `get_phase_submission_context` reads it back, and `partials/verification_feedback.html` already renders each dimension's name, rationale, and next steps.

It was **collapsed behind a click**. The `— Verified / All checks passed` line observed while dogfooding *is* that panel's collapsed header. So this is a disclosure-default bug, not missing plumbing.

## Change

Answering the issue's open question — which parts are useful to show, and should failed and passed differ:

- **Failed grade → opens expanded.** The per-dimension rationale and next steps are the only things that tell a learner which dimension failed and why; hiding them behind a click is what pushes toward guess-and-resubmit. Failed dimensions already sort first.
- **Passed grade → stays collapsed.** Nothing to act on; the summary is the right level of detail, and #704 now carries the passed-state context.
- Failing header reads `N/M checks passed — what to fix` so the control states its purpose.

**Deliberately not surfaced:** score, confidence, `evidence_refs`, and `rubric_version`. `GradingResult.to_task_result()` drops them before persistence, so they are not in `feedback_json` at all — and a visible numeric rubric score invites optimizing for the grader rather than acting on the feedback. Happy to revisit if you disagree.

## Testing

- 2 new rendering tests: failing panel expanded with rationale + next steps, passing panel collapsed.
- `uv run poe check` green.