### PR TITLE
Add declarative Discord community provisioning

### DIFF
--- a/discord/README.md
+++ b/discord/README.md
@@ -1,0 +1,49 @@
+# Discord community provisioning
+
+`community.yaml` defines the roles, categories, channels, forum tags, Community
+settings, and AutoMod rules managed by `scripts/configure_discord.py`.
+
+The provisioner updates resources by name and does not delete unmanaged Discord
+resources.
+
+## Prerequisites
+
+Create and install a private Discord application bot with these permissions:
+
+- Manage Server
+- Manage Channels
+- Manage Roles
+- Moderate Members
+
+The first run also needs Administrator if the server does not have Community
+mode enabled. Remove Administrator after the first successful apply.
+
+Set credentials in the current terminal without committing them:
+
+```bash
+export DISCORD_GUILD_ID="your-server-id"
+read -s DISCORD_BOT_TOKEN
+export DISCORD_BOT_TOKEN
+```
+
+## Plan and apply
+
+Run a read-only plan:
+
+```bash
+uv run --package learn-to-cloud-shared \
+  python scripts/configure_discord.py plan
+```
+
+Apply the displayed changes:
+
+```bash
+uv run --package learn-to-cloud-shared \
+  python scripts/configure_discord.py apply
+```
+
+Run `plan` again after applying. It should report that no changes are required.
+
+Discord personal notification and DM settings are not server resources and
+remain manual. Configure Rules Screening and review Community Onboarding in the
+Discord UI after provisioning.

--- a/discord/README.md
+++ b/discord/README.md
@@ -46,4 +46,10 @@ Run `plan` again after applying. It should report that no changes are required.
 
 Discord personal notification and DM settings are not server resources and
 remain manual. Configure Rules Screening and review Community Onboarding in the
-Discord UI after provisioning.
+Discord UI after provisioning. For an existing Community server, also set:
+
+- Rules or Guidelines Channel: `start-here`
+- Community Updates Channel: `community-updates`
+
+Discord accepts bot requests to change these assignments but does not persist
+them on an already-enabled Community server.

--- a/discord/README.md
+++ b/discord/README.md
@@ -49,6 +49,17 @@ uv run --package learn-to-cloud-shared \
   python scripts/configure_discord.py apply
 ```
 
+Connect the managed GitHub repositories to `github-feed`:
+
+```bash
+uv run --package learn-to-cloud-shared \
+  python scripts/configure_discord.py connect-github
+```
+
+This command uses the current `gh` CLI authentication. It creates one Discord
+webhook and adds it to each configured repository without changing unrelated
+repository webhooks.
+
 Run `plan` again after applying. It should report that no changes are required.
 
 Discord personal notification and DM settings are not server resources and

--- a/discord/README.md
+++ b/discord/README.md
@@ -35,6 +35,13 @@ uv run --package learn-to-cloud-shared \
   python scripts/configure_discord.py plan
 ```
 
