### PR TITLE
Make the rubric score the only source of pass/fail

### DIFF
--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/grader_prompts.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/grader_prompts.py
@@ -58,14 +58,19 @@ If the evidence carries a `collection_warnings` field, we could not read
 all of the learner's work: files listed there were unreadable, truncated,
 or omitted. Judge only what you were given and do not penalize the learner
 for content those warnings say is missing.
+Score the evidence; do not decide the outcome. The grading service applies
+the rubric's passing_score to your score, so a pass/fail verdict from you is
+not used. Score honestly against the criteria rather than aiming at the
+threshold.
 Return only one JSON object with:
-- passed: true only when the evidence satisfies the rubric.
 - score: 0.0 to 1.0 based on rubric completeness.
-- feedback: concise learner-facing explanation of why the evidence did or
-  did not meet the rubric. When passed is true, name what was strong so the
-  learner understands why they passed.
-- next_steps: concrete remediation when passed is false.
-- failure_reason: stable snake_case reason when passed is false.
+- feedback: concise learner-facing explanation of how the evidence measured
+  against the rubric. Name what was strong as well as what fell short, so the
+  feedback reads the same whichever side of the threshold the score lands on.
+- next_steps: concrete remediation for whatever fell short. Leave empty only
+  when the evidence fully satisfies every criterion.
+- failure_reason: stable snake_case reason for the largest shortfall, or null
+  when the evidence fully satisfies every criterion.
 - evidence_refs: paths, URLs, task ids, or evidence ids used in the decision.
 Do not wrap the JSON in Markdown or include explanatory text outside the JSON.
 """.strip()
@@ -130,37 +135,37 @@ def _render(guidance: str) -> str:
 
 PHASE3_JOURNAL_API_PROMPT = GraderPrompt(
     id="phase3-journal-api",
-    version="2026-07-31",
+    version="2026-08-01",
     instructions=_render(_PHASE3_GUIDANCE),
-    checksum="86e3d22a55ffcd43",
+    checksum="9495a8b47a4a881c",
 )
 
 PHASE4_DEPLOYMENT_ARCHITECTURE_PROMPT = GraderPrompt(
     id="phase4-deployment-architecture",
-    version="2026-07-31",
+    version="2026-08-01",
     instructions=_render(_PHASE4_GUIDANCE),
-    checksum="8f72fa434bfb410c",
+    checksum="89bb5b35c3c81c67",
 )
 
 PHASE5_DEVOPS_IMPLEMENTATION_PROMPT = GraderPrompt(
     id="phase5-devops-implementation",
-    version="2026-07-31",
+    version="2026-08-01",
     instructions=_render(_PHASE5_GUIDANCE),
-    checksum="e0799635bc6aa722",
+    checksum="a7f4801f95996ad2",
 )
 
 PHASE6_SECURITY_SCANNING_PROMPT = GraderPrompt(
     id="phase6-security-scanning",
-    version="2026-07-31",
+    version="2026-08-01",
     instructions=_render(_PHASE6_GUIDANCE),
-    checksum="24ee8e6905ed4325",
+    checksum="9166519382ad6e4f",
 )
 
 PHASE7_CAREER_REFLECTION_PROMPT = GraderPrompt(
     id="phase7-career-reflection",
-    version="2026-07-31",
+    version="2026-08-01",
     instructions=_render(_PHASE7_GUIDANCE),
-    checksum="ab40258cb61d2070",
+    checksum="30e7b48923c64944",
 )
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -131,9 +131,9 @@ def _decision_to_grading_result(
     evidence: EvidenceBundle | None = None,
 ) -> GradingResult:
     grader = require_llm_rubric_grader(task)
-    passed = decision.passed and decision.score >= grader.passing_score
+    passed = decision.score >= grader.passing_score
     failure_reason = decision.failure_reason
-    if decision.passed and not passed:
+    if not passed and not failure_reason:
         failure_reason = "score_below_passing_threshold"
 
     feedback = decision.feedback

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/base.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/tasks/base.py
@@ -144,9 +144,12 @@ class LLMRubricGraderConfig(FrozenModel):
 
 
 class LLMGradingDecision(FrozenModel):
-    """Structured decision returned by the LLM grader."""
+    """Structured decision returned by the LLM grader.
 
