### PR TITLE
fix: keep grader next_steps visible on a passing requirement

### DIFF
--- a/api/src/learn_to_cloud/templates/partials/verification_feedback.html
+++ b/api/src/learn_to_cloud/templates/partials/verification_feedback.html
@@ -5,7 +5,9 @@
      A failing grade opens expanded (#699): the per-dimension rationale is the
      only thing that tells a learner which rubric dimension failed and why, and
      hiding it behind a click pushes them toward guess-and-resubmit. A passing
-     grade stays collapsed — there is nothing to act on.
+     grade stays collapsed, but its header advertises any next_steps the grader
+     returned so the advice isn't lost — a verified requirement can't be
+     resubmitted, so this is the learner's only copy.
 
      Required context:
        feedback_tasks   – list of dicts with keys: name, passed, message
@@ -16,6 +18,7 @@
 {% set total = feedback_tasks | length %}
 {% set failed = total - feedback_passed %}
 {% set all_passed = (feedback_passed == total) %}
+{% set suggestions = feedback_tasks | selectattr('next_steps') | list | length %}
 {% set _panel_id = 'feedback-panel-' ~ (requirement_slug | default('default')) %}
 
 <div
@@ -36,7 +39,7 @@
         <span class="flex items-center gap-2">
             {% if all_passed %}
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
-            All checks passed
+            All checks passed{% if suggestions %} — {{ suggestions }} suggestion{{ '' if suggestions == 1 else 's' }} to review{% endif %}
             {% else %}
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
             {{ feedback_passed }}/{{ total }} checks passed — what to fix
@@ -83,6 +86,9 @@
                         <span class="font-medium text-gray-700 dark:text-gray-300">{{ task.name }}</span>
                         {% if task.message %}
                         <p class="text-gray-500 dark:text-gray-400 mt-0.5 break-words">{{ task.message }}</p>
+                        {% endif %}
+                        {% if task.next_steps %}
+                        <p class="text-amber-600 dark:text-amber-400 mt-1 text-xs italic break-words">➔ {{ task.next_steps }}</p>
                         {% endif %}
                     </div>
                 </div>

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -128,7 +128,7 @@ def test_failing_feedback_panel_opens_by_default():
 
 @pytest.mark.unit
 def test_passing_feedback_panel_stays_collapsed():
-    """A passing grade has nothing to act on, so it stays a summary."""
+    """A passing grade with no advice stays a bare summary."""
     html = _render(
         "partials/verification_feedback.html",
         feedback_tasks=[{"name": "Logging", "passed": True, "message": "Good."}],
@@ -138,6 +138,46 @@ def test_passing_feedback_panel_stays_collapsed():
 
     assert 'x-data="{ expanded: false }"' in html
     assert "All checks passed" in html
+    assert "suggestion" not in html
+
+
+@pytest.mark.unit
+def test_passing_feedback_panel_keeps_next_steps():
+    """A verified requirement can't be resubmitted, so its advice must survive."""
+    html = _render(
+        "partials/verification_feedback.html",
+        feedback_tasks=[
+            {
+                "name": "Error Handling",
+                "passed": True,
+                "message": "Endpoints return the right status codes.",
+                "next_steps": "Consider parsing the LLM JSON more defensively.",
+            },
+            {"name": "Logging", "passed": True, "message": "Good."},
+        ],
+        feedback_passed=2,
+        requirement_slug="journal-api-implementation",
+    )
+
+    assert "All checks passed — 1 suggestion to review" in html
+    assert "Consider parsing the LLM JSON more defensively." in html
+
+
+@pytest.mark.unit
+def test_passing_feedback_panel_pluralizes_suggestions():
+    html = _render(
+        "partials/verification_feedback.html",
+        feedback_tasks=[
+            {"name": "A", "passed": True, "message": "ok", "next_steps": "do x"},
+            {"name": "B", "passed": True, "message": "ok", "next_steps": "do y"},
+        ],
+        feedback_passed=2,
+        requirement_slug="journal-api-implementation",
+    )
+
+    assert "All checks passed — 2 suggestions to review" in html
+    assert "do x" in html
+    assert "do y" in html
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

Found while dogfooding Phase 3. A passing `journal-api-implementation` submission persisted a rubric verdict that included `next_steps` ("Consider validating/parsing the LLM JSON response more defensively…"), but the page never showed it.

`partials/verification_feedback.html` renders `task.next_steps` **only** inside the failed-task loop. The passing-task loop rendered `name` and `message` and dropped `next_steps` on the floor. Since a verified requirement can't be resubmitted, that was the learner's only copy of the advice.

The rest of the pipeline was already correct — `submissions_service._record_feedback` includes `next_steps`, and both `requirement_card.html` and `verified_requirement_row.html` include the panel. The loss was purely in the template.

## Fix

- Render `next_steps` for passing tasks, using the same styling as the failing branch.
- The panel still stays collapsed on a pass, but the header now reads `All checks passed — N suggestions to review` when the grader returned any, so there's a reason to open it. With no suggestions the header is unchanged.

## Tests

- `test_passing_feedback_panel_keeps_next_steps` — advice survives a passing grade.
- `test_passing_feedback_panel_pluralizes_suggestions` — count and plural.
- `test_passing_feedback_panel_stays_collapsed` — tightened to assert no suggestion affordance appears when there's nothing to suggest.

`uv run poe check` passes.

## Not addressed

The same dogfood run turned up two local-dev-only issues, deliberately left out of this PR: `local.settings.example.json` ships empty `FOUNDRY_*` values (prod sets them from `infra/functions.tf`), and grading failures are invisible in local logs because there's no App Insights/OTLP collector locally.