### PR TITLE
Update Discord invite link

### DIFF
--- a/api/src/learn_to_cloud/rendering/context.py
+++ b/api/src/learn_to_cloud/rendering/context.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     )
 
 DISCUSSIONS_URL = "https://github.com/learntocloud/learn-to-cloud-app/discussions"
-DISCORD_URL = "https://discord.gg/sfdgmbWVf4"
+DISCORD_URL = "https://discord.gg/st7g2Hp77r"
 GITHUB_REPOSITORY_URL = "https://github.com/learntocloud/learn-to-cloud-app"
 MADEBYGPS_X_URL = "https://x.com/madebygps"
 LEARN_TO_CLOUD_X_URL = "https://x.com/learntocloud"

--- a/api/src/learn_to_cloud/templates/partials/footer.html
+++ b/api/src/learn_to_cloud/templates/partials/footer.html
@@ -13,7 +13,7 @@
             <span class="mx-1">&middot;</span>
             <a href="/terms" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Terms</a>
             <span class="mx-1">&middot;</span>
-            <a href="https://discord.gg/sfdgmbWVf4" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+            <a href="https://discord.gg/st7g2Hp77r" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
                 <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.54 5.34A16.3 16.3 0 0 0 15.44 4l-.5 1.02a15.3 15.3 0 0 0-5.88 0L8.56 4a16.5 16.5 0 0 0-4.1 1.35C1.86 9.18 1.16 12.9 1.5 16.57A16.8 16.8 0 0 0 6.52 19.1l1.23-1.68c-.68-.25-1.33-.57-1.94-.94l.48-.37c3.74 1.73 7.8 1.73 11.5 0l.5.37c-.62.37-1.27.69-1.95.94l1.23 1.68a16.7 16.7 0 0 0 5.02-2.53c.4-4.26-.68-7.94-3.05-11.23ZM8.68 14.35c-1.12 0-2.04-1.03-2.04-2.3s.9-2.3 2.04-2.3c1.15 0 2.06 1.04 2.04 2.3 0 1.27-.9 2.3-2.04 2.3Zm6.64 0c-1.12 0-2.04-1.03-2.04-2.3s.9-2.3 2.04-2.3c1.15 0 2.06 1.04 2.04 2.3 0 1.27-.9 2.3-2.04 2.3Z"/></svg>
                 Discord
             </a>

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -442,7 +442,7 @@ def test_community_page_renders_safe_external_resource_links():
     )
 
     expected_links = {
-        "https://discord.gg/sfdgmbWVf4",
+        "https://discord.gg/st7g2Hp77r",
         "https://github.com/learntocloud/learn-to-cloud-app/discussions",
         "https://youtube.com/made-by-gps",
         "https://github.com/learntocloud/learn-to-cloud-app",


### PR DESCRIPTION
## Summary

Replace the Discord invite added in the previous PR with the current invite URL across the Community page, global footer, and rendering test.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.