### PR TITLE
Replace dashboard community link with Discord

### DIFF
--- a/api/src/learn_to_cloud/rendering/context.py
+++ b/api/src/learn_to_cloud/rendering/context.py
@@ -214,10 +214,10 @@ COMMUNITY_LINKS: list[dict[str, str]] = [
 
 HELP_LINKS: list[dict[str, str]] = [
     {
-        "url": DISCUSSIONS_URL,
-        "label": "Ask the Community",
+        "url": DISCORD_URL,
+        "label": "Discord",
         "color": "text-indigo-500 dark:text-indigo-400",
-        "icon": _DISCUSSIONS_SVG,
+        "icon": _DISCORD_SVG,
     },
     {
         "url": MADEBYGPS_X_URL,

--- a/api/src/learn_to_cloud/templates/partials/footer.html
+++ b/api/src/learn_to_cloud/templates/partials/footer.html
@@ -3,33 +3,9 @@
         <p class="text-sm text-gray-500 dark:text-gray-400 text-center">
             &copy; {{ now.year }} Learn to Cloud
             <span class="mx-1">&middot;</span>
-            <a href="/curriculum" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Curriculum</a>
-            <span class="mx-1">&middot;</span>
-            <a href="/faq" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">FAQ</a>
-            <span class="mx-1">&middot;</span>
             <a href="/privacy" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Privacy</a>
             <span class="mx-1">&middot;</span>
             <a href="/terms" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Terms</a>
-            <span class="mx-1">&middot;</span>
-            <a href="https://discord.gg/st7g2Hp77r" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
-                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.54 5.34A16.3 16.3 0 0 0 15.44 4l-.5 1.02a15.3 15.3 0 0 0-5.88 0L8.56 4a16.5 16.5 0 0 0-4.1 1.35C1.86 9.18 1.16 12.9 1.5 16.57A16.8 16.8 0 0 0 6.52 19.1l1.23-1.68c-.68-.25-1.33-.57-1.94-.94l.48-.37c3.74 1.73 7.8 1.73 11.5 0l.5.37c-.62.37-1.27.69-1.95.94l1.23 1.68a16.7 16.7 0 0 0 5.02-2.53c.4-4.26-.68-7.94-3.05-11.23ZM8.68 14.35c-1.12 0-2.04-1.03-2.04-2.3s.9-2.3 2.04-2.3c1.15 0 2.06 1.04 2.04 2.3 0 1.27-.9 2.3-2.04 2.3Zm6.64 0c-1.12 0-2.04-1.03-2.04-2.3s.9-2.3 2.04-2.3c1.15 0 2.06 1.04 2.04 2.3 0 1.27-.9 2.3-2.04 2.3Z"/></svg>
-                Discord
-            </a>
-            <span class="mx-1">&middot;</span>
-            <a href="https://github.com/learntocloud/learn-to-cloud-app" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">
-                <svg class="h-4 w-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-                GitHub
-            </a>
-            <span class="mx-1">&middot;</span>
-            <a href="https://youtube.com/made-by-gps" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors">
-                <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg>
-                YouTube
-            </a>
-            <span class="mx-1">&middot;</span>
-            <a href="https://github.com/sponsors/madebygps" target="_blank" rel="noopener noreferrer" class="inline-flex items-center gap-1 text-gray-500 dark:text-gray-400 hover:text-pink-600 dark:hover:text-pink-400 transition-colors">
-                <svg class="h-4 w-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 008 13.393a20.561 20.561 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.75.75 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5zM8 14.25l-.345.666-.002-.001-.006-.003-.018-.01a7.643 7.643 0 01-.31-.17 22.075 22.075 0 01-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.08 22.08 0 01-3.744 2.584l-.018.01-.006.003h-.002L8 14.25zm0 0l.345.666a.752.752 0 01-.69 0L8 14.25z"/></svg>
-                Sponsor
-            </a>
         </p>
     </div>
 </footer>

--- a/api/src/learn_to_cloud/templates/partials/footer.html
+++ b/api/src/learn_to_cloud/templates/partials/footer.html
@@ -5,8 +5,6 @@
             <span class="mx-1">&middot;</span>
             <a href="/curriculum" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Curriculum</a>
             <span class="mx-1">&middot;</span>
-            <a href="/community" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Community</a>
-            <span class="mx-1">&middot;</span>
             <a href="/faq" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">FAQ</a>
             <span class="mx-1">&middot;</span>
             <a href="/privacy" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Privacy</a>

--- a/api/src/learn_to_cloud/templates/partials/navbar.html
+++ b/api/src/learn_to_cloud/templates/partials/navbar.html
@@ -11,6 +11,9 @@
                         Dashboard
                     </a>
                     {% endif %}
+                    <a href="/community" class="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
+                        Community
+                    </a>
                 </div>
             </div>
 

--- a/api/src/learn_to_cloud/templates/partials/navbar.html
+++ b/api/src/learn_to_cloud/templates/partials/navbar.html
@@ -14,6 +14,12 @@
                     <a href="/community" class="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
                         Community
                     </a>
+                    <a href="/curriculum" class="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
+                        Curriculum
+                    </a>
+                    <a href="/faq" class="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
+                        FAQ
+                    </a>
                 </div>
             </div>
 

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -8,6 +8,7 @@ import pytest
 from learn_to_cloud.core.templates import templates
 from learn_to_cloud.rendering.context import (
     COMMUNITY_LINKS,
+    HELP_LINKS,
     build_requirement_card_context,
 )
 
@@ -456,6 +457,24 @@ def test_community_page_renders_safe_external_resource_links():
     assert "GitHub Discussions" in html
     assert "Follow @madebygps" in html
     assert "Follow @learntocloud" in html
+
+
+@pytest.mark.unit
+def test_dashboard_help_section_links_to_discord():
+    dashboard = SimpleNamespace(
+        phases=[],
+        learning_percentage=0,
+        verification_percentage=0,
+        phases_completed=0,
+        total_phases=0,
+        is_program_complete=False,
+        continue_phase=None,
+    )
+
+    html = _render("pages/dashboard.html", dashboard=dashboard, help_links=HELP_LINKS)
+
+    assert 'href="https://discord.gg/st7g2Hp77r"' in html
+    assert "Ask the Community" not in html
 
 
 @pytest.mark.unit

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -478,12 +478,20 @@ def test_dashboard_help_section_links_to_discord():
 
 
 @pytest.mark.unit
-def test_community_link_is_in_navbar_not_footer():
+def test_primary_links_are_in_navbar_and_footer_is_minimal():
     navbar = _render("partials/navbar.html")
     footer = _render("partials/footer.html")
 
-    assert 'href="/community"' in navbar
-    assert 'href="/community"' not in footer
+    for path in ("/community", "/curriculum", "/faq"):
+        assert f'href="{path}"' in navbar
+        assert f'href="{path}"' not in footer
+
+    assert 'href="/privacy"' in footer
+    assert 'href="/terms"' in footer
+    assert "Discord" not in footer
+    assert "GitHub" not in footer
+    assert "YouTube" not in footer
+    assert "Sponsor" not in footer
 
 
 @pytest.mark.unit

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -478,6 +478,15 @@ def test_dashboard_help_section_links_to_discord():
 
 
 @pytest.mark.unit
+def test_community_link_is_in_navbar_not_footer():
+    navbar = _render("partials/navbar.html")
+    footer = _render("partials/footer.html")
+
+    assert 'href="/community"' in navbar
+    assert 'href="/community"' not in footer
+
+
+@pytest.mark.unit
 class TestDashboardPhaseRow:
     """The phase-row state/labels in pages/dashboard.html."""
 


### PR DESCRIPTION
## Summary
- replace the Need Help "Ask the Community" card with Discord
- move Community, Curriculum, and FAQ into the top navigation
- simplify the footer to copyright, Privacy, and Terms
- cover the navigation changes with rendering tests