### PR TITLE
Wire per-task grader model selection to a real deployment

### DIFF
--- a/apps/verification-functions/tests/test_verification_agents.py
+++ b/apps/verification-functions/tests/test_verification_agents.py
@@ -8,12 +8,28 @@ import httpx
 import openai
 import pytest
 import verification_agents
-from learn_to_cloud_shared.verification.tasks import CAREER_REFLECTION_RUBRIC_TASK
+from learn_to_cloud_shared.verification.tasks import (
+    CAREER_REFLECTION_RUBRIC_TASK,
+    PHASE3_LLM_TASKS,
+    PHASE4_LLM_TASKS,
+    PHASE5_LLM_TASKS,
+    PHASE6_LLM_TASKS,
+    PHASE7_LLM_TASKS,
+)
+
 from verification_agents import (
     ContentFilteredError,
     _find_content_filter_error,
     grade_evidence,
 )
+
+ALL_LLM_RUBRIC_TASKS = [
+    *PHASE3_LLM_TASKS,
+    *PHASE4_LLM_TASKS,
+    *PHASE5_LLM_TASKS,
+    *PHASE6_LLM_TASKS,
+    *PHASE7_LLM_TASKS,
+]
 
 
 def _content_filter_bad_request() -> openai.BadRequestError:
@@ -65,7 +81,12 @@ class _FakeAgent:
 def test_grade_evidence_translates_content_filter(monkeypatch) -> None:
     agent = _FakeAgent(_library_wrapped_filter_error())
     monkeypatch.setattr(
-        verification_agents, "get_verification_grader", lambda prompt_id: agent
+        verification_agents,
+        "get_verification_grader",
+        lambda prompt_id, model_deployment: agent,
+    )
+    monkeypatch.setattr(
+        verification_agents, "resolve_model_deployment", lambda task: "test-deploy"
     )
 
     with pytest.raises(ContentFilteredError):
@@ -75,8 +96,43 @@ def test_grade_evidence_translates_content_filter(monkeypatch) -> None:
 def test_grade_evidence_reraises_other_errors(monkeypatch) -> None:
     agent = _FakeAgent(RuntimeError("network down"))
     monkeypatch.setattr(
-        verification_agents, "get_verification_grader", lambda prompt_id: agent
+        verification_agents,
+        "get_verification_grader",
+        lambda prompt_id, model_deployment: agent,
+    )
+    monkeypatch.setattr(
+        verification_agents, "resolve_model_deployment", lambda task: "test-deploy"
     )
 
     with pytest.raises(RuntimeError, match="network down"):
         asyncio.run(grade_evidence(CAREER_REFLECTION_RUBRIC_TASK, "grade this"))
+
+
+def test_resolve_model_deployment_inherits_env_default(monkeypatch) -> None:
+    monkeypatch.setenv("FOUNDRY_PROJECT_ENDPOINT", "https://example.test/")
+    monkeypatch.setenv("FOUNDRY_MODEL_DEPLOYMENT_NAME", "gpt-5-mini-verifier")
+
+    assert (
+        verification_agents.resolve_model_deployment(CAREER_REFLECTION_RUBRIC_TASK)
+        == "gpt-5-mini-verifier"
+    )
+
+
+def test_resolve_model_deployment_prefers_task_override(monkeypatch) -> None:
+    monkeypatch.setenv("FOUNDRY_PROJECT_ENDPOINT", "https://example.test/")
+    monkeypatch.setenv("FOUNDRY_MODEL_DEPLOYMENT_NAME", "gpt-5-mini-verifier")
+    task = CAREER_REFLECTION_RUBRIC_TASK.model_copy(
+        update={
+            "grader": CAREER_REFLECTION_RUBRIC_TASK.grader.model_copy(
+                update={"model_deployment": "gpt-5-large-verifier"}
+            )
+        }
+    )
+
+    assert verification_agents.resolve_model_deployment(task) == "gpt-5-large-verifier"
+
+
+def test_all_shipped_tasks_inherit_the_deployed_model() -> None:
+    """Task configs must not hardcode a deployment name that infra may rename."""
+    for task in ALL_LLM_RUBRIC_TASKS:
+        assert task.grader.model_deployment is None

