### PR TITLE
docs: document the SIGINT stop procedure for the Functions host

### DIFF
--- a/.github/agents/dog-food.agent.md
+++ b/.github/agents/dog-food.agent.md
@@ -238,6 +238,12 @@ Cleanup is mandatory. Stop only the PIDs you started, including when startup
 failed partway. Leave `/tmp/dogfood-api.log` and `/tmp/dogfood-functions.log` in
 place for the user to inspect; the next run overwrites them.
 
+Stop the Functions host with `kill -INT <pid>`, not a plain `kill`. The Core
+Tools host installs no `SIGTERM` handler, so `kill` leaves it holding port 7071
+until it is force-killed, and the leftover process silently blocks the next
+run's port bind. `SIGINT` shuts it down in about a second, and sending it to the
+`uv run` wrapper PID you recorded propagates to the host correctly.
+
 ## Reporting standard
 
 Use the report template in the reference. Lead with findings, not with an

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Or use VS Code's **"API + Verification"** compound launch configuration.
 **Notes:**
 - The API does not start local dependencies for you. Run `docker compose up -d db azurite dts` first.
 - Verification submissions require the Durable Functions host on port `7071`.
+- Stop the Functions host with `Ctrl+C`, or `kill -INT <pid>` if you started it in
+  the background. The Core Tools host installs no `SIGTERM` handler, so a plain
+  `kill` leaves it holding port `7071` and blocks the next run; `SIGINT` shuts it
+  down in about a second and works on the `uv run` wrapper PID too.
 - Manage dependencies with `docker compose start` / `docker compose stop`.
 
 | Service | URL |


### PR DESCRIPTION
Closes #702. Standalone, docs only.

## What I measured

Reproduced in the devcontainer on Core Tools 4.12.1, isolating each layer of the process tree (`uv run` → npm/node shim → .NET host):

| Signal | Target | Result |
|---|---|---|
| SIGTERM | `uv run` wrapper | ignored, port 7071 held past 20s |
| SIGTERM | .NET `func` host | ignored, port 7071 held past 10s |
| SIGINT | .NET `func` host | clean exit, port free in under 2s |
| SIGINT | `uv run` wrapper | propagates, port free in under 2s |

## Conclusion

The issue asked whether the host is started in a way that detaches signal handling, or whether a documented stop procedure is the right answer. **It's the latter.**

Sending SIGTERM straight to the .NET host PID — bypassing both `uv` and the Node shim — is ignored just the same, so nothing in how we launch it is dropping the signal. The Core Tools host simply installs no SIGTERM handler and only handles SIGINT (the Ctrl+C path). Not fixable in this repo.

The good news for the workflow: SIGINT sent to the `uv run` wrapper PID — the one a developer or the dog-food agent actually records — propagates correctly, so the documented procedure needs no PID gymnastics. Just `kill -INT` instead of `kill`.

## Change

- `README.md`: local-dev note on stopping the host and why plain `kill` strands port 7071.
- `.github/agents/dog-food.agent.md`: the Cleanup section now specifies `kill -INT`, which removes the force-kill/port-conflict papercut from every dog-food run.

No code changes; `uv run poe check` green.