### PR TITLE
Move program overview back to footer

### DIFF
--- a/api/src/learn_to_cloud/templates/partials/footer.html
+++ b/api/src/learn_to_cloud/templates/partials/footer.html
@@ -3,6 +3,8 @@
         <p class="text-sm text-gray-500 dark:text-gray-400 text-center">
             &copy; {{ now.year }} Learn to Cloud
             <span class="mx-1">&middot;</span>
+            <a href="/curriculum" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Program overview</a>
+            <span class="mx-1">&middot;</span>
             <a href="/privacy" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Privacy</a>
             <span class="mx-1">&middot;</span>
             <a href="/terms" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Terms</a>

--- a/api/src/learn_to_cloud/templates/partials/navbar.html
+++ b/api/src/learn_to_cloud/templates/partials/navbar.html
@@ -14,9 +14,6 @@
                     <a href="/community" class="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
                         Community
                     </a>
-                    <a href="/curriculum" class="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
-                        Curriculum
-                    </a>
                     <a href="/faq" class="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
                         FAQ
                     </a>

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -482,10 +482,13 @@ def test_primary_links_are_in_navbar_and_footer_is_minimal():
     navbar = _render("partials/navbar.html")
     footer = _render("partials/footer.html")
 
-    for path in ("/community", "/curriculum", "/faq"):
+    for path in ("/community", "/faq"):
         assert f'href="{path}"' in navbar
         assert f'href="{path}"' not in footer
 
+    assert 'href="/curriculum"' not in navbar
+    assert 'href="/curriculum"' in footer
+    assert "Program overview" in footer
     assert 'href="/privacy"' in footer
     assert 'href="/terms"' in footer
     assert "Discord" not in footer


### PR DESCRIPTION
## Summary
- remove Curriculum from the signed-in top navigation
- restore the `/curriculum` footer link as "Program overview"
- update rendering coverage for the revised navigation placement