--- a/apps/verification-functions/verification_agents.py
+++ b/apps/verification-functions/verification_agents.py
@@ -21,6 +21,7 @@ from learn_to_cloud_shared.verification.grader_prompts import (
 from learn_to_cloud_shared.verification.tasks import (
     LLMGradingDecision,
     VerificationTask,
+    require_llm_rubric_grader,
 )
 
 CONTENT_FILTER_MARKER = "content_filter"
@@ -117,11 +118,11 @@ def _credential() -> DefaultAzureCredential | ManagedIdentityCredential:
 
 
 @cache
-def get_verification_grader(prompt_id: str) -> Agent[Any]:
-    """Return the lazily-constructed Foundry-backed grading agent for a prompt.
+def get_verification_grader(prompt_id: str, model_deployment: str) -> Agent[Any]:
+    """Return the lazily-constructed Foundry-backed grading agent.
 
-    Cached per prompt id so each phase's system prompt gets its own agent
-    instance instead of sharing one.
+    Cached per (prompt, deployment) so each phase's system prompt and model
+    selection gets its own agent instance instead of sharing one.
 
     Validates required config defensively: the orchestrator pre-checks it,
     but activities can run on a different worker, so this stays a guard.
@@ -131,7 +132,7 @@ def get_verification_grader(prompt_id: str) -> Agent[Any]:
     return Agent(
         client=FoundryChatClient(
             project_endpoint=config.project_endpoint,
-            model=config.model_deployment_name,
+            model=model_deployment,
             credential=_credential(),
         ),
         instructions=prompt.instructions,
@@ -148,9 +149,25 @@ def _require_prompt(prompt_id: str) -> GraderPrompt:
         raise RuntimeError(f"Unknown grader prompt {prompt_id!r}") from None
 
 
+def resolve_model_deployment(task: VerificationTask) -> str:
+    """Return the Foundry deployment a task grades with.
+
+    Tasks inherit ``FOUNDRY_MODEL_DEPLOYMENT_NAME`` unless they name their own
+    deployment, so routing one phase elsewhere is a task-config change rather
+    than a redeploy.
+    """
+    grader = require_llm_rubric_grader(task)
+    if grader.model_deployment:
+        return grader.model_deployment
+    return GradingConfig.from_env().model_deployment_name
+
+
 async def grade_evidence(task: VerificationTask, message: str) -> LLMGradingDecision:
     """Grade one self-contained verification prompt with the task's prompt."""
-    grader_agent = get_verification_grader(prompt_for_task(task).id)
+    grader_agent = get_verification_grader(
+        prompt_for_task(task).id,
+        resolve_model_deployment(task),
+    )
     try:
         response = await grader_agent.run(message, options=_GRADER_OPTIONS)
     except Exception as exc:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/base.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/base.py
@@ -86,7 +86,14 @@ class LLMRubricGraderConfig(FrozenModel):
     rubric_id: str
     prompt_id: str
     passing_score: float = Field(ge=0.0, le=1.0)
-    model: str | None = None
+    model_deployment: str | None = None
+    """Foundry *deployment* name to grade with, not a model name.
+
+    ``None`` inherits the deployment configured by
+    ``FOUNDRY_MODEL_DEPLOYMENT_NAME``, which is the normal case. Set this only
+    to route one task to a different deployment, and only to a deployment that
+    actually exists in the Foundry account.
+    """
 
 
 class LLMGradingDecision(FrozenModel):

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase3.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase3.py
@@ -78,7 +78,6 @@ JOURNAL_API_FINAL_RUBRIC_TASK = VerificationTask(
         rubric_id="phase3-journal-api-final-v1",
         prompt_id="phase3-journal-api",
         passing_score=0.8,
-        model="gpt-5-mini",
     ),
 )
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase4.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase4.py
@@ -61,7 +61,6 @@ DEPLOYMENT_ARCHITECTURE_RUBRIC_TASK = VerificationTask(
         rubric_id="phase4-deployment-architecture-v1",
         prompt_id="phase4-deployment-architecture",
         passing_score=0.7,
-        model="gpt-5-mini",
     ),
 )
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase5.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase5.py
@@ -102,7 +102,6 @@ DEVOPS_IMPLEMENTATION_RUBRIC_TASK = VerificationTask(
         rubric_id="phase5-devops-implementation-v1",
         prompt_id="phase5-devops-implementation",
         passing_score=0.8,
-        model="gpt-5-mini",
     ),
 )
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase6.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase6.py
@@ -59,7 +59,6 @@ SECURITY_SCANNING_RUBRIC_TASK = VerificationTask(
         rubric_id="phase6-security-scanning-v2",
         prompt_id="phase6-security-scanning",
         passing_score=0.75,
-        model="gpt-5-mini",
     ),
 )
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase7.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/phase7.py
@@ -53,7 +53,6 @@ CAREER_REFLECTION_RUBRIC_TASK = VerificationTask(
         rubric_id="phase7-career-reflection-v1",
         prompt_id="phase7-career-reflection",
         passing_score=0.6,
-        model="gpt-5-mini",
     ),
 )
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? -->

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.