### PR TITLE
Add Discord community link

### DIFF
--- a/api/src/learn_to_cloud/rendering/context.py
+++ b/api/src/learn_to_cloud/rendering/context.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     )
 
 DISCUSSIONS_URL = "https://github.com/learntocloud/learn-to-cloud-app/discussions"
+DISCORD_URL = "https://discord.gg/sfdgmbWVf4"
 GITHUB_REPOSITORY_URL = "https://github.com/learntocloud/learn-to-cloud-app"
 MADEBYGPS_X_URL = "https://x.com/madebygps"
 LEARN_TO_CLOUD_X_URL = "https://x.com/learntocloud"
@@ -152,7 +153,28 @@ _YOUTUBE_SVG = (
     ' 12l-6.273 3.568z"/></svg>'
 )
 
+_DISCORD_SVG = (
+    '<svg class="h-5 w-5" viewBox="0 0 24 24" fill="currentColor"'
+    ' aria-hidden="true"><path d="M19.54 5.34A16.3 16.3 0 0 0 15.44'
+    " 4l-.5 1.02a15.3 15.3 0 0 0-5.88 0L8.56 4a16.5 16.5 0 0 0"
+    "-4.1 1.35C1.86 9.18 1.16 12.9 1.5 16.57A16.8 16.8 0 0 0"
+    " 6.52 19.1l1.23-1.68c-.68-.25-1.33-.57-1.94-.94l.48-.37c3.74"
+    " 1.73 7.8 1.73 11.5 0l.5.37c-.62.37-1.27.69-1.95.94l1.23"
+    " 1.68a16.7 16.7 0 0 0 5.02-2.53c.4-4.26-.68-7.94-3.05"
+    "-11.23ZM8.68 14.35c-1.12 0-2.04-1.03-2.04-2.3s.9-2.3"
+    " 2.04-2.3c1.15 0 2.06 1.04 2.04 2.3 0 1.27-.9 2.3-2.04"
+    " 2.3Zm6.64 0c-1.12 0-2.04-1.03-2.04-2.3s.9-2.3 2.04-2.3"
+    'c1.15 0 2.06 1.04 2.04 2.3 0 1.27-.9 2.3-2.04 2.3Z"/></svg>'
+)
+
 COMMUNITY_LINKS: list[dict[str, str]] = [
+    {
+        "url": DISCORD_URL,
+        "label": "Discord",
+        "description": "Chat with other learners and get help in real time.",
+        "color": "text-indigo-500 dark:text-indigo-400",
+        "icon": _DISCORD_SVG,
+    },
     {
         "url": DISCUSSIONS_URL,
         "label": "GitHub Discussions",

--- a/api/src/learn_to_cloud/templates/partials/footer.html
+++ b/api/src/learn_to_cloud/templates/partials/footer.html
@@ -13,6 +13,11 @@
             <span class="mx-1">&middot;</span>
             <a href="/terms" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Terms</a>
             <span class="mx-1">&middot;</span>
+            <a href="https://discord.gg/sfdgmbWVf4" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.54 5.34A16.3 16.3 0 0 0 15.44 4l-.5 1.02a15.3 15.3 0 0 0-5.88 0L8.56 4a16.5 16.5 0 0 0-4.1 1.35C1.86 9.18 1.16 12.9 1.5 16.57A16.8 16.8 0 0 0 6.52 19.1l1.23-1.68c-.68-.25-1.33-.57-1.94-.94l.48-.37c3.74 1.73 7.8 1.73 11.5 0l.5.37c-.62.37-1.27.69-1.95.94l1.23 1.68a16.7 16.7 0 0 0 5.02-2.53c.4-4.26-.68-7.94-3.05-11.23ZM8.68 14.35c-1.12 0-2.04-1.03-2.04-2.3s.9-2.3 2.04-2.3c1.15 0 2.06 1.04 2.04 2.3 0 1.27-.9 2.3-2.04 2.3Zm6.64 0c-1.12 0-2.04-1.03-2.04-2.3s.9-2.3 2.04-2.3c1.15 0 2.06 1.04 2.04 2.3 0 1.27-.9 2.3-2.04 2.3Z"/></svg>
+                Discord
+            </a>
+            <span class="mx-1">&middot;</span>
             <a href="https://github.com/learntocloud/learn-to-cloud-app" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
                 <svg class="h-4 w-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                 GitHub

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -442,6 +442,7 @@ def test_community_page_renders_safe_external_resource_links():
     )
 
     expected_links = {
+        "https://discord.gg/sfdgmbWVf4",
         "https://github.com/learntocloud/learn-to-cloud-app/discussions",
         "https://youtube.com/made-by-gps",
         "https://github.com/learntocloud/learn-to-cloud-app",
@@ -451,6 +452,7 @@ def test_community_page_renders_safe_external_resource_links():
     for url in expected_links:
         assert f'href="{url}"' in html
     assert html.count('rel="noopener noreferrer"') >= len(expected_links)
+    assert "Discord" in html
     assert "GitHub Discussions" in html
     assert "Follow @madebygps" in html
     assert "Follow @learntocloud" in html

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -462,7 +462,7 @@ class TestCommunityPage:
         assert template.call_args[0][1] == "pages/community.html"
         ctx = template.call_args[0][2]
         assert ctx["community"] is mock_community
-        assert len(ctx["community_links"]) == 5
+        assert len(ctx["community_links"]) == 6
         assert ctx["user"] is None
 
     async def test_stats_redirects_permanently_to_community(self):


### PR DESCRIPTION
## Summary

Make the new Learn to Cloud Discord server discoverable by adding it to the Community page and global footer. The link uses the Discord icon, opens safely in a new tab, and is covered by the existing template and route tests.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.