+List the current server categories and channels:
+
+```bash
+uv run --package learn-to-cloud-shared \
+  python scripts/configure_discord.py inventory
+```
+
 Apply the displayed changes:
 
 ```bash

--- a/discord/community.yaml
+++ b/discord/community.yaml
@@ -1,0 +1,97 @@
+server:
+  description: Learn cloud engineering with a structured, hands-on curriculum.
+
+roles:
+  - name: Community Helper
+    mentionable: false
+    hoist: true
+    permissions:
+      - manage_messages
+      - manage_threads
+      - moderate_members
+  - name: Phase 0
+  - name: Phase 1
+  - name: Phase 2
+  - name: Phase 3
+  - name: Phase 4
+  - name: Phase 5
+  - name: Phase 6
+  - name: Phase 7
+
+categories:
+  - name: START HERE
+    channels:
+      - name: start-here
+        type: text
+        topic: Read the rules, follow the curriculum, and learn where to ask for help.
+      - name: announcements
+        type: text
+        topic: Official Learn to Cloud project and curriculum updates.
+      - name: github-feed
+        type: text
+        topic: Automated updates from GitHub Issues and Discussions.
+
+  - name: LEARN TOGETHER
+    channels:
+      - name: curriculum-help
+        type: forum
+        topic: >-
+          Search before posting. Include your goal, phase, instructions followed,
+          what you tried, exact error output, and what you expected. Do not tag or
+          DM maintainers for support. Confirmed product bugs belong in GitHub Issues.
+        require_tag: true
+        default_auto_archive_duration: 4320
+        tags:
+          - phase-0
+          - phase-1
+          - phase-2
+          - phase-3
+          - phase-4
+          - phase-5
+          - phase-6
+          - phase-7
+          - verification
+          - resolved
+      - name: show-your-work
+        type: forum
+        topic: Share projects, deployments, milestones, and career wins.
+        require_tag: true
+        default_auto_archive_duration: 10080
+        tags:
+          - project
+          - deployment
+          - milestone
+          - career-win
+      - name: study-room
+        type: text
+        topic: General learner conversation. Use curriculum-help for support.
+        rate_limit_per_user: 15
+      - name: contributors
+        type: forum
+        topic: Discuss contributions to the application and curriculum.
+        require_tag: true
+        default_auto_archive_duration: 10080
+        tags:
+          - app
+          - curriculum
+          - documentation
+
+  - name: COMMUNITY TEAM
+    private: true
+    allowed_roles:
+      - Community Helper
+    channels:
+      - name: helper-lounge
+        type: text
+        topic: Private coordination for community helpers.
+      - name: mod-log
+        type: text
+        topic: Private moderation and AutoMod alerts.
+
+automod:
+  - name: Block mention spam
+    trigger: mention_spam
+    mention_limit: 5
+    raid_protection: true
+    block_message: Too many mentions. Ask one clear question without tagging people.
+    alert_channel: mod-log

--- a/discord/community.yaml
+++ b/discord/community.yaml
@@ -20,6 +20,9 @@ roles:
   - name: Video Notifications
     mentionable: false
     hoist: false
+  - name: Community Member
+    mentionable: false
+    hoist: false
 
 categories:
   - name: START HERE

--- a/discord/community.yaml
+++ b/discord/community.yaml
@@ -52,6 +52,7 @@ categories:
         require_tag: true
         default_auto_archive_duration: 4320
         tags:
+          - guide
           - phase-0
           - phase-1
           - phase-2

--- a/discord/community.yaml
+++ b/discord/community.yaml
@@ -17,6 +17,9 @@ roles:
   - name: Phase 5
   - name: Phase 6
   - name: Phase 7
+  - name: Video Notifications
+    mentionable: false
+    hoist: false
 
 categories:
   - name: START HERE
@@ -27,6 +30,10 @@ categories:
       - name: announcements
         type: text
         topic: Official Learn to Cloud project and curriculum updates.
+      - name: content-updates
+        type: text
+        topic: New videos and creator content from madebygps.
+        read_only: true
       - name: github-feed
         type: text
         topic: Automated updates from GitHub Issues and Discussions.

--- a/discord/community.yaml
+++ b/discord/community.yaml
@@ -109,3 +109,18 @@ automod:
     raid_protection: true
     block_message: Too many mentions. Ask one clear question without tagging people.
     alert_channel: mod-log
+
+github:
+  channel: github-feed
+  webhook_name: Learn to Cloud GitHub
+  repositories:
+    - learntocloud/journal-starter
+    - learntocloud/learn-to-cloud-app
+    - learntocloud/linux-ctfs
+    - learntocloud/networking-lab
+  events:
+    - push
+    - issues
+    - pull_request
+    - release
+    - discussion

--- a/discord/community.yaml
+++ b/discord/community.yaml
@@ -84,6 +84,9 @@ categories:
       - name: helper-lounge
         type: text
         topic: Private coordination for community helpers.
+      - name: community-updates
+        type: text
+        topic: Official Discord updates for community moderators.
       - name: mod-log
         type: text
         topic: Private moderation and AutoMod alerts.

--- a/scripts/configure_discord.py
+++ b/scripts/configure_discord.py
@@ -440,9 +440,47 @@ def load_config(path: Path) -> dict[str, Any]:
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("command", choices=("plan", "apply"))
+    parser.add_argument("command", choices=("plan", "apply", "inventory"))
     parser.add_argument("--config", type=Path, default=CONFIG_PATH)
     return parser.parse_args()
+
+
+def print_inventory(channels: list[dict[str, Any]]) -> None:
+    """Print categories and channels without exposing credentials."""
+    type_names = {
+        0: "text",
+        2: "voice",
+        4: "category",
+        5: "announcement",
+        13: "stage",
+        15: "forum",
+        16: "media",
+    }
+    categories = sorted(
+        (channel for channel in channels if channel["type"] == 4),
+        key=lambda channel: channel.get("position", 0),
+    )
+    grouped: dict[str | None, list[dict[str, Any]]] = {}
+    for channel in channels:
+        if channel["type"] != 4:
+            grouped.setdefault(channel.get("parent_id"), []).append(channel)
+
+    def print_channels(children: list[dict[str, Any]]) -> None:
+        for channel in sorted(
+            children, key=lambda item: item.get("position", 0)
+        ):
+            type_name = type_names.get(channel["type"], f"type-{channel['type']}")
+            print(f"  {type_name:12} {channel['name']}")
+
+    for category in categories:
+        print(f"CATEGORY {category['name']}")
+        print_channels(grouped.pop(category["id"], []))
+    if ungrouped := grouped.pop(None, []):
+        print("UNCATEGORIZED")
+        print_channels(ungrouped)
+    for parent_id, children in grouped.items():
+        print(f"UNKNOWN CATEGORY {parent_id}")
+        print_channels(children)
 
 
 def main() -> int:
@@ -460,6 +498,11 @@ def main() -> int:
     try:
         client = DiscordClient(token)
         bot = client.request("GET", "/users/@me")
+        if args.command == "inventory":
+            channels = client.request("GET", f"/guilds/{guild_id}/channels")
+            print(f"Authenticated as {bot['username']} ({bot['id']}).")
+            print_inventory(channels)
+            return 0
         actions = Provisioner(
             client,
             guild_id,

--- a/scripts/configure_discord.py
+++ b/scripts/configure_discord.py
@@ -21,11 +21,24 @@ CONFIG_PATH = Path(__file__).resolve().parents[1] / "discord" / "community.yaml"
 CHANNEL_TYPES = {"text": 0, "category": 4, "forum": 15}
 PERMISSIONS = {
     "view_channel": 1 << 10,
+    "send_messages": 1 << 11,
     "manage_messages": 1 << 13,
     "manage_threads": 1 << 34,
+    "create_public_threads": 1 << 35,
+    "create_private_threads": 1 << 36,
+    "send_messages_in_threads": 1 << 38,
     "moderate_members": 1 << 40,
 }
 REQUIRE_TAG = 1 << 4
+READ_ONLY_DENY = sum(
+    PERMISSIONS[name]
+    for name in (
+        "send_messages",
+        "create_public_threads",
+        "create_private_threads",
+        "send_messages_in_threads",
+    )
+)
 
 
 class DiscordError(RuntimeError):
@@ -260,6 +273,15 @@ class Provisioner:
         }
         if "rate_limit_per_user" in config:
             payload["rate_limit_per_user"] = config["rate_limit_per_user"]
+        if config.get("read_only"):
+            payload["permission_overwrites"] = [
+                {
+                    "id": self.guild_id,
+                    "type": 0,
+                    "allow": "0",
+                    "deny": str(READ_ONLY_DENY),
+                }
+            ]
         if config["type"] == "forum":
             payload.update(
                 {
@@ -315,6 +337,35 @@ class Provisioner:
             existing.get("flags", 0) & REQUIRE_TAG
         ) != config.get("require_tag", False):
             differences.append("required-tag")
+        everyone_overwrite = next(
+            (
+                overwrite
+                for overwrite in existing.get("permission_overwrites", [])
+                if overwrite["id"] == self.guild_id and overwrite["type"] == 0
+            ),
+            None,
+        )
+        current_deny = int(everyone_overwrite["deny"]) if everyone_overwrite else 0
+        if config.get("read_only") and current_deny & READ_ONLY_DENY != READ_ONLY_DENY:
+            differences.append("read-only")
+            preserved_overwrites = [
+                dict(overwrite)
+                for overwrite in existing.get("permission_overwrites", [])
+                if not (
+                    overwrite["id"] == self.guild_id and overwrite["type"] == 0
+                )
+            ]
+            preserved_overwrites.append(
+                {
+                    "id": self.guild_id,
+                    "type": 0,
+                    "allow": (
+                        everyone_overwrite["allow"] if everyone_overwrite else "0"
+                    ),
+                    "deny": str(current_deny | READ_ONLY_DENY),
+                }
+            )
+            payload["permission_overwrites"] = preserved_overwrites
         if differences:
             detail = ", ".join(differences)
             self._record(

--- a/scripts/configure_discord.py
+++ b/scripts/configure_discord.py
@@ -140,7 +140,12 @@ class Provisioner:
                     created = self.client.request(
                         "POST", f"/guilds/{self.guild_id}/roles", payload
                     )
-                    roles_by_name[name] = created
+                else:
+                    created = {
+                        **payload,
+                        "id": f"planned:{name}",
+                    }
+                roles_by_name[name] = created
             elif any(
                 str(existing.get(key)) != str(value) for key, value in payload.items()
             ):

--- a/scripts/configure_discord.py
+++ b/scripts/configure_discord.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""Plan and apply the Learn to Cloud Discord server configuration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+API_BASE = "https://discord.com/api/v10"
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "discord" / "community.yaml"
+
+CHANNEL_TYPES = {"text": 0, "category": 4, "forum": 15}
+PERMISSIONS = {
+    "view_channel": 1 << 10,
+    "manage_messages": 1 << 13,
+    "manage_threads": 1 << 34,
+    "moderate_members": 1 << 40,
+}
+REQUIRE_TAG = 1 << 4
+
+
+class DiscordError(RuntimeError):
+    """An unsuccessful Discord API response."""
+
+
+class DiscordClient:
+    """Minimal Discord REST API client."""
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        data = json.dumps(payload).encode() if payload is not None else None
+        request = urllib.request.Request(
+            f"{API_BASE}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bot {self.token}",
+                "Content-Type": "application/json",
+                "User-Agent": "LearnToCloudCommunityManager/1.0",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                body = response.read()
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode(errors="replace")
+            raise DiscordError(
+                f"{method} {path} failed with HTTP {error.code}: {detail}"
+            ) from error
+        except urllib.error.URLError as error:
+            raise DiscordError(f"{method} {path} failed: {error.reason}") from error
+        return json.loads(body) if body else None
+
+
+@dataclass(frozen=True)
+class Action:
+    """A planned Discord configuration change."""
+
+    verb: str
+    resource: str
+
+
+class Provisioner:
+    """Reconcile managed Discord resources without deleting unmanaged resources."""
+
+    def __init__(
+        self,
+        client: DiscordClient,
+        guild_id: str,
+        config: dict[str, Any],
+        *,
+        apply: bool,
+    ) -> None:
+        self.client = client
+        self.guild_id = guild_id
+        self.config = config
+        self.apply = apply
+        self.actions: list[Action] = []
+
+    def run(self) -> list[Action]:
+        guild = self.client.request("GET", f"/guilds/{self.guild_id}")
+        roles = self.client.request("GET", f"/guilds/{self.guild_id}/roles")
+        channels = self.client.request("GET", f"/guilds/{self.guild_id}/channels")
+
+        roles_by_name = {role["name"]: role for role in roles}
+        self._reconcile_roles(roles_by_name)
+
+        channels_by_name = {channel["name"]: channel for channel in channels}
+        self._reconcile_non_forum_channels(channels_by_name, roles_by_name)
+        if self.apply:
+            channels = self.client.request("GET", f"/guilds/{self.guild_id}/channels")
+            channels_by_name = {channel["name"]: channel for channel in channels}
+
+        self._reconcile_community(guild, channels_by_name)
+        self._reconcile_forum_channels(channels_by_name, roles_by_name)
+        if self.apply:
+            channels = self.client.request("GET", f"/guilds/{self.guild_id}/channels")
+            channels_by_name = {channel["name"]: channel for channel in channels}
+
+        self._reconcile_automod(channels_by_name)
+        return self.actions
+
+    def _record(self, verb: str, resource: str) -> None:
+        self.actions.append(Action(verb, resource))
+
+    def _reconcile_roles(self, roles_by_name: dict[str, dict[str, Any]]) -> None:
+        for role_config in self.config["roles"]:
+            name = role_config["name"]
+            payload = {
+                "name": name,
+                "permissions": str(
+                    sum(
+                        PERMISSIONS[permission]
+                        for permission in role_config.get("permissions", [])
+                    )
+                ),
+                "hoist": role_config.get("hoist", False),
+                "mentionable": role_config.get("mentionable", False),
+            }
+            existing = roles_by_name.get(name)
+            if existing is None:
+                self._record("create", f"role {name}")
+                if self.apply:
+                    created = self.client.request(
+                        "POST", f"/guilds/{self.guild_id}/roles", payload
+                    )
+                    roles_by_name[name] = created
+            elif any(
+                str(existing.get(key)) != str(value) for key, value in payload.items()
+            ):
+                self._record("update", f"role {name}")
+                if self.apply:
+                    self.client.request(
+                        "PATCH",
+                        f"/guilds/{self.guild_id}/roles/{existing['id']}",
+                        payload,
+                    )
+
+    def _reconcile_non_forum_channels(
+        self,
+        channels_by_name: dict[str, dict[str, Any]],
+        roles_by_name: dict[str, dict[str, Any]],
+    ) -> None:
+        for category in self.config["categories"]:
+            category_channel = self._ensure_category(
+                category, channels_by_name, roles_by_name
+            )
+            for channel in category["channels"]:
+                if channel["type"] == "forum":
+                    continue
+                self._ensure_channel(channel, category_channel, channels_by_name)
+
+    def _reconcile_forum_channels(
+        self,
+        channels_by_name: dict[str, dict[str, Any]],
+        roles_by_name: dict[str, dict[str, Any]],
+    ) -> None:
+        for category in self.config["categories"]:
+            category_channel = self._ensure_category(
+                category, channels_by_name, roles_by_name
+            )
+            for channel in category["channels"]:
+                if channel["type"] != "forum":
+                    continue
+                self._ensure_channel(channel, category_channel, channels_by_name)
+
+    def _ensure_category(
+        self,
+        config: dict[str, Any],
+        channels_by_name: dict[str, dict[str, Any]],
+        roles_by_name: dict[str, dict[str, Any]],
+    ) -> dict[str, Any]:
+        name = config["name"]
+        existing = channels_by_name.get(name)
+        if existing is not None:
+            if existing["type"] != CHANNEL_TYPES["category"]:
+                raise DiscordError(
+                    f"Cannot manage category {name}: that name is used by "
+                    "a different channel type"
+                )
+            return existing
+
+        payload: dict[str, Any] = {
+            "name": name,
+            "type": CHANNEL_TYPES["category"],
+        }
+        if config.get("private"):
+            overwrites = [
+                {
+                    "id": self.guild_id,
+                    "type": 0,
+                    "allow": "0",
+                    "deny": str(PERMISSIONS["view_channel"]),
+                }
+            ]
+            for role_name in config.get("allowed_roles", []):
+                role = roles_by_name.get(role_name)
+                if role is None:
+                    raise DiscordError(
+                        f"Cannot create private category {name}: "
+                        f"role {role_name} does not exist"
+                    )
+                overwrites.append(
+                    {
+                        "id": role["id"],
+                        "type": 0,
+                        "allow": str(PERMISSIONS["view_channel"]),
+                        "deny": "0",
+                    }
+                )
+            payload["permission_overwrites"] = overwrites
+
+        self._record("create", f"category {name}")
+        if self.apply:
+            created = self.client.request(
+                "POST", f"/guilds/{self.guild_id}/channels", payload
+            )
+        else:
+            created = {
+                "id": f"planned:{name}",
+                "name": name,
+                "type": CHANNEL_TYPES["category"],
+            }
+        channels_by_name[name] = created
+        return created
+
+    def _ensure_channel(
+        self,
+        config: dict[str, Any],
+        category: dict[str, Any],
+        channels_by_name: dict[str, dict[str, Any]],
+    ) -> None:
+        name = config["name"]
+        payload: dict[str, Any] = {
+            "name": name,
+            "type": CHANNEL_TYPES[config["type"]],
+            "parent_id": category["id"],
+            "topic": config.get("topic"),
+        }
+        if "rate_limit_per_user" in config:
+            payload["rate_limit_per_user"] = config["rate_limit_per_user"]
+        if config["type"] == "forum":
+            payload.update(
+                {
+                    "available_tags": [
+                        {"name": tag, "moderated": False}
+                        for tag in config.get("tags", [])
+                    ],
+                    "default_auto_archive_duration": config.get(
+                        "default_auto_archive_duration", 4320
+                    ),
+                    "default_forum_layout": 1,
+                    "default_sort_order": 0,
+                    "flags": REQUIRE_TAG if config.get("require_tag") else 0,
+                }
+            )
+
+        existing = channels_by_name.get(name)
+        if existing is None:
+            self._record("create", f"{config['type']} channel {name}")
+            if self.apply:
+                created = self.client.request(
+                    "POST", f"/guilds/{self.guild_id}/channels", payload
+                )
+            else:
+                created = {
+                    **payload,
+                    "id": f"planned:{name}",
+                    "available_tags": payload.get("available_tags", []),
+                    "flags": payload.get("flags", 0),
+                }
+            channels_by_name[name] = created
+            return
+        if existing["type"] != CHANNEL_TYPES[config["type"]]:
+            raise DiscordError(
+                f"Cannot manage channel {name}: its existing type does not match "
+                f"{config['type']}"
+            )
+
+        current_tags = [tag["name"] for tag in existing.get("available_tags", [])]
+        desired_tags = config.get("tags", [])
+        changed = (
+            existing.get("parent_id") != category["id"]
+            or existing.get("topic") != payload["topic"]
+            or existing.get("rate_limit_per_user", 0)
+            != payload.get("rate_limit_per_user", 0)
+            or current_tags != desired_tags
+            or (
+                config["type"] == "forum"
+                and bool(existing.get("flags", 0) & REQUIRE_TAG)
+                != config.get("require_tag", False)
+            )
+        )
+        if changed:
+            self._record("update", f"{config['type']} channel {name}")
+            if self.apply:
+                payload.pop("type")
+                self.client.request("PATCH", f"/channels/{existing['id']}", payload)
+
+    def _reconcile_community(
+        self,
+        guild: dict[str, Any],
+        channels_by_name: dict[str, dict[str, Any]],
+    ) -> None:
+        start_here = channels_by_name.get("start-here")
+        announcements = channels_by_name.get("announcements")
+        if start_here is None or announcements is None:
+            if self.apply:
+                raise DiscordError(
+                    "start-here and announcements are required before Community setup"
+                )
+            self._record("enable", "Community server features")
+            return
+
+        payload = {
+            "description": self.config["server"]["description"],
+            "verification_level": max(guild.get("verification_level", 0), 1),
+            "explicit_content_filter": 2,
+            "rules_channel_id": start_here["id"],
+            "public_updates_channel_id": announcements["id"],
+            "features": sorted(set(guild.get("features", [])) | {"COMMUNITY"}),
+        }
+        if "COMMUNITY" not in guild.get("features", []):
+            self._record("enable", "Community server features")
+            if self.apply:
+                self.client.request("PATCH", f"/guilds/{self.guild_id}", payload)
+        elif any(
+            guild.get(key) != value
+            for key, value in payload.items()
+            if key != "features"
+        ):
+            self._record("update", "Community server settings")
+            if self.apply:
+                payload.pop("features")
+                self.client.request("PATCH", f"/guilds/{self.guild_id}", payload)
+
+    def _reconcile_automod(
+        self, channels_by_name: dict[str, dict[str, Any]]
+    ) -> None:
+        existing_rules = self.client.request(
+            "GET", f"/guilds/{self.guild_id}/auto-moderation/rules"
+        )
+        rules_by_name = {rule["name"]: rule for rule in existing_rules}
+        for config in self.config.get("automod", []):
+            if config["trigger"] != "mention_spam":
+                raise DiscordError(f"Unsupported AutoMod trigger: {config['trigger']}")
+            alert_channel = channels_by_name.get(config["alert_channel"])
+            if alert_channel is None:
+                if self.apply:
+                    raise DiscordError(
+                        f"AutoMod alert channel {config['alert_channel']} is missing"
+                    )
+                continue
+            payload = {
+                "name": config["name"],
+                "event_type": 1,
+                "trigger_type": 5,
+                "trigger_metadata": {
+                    "mention_total_limit": config["mention_limit"],
+                    "mention_raid_protection_enabled": config["raid_protection"],
+                },
+                "actions": [
+                    {
+                        "type": 1,
+                        "metadata": {"custom_message": config["block_message"]},
+                    },
+                    {"type": 2, "metadata": {"channel_id": alert_channel["id"]}},
+                ],
+                "enabled": True,
+            }
+            existing = rules_by_name.get(config["name"])
+            if existing is None:
+                self._record("create", f"AutoMod rule {config['name']}")
+                if self.apply:
+                    self.client.request(
+                        "POST",
+                        f"/guilds/{self.guild_id}/auto-moderation/rules",
+                        payload,
+                    )
+            elif any(existing.get(key) != value for key, value in payload.items()):
+                self._record("update", f"AutoMod rule {config['name']}")
+                if self.apply:
+                    self.client.request(
+                        "PATCH",
+                        (
+                            f"/guilds/{self.guild_id}/auto-moderation/rules/"
+                            f"{existing['id']}"
+                        ),
+                        payload,
+                    )
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    """Load the declarative server configuration."""
+    with path.open(encoding="utf-8") as config_file:
+        config = yaml.safe_load(config_file)
+    if not isinstance(config, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return config
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("plan", "apply"))
+    parser.add_argument("--config", type=Path, default=CONFIG_PATH)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the Discord configuration reconciliation."""
+    args = parse_args()
+    token = os.environ.get("DISCORD_BOT_TOKEN")
+    guild_id = os.environ.get("DISCORD_GUILD_ID")
+    if not token or not guild_id:
+        print(
+            "Set DISCORD_BOT_TOKEN and DISCORD_GUILD_ID before running this command.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        client = DiscordClient(token)
+        bot = client.request("GET", "/users/@me")
+        actions = Provisioner(
+            client,
+            guild_id,
+            load_config(args.config),
+            apply=args.command == "apply",
+        ).run()
+    except (DiscordError, OSError, ValueError, yaml.YAMLError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Authenticated as {bot['username']} ({bot['id']}).")
+    if not actions:
+        print("No changes required.")
+        return 0
+    for action in actions:
+        print(f"{action.verb.upper():7} {action.resource}")
+    if args.command == "plan":
+        print("Plan only; run with 'apply' to make these changes.")
+    else:
+        print(f"Applied {len(actions)} change(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/configure_discord.py
+++ b/scripts/configure_discord.py
@@ -330,11 +330,12 @@ class Provisioner:
         channels_by_name: dict[str, dict[str, Any]],
     ) -> None:
         start_here = channels_by_name.get("start-here")
-        announcements = channels_by_name.get("announcements")
-        if start_here is None or announcements is None:
+        community_updates = channels_by_name.get("community-updates")
+        if start_here is None or community_updates is None:
             if self.apply:
                 raise DiscordError(
-                    "start-here and announcements are required before Community setup"
+                    "start-here and community-updates are required before "
+                    "Community setup"
                 )
             self._record("enable", "Community server features")
             return
@@ -344,7 +345,7 @@ class Provisioner:
             "verification_level": max(guild.get("verification_level", 0), 1),
             "explicit_content_filter": 2,
             "rules_channel_id": start_here["id"],
-            "public_updates_channel_id": announcements["id"],
+            "public_updates_channel_id": community_updates["id"],
             "features": sorted(set(guild.get("features", [])) | {"COMMUNITY"}),
         }
         differences = [

--- a/scripts/configure_discord.py
+++ b/scripts/configure_discord.py
@@ -300,20 +300,26 @@ class Provisioner:
 
         current_tags = [tag["name"] for tag in existing.get("available_tags", [])]
         desired_tags = config.get("tags", [])
-        changed = (
-            existing.get("parent_id") != category["id"]
-            or existing.get("topic") != payload["topic"]
-            or existing.get("rate_limit_per_user", 0)
-            != payload.get("rate_limit_per_user", 0)
-            or current_tags != desired_tags
-            or (
-                config["type"] == "forum"
-                and bool(existing.get("flags", 0) & REQUIRE_TAG)
-                != config.get("require_tag", False)
+        differences: list[str] = []
+        if existing.get("parent_id") != category["id"]:
+            differences.append("category")
+        if (existing.get("topic") or None) != (payload["topic"] or None):
+            differences.append("topic")
+        if (existing.get("rate_limit_per_user") or 0) != payload.get(
+            "rate_limit_per_user", 0
+        ):
+            differences.append("slowmode")
+        if set(current_tags) != set(desired_tags):
+            differences.append("tags")
+        if config["type"] == "forum" and bool(
+            existing.get("flags", 0) & REQUIRE_TAG
+        ) != config.get("require_tag", False):
+            differences.append("required-tag")
+        if differences:
+            detail = ", ".join(differences)
+            self._record(
+                "update", f"{config['type']} channel {name} ({detail})"
             )
-        )
-        if changed:
-            self._record("update", f"{config['type']} channel {name}")
             if self.apply:
                 payload.pop("type")
                 self.client.request("PATCH", f"/channels/{existing['id']}", payload)
@@ -341,16 +347,18 @@ class Provisioner:
             "public_updates_channel_id": announcements["id"],
             "features": sorted(set(guild.get("features", [])) | {"COMMUNITY"}),
         }
+        differences = [
+            key
+            for key, value in payload.items()
+            if key != "features" and guild.get(key) != value
+        ]
         if "COMMUNITY" not in guild.get("features", []):
             self._record("enable", "Community server features")
             if self.apply:
                 self.client.request("PATCH", f"/guilds/{self.guild_id}", payload)
-        elif any(
-            guild.get(key) != value
-            for key, value in payload.items()
-            if key != "features"
-        ):
-            self._record("update", "Community server settings")
+        elif differences:
+            detail = ", ".join(differences)
+            self._record("update", f"Community server settings ({detail})")
             if self.apply:
                 payload.pop("features")
                 self.client.request("PATCH", f"/guilds/{self.guild_id}", payload)

--- a/scripts/configure_discord.py
+++ b/scripts/configure_discord.py
@@ -340,20 +340,28 @@ class Provisioner:
             self._record("enable", "Community server features")
             return
 
-        payload = {
+        payload: dict[str, Any] = {
             "description": self.config["server"]["description"],
             "verification_level": max(guild.get("verification_level", 0), 1),
             "explicit_content_filter": 2,
-            "rules_channel_id": start_here["id"],
-            "public_updates_channel_id": community_updates["id"],
-            "features": sorted(set(guild.get("features", [])) | {"COMMUNITY"}),
         }
+        community_enabled = "COMMUNITY" in guild.get("features", [])
+        if not community_enabled:
+            payload.update(
+                {
+                    "rules_channel_id": start_here["id"],
+                    "public_updates_channel_id": community_updates["id"],
+                    "features": sorted(
+                        set(guild.get("features", [])) | {"COMMUNITY"}
+                    ),
+                }
+            )
         differences = [
             key
             for key, value in payload.items()
             if key != "features" and guild.get(key) != value
         ]
-        if "COMMUNITY" not in guild.get("features", []):
+        if not community_enabled:
             self._record("enable", "Community server features")
             if self.apply:
                 self.client.request("PATCH", f"/guilds/{self.guild_id}", payload)

--- a/scripts/configure_discord.py
+++ b/scripts/configure_discord.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 import urllib.error
 import urllib.request
@@ -79,6 +80,39 @@ class DiscordClient:
         except urllib.error.URLError as error:
             raise DiscordError(f"{method} {path} failed: {error.reason}") from error
         return json.loads(body) if body else None
+
+
+def gh_api(
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    """Call GitHub through its authenticated CLI without exposing credentials."""
+    command = [
+        "gh",
+        "api",
+        path,
+        "--method",
+        method,
+        "--header",
+        "Accept: application/vnd.github+json",
+    ]
+    if payload is not None:
+        command.extend(("--input", "-"))
+    try:
+        result = subprocess.run(
+            command,
+            input=json.dumps(payload) if payload is not None else None,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise DiscordError("The gh CLI is required for GitHub integration") from error
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise DiscordError(f"GitHub API {method} {path} failed: {detail}")
+    return json.loads(result.stdout) if result.stdout else None
 
 
 @dataclass(frozen=True)
@@ -491,7 +525,9 @@ def load_config(path: Path) -> dict[str, Any]:
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("command", choices=("plan", "apply", "inventory"))
+    parser.add_argument(
+        "command", choices=("plan", "apply", "inventory", "connect-github")
+    )
     parser.add_argument("--config", type=Path, default=CONFIG_PATH)
     return parser.parse_args()
 
@@ -534,6 +570,73 @@ def print_inventory(channels: list[dict[str, Any]]) -> None:
         print_channels(children)
 
 
+def connect_github(
+    client: DiscordClient,
+    guild_id: str,
+    config: dict[str, Any],
+) -> list[Action]:
+    """Connect configured GitHub repositories to the Discord feed channel."""
+    github_config = config["github"]
+    channels = client.request("GET", f"/guilds/{guild_id}/channels")
+    channel = next(
+        (
+            item
+            for item in channels
+            if item["name"] == github_config["channel"] and item["type"] == 0
+        ),
+        None,
+    )
+    if channel is None:
+        raise DiscordError(
+            f"Discord channel {github_config['channel']} does not exist"
+        )
+
+    discord_hooks = client.request("GET", f"/channels/{channel['id']}/webhooks")
+    webhook = next(
+        (
+            item
+            for item in discord_hooks
+            if item.get("name") == github_config["webhook_name"]
+        ),
+        None,
+    )
+    actions: list[Action] = []
+    if webhook is None:
+        webhook = client.request(
+            "POST",
+            f"/channels/{channel['id']}/webhooks",
+            {"name": github_config["webhook_name"]},
+        )
+        actions.append(Action("create", "Discord GitHub webhook"))
+    if not webhook.get("token"):
+        raise DiscordError(
+            "Discord did not return the managed webhook token; delete the "
+            f"{github_config['webhook_name']} webhook and retry"
+        )
+
+    delivery_url = (
+        f"https://discord.com/api/webhooks/{webhook['id']}/"
+        f"{webhook['token']}/github"
+    )
+    hook_payload = {
+        "name": "web",
+        "active": True,
+        "events": github_config["events"],
+        "config": {
+            "url": delivery_url,
+            "content_type": "json",
+            "insecure_ssl": "0",
+        },
+    }
+    for repository in github_config["repositories"]:
+        hooks = gh_api("GET", f"repos/{repository}/hooks")
+        if any(hook.get("config", {}).get("url") == delivery_url for hook in hooks):
+            continue
+        gh_api("POST", f"repos/{repository}/hooks", hook_payload)
+        actions.append(Action("connect", f"GitHub repository {repository}"))
+    return actions
+
+
 def main() -> int:
     """Run the Discord configuration reconciliation."""
     args = parse_args()
@@ -554,10 +657,21 @@ def main() -> int:
             print(f"Authenticated as {bot['username']} ({bot['id']}).")
             print_inventory(channels)
             return 0
+        config = load_config(args.config)
+        if args.command == "connect-github":
+            actions = connect_github(client, guild_id, config)
+            print(f"Authenticated as {bot['username']} ({bot['id']}).")
+            if not actions:
+                print("GitHub repositories are already connected.")
+                return 0
+            for action in actions:
+                print(f"{action.verb.upper():7} {action.resource}")
+            print(f"Applied {len(actions)} integration change(s).")
+            return 0
         actions = Provisioner(
             client,
             guild_id,
-            load_config(args.config),
+            config,
             apply=args.command == "apply",
         ).run()
     except (DiscordError, OSError, ValueError, yaml.YAMLError) as error:

--- a/scripts/tests/test_check_docs.py
+++ b/scripts/tests/test_check_docs.py
@@ -12,7 +12,7 @@ class CheckDocsTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary_directory = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary_directory.cleanup)
-        self.repo_root = Path(self.temporary_directory.name)
+        self.repo_root = Path(self.temporary_directory.name).resolve()
         self.docs_root = self.repo_root / "docs"
         self.scaling_index = self.docs_root / "scaling-with-github" / "index.html"
         self.scaling_index.parent.mkdir(parents=True)

--- a/scripts/tests/test_configure_discord.py
+++ b/scripts/tests/test_configure_discord.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import unittest
 from typing import Any
+from unittest.mock import patch
 
-from scripts.configure_discord import Provisioner
+from scripts.configure_discord import Provisioner, print_inventory
 
 
 class FakeDiscordClient:
@@ -161,6 +162,39 @@ class ProvisionerTests(unittest.TestCase):
         actions = Provisioner(client, "guild", config, apply=False).run()
 
         self.assertEqual(actions, [])
+
+    def test_inventory_groups_channels_by_category(self) -> None:
+        channels = [
+            {"id": "cat", "name": "LEARN", "type": 4, "position": 1},
+            {
+                "id": "help",
+                "name": "help",
+                "type": 15,
+                "parent_id": "cat",
+                "position": 2,
+            },
+            {
+                "id": "chat",
+                "name": "chat",
+                "type": 0,
+                "parent_id": None,
+                "position": 1,
+            },
+        ]
+
+        with patch("builtins.print") as print_mock:
+            print_inventory(channels)
+
+        lines = [call.args[0] for call in print_mock.call_args_list]
+        self.assertEqual(
+            lines,
+            [
+                "CATEGORY LEARN",
+                "  forum        help",
+                "UNCATEGORIZED",
+                "  text         chat",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_configure_discord.py
+++ b/scripts/tests/test_configure_discord.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 import unittest
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
-from scripts.configure_discord import READ_ONLY_DENY, Provisioner, print_inventory
+from scripts.configure_discord import (
+    READ_ONLY_DENY,
+    DiscordClient,
+    Provisioner,
+    connect_github,
+    print_inventory,
+)
 
 
-class FakeDiscordClient:
+class FakeDiscordClient(DiscordClient):
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
 
@@ -225,6 +231,52 @@ class ProvisionerTests(unittest.TestCase):
             "text channel content-updates (read-only)",
         )
         self.assertGreater(READ_ONLY_DENY, 0)
+
+    @patch("scripts.configure_discord.gh_api")
+    def test_connect_github_preserves_unrelated_hooks(self, gh_api_mock) -> None:
+        client = FakeDiscordClient()
+        client.request = Mock(
+            side_effect=[
+                [{"id": "feed", "name": "github-feed", "type": 0}],
+                [
+                    {
+                        "id": "discord-hook",
+                        "name": "Learn to Cloud GitHub",
+                        "token": "discord-token",
+                    }
+                ],
+            ]
+        )
+        gh_api_mock.side_effect = [
+            [{"config": {"url": "https://example.com/unrelated"}}],
+            {},
+            [
+                {
+                    "config": {
+                        "url": (
+                            "https://discord.com/api/webhooks/"
+                            "discord-hook/discord-token/github"
+                        )
+                    }
+                }
+            ],
+        ]
+        config = {
+            "github": {
+                "channel": "github-feed",
+                "webhook_name": "Learn to Cloud GitHub",
+                "repositories": ["owner/first", "owner/second"],
+                "events": ["push"],
+            }
+        }
+
+        actions = connect_github(client, "guild", config)
+
+        self.assertEqual(
+            [action.resource for action in actions],
+            ["GitHub repository owner/first"],
+        )
+        self.assertEqual(gh_api_mock.call_count, 3)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_configure_discord.py
+++ b/scripts/tests/test_configure_discord.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import unittest
+from typing import Any
+
+from scripts.configure_discord import Provisioner
+
+
+class FakeDiscordClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        self.calls.append((method, path, payload))
+        if path == "/guilds/guild":
+            return {
+                "features": [],
+                "verification_level": 0,
+                "explicit_content_filter": 0,
+            }
+        if path == "/guilds/guild/roles":
+            return [{"id": "guild", "name": "@everyone"}]
+        if path == "/guilds/guild/channels":
+            return []
+        if path == "/guilds/guild/auto-moderation/rules":
+            return []
+        raise AssertionError(f"Unexpected request: {method} {path}")
+
+
+class ProvisionerTests(unittest.TestCase):
+    def test_plan_includes_managed_resources_without_writes(self) -> None:
+        client = FakeDiscordClient()
+        config = {
+            "server": {"description": "Community"},
+            "roles": [{"name": "Community Helper"}],
+            "categories": [
+                {
+                    "name": "START HERE",
+                    "channels": [
+                        {"name": "start-here", "type": "text"},
+                        {"name": "announcements", "type": "text"},
+                    ],
+                },
+                {
+                    "name": "LEARN",
+                    "channels": [
+                        {
+                            "name": "curriculum-help",
+                            "type": "forum",
+                            "require_tag": True,
+                            "tags": ["phase-0"],
+                        }
+                    ],
+                },
+                {
+                    "name": "STAFF",
+                    "channels": [{"name": "mod-log", "type": "text"}],
+                },
+            ],
+            "automod": [
+                {
+                    "name": "Block mention spam",
+                    "trigger": "mention_spam",
+                    "mention_limit": 5,
+                    "raid_protection": True,
+                    "block_message": "Too many mentions.",
+                    "alert_channel": "mod-log",
+                }
+            ],
+        }
+
+        actions = Provisioner(client, "guild", config, apply=False).run()
+
+        resources = {action.resource for action in actions}
+        self.assertIn("role Community Helper", resources)
+        self.assertIn("category START HERE", resources)
+        self.assertIn("text channel start-here", resources)
+        self.assertIn("forum channel curriculum-help", resources)
+        self.assertIn("Community server features", resources)
+        self.assertIn("AutoMod rule Block mention spam", resources)
+        self.assertFalse(
+            any(method != "GET" for method, _, _ in client.calls),
+            "plan must not write to Discord",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_configure_discord.py
+++ b/scripts/tests/test_configure_discord.py
@@ -90,6 +90,75 @@ class ProvisionerTests(unittest.TestCase):
             "plan must not write to Discord",
         )
 
+    def test_equivalent_forum_values_do_not_trigger_update(self) -> None:
+        client = FakeDiscordClient()
+        client.request = lambda method, path, payload=None: {
+            "/guilds/guild": {
+                "features": ["COMMUNITY"],
+                "description": "Community",
+                "verification_level": 1,
+                "explicit_content_filter": 2,
+                "rules_channel_id": "start",
+                "public_updates_channel_id": "announcements",
+            },
+            "/guilds/guild/roles": [{"id": "guild", "name": "@everyone"}],
+            "/guilds/guild/channels": [
+                {"id": "category", "name": "LEARN", "type": 4},
+                {
+                    "id": "start",
+                    "name": "start-here",
+                    "type": 0,
+                    "parent_id": "category",
+                    "topic": None,
+                },
+                {
+                    "id": "announcements",
+                    "name": "announcements",
+                    "type": 0,
+                    "parent_id": "category",
+                    "topic": None,
+                },
+                {
+                    "id": "forum",
+                    "name": "curriculum-help",
+                    "type": 15,
+                    "parent_id": "category",
+                    "topic": None,
+                    "rate_limit_per_user": None,
+                    "available_tags": [
+                        {"id": "2", "name": "resolved"},
+                        {"id": "1", "name": "phase-0"},
+                    ],
+                    "flags": 16,
+                },
+            ],
+            "/guilds/guild/auto-moderation/rules": [],
+        }[path]
+        config = {
+            "server": {"description": "Community"},
+            "roles": [],
+            "categories": [
+                {
+                    "name": "LEARN",
+                    "channels": [
+                        {"name": "start-here", "type": "text"},
+                        {"name": "announcements", "type": "text"},
+                        {
+                            "name": "curriculum-help",
+                            "type": "forum",
+                            "require_tag": True,
+                            "tags": ["phase-0", "resolved"],
+                        },
+                    ],
+                }
+            ],
+            "automod": [],
+        }
+
+        actions = Provisioner(client, "guild", config, apply=False).run()
+
+        self.assertEqual(actions, [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_configure_discord.py
+++ b/scripts/tests/test_configure_discord.py
@@ -61,7 +61,10 @@ class ProvisionerTests(unittest.TestCase):
                     "name": "STAFF",
                     "private": True,
                     "allowed_roles": ["Community Helper"],
-                    "channels": [{"name": "mod-log", "type": "text"}],
+                    "channels": [
+                        {"name": "community-updates", "type": "text"},
+                        {"name": "mod-log", "type": "text"},
+                    ],
                 },
             ],
             "automod": [
@@ -99,7 +102,7 @@ class ProvisionerTests(unittest.TestCase):
                 "verification_level": 1,
                 "explicit_content_filter": 2,
                 "rules_channel_id": "start",
-                "public_updates_channel_id": "announcements",
+                "public_updates_channel_id": "community-updates",
             },
             "/guilds/guild/roles": [{"id": "guild", "name": "@everyone"}],
             "/guilds/guild/channels": [
@@ -112,8 +115,8 @@ class ProvisionerTests(unittest.TestCase):
                     "topic": None,
                 },
                 {
-                    "id": "announcements",
-                    "name": "announcements",
+                    "id": "community-updates",
+                    "name": "community-updates",
                     "type": 0,
                     "parent_id": "category",
                     "topic": None,
@@ -142,7 +145,7 @@ class ProvisionerTests(unittest.TestCase):
                     "name": "LEARN",
                     "channels": [
                         {"name": "start-here", "type": "text"},
-                        {"name": "announcements", "type": "text"},
+                        {"name": "community-updates", "type": "text"},
                         {
                             "name": "curriculum-help",
                             "type": "forum",

--- a/scripts/tests/test_configure_discord.py
+++ b/scripts/tests/test_configure_discord.py
@@ -101,8 +101,8 @@ class ProvisionerTests(unittest.TestCase):
                 "description": "Community",
                 "verification_level": 1,
                 "explicit_content_filter": 2,
-                "rules_channel_id": "start",
-                "public_updates_channel_id": "community-updates",
+                "rules_channel_id": "discord-managed-rules",
+                "public_updates_channel_id": "discord-managed-updates",
             },
             "/guilds/guild/roles": [{"id": "guild", "name": "@everyone"}],
             "/guilds/guild/channels": [

--- a/scripts/tests/test_configure_discord.py
+++ b/scripts/tests/test_configure_discord.py
@@ -59,6 +59,8 @@ class ProvisionerTests(unittest.TestCase):
                 },
                 {
                     "name": "STAFF",
+                    "private": True,
+                    "allowed_roles": ["Community Helper"],
                     "channels": [{"name": "mod-log", "type": "text"}],
                 },
             ],

--- a/scripts/tests/test_configure_discord.py
+++ b/scripts/tests/test_configure_discord.py
@@ -4,7 +4,7 @@ import unittest
 from typing import Any
 from unittest.mock import patch
 
-from scripts.configure_discord import Provisioner, print_inventory
+from scripts.configure_discord import READ_ONLY_DENY, Provisioner, print_inventory
 
 
 class FakeDiscordClient:
@@ -195,6 +195,36 @@ class ProvisionerTests(unittest.TestCase):
                 "  text         chat",
             ],
         )
+
+    def test_read_only_channel_plan_detects_missing_permissions(self) -> None:
+        provisioner = Provisioner(FakeDiscordClient(), "guild", {}, apply=False)
+        channels = {
+            "content-updates": {
+                "id": "content",
+                "name": "content-updates",
+                "type": 0,
+                "parent_id": "category",
+                "topic": "Videos",
+                "permission_overwrites": [],
+            }
+        }
+
+        provisioner._ensure_channel(
+            {
+                "name": "content-updates",
+                "type": "text",
+                "topic": "Videos",
+                "read_only": True,
+            },
+            {"id": "category"},
+            channels,
+        )
+
+        self.assertEqual(
+            provisioner.actions[0].resource,
+            "text channel content-updates (read-only)",
+        )
+        self.assertGreater(READ_ONLY_DENY, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a safe, idempotent Discord `plan`/`apply` provisioner
- define curriculum-oriented roles, forums, tags, private helper channels, and AutoMod
- document bot permissions and operating steps
- fix the existing macOS temporary-path test fixture so the repository quality gate runs reliably

## Validation
- `uv run poe check`
- `uv run --package learn-to-cloud-shared python -m unittest scripts.tests.test_configure_discord`