-    passed: bool
+    Carries a rubric score, not a verdict: the pass threshold is applied by
+    :func:`_decision_to_grading_result` so pass/fail has one source of truth.
+    """
+
     score: float = Field(ge=0.0, le=1.0)
     feedback: str
     next_steps: str = ""

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -103,9 +103,7 @@ def test_apply_llm_grading_decisions_appends_feedback_when_passed():
             LLMGradingDecisionPayload(
                 task=PHASE6_LLM_TASKS[0],
                 decision=LLMGradingDecision(
-                    passed=True,
                     score=0.92,
-                    confidence=0.88,
                     feedback="The evidence satisfies the security scanning rubric.",
                     evidence_refs=[".github/dependabot.yml"],
                 ),
@@ -129,9 +127,7 @@ def test_apply_phase3_llm_decision_appends_feedback_when_passed():
             LLMGradingDecisionPayload(
                 task=PHASE3_LLM_TASKS[0],
                 decision=LLMGradingDecision(
-                    passed=True,
                     score=0.91,
-                    confidence=0.86,
                     feedback="The final Journal API implementation is maintainable.",
                     evidence_refs=["api/routers/journal_router.py"],
                 ),
@@ -156,9 +152,7 @@ def test_apply_llm_grading_decisions_fails_when_score_is_below_threshold():
             LLMGradingDecisionPayload(
                 task=PHASE6_LLM_TASKS[0],
                 decision=LLMGradingDecision(
-                    passed=True,
                     score=0.5,
-                    confidence=0.8,
                     feedback="The evidence is incomplete.",
                     next_steps="Add a Dependabot updates entry.",
                     evidence_refs=[".github/dependabot.yml"],
@@ -185,9 +179,7 @@ def test_phase5_holistic_review_enforces_strict_threshold():
             LLMGradingDecisionPayload(
                 task=PHASE5_LLM_TASKS[0],
                 decision=LLMGradingDecision(
-                    passed=True,
                     score=0.79,
-                    confidence=0.9,
                     feedback="Most areas are sound, but the manifests conflict.",
                     next_steps="Align the image and port configuration.",
                     evidence_refs=["Dockerfile", "k8s/deployment.yaml"],
@@ -261,9 +253,7 @@ def test_apply_phase7_llm_decision_appends_feedback_when_passed():
             LLMGradingDecisionPayload(
                 task=PHASE7_LLM_TASKS[0],
                 decision=LLMGradingDecision(
-                    passed=True,
                     score=0.82,
-                    confidence=0.8,
                     feedback="Genuine, specific reflection across all three answers.",
                     evidence_refs=["career-reflection.md"],
                 ),
@@ -285,7 +275,6 @@ def test_failure_with_incomplete_evidence_is_marked_not_learner_fault() -> None:
     result = _decision_to_grading_result(
         task,
         LLMGradingDecision(
-            passed=False,
             score=0.2,
             feedback="The Dockerfile does not pin a base image version.",
             next_steps="Pin the base image.",
@@ -307,7 +296,6 @@ def test_pass_with_incomplete_evidence_is_left_alone() -> None:
     result = _decision_to_grading_result(
         task,
         LLMGradingDecision(
-            passed=True,
             score=0.95,
             feedback="Solid pipeline.",
         ),
@@ -327,7 +315,6 @@ def test_failure_with_complete_evidence_keeps_its_reason() -> None:
     result = _decision_to_grading_result(
         task,
         LLMGradingDecision(
-            passed=False,
             score=0.2,
             feedback="No CI workflow found.",
             failure_reason="missing_ci_workflow",
@@ -337,3 +324,42 @@ def test_failure_with_complete_evidence_keeps_its_reason() -> None:
 
     assert result.failure_reason == "missing_ci_workflow"
     assert result.feedback == "No CI workflow found."
+
+
+@pytest.mark.parametrize("offset", [-0.5, -0.01, 0.0, 0.2])
+def test_score_alone_decides_the_outcome(offset: float) -> None:
+    """The threshold lives in code, so the model cannot vote against its score."""
+    task = PHASE3_LLM_TASKS[0]
+    threshold = task.grader.passing_score
+    score = min(max(threshold + offset, 0.0), 1.0)
+
+    result = _decision_to_grading_result(
+        task,
+        LLMGradingDecision(score=score, feedback="Reviewed."),
+    )
+
+    assert result.passed is (score >= threshold)
+    assert result.score == score
+
+
+def test_a_model_supplied_passed_field_is_ignored() -> None:
+    """Old-shape payloads must not resurrect a second source of truth."""
+    task = PHASE3_LLM_TASKS[0]
+
+    result = _decision_to_grading_result(
+        task,
+        LLMGradingDecision.model_validate(
+            {"passed": True, "score": 0.1, "feedback": "Reviewed."}
+        ),
+    )
+
+    assert result.passed is False
+
+
+def test_low_score_without_a_reason_gets_a_stable_fallback() -> None:
+    result = _decision_to_grading_result(
+        PHASE3_LLM_TASKS[0],
+        LLMGradingDecision(score=0.1, feedback="Reviewed."),
+    )
+
+    assert result.failure_reason == "score_below_passing_threshold"


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? -->

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.