### PR TITLE
Redesign homepage learning journey

### DIFF
--- a/.impeccable/critique/2026-08-10T20-36-19Z__api-src-learn-to-cloud-templates-pages-home-html.md
+++ b/.impeccable/critique/2026-08-10T20-36-19Z__api-src-learn-to-cloud-templates-pages-home-html.md
@@ -1,0 +1,109 @@
+---
+target: homepage
+total_score: 20
+max_score: 28
+na_heuristics: 5,7,9
+p0_count: 0
+p1_count: 3
+timestamp: 2026-08-10T20-36-19Z
+slug: api-src-learn-to-cloud-templates-pages-home-html
+---
+Method: dual-agent (A: homepage-design-review · B: homepage-detector-review)
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|---|---:|---|
+| 1 | Visibility of System Status | 3 | The primary CTA does not explain the next step or GitHub authentication. |
+| 2 | Match System / Real World | 3 | The phase sequence is clear, but Phase 0 and cloud acronyms assume prior literacy. |
+| 3 | User Control and Freedom | 3 | Community and FAQ disappear on mobile with no replacement navigation. |
+| 4 | Consistency and Standards | 3 | “Get Started” and “Sign in with GitHub” describe the same destination differently. |
+| 5 | Error Prevention | n/a | No input or destructive action exists on this surface. |
+| 6 | Recognition Rather Than Recall | 3 | Card styling suggests the phase summaries are clickable when they are not. |
+| 7 | Flexibility and Efficiency | n/a | Not meaningfully applicable to this persuasive landing page. |
+| 8 | Aesthetic and Minimalist Design | 2 | Eight equally weighted cards flatten the narrative and dilute the CTA. |
+| 9 | Error Recovery | n/a | No recoverable workflow or error state exists on this surface. |
+| 10 | Help and Documentation | 3 | Help routes exist on desktop, but FAQ is unavailable from mobile navigation. |
+| **Total** | | **20/28** | **Good baseline, weak product expression** |
+
+## Design Specificity Verdict
+
+**LLM assessment:** Category-interchangeable with product-specific content. The logo, phase names, and “prove your skills” language identify Learn to Cloud, but the centered logo, blue CTA, and uniform bordered-card grid could belong to almost any course platform. The interface does not embody progression, hands-on verification, cloud systems, or the transition from beginner to job-ready.
+
+**Deterministic scan:** The CLI detector returned 0 findings for `api/src/learn_to_cloud/templates/pages/home.html`. This means no registered source-level anti-patterns were detected; it does not invalidate the structural, responsive, or experiential issues found in the design review. There were no false positives.
+
+**Visual evidence:** Production was reachable, but no browser automation, mutable DOM evaluation, fresh-tab control, or console-reading interface was exposed. No reliable user-visible overlay is available.
+
+## Overall Impression
+
+The homepage is calm, legible, and credible, but it presents a syllabus rather than a transformation. The biggest opportunity is to turn the phase inventory into an authored learning journey that makes beginners feel capable and shows how skills are proven.
+
+## What’s Working
+
+1. The value proposition clearly communicates structure, practice, challenges, and verification.
+2. Phase names and summaries make the curriculum breadth understandable without inflated marketing language.
+3. The constrained width, responsive grid, semantic links, meaningful logo alt text, and light/dark support form a solid baseline.
+
+## Priority Issues
+
+### [P1] The homepage lacks an authored learning narrative
+
+**Why it matters:** Visitors see inventory, not transformation, so the product feels replaceable and offers no emotional peak.
+
+**Fix:** Recompose the hero and journey around a clear beginner-to-proven-practitioner arc. Show a concrete outcome, how verification works, and one unmistakable moment of learner progress.
+
+**Suggested command:** `/impeccable bolder`
+
+### [P1] Mobile navigation removes trust and help routes
+
+**Why it matters:** Community and FAQ disappear below the `sm` breakpoint, leaving first-time mobile visitors without reassurance or support.
+
+**Fix:** Add a compact mobile navigation pattern that preserves Community, FAQ, curriculum, theme, and authentication access with 44px touch targets.
+
+**Suggested command:** `/impeccable adapt`
+
+### [P1] Authentication intent is inconsistent
+
+**Why it matters:** “Get Started” silently leads to GitHub authentication while the secondary sign-in action names GitHub, creating uncertainty at the highest-value conversion point.
+
+**Fix:** Use one authentication vocabulary and disclose the GitHub step near the primary CTA without adding friction.
+
+**Suggested command:** `/impeccable clarify`
+
+### [P2] The journey grid is flat and behaviorally ambiguous
+
+**Why it matters:** Eight identical, noninteractive cards exceed a comfortable chunk size, appear clickable, and provide no recommended starting point, duration, or progression model.
+
+**Fix:** Group phases into a smaller number of meaningful chapters, establish a visible path, and either make phase items genuine destinations or remove card affordances.
+
+**Suggested command:** `/impeccable layout`
+
+### [P2] Accessibility details weaken the baseline
+
+**Why it matters:** The page has no textual `h1`; low-emphasis phase numbers may miss contrast targets; several navbar controls appear smaller than recommended touch targets.
+
+**Fix:** Add a meaningful visible heading, verify text contrast in both themes, and increase interactive hit areas.
+
+**Suggested command:** `/impeccable audit`
+
+## Persona Red Flags
+
+**Jordan (First-Timer):** “Phase 0” is unexplained, cloud acronyms arrive immediately, and “Get Started” conceals the GitHub requirement. No prerequisite, time-commitment, or beginner reassurance answers whether this path is realistic.
+
+**Casey (Distracted Mobile User):** Community and FAQ vanish, the eight-card sequence creates a long undifferentiated scroll, and small utility controls increase missed taps.
+
+**Riley (Stress Tester):** If `phases` is empty, the entire journey disappears without an empty state. The “prove your skills” promise has no visible evidence, and the same login destination has two labels.
+
+## Minor Observations
+
+- The large hero logo repeats the brand already present in the navbar.
+- Authenticated visitors see generic curriculum inventory instead of contextual progress.
+- Uneven phase-description lengths can create inconsistent card density.
+- “Program overview” in the footer duplicates the curriculum destination under another label.
+
+## Questions to Consider
+
+- Is the homepage selling a curriculum, a career transformation, or a system for proving competence?
+- What should a nervous beginner feel certain about within five seconds?
+- Why are phases presented as cards if visitors cannot enter them?
+- What would make a learner think, “I can actually finish this”?

--- a/api/src/learn_to_cloud/services/dashboard_service.py
+++ b/api/src/learn_to_cloud/services/dashboard_service.py
@@ -75,7 +75,13 @@ async def get_dashboard_data(
     ]
 
     continue_phase: ContinuePhaseData | None = None
-    if not user_progress.is_program_complete:
+    has_activity = any(
+        progress.learning.steps_completed > 0
+        or progress.verification.requirements_verified > 0
+        for progress in user_progress.phases.values()
+    )
+    is_program_complete = bool(phases) and user_progress.is_program_complete
+    if not is_program_complete and has_activity:
         current_id = user_progress.current_phase
         current = next((p for p in phases if p.order == current_id), None)
         if current is not None:
@@ -104,6 +110,6 @@ async def get_dashboard_data(
         verification_percentage=round(user_progress.overall_verification_percentage, 1),
         phases_completed=user_progress.phases_completed,
         total_phases=user_progress.total_phases,
-        is_program_complete=user_progress.is_program_complete,
+        is_program_complete=is_program_complete,
         continue_phase=continue_phase,
     )

--- a/api/src/learn_to_cloud/static/css/styles.css
+++ b/api/src/learn_to_cloud/static/css/styles.css
@@ -998,9 +998,6 @@
   .pt-6 {
     padding-top: calc(var(--spacing) * 6);
   }
-  .pt-8 {
-    padding-top: calc(var(--spacing) * 8);
-  }
   .pt-16 {
     padding-top: calc(var(--spacing) * 16);
   }

--- a/api/src/learn_to_cloud/static/css/styles.css
+++ b/api/src/learn_to_cloud/static/css/styles.css
@@ -49,10 +49,9 @@
     --color-blue-700: oklch(48.8% 0.243 264.376);
     --color-blue-800: oklch(42.4% 0.199 265.638);
     --color-blue-900: oklch(37.9% 0.146 265.522);
+    --color-blue-950: oklch(28.2% 0.091 267.935);
     --color-indigo-400: oklch(67.3% 0.182 276.935);
     --color-indigo-500: oklch(58.5% 0.233 277.117);
-    --color-pink-400: oklch(71.8% 0.202 349.761);
-    --color-pink-600: oklch(59.2% 0.249 0.584);
     --color-gray-50: oklch(98.5% 0.002 247.839);
     --color-gray-100: oklch(96.7% 0.003 264.542);
     --color-gray-200: oklch(92.8% 0.006 264.531);
@@ -63,13 +62,16 @@
     --color-gray-700: oklch(37.3% 0.034 259.733);
     --color-gray-800: oklch(27.8% 0.033 256.848);
     --color-gray-900: oklch(21% 0.034 264.665);
+    --color-gray-950: oklch(13% 0.028 261.692);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
     --container-xs: 20rem;
     --container-sm: 24rem;
     --container-md: 28rem;
+    --container-xl: 36rem;
     --container-2xl: 42rem;
+    --container-3xl: 48rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
@@ -84,6 +86,8 @@
     --text-2xl--line-height: calc(2 / 1.5);
     --text-3xl: 1.875rem;
     --text-3xl--line-height: calc(2.25 / 1.875);
+    --text-4xl: 2.25rem;
+    --text-4xl--line-height: calc(2.5 / 2.25);
     --text-6xl: 3.75rem;
     --text-6xl--line-height: 1;
     --font-weight-normal: 400;
@@ -92,12 +96,12 @@
     --font-weight-bold: 700;
     --tracking-wide: 0.025em;
     --leading-tight: 1.25;
-    --leading-relaxed: 1.625;
     --radius-sm: 0.25rem;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --radius-xl: 0.75rem;
     --animate-spin: spin 1s linear infinite;
+    --blur-3xl: 64px;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
@@ -298,6 +302,9 @@
   .top-2 {
     top: calc(var(--spacing) * 2);
   }
+  .top-8 {
+    top: calc(var(--spacing) * 8);
+  }
   .top-full {
     top: 100%;
   }
@@ -306,6 +313,18 @@
   }
   .right-2 {
     right: calc(var(--spacing) * 2);
+  }
+  .bottom-8 {
+    bottom: calc(var(--spacing) * 8);
+  }
+  .left-\[1\.1875rem\] {
+    left: 1.1875rem;
+  }
+  .-z-10 {
+    z-index: calc(10 * -1);
+  }
+  .z-10 {
+    z-index: 10;
   }
   .z-50 {
     z-index: 50;
@@ -409,8 +428,14 @@
   .ml-1 {
     margin-left: calc(var(--spacing) * 1);
   }
+  .ml-2 {
+    margin-left: calc(var(--spacing) * 2);
+  }
   .ml-4 {
     margin-left: calc(var(--spacing) * 4);
+  }
+  .ml-auto {
+    margin-left: auto;
   }
   .line-clamp-2 {
     overflow: hidden;
@@ -460,23 +485,38 @@
   .h-6 {
     height: calc(var(--spacing) * 6);
   }
+  .h-7 {
+    height: calc(var(--spacing) * 7);
+  }
   .h-8 {
     height: calc(var(--spacing) * 8);
   }
   .h-9 {
     height: calc(var(--spacing) * 9);
   }
+  .h-10 {
+    height: calc(var(--spacing) * 10);
+  }
+  .h-11 {
+    height: calc(var(--spacing) * 11);
+  }
   .h-16 {
     height: calc(var(--spacing) * 16);
   }
-  .h-24 {
-    height: calc(var(--spacing) * 24);
+  .h-56 {
+    height: calc(var(--spacing) * 56);
   }
   .h-full {
     height: 100%;
   }
+  .h-px {
+    height: 1px;
+  }
   .max-h-64 {
     max-height: calc(var(--spacing) * 64);
+  }
+  .min-h-11 {
+    min-height: calc(var(--spacing) * 11);
   }
   .w-4 {
     width: calc(var(--spacing) * 4);
@@ -487,8 +527,17 @@
   .w-6 {
     width: calc(var(--spacing) * 6);
   }
+  .w-7 {
+    width: calc(var(--spacing) * 7);
+  }
   .w-8 {
     width: calc(var(--spacing) * 8);
+  }
+  .w-10 {
+    width: calc(var(--spacing) * 10);
+  }
+  .w-11 {
+    width: calc(var(--spacing) * 11);
   }
   .w-20 {
     width: calc(var(--spacing) * 20);
@@ -499,11 +548,20 @@
   .w-48 {
     width: calc(var(--spacing) * 48);
   }
+  .w-56 {
+    width: calc(var(--spacing) * 56);
+  }
   .w-full {
     width: 100%;
   }
+  .w-px {
+    width: 1px;
+  }
   .max-w-2xl {
     max-width: var(--container-2xl);
+  }
+  .max-w-3xl {
+    max-width: var(--container-3xl);
   }
   .max-w-content {
     max-width: var(--container-content);
@@ -516,6 +574,9 @@
   }
   .max-w-sm {
     max-width: var(--container-sm);
+  }
+  .max-w-xl {
+    max-width: var(--container-xl);
   }
   .max-w-xs {
     max-width: var(--container-xs);
@@ -562,6 +623,12 @@
   .grid-cols-1 {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }
+  .grid-cols-\[2\.5rem_1fr\] {
+    grid-template-columns: 2.5rem 1fr;
+  }
+  .grid-cols-\[3rem_1fr_auto\] {
+    grid-template-columns: 3rem 1fr auto;
+  }
   .flex-col {
     flex-direction: column;
   }
@@ -601,8 +668,14 @@
   .gap-4 {
     gap: calc(var(--spacing) * 4);
   }
+  .gap-5 {
+    gap: calc(var(--spacing) * 5);
+  }
   .gap-8 {
     gap: calc(var(--spacing) * 8);
+  }
+  .gap-12 {
+    gap: calc(var(--spacing) * 12);
   }
   .space-y-1 {
     :where(& > :not(:last-child)) {
@@ -645,9 +718,6 @@
       margin-block-start: calc(calc(var(--spacing) * 8) * var(--tw-space-y-reverse));
       margin-block-end: calc(calc(var(--spacing) * 8) * calc(1 - var(--tw-space-y-reverse)));
     }
-  }
-  .gap-x-6 {
-    column-gap: calc(var(--spacing) * 6);
   }
   .truncate {
     overflow: hidden;
@@ -721,6 +791,9 @@
   .border-blue-500 {
     border-color: var(--color-blue-500);
   }
+  .border-blue-700 {
+    border-color: var(--color-blue-700);
+  }
   .border-gray-100 {
     border-color: var(--color-gray-100);
   }
@@ -766,11 +839,23 @@
   .bg-blue-100 {
     background-color: var(--color-blue-100);
   }
+  .bg-blue-100\/70 {
+    background-color: color-mix(in srgb, oklch(93.2% 0.032 255.585) 70%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-blue-100) 70%, transparent);
+    }
+  }
+  .bg-blue-200 {
+    background-color: var(--color-blue-200);
+  }
   .bg-blue-500 {
     background-color: var(--color-blue-500);
   }
   .bg-blue-600 {
     background-color: var(--color-blue-600);
+  }
+  .bg-blue-700 {
+    background-color: var(--color-blue-700);
   }
   .bg-gray-50 {
     background-color: var(--color-gray-50);
@@ -856,6 +941,9 @@
   .p-6 {
     padding: calc(var(--spacing) * 6);
   }
+  .p-8 {
+    padding: calc(var(--spacing) * 8);
+  }
   .px-1 {
     padding-inline: calc(var(--spacing) * 1);
   }
@@ -889,6 +977,9 @@
   .py-3 {
     padding-block: calc(var(--spacing) * 3);
   }
+  .py-6 {
+    padding-block: calc(var(--spacing) * 6);
+  }
   .py-8 {
     padding-block: calc(var(--spacing) * 8);
   }
@@ -901,11 +992,17 @@
   .pt-6 {
     padding-top: calc(var(--spacing) * 6);
   }
+  .pt-8 {
+    padding-top: calc(var(--spacing) * 8);
+  }
   .pr-3 {
     padding-right: calc(var(--spacing) * 3);
   }
   .pb-4 {
     padding-bottom: calc(var(--spacing) * 4);
+  }
+  .pb-16 {
+    padding-bottom: calc(var(--spacing) * 16);
   }
   .pl-1 {
     padding-left: calc(var(--spacing) * 1);
@@ -929,6 +1026,10 @@
   .text-3xl {
     font-size: var(--text-3xl);
     line-height: var(--tw-leading, var(--text-3xl--line-height));
+  }
+  .text-4xl {
+    font-size: var(--text-4xl);
+    line-height: var(--tw-leading, var(--text-4xl--line-height));
   }
   .text-6xl {
     font-size: var(--text-6xl);
@@ -954,13 +1055,17 @@
     font-size: var(--text-xs);
     line-height: var(--tw-leading, var(--text-xs--line-height));
   }
+  .leading-6 {
+    --tw-leading: calc(var(--spacing) * 6);
+    line-height: calc(var(--spacing) * 6);
+  }
+  .leading-7 {
+    --tw-leading: calc(var(--spacing) * 7);
+    line-height: calc(var(--spacing) * 7);
+  }
   .leading-8 {
     --tw-leading: calc(var(--spacing) * 8);
     line-height: calc(var(--spacing) * 8);
-  }
-  .leading-relaxed {
-    --tw-leading: var(--leading-relaxed);
-    line-height: var(--leading-relaxed);
   }
   .leading-tight {
     --tw-leading: var(--leading-tight);
@@ -982,12 +1087,34 @@
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
   }
+  .tracking-\[-0\.02em\] {
+    --tw-tracking: -0.02em;
+    letter-spacing: -0.02em;
+  }
+  .tracking-\[-0\.025em\] {
+    --tw-tracking: -0.025em;
+    letter-spacing: -0.025em;
+  }
+  .tracking-\[-0\.035em\] {
+    --tw-tracking: -0.035em;
+    letter-spacing: -0.035em;
+  }
+  .tracking-\[0\.16em\] {
+    --tw-tracking: 0.16em;
+    letter-spacing: 0.16em;
+  }
   .tracking-wide {
     --tw-tracking: var(--tracking-wide);
     letter-spacing: var(--tracking-wide);
   }
+  .text-balance {
+    text-wrap: balance;
+  }
   .break-words {
     overflow-wrap: break-word;
+  }
+  .break-all {
+    word-break: break-all;
   }
   .text-amber-500 {
     color: var(--color-amber-500);
@@ -1036,6 +1163,9 @@
   }
   .text-gray-900 {
     color: var(--color-gray-900);
+  }
+  .text-gray-950 {
+    color: var(--color-gray-950);
   }
   .text-green-500 {
     color: var(--color-green-500);
@@ -1086,6 +1216,12 @@
   .underline {
     text-decoration-line: underline;
   }
+  .decoration-gray-300 {
+    text-decoration-color: var(--color-gray-300);
+  }
+  .underline-offset-4 {
+    text-underline-offset: 4px;
+  }
   .placeholder-gray-400 {
     &::placeholder {
       color: var(--color-gray-400);
@@ -1114,8 +1250,18 @@
     --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
+  .shadow-blue-950\/20 {
+    --tw-shadow-color: color-mix(in srgb, oklch(28.2% 0.091 267.935) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-blue-950) 20%, transparent) var(--tw-shadow-alpha), transparent);
+    }
+  }
   .ring-gray-200 {
     --tw-ring-color: var(--color-gray-200);
+  }
+  .blur-3xl {
+    --tw-blur: blur(var(--blur-3xl));
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
@@ -1152,10 +1298,56 @@
     -webkit-user-select: none;
     user-select: none;
   }
+  .group-hover\:translate-x-1 {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        --tw-translate-x: calc(var(--spacing) * 1);
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
+    }
+  }
+  .group-hover\:bg-blue-100 {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        background-color: var(--color-blue-100);
+      }
+    }
+  }
+  .group-hover\:text-blue-700 {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        color: var(--color-blue-700);
+      }
+    }
+  }
+  .group-hover\:text-blue-900 {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        color: var(--color-blue-900);
+      }
+    }
+  }
+  .hover\:border-blue-300 {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-blue-300);
+      }
+    }
+  }
   .hover\:border-blue-500 {
     &:hover {
       @media (hover: hover) {
         border-color: var(--color-blue-500);
+      }
+    }
+  }
+  .hover\:bg-blue-50\/50 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: color-mix(in srgb, oklch(97% 0.014 254.604) 50%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-blue-50) 50%, transparent);
+        }
       }
     }
   }
@@ -1170,6 +1362,13 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-blue-500);
+      }
+    }
+  }
+  .hover\:bg-blue-600 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-blue-600);
       }
     }
   }
@@ -1222,6 +1421,13 @@
       }
     }
   }
+  .hover\:text-blue-700 {
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-blue-700);
+      }
+    }
+  }
   .hover\:text-gray-600 {
     &:hover {
       @media (hover: hover) {
@@ -1243,20 +1449,6 @@
       }
     }
   }
-  .hover\:text-pink-600 {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-pink-600);
-      }
-    }
-  }
-  .hover\:text-red-600 {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-red-600);
-      }
-    }
-  }
   .hover\:no-underline {
     &:hover {
       @media (hover: hover) {
@@ -1268,6 +1460,13 @@
     &:hover {
       @media (hover: hover) {
         text-decoration-line: underline;
+      }
+    }
+  }
+  .hover\:decoration-blue-500 {
+    &:hover {
+      @media (hover: hover) {
+        text-decoration-color: var(--color-blue-500);
       }
     }
   }
@@ -1309,6 +1508,11 @@
       outline-style: none;
     }
   }
+  .focus-visible\:rounded-md {
+    &:focus-visible {
+      border-radius: var(--radius-md);
+    }
+  }
   .focus-visible\:ring-2 {
     &:focus-visible {
       --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
@@ -1318,6 +1522,27 @@
   .focus-visible\:ring-blue-500 {
     &:focus-visible {
       --tw-ring-color: var(--color-blue-500);
+    }
+  }
+  .focus-visible\:outline-2 {
+    &:focus-visible {
+      outline-style: var(--tw-outline-style);
+      outline-width: 2px;
+    }
+  }
+  .focus-visible\:outline-offset-2 {
+    &:focus-visible {
+      outline-offset: 2px;
+    }
+  }
+  .focus-visible\:outline-offset-4 {
+    &:focus-visible {
+      outline-offset: 4px;
+    }
+  }
+  .focus-visible\:outline-blue-700 {
+    &:focus-visible {
+      outline-color: var(--color-blue-700);
     }
   }
   .focus-visible\:ring-inset {
@@ -1330,9 +1555,19 @@
       opacity: 50%;
     }
   }
+  .sm\:block {
+    @media (width >= 40rem) {
+      display: block;
+    }
+  }
   .sm\:flex {
     @media (width >= 40rem) {
       display: flex;
+    }
+  }
+  .sm\:hidden {
+    @media (width >= 40rem) {
+      display: none;
     }
   }
   .sm\:inline {
@@ -1340,9 +1575,9 @@
       display: inline;
     }
   }
-  .sm\:h-32 {
+  .sm\:inline-flex {
     @media (width >= 40rem) {
-      height: calc(var(--spacing) * 32);
+      display: inline-flex;
     }
   }
   .sm\:w-24 {
@@ -1360,9 +1595,29 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
+  .sm\:grid-cols-\[4rem_1fr_auto\] {
+    @media (width >= 40rem) {
+      grid-template-columns: 4rem 1fr auto;
+    }
+  }
+  .sm\:flex-row {
+    @media (width >= 40rem) {
+      flex-direction: row;
+    }
+  }
+  .sm\:items-center {
+    @media (width >= 40rem) {
+      align-items: center;
+    }
+  }
   .sm\:gap-4 {
     @media (width >= 40rem) {
       gap: calc(var(--spacing) * 4);
+    }
+  }
+  .sm\:gap-6 {
+    @media (width >= 40rem) {
+      gap: calc(var(--spacing) * 6);
     }
   }
   .sm\:px-6 {
@@ -1370,15 +1625,43 @@
       padding-inline: calc(var(--spacing) * 6);
     }
   }
-  .sm\:py-12 {
+  .sm\:py-20 {
     @media (width >= 40rem) {
-      padding-block: calc(var(--spacing) * 12);
+      padding-block: calc(var(--spacing) * 20);
+    }
+  }
+  .sm\:pt-12 {
+    @media (width >= 40rem) {
+      padding-top: calc(var(--spacing) * 12);
+    }
+  }
+  .sm\:pb-20 {
+    @media (width >= 40rem) {
+      padding-bottom: calc(var(--spacing) * 20);
+    }
+  }
+  .sm\:text-4xl {
+    @media (width >= 40rem) {
+      font-size: var(--text-4xl);
+      line-height: var(--tw-leading, var(--text-4xl--line-height));
+    }
+  }
+  .sm\:text-6xl {
+    @media (width >= 40rem) {
+      font-size: var(--text-6xl);
+      line-height: var(--tw-leading, var(--text-6xl--line-height));
     }
   }
   .sm\:text-sm {
     @media (width >= 40rem) {
       font-size: var(--text-sm);
       line-height: var(--tw-leading, var(--text-sm--line-height));
+    }
+  }
+  .sm\:leading-\[1\.05\] {
+    @media (width >= 40rem) {
+      --tw-leading: 1.05;
+      line-height: 1.05;
     }
   }
   .lg\:grid-cols-3 {
@@ -1389,6 +1672,11 @@
   .lg\:grid-cols-4 {
     @media (width >= 64rem) {
       grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+  .lg\:grid-cols-\[minmax\(0\,1\.2fr\)_minmax\(17rem\,0\.8fr\)\] {
+    @media (width >= 64rem) {
+      grid-template-columns: minmax(0,1.2fr) minmax(17rem,0.8fr);
     }
   }
   .lg\:px-8 {
@@ -1409,6 +1697,16 @@
   .dark\:border-amber-800 {
     &:where(.dark, .dark *) {
       border-color: var(--color-amber-800);
+    }
+  }
+  .dark\:border-blue-400 {
+    &:where(.dark, .dark *) {
+      border-color: var(--color-blue-400);
+    }
+  }
+  .dark\:border-blue-700 {
+    &:where(.dark, .dark *) {
+      border-color: var(--color-blue-700);
     }
   }
   .dark\:border-blue-800 {
@@ -1467,9 +1765,19 @@
       }
     }
   }
+  .dark\:bg-blue-400 {
+    &:where(.dark, .dark *) {
+      background-color: var(--color-blue-400);
+    }
+  }
   .dark\:bg-blue-500 {
     &:where(.dark, .dark *) {
       background-color: var(--color-blue-500);
+    }
+  }
+  .dark\:bg-blue-800 {
+    &:where(.dark, .dark *) {
+      background-color: var(--color-blue-800);
     }
   }
   .dark\:bg-blue-900 {
@@ -1490,6 +1798,19 @@
       background-color: color-mix(in srgb, oklch(37.9% 0.146 265.522) 40%, transparent);
       @supports (color: color-mix(in lab, red, red)) {
         background-color: color-mix(in oklab, var(--color-blue-900) 40%, transparent);
+      }
+    }
+  }
+  .dark\:bg-blue-950 {
+    &:where(.dark, .dark *) {
+      background-color: var(--color-blue-950);
+    }
+  }
+  .dark\:bg-blue-950\/50 {
+    &:where(.dark, .dark *) {
+      background-color: color-mix(in srgb, oklch(28.2% 0.091 267.935) 50%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-blue-950) 50%, transparent);
       }
     }
   }
@@ -1613,6 +1934,11 @@
       color: var(--color-blue-400);
     }
   }
+  .dark\:text-blue-950 {
+    &:where(.dark, .dark *) {
+      color: var(--color-blue-950);
+    }
+  }
   .dark\:text-gray-100 {
     &:where(.dark, .dark *) {
       color: var(--color-gray-100);
@@ -1698,9 +2024,41 @@
       color: var(--color-white);
     }
   }
+  .dark\:decoration-gray-600 {
+    &:where(.dark, .dark *) {
+      text-decoration-color: var(--color-gray-600);
+    }
+  }
   .dark\:ring-gray-700 {
     &:where(.dark, .dark *) {
       --tw-ring-color: var(--color-gray-700);
+    }
+  }
+  .dark\:group-hover\:bg-blue-900 {
+    &:where(.dark, .dark *) {
+      &:is(:where(.group):hover *) {
+        @media (hover: hover) {
+          background-color: var(--color-blue-900);
+        }
+      }
+    }
+  }
+  .dark\:group-hover\:text-blue-100 {
+    &:where(.dark, .dark *) {
+      &:is(:where(.group):hover *) {
+        @media (hover: hover) {
+          color: var(--color-blue-100);
+        }
+      }
+    }
+  }
+  .dark\:group-hover\:text-blue-300 {
+    &:where(.dark, .dark *) {
+      &:is(:where(.group):hover *) {
+        @media (hover: hover) {
+          color: var(--color-blue-300);
+        }
+      }
     }
   }
   .dark\:hover\:border-blue-400 {
@@ -1712,6 +2070,24 @@
       }
     }
   }
+  .dark\:hover\:border-blue-700 {
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          border-color: var(--color-blue-700);
+        }
+      }
+    }
+  }
+  .dark\:hover\:bg-blue-400 {
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: var(--color-blue-400);
+        }
+      }
+    }
+  }
   .dark\:hover\:bg-blue-900\/30 {
     &:where(.dark, .dark *) {
       &:hover {
@@ -1719,6 +2095,18 @@
           background-color: color-mix(in srgb, oklch(37.9% 0.146 265.522) 30%, transparent);
           @supports (color: color-mix(in lab, red, red)) {
             background-color: color-mix(in oklab, var(--color-blue-900) 30%, transparent);
+          }
+        }
+      }
+    }
+  }
+  .dark\:hover\:bg-blue-950\/20 {
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: color-mix(in srgb, oklch(28.2% 0.091 267.935) 20%, transparent);
+          @supports (color: color-mix(in lab, red, red)) {
+            background-color: color-mix(in oklab, var(--color-blue-950) 20%, transparent);
           }
         }
       }
@@ -1795,24 +2183,6 @@
       &:hover {
         @media (hover: hover) {
           color: var(--color-gray-300);
-        }
-      }
-    }
-  }
-  .dark\:hover\:text-pink-400 {
-    &:where(.dark, .dark *) {
-      &:hover {
-        @media (hover: hover) {
-          color: var(--color-pink-400);
-        }
-      }
-    }
-  }
-  .dark\:hover\:text-red-400 {
-    &:where(.dark, .dark *) {
-      &:hover {
-        @media (hover: hover) {
-          color: var(--color-red-400);
         }
       }
     }
@@ -2148,6 +2518,26 @@
   syntax: "*";
   inherits: false;
 }
+@property --tw-translate-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-translate-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
 @keyframes spin {
   to {
     transform: rotate(360deg);
@@ -2208,6 +2598,10 @@
       --tw-drop-shadow-alpha: 100%;
       --tw-drop-shadow-size: initial;
       --tw-duration: initial;
+      --tw-translate-x: 0;
+      --tw-translate-y: 0;
+      --tw-translate-z: 0;
+      --tw-outline-style: solid;
     }
   }
 }

--- a/api/src/learn_to_cloud/static/css/styles.css
+++ b/api/src/learn_to_cloud/static/css/styles.css
@@ -39,6 +39,7 @@
     --color-green-700: oklch(52.7% 0.154 150.069);
     --color-green-800: oklch(44.8% 0.119 151.328);
     --color-green-900: oklch(39.3% 0.095 152.535);
+    --color-green-950: oklch(26.6% 0.065 152.934);
     --color-blue-50: oklch(97% 0.014 254.604);
     --color-blue-100: oklch(93.2% 0.032 255.585);
     --color-blue-200: oklch(88.2% 0.059 254.128);
@@ -63,6 +64,10 @@
     --color-gray-800: oklch(27.8% 0.033 256.848);
     --color-gray-900: oklch(21% 0.034 264.665);
     --color-gray-950: oklch(13% 0.028 261.692);
+    --color-zinc-100: oklch(96.7% 0.001 286.375);
+    --color-zinc-300: oklch(87.1% 0.006 286.286);
+    --color-zinc-700: oklch(37% 0.013 285.805);
+    --color-zinc-800: oklch(27.4% 0.006 286.033);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
@@ -361,9 +366,6 @@
   .mt-1 {
     margin-top: calc(var(--spacing) * 1);
   }
-  .mt-1\.5 {
-    margin-top: calc(var(--spacing) * 1.5);
-  }
   .mt-2 {
     margin-top: calc(var(--spacing) * 2);
   }
@@ -382,6 +384,9 @@
   .mt-8 {
     margin-top: calc(var(--spacing) * 8);
   }
+  .mt-10 {
+    margin-top: calc(var(--spacing) * 10);
+  }
   .mt-12 {
     margin-top: calc(var(--spacing) * 12);
   }
@@ -393,9 +398,6 @@
   }
   .-mb-px {
     margin-bottom: -1px;
-  }
-  .mb-0\.5 {
-    margin-bottom: calc(var(--spacing) * 0.5);
   }
   .mb-1 {
     margin-bottom: calc(var(--spacing) * 1);
@@ -414,6 +416,9 @@
   }
   .mb-8 {
     margin-bottom: calc(var(--spacing) * 8);
+  }
+  .mb-10 {
+    margin-bottom: calc(var(--spacing) * 10);
   }
   .mb-12 {
     margin-bottom: calc(var(--spacing) * 12);
@@ -456,9 +461,6 @@
   }
   .table {
     display: table;
-  }
-  .h-1\.5 {
-    height: calc(var(--spacing) * 1.5);
   }
   .h-2 {
     height: calc(var(--spacing) * 2);
@@ -522,6 +524,9 @@
   }
   .w-8 {
     width: calc(var(--spacing) * 8);
+  }
+  .w-9 {
+    width: calc(var(--spacing) * 9);
   }
   .w-10 {
     width: calc(var(--spacing) * 10);
@@ -607,9 +612,6 @@
   .list-disc {
     list-style-type: disc;
   }
-  .grid-cols-1 {
-    grid-template-columns: repeat(1, minmax(0, 1fr));
-  }
   .grid-cols-\[2\.75rem_1fr\] {
     grid-template-columns: 2.75rem 1fr;
   }
@@ -625,8 +627,14 @@
   .flex-wrap {
     flex-wrap: wrap;
   }
+  .items-baseline {
+    align-items: baseline;
+  }
   .items-center {
     align-items: center;
+  }
+  .items-end {
+    align-items: flex-end;
   }
   .items-start {
     align-items: flex-start;
@@ -660,6 +668,9 @@
   }
   .gap-5 {
     gap: calc(var(--spacing) * 5);
+  }
+  .gap-6 {
+    gap: calc(var(--spacing) * 6);
   }
   .gap-8 {
     gap: calc(var(--spacing) * 8);
@@ -785,10 +796,6 @@
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 2px;
   }
-  .border-l-3 {
-    border-left-style: var(--tw-border-style);
-    border-left-width: 3px;
-  }
   .border-dashed {
     --tw-border-style: dashed;
     border-style: dashed;
@@ -826,12 +833,6 @@
   .border-t-transparent {
     border-top-color: transparent;
   }
-  .border-l-blue-500 {
-    border-left-color: var(--color-blue-500);
-  }
-  .border-l-green-500 {
-    border-left-color: var(--color-green-500);
-  }
   .bg-amber-50 {
     background-color: var(--color-amber-50);
   }
@@ -855,6 +856,9 @@
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-blue-100) 70%, transparent);
     }
+  }
+  .bg-blue-400 {
+    background-color: var(--color-blue-400);
   }
   .bg-blue-500 {
     background-color: var(--color-blue-500);
@@ -889,9 +893,6 @@
   .bg-green-100 {
     background-color: var(--color-green-100);
   }
-  .bg-green-400 {
-    background-color: var(--color-green-400);
-  }
   .bg-green-500 {
     background-color: var(--color-green-500);
   }
@@ -907,29 +908,8 @@
   .bg-white {
     background-color: var(--color-white);
   }
-  .bg-white\/20 {
-    background-color: color-mix(in srgb, #fff 20%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-white) 20%, transparent);
-    }
-  }
-  .bg-white\/70 {
-    background-color: color-mix(in srgb, #fff 70%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-white) 70%, transparent);
-    }
-  }
-  .bg-gradient-to-br {
-    --tw-gradient-position: to bottom right in oklab;
-    background-image: linear-gradient(var(--tw-gradient-stops));
-  }
-  .from-blue-500 {
-    --tw-gradient-from: var(--color-blue-500);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
-  }
-  .to-blue-600 {
-    --tw-gradient-to: var(--color-blue-600);
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  .bg-zinc-100 {
+    background-color: var(--color-zinc-100);
   }
   .p-1 {
     padding: calc(var(--spacing) * 1);
@@ -1005,6 +985,9 @@
   }
   .pt-6 {
     padding-top: calc(var(--spacing) * 6);
+  }
+  .pt-8 {
+    padding-top: calc(var(--spacing) * 8);
   }
   .pt-12 {
     padding-top: calc(var(--spacing) * 12);
@@ -1165,9 +1148,6 @@
   .text-amber-800 {
     color: var(--color-amber-800);
   }
-  .text-blue-100 {
-    color: var(--color-blue-100);
-  }
   .text-blue-500 {
     color: var(--color-blue-500);
   }
@@ -1219,6 +1199,9 @@
   .text-green-800 {
     color: var(--color-green-800);
   }
+  .text-green-950 {
+    color: var(--color-green-950);
+  }
   .text-indigo-500 {
     color: var(--color-indigo-500);
   }
@@ -1236,6 +1219,9 @@
   }
   .text-white {
     color: var(--color-white);
+  }
+  .text-zinc-700 {
+    color: var(--color-zinc-700);
   }
   .lowercase {
     text-transform: lowercase;
@@ -1272,10 +1258,6 @@
   }
   .opacity-50 {
     opacity: 50%;
-  }
-  .shadow {
-    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
-    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
   .shadow-lg {
     --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
@@ -1388,6 +1370,13 @@
       }
     }
   }
+  .hover\:border-blue-400 {
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-blue-400);
+      }
+    }
+  }
   .hover\:border-blue-500 {
     &:hover {
       @media (hover: hover) {
@@ -1402,13 +1391,6 @@
         @supports (color: color-mix(in lab, red, red)) {
           background-color: color-mix(in oklab, var(--color-blue-50) 50%, transparent);
         }
-      }
-    }
-  }
-  .hover\:bg-blue-100 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-blue-100);
       }
     }
   }
@@ -1451,13 +1433,6 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-red-500);
-      }
-    }
-  }
-  .hover\:bg-white {
-    &:hover {
-      @media (hover: hover) {
-        background-color: var(--color-white);
       }
     }
   }
@@ -1661,6 +1636,11 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
+  .sm\:grid-cols-\[2\.75rem_1fr_auto\] {
+    @media (width >= 40rem) {
+      grid-template-columns: 2.75rem 1fr auto;
+    }
+  }
   .sm\:grid-cols-\[4rem_1fr\] {
     @media (width >= 40rem) {
       grid-template-columns: 4rem 1fr;
@@ -1704,6 +1684,11 @@
   .sm\:gap-8 {
     @media (width >= 40rem) {
       gap: calc(var(--spacing) * 8);
+    }
+  }
+  .sm\:gap-10 {
+    @media (width >= 40rem) {
+      gap: calc(var(--spacing) * 10);
     }
   }
   .sm\:px-6 {
@@ -1781,11 +1766,6 @@
       grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
-  .lg\:grid-cols-4 {
-    @media (width >= 64rem) {
-      grid-template-columns: repeat(4, minmax(0, 1fr));
-    }
-  }
   .lg\:grid-cols-\[minmax\(0\,1\.2fr\)_minmax\(17rem\,0\.8fr\)\] {
     @media (width >= 64rem) {
       grid-template-columns: minmax(0,1.2fr) minmax(17rem,0.8fr);
@@ -1856,16 +1836,6 @@
       border-color: var(--color-red-800);
     }
   }
-  .dark\:border-l-blue-400 {
-    &:where(.dark, .dark *) {
-      border-left-color: var(--color-blue-400);
-    }
-  }
-  .dark\:border-l-green-400 {
-    &:where(.dark, .dark *) {
-      border-left-color: var(--color-green-400);
-    }
-  }
   .dark\:bg-amber-900 {
     &:where(.dark, .dark *) {
       background-color: var(--color-amber-900);
@@ -1902,17 +1872,17 @@
       }
     }
   }
-  .dark\:bg-blue-900\/40 {
-    &:where(.dark, .dark *) {
-      background-color: color-mix(in srgb, oklch(37.9% 0.146 265.522) 40%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-blue-900) 40%, transparent);
-      }
-    }
-  }
   .dark\:bg-blue-950 {
     &:where(.dark, .dark *) {
       background-color: var(--color-blue-950);
+    }
+  }
+  .dark\:bg-blue-950\/40 {
+    &:where(.dark, .dark *) {
+      background-color: color-mix(in srgb, oklch(28.2% 0.091 267.935) 40%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-blue-950) 40%, transparent);
+      }
     }
   }
   .dark\:bg-blue-950\/50 {
@@ -1975,11 +1945,16 @@
       }
     }
   }
-  .dark\:bg-green-900\/40 {
+  .dark\:bg-green-950 {
     &:where(.dark, .dark *) {
-      background-color: color-mix(in srgb, oklch(39.3% 0.095 152.535) 40%, transparent);
+      background-color: var(--color-green-950);
+    }
+  }
+  .dark\:bg-green-950\/30 {
+    &:where(.dark, .dark *) {
+      background-color: color-mix(in srgb, oklch(26.6% 0.065 152.934) 30%, transparent);
       @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-green-900) 40%, transparent);
+        background-color: color-mix(in oklab, var(--color-green-950) 30%, transparent);
       }
     }
   }
@@ -2001,16 +1976,9 @@
       background-color: var(--color-white);
     }
   }
-  .dark\:from-blue-600 {
+  .dark\:bg-zinc-800 {
     &:where(.dark, .dark *) {
-      --tw-gradient-from: var(--color-blue-600);
-      --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
-    }
-  }
-  .dark\:to-blue-800 {
-    &:where(.dark, .dark *) {
-      --tw-gradient-to: var(--color-blue-800);
-      --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+      background-color: var(--color-zinc-800);
     }
   }
   .dark\:text-amber-200 {
@@ -2093,6 +2061,11 @@
       color: var(--color-gray-900);
     }
   }
+  .dark\:text-green-100 {
+    &:where(.dark, .dark *) {
+      color: var(--color-green-100);
+    }
+  }
   .dark\:text-green-200 {
     &:where(.dark, .dark *) {
       color: var(--color-green-200);
@@ -2136,6 +2109,11 @@
   .dark\:text-white {
     &:where(.dark, .dark *) {
       color: var(--color-white);
+    }
+  }
+  .dark\:text-zinc-300 {
+    &:where(.dark, .dark *) {
+      color: var(--color-zinc-300);
     }
   }
   .dark\:decoration-blue-800 {
@@ -2198,6 +2176,15 @@
       }
     }
   }
+  .dark\:hover\:border-blue-500 {
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          border-color: var(--color-blue-500);
+        }
+      }
+    }
+  }
   .dark\:hover\:border-blue-700 {
     &:where(.dark, .dark *) {
       &:hover {
@@ -2207,23 +2194,20 @@
       }
     }
   }
+  .dark\:hover\:bg-blue-300 {
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: var(--color-blue-300);
+        }
+      }
+    }
+  }
   .dark\:hover\:bg-blue-400 {
     &:where(.dark, .dark *) {
       &:hover {
         @media (hover: hover) {
           background-color: var(--color-blue-400);
-        }
-      }
-    }
-  }
-  .dark\:hover\:bg-blue-900\/30 {
-    &:where(.dark, .dark *) {
-      &:hover {
-        @media (hover: hover) {
-          background-color: color-mix(in srgb, oklch(37.9% 0.146 265.522) 30%, transparent);
-          @supports (color: color-mix(in lab, red, red)) {
-            background-color: color-mix(in oklab, var(--color-blue-900) 30%, transparent);
-          }
         }
       }
     }
@@ -2263,18 +2247,6 @@
       &:hover {
         @media (hover: hover) {
           background-color: var(--color-gray-800);
-        }
-      }
-    }
-  }
-  .dark\:hover\:bg-gray-800\/50 {
-    &:where(.dark, .dark *) {
-      &:hover {
-        @media (hover: hover) {
-          background-color: color-mix(in srgb, oklch(27.8% 0.033 256.848) 50%, transparent);
-          @supports (color: color-mix(in lab, red, red)) {
-            background-color: color-mix(in oklab, var(--color-gray-800) 50%, transparent);
-          }
         }
       }
     }
@@ -2463,48 +2435,6 @@
   syntax: "*";
   inherits: false;
   initial-value: solid;
-}
-@property --tw-gradient-position {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-gradient-from {
-  syntax: "<color>";
-  inherits: false;
-  initial-value: #0000;
-}
-@property --tw-gradient-via {
-  syntax: "<color>";
-  inherits: false;
-  initial-value: #0000;
-}
-@property --tw-gradient-to {
-  syntax: "<color>";
-  inherits: false;
-  initial-value: #0000;
-}
-@property --tw-gradient-stops {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-gradient-via-stops {
-  syntax: "*";
-  inherits: false;
-}
-@property --tw-gradient-from-position {
-  syntax: "<length-percentage>";
-  inherits: false;
-  initial-value: 0%;
-}
-@property --tw-gradient-via-position {
-  syntax: "<length-percentage>";
-  inherits: false;
-  initial-value: 50%;
-}
-@property --tw-gradient-to-position {
-  syntax: "<length-percentage>";
-  inherits: false;
-  initial-value: 100%;
 }
 @property --tw-leading {
   syntax: "*";
@@ -2696,15 +2626,6 @@
       --tw-space-y-reverse: 0;
       --tw-divide-y-reverse: 0;
       --tw-border-style: solid;
-      --tw-gradient-position: initial;
-      --tw-gradient-from: #0000;
-      --tw-gradient-via: #0000;
-      --tw-gradient-to: #0000;
-      --tw-gradient-stops: initial;
-      --tw-gradient-via-stops: initial;
-      --tw-gradient-from-position: 0%;
-      --tw-gradient-via-position: 50%;
-      --tw-gradient-to-position: 100%;
       --tw-leading: initial;
       --tw-font-weight: initial;
       --tw-tracking: initial;

--- a/api/src/learn_to_cloud/static/css/styles.css
+++ b/api/src/learn_to_cloud/static/css/styles.css
@@ -88,6 +88,8 @@
     --text-3xl--line-height: calc(2.25 / 1.875);
     --text-4xl: 2.25rem;
     --text-4xl--line-height: calc(2.5 / 2.25);
+    --text-5xl: 3rem;
+    --text-5xl--line-height: 1;
     --text-6xl: 3.75rem;
     --text-6xl--line-height: 1;
     --font-weight-normal: 400;
@@ -380,11 +382,11 @@
   .mt-8 {
     margin-top: calc(var(--spacing) * 8);
   }
-  .mt-10 {
-    margin-top: calc(var(--spacing) * 10);
-  }
   .mt-12 {
     margin-top: calc(var(--spacing) * 12);
+  }
+  .mt-14 {
+    margin-top: calc(var(--spacing) * 14);
   }
   .mt-16 {
     margin-top: calc(var(--spacing) * 16);
@@ -421,9 +423,6 @@
   }
   .ml-2 {
     margin-left: calc(var(--spacing) * 2);
-  }
-  .ml-4 {
-    margin-left: calc(var(--spacing) * 4);
   }
   .ml-auto {
     margin-left: auto;
@@ -614,6 +613,9 @@
   .grid-cols-\[2\.75rem_1fr\] {
     grid-template-columns: 2.75rem 1fr;
   }
+  .grid-cols-\[3rem_1fr\] {
+    grid-template-columns: 3rem 1fr;
+  }
   .grid-cols-\[3rem_1fr_auto\] {
     grid-template-columns: 3rem 1fr auto;
   }
@@ -706,6 +708,9 @@
       margin-block-start: calc(calc(var(--spacing) * 8) * var(--tw-space-y-reverse));
       margin-block-end: calc(calc(var(--spacing) * 8) * calc(1 - var(--tw-space-y-reverse)));
     }
+  }
+  .gap-x-8 {
+    column-gap: calc(var(--spacing) * 8);
   }
   .divide-y {
     :where(& > :not(:last-child)) {
@@ -983,6 +988,9 @@
   .py-4 {
     padding-block: calc(var(--spacing) * 4);
   }
+  .py-5 {
+    padding-block: calc(var(--spacing) * 5);
+  }
   .py-6 {
     padding-block: calc(var(--spacing) * 6);
   }
@@ -992,11 +1000,14 @@
   .py-16 {
     padding-block: calc(var(--spacing) * 16);
   }
-  .pt-3 {
-    padding-top: calc(var(--spacing) * 3);
+  .pt-4 {
+    padding-top: calc(var(--spacing) * 4);
   }
   .pt-6 {
     padding-top: calc(var(--spacing) * 6);
+  }
+  .pt-12 {
+    padding-top: calc(var(--spacing) * 12);
   }
   .pt-16 {
     padding-top: calc(var(--spacing) * 16);
@@ -1010,11 +1021,20 @@
   .pb-4 {
     padding-bottom: calc(var(--spacing) * 4);
   }
+  .pb-8 {
+    padding-bottom: calc(var(--spacing) * 8);
+  }
+  .pb-12 {
+    padding-bottom: calc(var(--spacing) * 12);
+  }
   .pb-16 {
     padding-bottom: calc(var(--spacing) * 16);
   }
   .pl-1 {
     padding-left: calc(var(--spacing) * 1);
+  }
+  .pl-16 {
+    padding-left: calc(var(--spacing) * 16);
   }
   .pl-\[4\.5rem\] {
     padding-left: 4.5rem;
@@ -1112,6 +1132,10 @@
     --tw-tracking: -0.035em;
     letter-spacing: -0.035em;
   }
+  .tracking-\[0\.12em\] {
+    --tw-tracking: 0.12em;
+    letter-spacing: 0.12em;
+  }
   .tracking-\[0\.16em\] {
     --tw-tracking: 0.16em;
     letter-spacing: 0.16em;
@@ -1155,6 +1179,9 @@
   }
   .text-blue-800 {
     color: var(--color-blue-800);
+  }
+  .text-blue-950 {
+    color: var(--color-blue-950);
   }
   .text-gray-300 {
     color: var(--color-gray-300);
@@ -1229,6 +1256,9 @@
   .underline {
     text-decoration-line: underline;
   }
+  .decoration-blue-200 {
+    text-decoration-color: var(--color-blue-200);
+  }
   .decoration-gray-300 {
     text-decoration-color: var(--color-gray-300);
   }
@@ -1253,10 +1283,6 @@
   }
   .shadow-sm {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
-    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-  }
-  .shadow-xs {
-    --tw-shadow: 0 1px 2px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.05));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
   .ring-1 {
@@ -1337,6 +1363,21 @@
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
         color: var(--color-blue-900);
+      }
+    }
+  }
+  .group-hover\/topic\:translate-x-0\.5 {
+    &:is(:where(.group\/topic):hover *) {
+      @media (hover: hover) {
+        --tw-translate-x: calc(var(--spacing) * 0.5);
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
+    }
+  }
+  .group-hover\/topic\:text-blue-700 {
+    &:is(:where(.group\/topic):hover *) {
+      @media (hover: hover) {
+        color: var(--color-blue-700);
       }
     }
   }
@@ -1483,6 +1524,13 @@
       }
     }
   }
+  .hover\:decoration-blue-600 {
+    &:hover {
+      @media (hover: hover) {
+        text-decoration-color: var(--color-blue-600);
+      }
+    }
+  }
   .focus\:border-blue-500 {
     &:focus {
       border-color: var(--color-blue-500);
@@ -1524,6 +1572,11 @@
   .focus-visible\:rounded-md {
     &:focus-visible {
       border-radius: var(--radius-md);
+    }
+  }
+  .focus-visible\:rounded-sm {
+    &:focus-visible {
+      border-radius: var(--radius-sm);
     }
   }
   .focus-visible\:ring-2 {
@@ -1608,9 +1661,19 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
+  .sm\:grid-cols-\[4rem_1fr\] {
+    @media (width >= 40rem) {
+      grid-template-columns: 4rem 1fr;
+    }
+  }
   .sm\:grid-cols-\[4rem_1fr_auto\] {
     @media (width >= 40rem) {
       grid-template-columns: 4rem 1fr auto;
+    }
+  }
+  .sm\:grid-cols-\[minmax\(0\,1fr\)_auto\] {
+    @media (width >= 40rem) {
+      grid-template-columns: minmax(0,1fr) auto;
     }
   }
   .sm\:flex-row {
@@ -1623,6 +1686,11 @@
       align-items: center;
     }
   }
+  .sm\:items-end {
+    @media (width >= 40rem) {
+      align-items: flex-end;
+    }
+  }
   .sm\:gap-4 {
     @media (width >= 40rem) {
       gap: calc(var(--spacing) * 4);
@@ -1633,9 +1701,19 @@
       gap: calc(var(--spacing) * 6);
     }
   }
+  .sm\:gap-8 {
+    @media (width >= 40rem) {
+      gap: calc(var(--spacing) * 8);
+    }
+  }
   .sm\:px-6 {
     @media (width >= 40rem) {
       padding-inline: calc(var(--spacing) * 6);
+    }
+  }
+  .sm\:pt-8 {
+    @media (width >= 40rem) {
+      padding-top: calc(var(--spacing) * 8);
     }
   }
   .sm\:pt-12 {
@@ -1643,9 +1721,19 @@
       padding-top: calc(var(--spacing) * 12);
     }
   }
+  .sm\:pt-16 {
+    @media (width >= 40rem) {
+      padding-top: calc(var(--spacing) * 16);
+    }
+  }
   .sm\:pt-20 {
     @media (width >= 40rem) {
       padding-top: calc(var(--spacing) * 20);
+    }
+  }
+  .sm\:pb-16 {
+    @media (width >= 40rem) {
+      padding-bottom: calc(var(--spacing) * 16);
     }
   }
   .sm\:pb-20 {
@@ -1653,10 +1741,21 @@
       padding-bottom: calc(var(--spacing) * 20);
     }
   }
+  .sm\:pl-\[5\.5rem\] {
+    @media (width >= 40rem) {
+      padding-left: 5.5rem;
+    }
+  }
   .sm\:text-4xl {
     @media (width >= 40rem) {
       font-size: var(--text-4xl);
       line-height: var(--tw-leading, var(--text-4xl--line-height));
+    }
+  }
+  .sm\:text-5xl {
+    @media (width >= 40rem) {
+      font-size: var(--text-5xl);
+      line-height: var(--tw-leading, var(--text-5xl--line-height));
     }
   }
   .sm\:text-6xl {
@@ -1929,6 +2028,11 @@
       color: var(--color-amber-400);
     }
   }
+  .dark\:text-blue-100 {
+    &:where(.dark, .dark *) {
+      color: var(--color-blue-100);
+    }
+  }
   .dark\:text-blue-200 {
     &:where(.dark, .dark *) {
       color: var(--color-blue-200);
@@ -2034,6 +2138,11 @@
       color: var(--color-white);
     }
   }
+  .dark\:decoration-blue-800 {
+    &:where(.dark, .dark *) {
+      text-decoration-color: var(--color-blue-800);
+    }
+  }
   .dark\:decoration-gray-600 {
     &:where(.dark, .dark *) {
       text-decoration-color: var(--color-gray-600);
@@ -2065,6 +2174,15 @@
   .dark\:group-hover\:text-blue-300 {
     &:where(.dark, .dark *) {
       &:is(:where(.group):hover *) {
+        @media (hover: hover) {
+          color: var(--color-blue-300);
+        }
+      }
+    }
+  }
+  .dark\:group-hover\/topic\:text-blue-300 {
+    &:where(.dark, .dark *) {
+      &:is(:where(.group\/topic):hover *) {
         @media (hover: hover) {
           color: var(--color-blue-300);
         }
@@ -2202,6 +2320,15 @@
       &:hover {
         @media (hover: hover) {
           color: var(--color-white);
+        }
+      }
+    }
+  }
+  .dark\:hover\:decoration-blue-300 {
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          text-decoration-color: var(--color-blue-300);
         }
       }
     }

--- a/api/src/learn_to_cloud/static/css/styles.css
+++ b/api/src/learn_to_cloud/static/css/styles.css
@@ -24,11 +24,11 @@
     --color-amber-200: oklch(92.4% 0.12 95.746);
     --color-amber-300: oklch(87.9% 0.169 91.605);
     --color-amber-400: oklch(82.8% 0.189 84.429);
-    --color-amber-500: oklch(76.9% 0.188 70.08);
     --color-amber-600: oklch(66.6% 0.179 58.318);
     --color-amber-700: oklch(55.5% 0.163 48.998);
     --color-amber-800: oklch(47.3% 0.137 46.201);
     --color-amber-900: oklch(41.4% 0.112 45.904);
+    --color-amber-950: oklch(27.9% 0.077 45.635);
     --color-green-50: oklch(98.2% 0.018 155.826);
     --color-green-100: oklch(96.2% 0.044 156.743);
     --color-green-200: oklch(92.5% 0.084 155.995);
@@ -97,16 +97,13 @@
     --text-5xl--line-height: 1;
     --text-6xl: 3.75rem;
     --text-6xl--line-height: 1;
-    --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
     --tracking-wide: 0.025em;
-    --leading-tight: 1.25;
     --radius-sm: 0.25rem;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
-    --radius-xl: 0.75rem;
     --animate-spin: spin 1s linear infinite;
     --blur-3xl: 64px;
     --default-transition-duration: 150ms;
@@ -327,6 +324,9 @@
   .z-50 {
     z-index: 50;
   }
+  .col-start-2 {
+    grid-column-start: 2;
+  }
   .container {
     width: 100%;
     @media (width >= 40rem) {
@@ -348,9 +348,6 @@
   .mx-1 {
     margin-inline: calc(var(--spacing) * 1);
   }
-  .mx-2 {
-    margin-inline: calc(var(--spacing) * 2);
-  }
   .mx-4 {
     margin-inline: calc(var(--spacing) * 4);
   }
@@ -369,6 +366,9 @@
   .mt-2 {
     margin-top: calc(var(--spacing) * 2);
   }
+  .mt-2\.5 {
+    margin-top: calc(var(--spacing) * 2.5);
+  }
   .mt-3 {
     margin-top: calc(var(--spacing) * 3);
   }
@@ -380,6 +380,9 @@
   }
   .mt-6 {
     margin-top: calc(var(--spacing) * 6);
+  }
+  .mt-7 {
+    margin-top: calc(var(--spacing) * 7);
   }
   .mt-8 {
     margin-top: calc(var(--spacing) * 8);
@@ -398,9 +401,6 @@
   }
   .-mb-px {
     margin-bottom: -1px;
-  }
-  .mb-1 {
-    margin-bottom: calc(var(--spacing) * 1);
   }
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
@@ -431,12 +431,6 @@
   }
   .ml-auto {
     margin-left: auto;
-  }
-  .line-clamp-2 {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
   }
   .block {
     display: block;
@@ -534,12 +528,6 @@
   .w-11 {
     width: calc(var(--spacing) * 11);
   }
-  .w-20 {
-    width: calc(var(--spacing) * 20);
-  }
-  .w-28 {
-    width: calc(var(--spacing) * 28);
-  }
   .w-48 {
     width: calc(var(--spacing) * 48);
   }
@@ -615,6 +603,9 @@
   .grid-cols-\[2\.75rem_1fr\] {
     grid-template-columns: 2.75rem 1fr;
   }
+  .grid-cols-\[2\.75rem_1fr_auto\] {
+    grid-template-columns: 2.75rem 1fr auto;
+  }
   .grid-cols-\[3rem_1fr\] {
     grid-template-columns: 3rem 1fr;
   }
@@ -650,9 +641,6 @@
   }
   .gap-1 {
     gap: calc(var(--spacing) * 1);
-  }
-  .gap-1\.5 {
-    gap: calc(var(--spacing) * 1.5);
   }
   .gap-2 {
     gap: calc(var(--spacing) * 2);
@@ -704,6 +692,13 @@
       --tw-space-y-reverse: 0;
       margin-block-start: calc(calc(var(--spacing) * 4) * var(--tw-space-y-reverse));
       margin-block-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-y-reverse)));
+    }
+  }
+  .space-y-5 {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 5) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 5) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
   .space-y-6 {
@@ -769,9 +764,6 @@
   .rounded-sm {
     border-radius: var(--radius-sm);
   }
-  .rounded-xl {
-    border-radius: var(--radius-xl);
-  }
   .border {
     border-style: var(--tw-border-style);
     border-width: 1px;
@@ -796,10 +788,6 @@
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 2px;
   }
-  .border-dashed {
-    --tw-border-style: dashed;
-    border-style: dashed;
-  }
   .border-amber-200 {
     border-color: var(--color-amber-200);
   }
@@ -820,6 +808,9 @@
   }
   .border-gray-300 {
     border-color: var(--color-gray-300);
+  }
+  .border-gray-400 {
+    border-color: var(--color-gray-400);
   }
   .border-green-200 {
     border-color: var(--color-green-200);
@@ -992,11 +983,14 @@
   .pt-12 {
     padding-top: calc(var(--spacing) * 12);
   }
+  .pt-14 {
+    padding-top: calc(var(--spacing) * 14);
+  }
   .pt-16 {
     padding-top: calc(var(--spacing) * 16);
   }
-  .pr-3 {
-    padding-right: calc(var(--spacing) * 3);
+  .pr-4 {
+    padding-right: calc(var(--spacing) * 4);
   }
   .pb-0 {
     padding-bottom: calc(var(--spacing) * 0);
@@ -1006,6 +1000,9 @@
   }
   .pb-8 {
     padding-bottom: calc(var(--spacing) * 8);
+  }
+  .pb-10 {
+    padding-bottom: calc(var(--spacing) * 10);
   }
   .pb-12 {
     padding-bottom: calc(var(--spacing) * 12);
@@ -1018,9 +1015,6 @@
   }
   .pl-16 {
     padding-left: calc(var(--spacing) * 16);
-  }
-  .pl-\[4\.5rem\] {
-    padding-left: 4.5rem;
   }
   .text-center {
     text-align: center;
@@ -1083,10 +1077,6 @@
     --tw-leading: calc(var(--spacing) * 8);
     line-height: calc(var(--spacing) * 8);
   }
-  .leading-tight {
-    --tw-leading: var(--leading-tight);
-    line-height: var(--leading-tight);
-  }
   .font-bold {
     --tw-font-weight: var(--font-weight-bold);
     font-weight: var(--font-weight-bold);
@@ -1095,10 +1085,6 @@
     --tw-font-weight: var(--font-weight-medium);
     font-weight: var(--font-weight-medium);
   }
-  .font-normal {
-    --tw-font-weight: var(--font-weight-normal);
-    font-weight: var(--font-weight-normal);
-  }
   .font-semibold {
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
@@ -1106,6 +1092,10 @@
   .tracking-\[-0\.02em\] {
     --tw-tracking: -0.02em;
     letter-spacing: -0.02em;
+  }
+  .tracking-\[-0\.03em\] {
+    --tw-tracking: -0.03em;
+    letter-spacing: -0.03em;
   }
   .tracking-\[-0\.025em\] {
     --tw-tracking: -0.025em;
@@ -1136,9 +1126,6 @@
   .break-all {
     word-break: break-all;
   }
-  .text-amber-500 {
-    color: var(--color-amber-500);
-  }
   .text-amber-600 {
     color: var(--color-amber-600);
   }
@@ -1148,8 +1135,8 @@
   .text-amber-800 {
     color: var(--color-amber-800);
   }
-  .text-blue-500 {
-    color: var(--color-blue-500);
+  .text-amber-950 {
+    color: var(--color-amber-950);
   }
   .text-blue-600 {
     color: var(--color-blue-600);
@@ -1159,6 +1146,9 @@
   }
   .text-blue-800 {
     color: var(--color-blue-800);
+  }
+  .text-blue-900 {
+    color: var(--color-blue-900);
   }
   .text-blue-950 {
     color: var(--color-blue-950);
@@ -1256,9 +1246,6 @@
       color: var(--color-gray-400);
     }
   }
-  .opacity-50 {
-    opacity: 50%;
-  }
   .shadow-lg {
     --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -1315,9 +1302,13 @@
     -webkit-user-select: all;
     user-select: all;
   }
-  .select-none {
-    -webkit-user-select: none;
-    user-select: none;
+  .group-hover\:translate-x-0\.5 {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        --tw-translate-x: calc(var(--spacing) * 0.5);
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
+    }
   }
   .group-hover\:translate-x-1 {
     &:is(:where(.group):hover *) {
@@ -1363,6 +1354,22 @@
       }
     }
   }
+  .focus-within\:outline-2 {
+    &:focus-within {
+      outline-style: var(--tw-outline-style);
+      outline-width: 2px;
+    }
+  }
+  .focus-within\:outline-offset-2 {
+    &:focus-within {
+      outline-offset: 2px;
+    }
+  }
+  .focus-within\:outline-blue-700 {
+    &:focus-within {
+      outline-color: var(--color-blue-700);
+    }
+  }
   .hover\:border-blue-300 {
     &:hover {
       @media (hover: hover) {
@@ -1381,16 +1388,6 @@
     &:hover {
       @media (hover: hover) {
         border-color: var(--color-blue-500);
-      }
-    }
-  }
-  .hover\:bg-blue-50\/50 {
-    &:hover {
-      @media (hover: hover) {
-        background-color: color-mix(in srgb, oklch(97% 0.014 254.604) 50%, transparent);
-        @supports (color: color-mix(in lab, red, red)) {
-          background-color: color-mix(in oklab, var(--color-blue-50) 50%, transparent);
-        }
       }
     }
   }
@@ -1440,13 +1437,6 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-blue-500);
-      }
-    }
-  }
-  .hover\:text-blue-600 {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-blue-600);
       }
     }
   }
@@ -1528,22 +1518,6 @@
       --tw-ring-color: var(--color-blue-500);
     }
   }
-  .focus\:outline-hidden {
-    &:focus {
-      --tw-outline-style: none;
-      outline-style: none;
-      @media (forced-colors: active) {
-        outline: 2px solid transparent;
-        outline-offset: 2px;
-      }
-    }
-  }
-  .focus\:outline-none {
-    &:focus {
-      --tw-outline-style: none;
-      outline-style: none;
-    }
-  }
   .focus-visible\:rounded-md {
     &:focus-visible {
       border-radius: var(--radius-md);
@@ -1552,17 +1526,6 @@
   .focus-visible\:rounded-sm {
     &:focus-visible {
       border-radius: var(--radius-sm);
-    }
-  }
-  .focus-visible\:ring-2 {
-    &:focus-visible {
-      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
-      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-    }
-  }
-  .focus-visible\:ring-blue-500 {
-    &:focus-visible {
-      --tw-ring-color: var(--color-blue-500);
     }
   }
   .focus-visible\:outline-2 {
@@ -1581,19 +1544,39 @@
       outline-offset: 4px;
     }
   }
+  .focus-visible\:outline-amber-700 {
+    &:focus-visible {
+      outline-color: var(--color-amber-700);
+    }
+  }
   .focus-visible\:outline-blue-700 {
     &:focus-visible {
       outline-color: var(--color-blue-700);
     }
   }
-  .focus-visible\:ring-inset {
-    &:focus-visible {
-      --tw-ring-inset: inset;
-    }
-  }
   .disabled\:opacity-50 {
     &:disabled {
       opacity: 50%;
+    }
+  }
+  .sm\:col-start-2 {
+    @media (width >= 40rem) {
+      grid-column-start: 2;
+    }
+  }
+  .sm\:col-start-auto {
+    @media (width >= 40rem) {
+      grid-column-start: auto;
+    }
+  }
+  .sm\:mt-0 {
+    @media (width >= 40rem) {
+      margin-top: calc(var(--spacing) * 0);
+    }
+  }
+  .sm\:mt-16 {
+    @media (width >= 40rem) {
+      margin-top: calc(var(--spacing) * 16);
     }
   }
   .sm\:block {
@@ -1621,14 +1604,9 @@
       display: inline-flex;
     }
   }
-  .sm\:w-24 {
+  .sm\:flex-1 {
     @media (width >= 40rem) {
-      width: calc(var(--spacing) * 24);
-    }
-  }
-  .sm\:w-44 {
-    @media (width >= 40rem) {
-      width: calc(var(--spacing) * 44);
+      flex: 1;
     }
   }
   .sm\:grid-cols-2 {
@@ -1671,6 +1649,16 @@
       align-items: flex-end;
     }
   }
+  .sm\:items-start {
+    @media (width >= 40rem) {
+      align-items: flex-start;
+    }
+  }
+  .sm\:gap-3 {
+    @media (width >= 40rem) {
+      gap: calc(var(--spacing) * 3);
+    }
+  }
   .sm\:gap-4 {
     @media (width >= 40rem) {
       gap: calc(var(--spacing) * 4);
@@ -1696,6 +1684,11 @@
       padding-inline: calc(var(--spacing) * 6);
     }
   }
+  .sm\:pt-3 {
+    @media (width >= 40rem) {
+      padding-top: calc(var(--spacing) * 3);
+    }
+  }
   .sm\:pt-8 {
     @media (width >= 40rem) {
       padding-top: calc(var(--spacing) * 8);
@@ -1706,6 +1699,11 @@
       padding-top: calc(var(--spacing) * 12);
     }
   }
+  .sm\:pt-14 {
+    @media (width >= 40rem) {
+      padding-top: calc(var(--spacing) * 14);
+    }
+  }
   .sm\:pt-16 {
     @media (width >= 40rem) {
       padding-top: calc(var(--spacing) * 16);
@@ -1714,6 +1712,11 @@
   .sm\:pt-20 {
     @media (width >= 40rem) {
       padding-top: calc(var(--spacing) * 20);
+    }
+  }
+  .sm\:pb-12 {
+    @media (width >= 40rem) {
+      padding-bottom: calc(var(--spacing) * 12);
     }
   }
   .sm\:pb-16 {
@@ -1729,6 +1732,11 @@
   .sm\:pl-\[5\.5rem\] {
     @media (width >= 40rem) {
       padding-left: 5.5rem;
+    }
+  }
+  .sm\:pl-\[5\.75rem\] {
+    @media (width >= 40rem) {
+      padding-left: 5.75rem;
     }
   }
   .sm\:text-4xl {
@@ -1749,21 +1757,10 @@
       line-height: var(--tw-leading, var(--text-6xl--line-height));
     }
   }
-  .sm\:text-sm {
-    @media (width >= 40rem) {
-      font-size: var(--text-sm);
-      line-height: var(--tw-leading, var(--text-sm--line-height));
-    }
-  }
   .sm\:leading-\[1\.05\] {
     @media (width >= 40rem) {
       --tw-leading: 1.05;
       line-height: 1.05;
-    }
-  }
-  .lg\:grid-cols-3 {
-    @media (width >= 64rem) {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
   .lg\:grid-cols-\[minmax\(0\,1\.2fr\)_minmax\(17rem\,0\.8fr\)\] {
@@ -1808,6 +1805,11 @@
       border-color: var(--color-blue-900);
     }
   }
+  .dark\:border-gray-500 {
+    &:where(.dark, .dark *) {
+      border-color: var(--color-gray-500);
+    }
+  }
   .dark\:border-gray-600 {
     &:where(.dark, .dark *) {
       border-color: var(--color-gray-600);
@@ -1849,6 +1851,14 @@
       }
     }
   }
+  .dark\:bg-amber-950\/30 {
+    &:where(.dark, .dark *) {
+      background-color: color-mix(in srgb, oklch(27.9% 0.077 45.635) 30%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-amber-950) 30%, transparent);
+      }
+    }
+  }
   .dark\:bg-blue-400 {
     &:where(.dark, .dark *) {
       background-color: var(--color-blue-400);
@@ -1862,14 +1872,6 @@
   .dark\:bg-blue-900 {
     &:where(.dark, .dark *) {
       background-color: var(--color-blue-900);
-    }
-  }
-  .dark\:bg-blue-900\/20 {
-    &:where(.dark, .dark *) {
-      background-color: color-mix(in srgb, oklch(37.9% 0.146 265.522) 20%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-blue-900) 20%, transparent);
-      }
     }
   }
   .dark\:bg-blue-950 {
@@ -1929,14 +1931,6 @@
       background-color: var(--color-green-900);
     }
   }
-  .dark\:bg-green-900\/10 {
-    &:where(.dark, .dark *) {
-      background-color: color-mix(in srgb, oklch(39.3% 0.095 152.535) 10%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-green-900) 10%, transparent);
-      }
-    }
-  }
   .dark\:bg-green-900\/20 {
     &:where(.dark, .dark *) {
       background-color: color-mix(in srgb, oklch(39.3% 0.095 152.535) 20%, transparent);
@@ -1948,6 +1942,14 @@
   .dark\:bg-green-950 {
     &:where(.dark, .dark *) {
       background-color: var(--color-green-950);
+    }
+  }
+  .dark\:bg-green-950\/20 {
+    &:where(.dark, .dark *) {
+      background-color: color-mix(in srgb, oklch(26.6% 0.065 152.934) 20%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-green-950) 20%, transparent);
+      }
     }
   }
   .dark\:bg-green-950\/30 {
@@ -1979,6 +1981,11 @@
   .dark\:bg-zinc-800 {
     &:where(.dark, .dark *) {
       background-color: var(--color-zinc-800);
+    }
+  }
+  .dark\:text-amber-100 {
+    &:where(.dark, .dark *) {
+      color: var(--color-amber-100);
     }
   }
   .dark\:text-amber-200 {
@@ -2044,11 +2051,6 @@
   .dark\:text-gray-500 {
     &:where(.dark, .dark *) {
       color: var(--color-gray-500);
-    }
-  }
-  .dark\:text-gray-600 {
-    &:where(.dark, .dark *) {
-      color: var(--color-gray-600);
     }
   }
   .dark\:text-gray-700 {
@@ -2212,18 +2214,6 @@
       }
     }
   }
-  .dark\:hover\:bg-blue-950\/20 {
-    &:where(.dark, .dark *) {
-      &:hover {
-        @media (hover: hover) {
-          background-color: color-mix(in srgb, oklch(28.2% 0.091 267.935) 20%, transparent);
-          @supports (color: color-mix(in lab, red, red)) {
-            background-color: color-mix(in oklab, var(--color-blue-950) 20%, transparent);
-          }
-        }
-      }
-    }
-  }
   .dark\:hover\:bg-gray-200 {
     &:where(.dark, .dark *) {
       &:hover {
@@ -2251,20 +2241,23 @@
       }
     }
   }
+  .dark\:hover\:bg-gray-800\/50 {
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: color-mix(in srgb, oklch(27.8% 0.033 256.848) 50%, transparent);
+          @supports (color: color-mix(in lab, red, red)) {
+            background-color: color-mix(in oklab, var(--color-gray-800) 50%, transparent);
+          }
+        }
+      }
+    }
+  }
   .dark\:hover\:text-blue-300 {
     &:where(.dark, .dark *) {
       &:hover {
         @media (hover: hover) {
           color: var(--color-blue-300);
-        }
-      }
-    }
-  }
-  .dark\:hover\:text-blue-400 {
-    &:where(.dark, .dark *) {
-      &:hover {
-        @media (hover: hover) {
-          color: var(--color-blue-400);
         }
       }
     }

--- a/api/src/learn_to_cloud/static/css/styles.css
+++ b/api/src/learn_to_cloud/static/css/styles.css
@@ -314,17 +314,8 @@
   .right-2 {
     right: calc(var(--spacing) * 2);
   }
-  .bottom-8 {
-    bottom: calc(var(--spacing) * 8);
-  }
-  .left-\[1\.1875rem\] {
-    left: 1.1875rem;
-  }
   .-z-10 {
     z-index: calc(10 * -1);
-  }
-  .z-10 {
-    z-index: 10;
   }
   .z-50 {
     z-index: 50;
@@ -554,9 +545,6 @@
   .w-full {
     width: 100%;
   }
-  .w-px {
-    width: 1px;
-  }
   .max-w-2xl {
     max-width: var(--container-2xl);
   }
@@ -623,8 +611,8 @@
   .grid-cols-1 {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }
-  .grid-cols-\[2\.5rem_1fr\] {
-    grid-template-columns: 2.5rem 1fr;
+  .grid-cols-\[2\.75rem_1fr\] {
+    grid-template-columns: 2.75rem 1fr;
   }
   .grid-cols-\[3rem_1fr_auto\] {
     grid-template-columns: 3rem 1fr auto;
@@ -719,6 +707,20 @@
       margin-block-end: calc(calc(var(--spacing) * 8) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
+  .divide-y {
+    :where(& > :not(:last-child)) {
+      --tw-divide-y-reverse: 0;
+      border-bottom-style: var(--tw-border-style);
+      border-top-style: var(--tw-border-style);
+      border-top-width: calc(1px * var(--tw-divide-y-reverse));
+      border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+    }
+  }
+  .divide-blue-100 {
+    :where(& > :not(:last-child)) {
+      border-color: var(--color-blue-100);
+    }
+  }
   .truncate {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -762,6 +764,10 @@
     border-style: var(--tw-border-style);
     border-width: 2px;
   }
+  .border-y {
+    border-block-style: var(--tw-border-style);
+    border-block-width: 1px;
+  }
   .border-t {
     border-top-style: var(--tw-border-style);
     border-top-width: 1px;
@@ -785,14 +791,14 @@
   .border-amber-200 {
     border-color: var(--color-amber-200);
   }
+  .border-blue-100 {
+    border-color: var(--color-blue-100);
+  }
   .border-blue-200 {
     border-color: var(--color-blue-200);
   }
   .border-blue-500 {
     border-color: var(--color-blue-500);
-  }
-  .border-blue-700 {
-    border-color: var(--color-blue-700);
   }
   .border-gray-100 {
     border-color: var(--color-gray-100);
@@ -844,9 +850,6 @@
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-blue-100) 70%, transparent);
     }
-  }
-  .bg-blue-200 {
-    background-color: var(--color-blue-200);
   }
   .bg-blue-500 {
     background-color: var(--color-blue-500);
@@ -977,6 +980,9 @@
   .py-3 {
     padding-block: calc(var(--spacing) * 3);
   }
+  .py-4 {
+    padding-block: calc(var(--spacing) * 4);
+  }
   .py-6 {
     padding-block: calc(var(--spacing) * 6);
   }
@@ -995,8 +1001,14 @@
   .pt-8 {
     padding-top: calc(var(--spacing) * 8);
   }
+  .pt-16 {
+    padding-top: calc(var(--spacing) * 16);
+  }
   .pr-3 {
     padding-right: calc(var(--spacing) * 3);
+  }
+  .pb-0 {
+    padding-bottom: calc(var(--spacing) * 0);
   }
   .pb-4 {
     padding-bottom: calc(var(--spacing) * 4);
@@ -1054,6 +1066,10 @@
   .text-xs {
     font-size: var(--text-xs);
     line-height: var(--tw-leading, var(--text-xs--line-height));
+  }
+  .leading-5 {
+    --tw-leading: calc(var(--spacing) * 5);
+    line-height: calc(var(--spacing) * 5);
   }
   .leading-6 {
     --tw-leading: calc(var(--spacing) * 6);
@@ -1625,14 +1641,14 @@
       padding-inline: calc(var(--spacing) * 6);
     }
   }
-  .sm\:py-20 {
-    @media (width >= 40rem) {
-      padding-block: calc(var(--spacing) * 20);
-    }
-  }
   .sm\:pt-12 {
     @media (width >= 40rem) {
       padding-top: calc(var(--spacing) * 12);
+    }
+  }
+  .sm\:pt-20 {
+    @media (width >= 40rem) {
+      padding-top: calc(var(--spacing) * 20);
     }
   }
   .sm\:pb-20 {
@@ -1694,24 +1710,26 @@
       display: none;
     }
   }
+  .dark\:divide-blue-900 {
+    &:where(.dark, .dark *) {
+      :where(& > :not(:last-child)) {
+        border-color: var(--color-blue-900);
+      }
+    }
+  }
   .dark\:border-amber-800 {
     &:where(.dark, .dark *) {
       border-color: var(--color-amber-800);
     }
   }
-  .dark\:border-blue-400 {
-    &:where(.dark, .dark *) {
-      border-color: var(--color-blue-400);
-    }
-  }
-  .dark\:border-blue-700 {
-    &:where(.dark, .dark *) {
-      border-color: var(--color-blue-700);
-    }
-  }
   .dark\:border-blue-800 {
     &:where(.dark, .dark *) {
       border-color: var(--color-blue-800);
+    }
+  }
+  .dark\:border-blue-900 {
+    &:where(.dark, .dark *) {
+      border-color: var(--color-blue-900);
     }
   }
   .dark\:border-gray-600 {
@@ -1773,11 +1791,6 @@
   .dark\:bg-blue-500 {
     &:where(.dark, .dark *) {
       background-color: var(--color-blue-500);
-    }
-  }
-  .dark\:bg-blue-800 {
-    &:where(.dark, .dark *) {
-      background-color: var(--color-blue-800);
     }
   }
   .dark\:bg-blue-900 {
@@ -2317,6 +2330,11 @@
   inherits: false;
   initial-value: 0;
 }
+@property --tw-divide-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
 @property --tw-border-style {
   syntax: "*";
   inherits: false;
@@ -2552,6 +2570,7 @@
       --tw-skew-x: initial;
       --tw-skew-y: initial;
       --tw-space-y-reverse: 0;
+      --tw-divide-y-reverse: 0;
       --tw-border-style: solid;
       --tw-gradient-position: initial;
       --tw-gradient-from: #0000;

--- a/api/src/learn_to_cloud/templates/pages/community.html
+++ b/api/src/learn_to_cloud/templates/pages/community.html
@@ -1,143 +1,164 @@
 {% extends "base.html" %}
+{% set footer_margin = "mt-8" %}
 {% block title %}Community - Learn to Cloud{% endblock %}
-{% block description %}Meet the Learn to Cloud community, explore learner progress, celebrate curriculum graduates, and see the latest updates.{% endblock %}
+{% block description %}Meet the Learn to Cloud community, explore verified learner progress, celebrate curriculum graduates, and see the latest updates.{% endblock %}
 
 {% block content %}
-<div class="mb-8">
-    <h1 class="text-3xl font-bold text-gray-900 dark:text-white">Learn to Cloud community</h1>
-    <p class="text-gray-600 dark:text-gray-400 mt-2">
-        See how learners are progressing through the curriculum and celebrate those who have completed it.
+<header class="border-b border-gray-200 pb-12 pt-4 dark:border-gray-700 sm:pb-16 sm:pt-8">
+    <h1 class="text-balance text-4xl font-bold tracking-[-0.035em] text-gray-950 dark:text-white sm:text-5xl">Learn to Cloud community</h1>
+    <p class="mt-5 max-w-2xl text-lg leading-8 text-gray-600 dark:text-gray-300">
+        Ask for help, learn in public, and see the verified work learners are completing across the curriculum.
     </p>
-</div>
+</header>
 
-{# ── Progress funnel ──────────────────────────────────────────── #}
-<section class="mb-12">
-    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-1">Progress funnel</h2>
-    <p class="text-base text-gray-500 dark:text-gray-400 mb-6">
-        How many learners have verified every project in each phase.
-    </p>
-
-    <div class="max-w-2xl mx-auto space-y-2" role="img" aria-label="Progress funnel">
-        {% for level in community.funnel %}
-        <div class="flex items-center gap-3 sm:gap-4">
-            {# Label #}
-            <div class="w-28 sm:w-44 flex-shrink-0 text-right">
-                <p class="text-xs sm:text-sm leading-tight {{ 'font-semibold text-gray-900 dark:text-white' if level.is_total else 'font-medium text-gray-700 dark:text-gray-300' }}"
-                   title="{{ level.label }}">{{ level.label }}</p>
-            </div>
-
-            {# Centered tapering bar #}
-            <div class="flex-1 flex justify-center min-w-0">
-                <div class="flex items-center justify-center h-9 rounded-md px-2 text-sm font-semibold tabular-nums text-white shadow-sm
-                            {{ 'bg-blue-600 dark:bg-blue-500' if level.is_total else 'bg-blue-500 dark:bg-blue-500' }}"
-                     style="width: {{ level.pct_of_total | round(2) }}%; min-width: 3.25rem; {{ '' if level.is_total else 'opacity: %.2f;' | format(1 - loop.index0 * 0.06 if 1 - loop.index0 * 0.06 > 0.55 else 0.55) }}">
-                    {{ level.count }}
-                </div>
-            </div>
-
-            {# Percentages #}
-            <div class="w-20 sm:w-24 flex-shrink-0 text-left tabular-nums leading-tight">
-                {% if level.is_total %}
-                <p class="text-xs text-gray-400 dark:text-gray-500">accounts</p>
-                {% else %}
-                <p class="text-xs sm:text-sm font-medium text-gray-700 dark:text-gray-300">{{ level.pct_of_total | round(1) }}%</p>
-                {% if level.pct_of_previous is not none %}
-                <p class="text-xs text-gray-400 dark:text-gray-500">{{ level.pct_of_previous | round(0) | int }}% of prev</p>
-                {% endif %}
-                {% endif %}
-            </div>
-        </div>
-        {% endfor %}
+<section class="pt-12 sm:pt-16" aria-labelledby="connect-heading">
+    <div class="max-w-2xl">
+        <h2 id="connect-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Connect with the community</h2>
+        <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-300">Get unstuck, follow project updates, and find more ways to learn.</p>
     </div>
-    <p class="mt-5 text-xs text-gray-400 dark:text-gray-500 text-center">
-        Later phases require completing earlier ones, so the funnel narrows as learners advance.
-        Percentages show share of total accounts and conversion from the previous phase.
-    </p>
+
+    <ul class="mt-8 grid gap-x-8 sm:grid-cols-2">
+        {% for link in community_links %}
+        <li class="border-t border-gray-200 dark:border-gray-700">
+            <a href="{{ link.url }}" target="_blank" rel="noopener noreferrer"
+               class="group grid min-h-11 grid-cols-[2.75rem_1fr_auto] items-center gap-3 py-4 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700">
+                <span class="flex h-10 w-10 items-center justify-center rounded-md bg-gray-100 dark:bg-gray-800 {{ link.color }}" aria-hidden="true">
+                    {{ link.icon | safe }}
+                </span>
+                <span>
+                    <span class="block text-sm font-bold text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ link.label }}</span>
+                    <span class="mt-1 block text-sm leading-5 text-gray-600 dark:text-gray-400">{{ link.description }}</span>
+                </span>
+                <svg class="h-4 w-4 text-gray-400 transition-transform group-hover:translate-x-0.5 group-hover:text-blue-700 dark:text-gray-500 dark:group-hover:text-blue-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
+                </svg>
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
 </section>
 
-{# ── Curriculum graduates ─────────────────────────────────────── #}
-<section class="mb-12">
-    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-1">
+<section class="pt-14 sm:pt-16" aria-labelledby="progress-heading">
+    <div class="max-w-2xl">
+        <h2 id="progress-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Verified progress across the curriculum</h2>
+        <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-300">
+            Each level counts learners who have verified every project in that phase. Later phases require the earlier work first.
+        </p>
+    </div>
+
+    {% if community.funnel %}
+    <ol class="mt-8 space-y-5">
+        {% for level in community.funnel %}
+        <li>
+            <div class="flex items-end justify-between gap-4">
+                <p class="min-w-0 text-sm {% if level.is_total %}font-bold text-gray-950 dark:text-white{% else %}font-medium text-gray-700 dark:text-gray-300{% endif %}">
+                    {{ level.label }}
+                </p>
+                <p class="shrink-0 text-right text-sm tabular-nums">
+                    <strong class="font-bold text-gray-950 dark:text-white">{{ level.count }}</strong>
+                    {% if level.is_total %}
+                    <span class="ml-1 text-gray-500 dark:text-gray-400">accounts</span>
+                    {% else %}
+                    <span class="ml-1 text-gray-500 dark:text-gray-400">{{ level.pct_of_total | round(1) }}%</span>
+                    {% endif %}
+                </p>
+            </div>
+            <div class="mt-2 h-2.5 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700" aria-hidden="true">
+                <div class="h-full rounded-full {% if level.is_total %}bg-blue-700 dark:bg-blue-400{% else %}bg-blue-500 dark:bg-blue-500{% endif %}" style="width: {{ level.pct_of_total | round(2) }}%"></div>
+            </div>
+            {% if not level.is_total and level.pct_of_previous is not none %}
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ level.pct_of_previous | round(0) | int }}% advanced from the previous phase</p>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ol>
+    {% else %}
+    <div class="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
+        <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">Verified learner progress is temporarily unavailable.</p>
+    </div>
+    {% endif %}
+</section>
+
+<section class="pt-14 sm:pt-16" aria-labelledby="graduates-heading">
+    <h2 id="graduates-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">
         Curriculum graduates
-        <span class="ml-1 text-base font-normal text-gray-500 dark:text-gray-400">({{ community.graduates | length }})</span>
+        <span class="ml-1 text-lg font-medium text-gray-500 dark:text-gray-400">({{ community.graduates | length }})</span>
     </h2>
-    <p class="text-base text-gray-500 dark:text-gray-400 mb-4">
-        Learners who have verified every project across all phases.
-    </p>
+    <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-300">Learners who have verified every project across all phases.</p>
 
     {% if community.graduates %}
-    <ul class="flex flex-wrap gap-2">
+    <ul class="mt-6 flex flex-wrap gap-2">
         {% for member in community.graduates %}
         <li>
             <a href="https://github.com/{{ member.github_username }}" target="_blank" rel="noopener noreferrer"
-               class="inline-flex items-center gap-2 rounded-full border border-gray-200 dark:border-gray-700 py-1 pl-1 pr-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+               class="inline-flex min-h-11 items-center gap-2 rounded-full border border-gray-300 py-1 pl-1 pr-4 transition-colors hover:border-blue-400 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:hover:border-blue-500 dark:hover:text-blue-300">
                 {% if member.avatar_url %}
-                <img src="{{ member.avatar_url }}" alt="{{ member.github_username }}" class="h-6 w-6 rounded-full" loading="lazy">
+                <img src="{{ member.avatar_url }}" alt="" class="h-9 w-9 rounded-full" loading="lazy">
                 {% else %}
-                <span class="h-6 w-6 rounded-full bg-gray-200 dark:bg-gray-700 inline-flex items-center justify-center text-xs text-gray-500 dark:text-gray-400">{{ member.github_username[0] | upper }}</span>
+                <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-gray-200 text-sm font-bold text-gray-700 dark:bg-gray-700 dark:text-gray-200" aria-hidden="true">{{ member.github_username[0] | upper }}</span>
                 {% endif %}
-                <span class="text-sm text-gray-700 dark:text-gray-300">{{ member.github_username }}</span>
+                <span class="text-sm font-bold">{{ member.github_username }}</span>
+                <span class="sr-only">on GitHub</span>
             </a>
         </li>
         {% endfor %}
     </ul>
     {% else %}
-    <div class="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 p-6 text-center">
-        <p class="text-sm text-gray-500 dark:text-gray-400">No one has finished the entire curriculum yet. Be the first!</p>
+    <div class="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
+        <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">No learner has verified the entire curriculum yet. The first graduate will appear here.</p>
     </div>
     {% endif %}
 </section>
 
-{# ── Connect with the community ─────────────────────────────── #}
-<section class="mb-12">
-    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-1">Connect with the community</h2>
-    <p class="text-base text-gray-500 dark:text-gray-400 mb-6">
-        Ask questions, follow project updates, and find more ways to learn.
-    </p>
+<section class="pt-14 sm:pt-16" aria-labelledby="updates-heading">
+    <h2 id="updates-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Latest curriculum updates</h2>
 
-    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {% for link in community_links %}
-        <a href="{{ link.url }}" target="_blank" rel="noopener noreferrer"
-           class="group rounded-lg border border-gray-200 dark:border-gray-700 p-5 hover:border-blue-300 hover:bg-blue-50/50 dark:hover:border-blue-700 dark:hover:bg-blue-950/20 transition-colors">
-            <span class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-800 {{ link.color }}">
-                {{ link.icon | safe }}
-            </span>
-            <h3 class="mt-4 text-base font-semibold text-gray-900 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">
-                {{ link.label }}
-            </h3>
-            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{{ link.description }}</p>
-        </a>
-        {% endfor %}
-    </div>
-</section>
-
-{# ── Latest curriculum updates ────────────────────────────────── #}
-<section class="mb-8">
-    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-4">Latest curriculum updates</h2>
-
-    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    {% if community.repo_updates %}
+    <ul class="mt-6 border-y border-gray-200 dark:border-gray-700">
         {% for repo in community.repo_updates %}
-        <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4 flex flex-col">
-            <a href="{{ repo.url }}" target="_blank" rel="noopener noreferrer"
-               class="text-base font-semibold text-gray-900 dark:text-white hover:text-blue-600 dark:hover:text-blue-400 transition-colors">
-                {{ repo.name }}
-            </a>
-            {% if repo.available %}
-            <a href="{{ repo.commit_url }}" target="_blank" rel="noopener noreferrer"
-               class="mt-2 text-sm text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 line-clamp-2">
-                {{ repo.commit_message or "(no commit message)" }}
-            </a>
-            <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-                {% if repo.commit_author %}{{ repo.commit_author }}{% endif %}
-                {% if repo.committed_at %}
-                <span class="mx-1">&middot;</span>{{ repo.committed_at.strftime('%b %d, %Y') }}
+        <li class="{% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %} py-5">
+            <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start sm:gap-6">
+                <div class="min-w-0">
+                    <a href="{{ repo.url }}" target="_blank" rel="noopener noreferrer"
+                       class="inline-flex min-h-11 items-center break-words text-base font-bold text-gray-950 transition-colors hover:text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-white dark:hover:text-blue-300">
+                        {{ repo.name }}
+                    </a>
+                    {% if repo.available %}
+                    <a href="{{ repo.commit_url }}" target="_blank" rel="noopener noreferrer"
+                       class="inline-flex min-h-11 items-center break-words text-sm leading-6 text-gray-700 transition-colors hover:text-blue-700 focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-blue-300">
+                        {{ repo.commit_message or "(no commit message)" }}
+                    </a>
+                    {% else %}
+                    <p class="text-sm text-gray-500 dark:text-gray-400">Latest activity unavailable right now.</p>
+                    {% endif %}
+                </div>
+                {% if repo.available and (repo.commit_author or repo.committed_at) %}
+                <p class="text-xs text-gray-500 dark:text-gray-400 sm:pt-3">
+                    {% if repo.commit_author %}{{ repo.commit_author }}{% endif %}
+                    {% if repo.committed_at %}
+                    <span class="mx-1">&middot;</span>{{ repo.committed_at.strftime('%b %d, %Y') }}
+                    {% endif %}
+                </p>
                 {% endif %}
-            </p>
-            {% else %}
-            <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Latest activity unavailable right now.</p>
-            {% endif %}
-        </div>
+            </div>
+        </li>
         {% endfor %}
+    </ul>
+    {% else %}
+    <div class="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
+        <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">Curriculum updates are temporarily unavailable.</p>
+    </div>
+    {% endif %}
+</section>
+
+{% if not user %}
+<section class="pb-0 pt-14 text-center sm:pt-16" aria-labelledby="join-heading">
+    <h2 id="join-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Build your own verified progress.</h2>
+    <p class="mx-auto mt-3 max-w-xl text-base leading-7 text-gray-600 dark:text-gray-300">Browse the curriculum freely. Sign in when you want to save progress and submit verification work.</p>
+    <div class="mt-6 flex flex-wrap justify-center gap-3">
+        <a href="/curriculum" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-5 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">Explore the curriculum</a>
+        <a href="/auth/login" hx-boost="false" class="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-300 px-5 py-2.5 text-sm font-bold text-gray-900 hover:border-blue-400 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:text-white dark:hover:border-blue-500 dark:hover:text-blue-300">Sign in with GitHub</a>
     </div>
 </section>
+{% endif %}
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/curriculum.html
+++ b/api/src/learn_to_cloud/templates/pages/curriculum.html
@@ -1,65 +1,149 @@
 {% extends "base.html" %}
+{% set footer_margin = "mt-8" %}
 {% block title %}Curriculum - Learn to Cloud{% endblock %}
-{% block description %}Explore the full Learn to Cloud curriculum — 7 phases covering Linux, networking, programming, cloud deployment, DevOps, and security.{% endblock %}
+{% block description %}Explore the complete Learn to Cloud curriculum, from technical foundations through cloud deployment, DevOps, security, and career preparation.{% endblock %}
 
 {% block content %}
-<div class="mb-8">
-    <h1 class="text-3xl font-bold text-gray-900 dark:text-white">Curriculum</h1>
-    <p class="text-gray-600 dark:text-gray-400 mt-2">
-        Everything you'll learn on your path to cloud computing, from zero to job-ready.
-    </p>
-</div>
+<header class="border-b border-gray-200 pb-12 pt-4 dark:border-gray-700 sm:pb-16 sm:pt-8">
+    <div class="grid gap-8 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+        <div class="max-w-3xl">
+            <h1 class="text-balance text-4xl font-bold tracking-[-0.035em] text-gray-950 dark:text-white sm:text-5xl">
+                The complete cloud curriculum.
+            </h1>
+            <p class="mt-5 max-w-2xl text-lg leading-8 text-gray-600 dark:text-gray-300">
+                Build your foundation first, then use it to create, deploy, automate, secure, and explain real cloud work.
+            </p>
+        </div>
+        {% if user %}
+        <a href="/dashboard" class="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-300 px-4 py-2.5 text-sm font-bold text-gray-900 transition-colors hover:border-blue-500 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:text-white dark:hover:border-blue-400 dark:hover:text-blue-300">
+            View your progress
+        </a>
+        {% endif %}
+    </div>
 
-<div class="space-y-6">
+    <div class="mt-8 grid gap-4 border-y border-blue-100 py-5 text-sm dark:border-blue-900 sm:grid-cols-2 sm:gap-8">
+        <p class="leading-6 text-blue-950 dark:text-blue-100">
+            <strong class="font-bold">Learn in sequence.</strong>
+            Each phase builds on skills introduced earlier in the path.
+        </p>
+        <p class="leading-6 text-blue-950 dark:text-blue-100">
+            <strong class="font-bold">Prove the work.</strong>
+            Phase pages pair learning topics with hands-on verification.
+        </p>
+    </div>
+</header>
+
+{% if phases %}
+<section class="pb-0 pt-12 sm:pt-16" aria-label="Curriculum phases">
     {% for phase in phases %}
-    <div x-data="{ open: false }" class="rounded-lg border border-gray-200 dark:border-gray-700">
-        <button
-            @click="open = !open"
-            class="w-full flex items-center justify-between p-4 text-left cursor-pointer"
-            :aria-expanded="open"
-            aria-controls="phase-{{ phase.order }}-content"
-        >
-            <div>
-                <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
-                    <span class="text-gray-400 dark:text-gray-500 font-normal">Phase {{ phase.order }}</span>
-                    {{ phase.name }}
-                </h2>
-                <p class="text-base text-gray-500 dark:text-gray-400 mt-0.5">
+    {% if loop.index0 == 0 or loop.index0 == 3 or loop.index0 == 6 %}
+    <div class="{% if not loop.first %}mt-14{% endif %} mb-3 flex items-center gap-5">
+        <h2 class="text-xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">
+            {% if loop.index0 == 0 %}Learn the systems{% elif loop.index0 == 3 %}Build and deploy{% else %}Secure and advance{% endif %}
+        </h2>
+        <div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>
+    </div>
+    {% endif %}
+
+    <section x-data="{ open: false }" class="{% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %}">
+        <div class="grid grid-cols-[3rem_1fr] gap-4 py-6 sm:grid-cols-[4rem_1fr] sm:gap-6">
+            <span class="flex h-11 w-11 items-center justify-center rounded-full {% if loop.first %}bg-blue-700 text-white dark:bg-blue-400 dark:text-blue-950{% else %}bg-blue-50 text-blue-800 dark:bg-blue-950 dark:text-blue-200{% endif %} text-sm font-bold">
+                {{ phase.order }}
+            </span>
+            <div class="min-w-0">
+                <div class="flex flex-wrap items-center gap-2">
+                    <h3>
+                        <button
+                            type="button"
+                            @click="open = !open"
+                            class="group inline-flex min-h-11 cursor-pointer items-center gap-2 rounded-md text-left text-lg font-bold text-gray-950 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-white dark:hover:text-blue-300"
+                            :aria-expanded="open"
+                            aria-controls="phase-{{ phase.order }}-content"
+                            aria-describedby="phase-{{ phase.order }}-description phase-{{ phase.order }}-topic-count"
+                        >
+                            <span>{{ phase.name }}</span>
+                            <svg
+                                class="h-5 w-5 shrink-0 text-blue-700 transition-transform dark:text-blue-300"
+                                :class="{ 'rotate-180': open }"
+                                viewBox="0 0 20 20"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="1.8"
+                                aria-hidden="true"
+                            >
+                                <path stroke-linecap="round" stroke-linejoin="round" d="m5 7.5 5 5 5-5"/>
+                            </svg>
+                        </button>
+                    </h3>
+                    {% if loop.first %}
+                    <span class="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-bold text-blue-800 dark:bg-blue-950 dark:text-blue-200">Start here</span>
+                    {% endif %}
+                </div>
+                <span id="phase-{{ phase.order }}-description" class="mt-2 block max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
                     {{ phase.short_description | default(phase.description) }}
-                </p>
+                </span>
+                <span id="phase-{{ phase.order }}-topic-count" class="mt-3 block text-xs font-bold uppercase tracking-[0.12em] text-gray-500 dark:text-gray-400">
+                    {{ phase.topics | length }} topic{% if phase.topics | length != 1 %}s{% endif %}
+                </span>
             </div>
-            <svg
-                class="w-5 h-5 text-gray-400 flex-shrink-0 ml-4 transition-transform"
-                :class="{ 'rotate-180': open }"
-                fill="none" stroke="currentColor" viewBox="0 0 24 24"
-                aria-hidden="true"
-            >
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-            </svg>
-        </button>
+        </div>
 
         <div x-show="open" x-collapse x-cloak id="phase-{{ phase.order }}-content">
-            <div class="border-t border-gray-200 dark:border-gray-700 px-4 pb-4 pt-3">
-                <ul class="space-y-2">
+            <div class="pb-8 pl-16 sm:pl-[5.5rem]">
+                {% if phase.topics %}
+                <p class="mb-3 text-sm font-bold text-gray-950 dark:text-white">Topics in this phase</p>
+                <ul class="grid gap-x-8 sm:grid-cols-2">
                     {% for topic in phase.topics %}
-                    <li class="flex items-center gap-2 text-base">
-                        <span class="text-gray-300 dark:text-gray-600 flex-shrink-0">•</span>
-                        <span class="text-gray-700 dark:text-gray-300">{{ topic.name }}</span>
+                    <li class="border-t border-gray-200 dark:border-gray-700">
+                        <a href="/phase/{{ phase.order }}/{{ topic.slug }}" class="group/topic flex min-h-11 items-center justify-between gap-3 py-3 text-sm font-medium text-gray-700 transition-colors hover:text-blue-700 focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-blue-300">
+                            <span>{{ topic.name }}</span>
+                            <svg class="h-4 w-4 shrink-0 text-gray-400 transition-transform group-hover/topic:translate-x-0.5 group-hover/topic:text-blue-700 dark:text-gray-500 dark:group-hover/topic:text-blue-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
+                            </svg>
+                        </a>
                     </li>
                     {% endfor %}
                 </ul>
+                {% else %}
+                <p class="text-sm leading-6 text-gray-600 dark:text-gray-400">Topics for this phase are being prepared.</p>
+                {% endif %}
+
+                <a href="/phase/{{ phase.order }}" class="mt-5 inline-flex min-h-11 items-center font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 transition-colors hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300">
+                    Open Phase {{ phase.order }}
+                </a>
             </div>
         </div>
-    </div>
+    </section>
     {% endfor %}
-</div>
+</section>
+{% else %}
+<section class="pb-0 pt-12 sm:pt-16" aria-labelledby="curriculum-unavailable">
+    <div class="rounded-lg border border-gray-200 bg-gray-50 p-8 dark:border-gray-700 dark:bg-gray-800/50">
+        <h2 id="curriculum-unavailable" class="text-2xl font-bold text-gray-950 dark:text-white">The curriculum is temporarily unavailable.</h2>
+        <p class="mt-3 max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-300">
+            The curriculum did not load. Try again, or visit the FAQ for more information about Learn to Cloud.
+        </p>
+        <div class="mt-5 flex flex-wrap items-center gap-4">
+            <a href="/curriculum" hx-boost="false" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
+                Try again
+            </a>
+            <a href="/faq" class="inline-flex min-h-11 items-center font-semibold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">
+                Visit the FAQ
+            </a>
+        </div>
+    </div>
+</section>
+{% endif %}
 
-{% if not user %}
-<div class="mt-10 text-center">
-    <p class="text-gray-600 dark:text-gray-400 mb-4">Ready to start learning?</p>
-    <a href="/auth/login" hx-boost="false" class="inline-flex items-center gap-2 rounded-md bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-blue-500">
-        Sign in to get started →
+{% if not user and phases %}
+<section class="pb-0 pt-12 text-center sm:pt-16" aria-labelledby="save-progress-heading">
+    <h2 id="save-progress-heading" class="text-2xl font-bold text-gray-950 dark:text-white">Keep your place as you learn.</h2>
+    <p class="mx-auto mt-3 max-w-xl text-base leading-7 text-gray-600 dark:text-gray-300">
+        Browse the full curriculum without an account. Sign in when you want to track progress and submit verification work.
+    </p>
+    <a href="/auth/login" hx-boost="false" class="mt-6 inline-flex min-h-11 items-center justify-center rounded-md bg-gray-900 px-5 py-2.5 text-sm font-bold text-white transition-colors hover:bg-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200">
+        Sign in with GitHub
     </a>
-</div>
+</section>
 {% endif %}
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/dashboard.html
+++ b/api/src/learn_to_cloud/templates/pages/dashboard.html
@@ -1,81 +1,170 @@
 {% extends "layouts/content_page.html" %}
+{% set footer_margin = "mt-8" %}
 {% block title %}Dashboard - Learn to Cloud{% endblock %}
 
 {% block page_header %}
-<h1 class="text-3xl font-bold text-gray-900 dark:text-white">Welcome, {{ user.first_name or user.github_username }} 👋</h1>
+<h1 class="text-3xl font-bold tracking-[-0.025em] text-gray-950 dark:text-white">Dashboard</h1>
+<p class="mt-2 break-words text-base text-gray-600 dark:text-gray-300">
+    Welcome back, {{ user.first_name or user.github_username }}.
+</p>
 {% endblock %}
 
 {% block page_body %}
-{# Primary verification progress and secondary learning progress. #}
-<div class="relative overflow-hidden p-5 rounded-xl bg-gradient-to-br from-blue-500 to-blue-600 dark:from-blue-600 dark:to-blue-800 mb-8 shadow">
-    <h2 class="text-lg font-bold text-white mb-1">Overall Progress</h2>
-    <p class="text-sm text-blue-100 mb-4">
-        {{ dashboard.phases_completed }} of {{ dashboard.total_phases }} phases complete.
-        Complete each phase's verification to progress.
-    </p>
-
-    <div class="mb-3">
-        <p class="text-sm font-medium text-white mb-1">Verification progress — {{ dashboard.verification_percentage | round(0) | int }}% of requirements</p>
-        <div
-            class="h-2.5 bg-white/20 rounded-full overflow-hidden"
-            role="progressbar"
-            aria-valuenow="{{ dashboard.verification_percentage | round(0) | int }}"
-            aria-valuemin="0"
-            aria-valuemax="100"
-            aria-label="Requirements verified: {{ dashboard.verification_percentage | round(0) | int }} percent"
-        >
-            <div class="h-full rounded-full transition-all {{ 'bg-green-400' if dashboard.is_program_complete else 'bg-white' }}" style="width: {{ dashboard.verification_percentage }}%"></div>
-        </div>
-    </div>
-
-    <div>
-        <p class="text-xs text-blue-100 mb-1">Learning progress — {{ dashboard.learning_percentage | round(0) | int }}% of learning steps</p>
-        <div
-            class="h-1.5 bg-white/20 rounded-full overflow-hidden"
-            role="progressbar"
-            aria-valuenow="{{ dashboard.learning_percentage | round(0) | int }}"
-            aria-valuemin="0"
-            aria-valuemax="100"
-            aria-label="Learning steps checked: {{ dashboard.learning_percentage | round(0) | int }} percent"
-        >
-            <div class="h-full rounded-full transition-all bg-white/70" style="width: {{ dashboard.learning_percentage }}%"></div>
-        </div>
-    </div>
-</div>
-
-{# ── Continue where you left off ──
-   Points at the first unchecked step's topic, or the phase's verification
-   section once every current step is checked. #}
 {% if dashboard.continue_phase %}
-<a href="{{ dashboard.continue_phase.destination_url }}" class="flex items-center justify-between p-4 rounded-lg border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors mb-6">
-    <div>
-        <p class="text-xs font-medium text-blue-600 dark:text-blue-400 mb-0.5">Continue where you left off</p>
-        <p class="text-sm font-semibold text-gray-900 dark:text-white">{{ dashboard.continue_phase.label }}</p>
+<section class="mb-10 rounded-lg border border-blue-200 bg-blue-50 p-5 dark:border-blue-800 dark:bg-blue-950/40" aria-labelledby="continue-heading">
+    <div class="flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-center">
+        <div class="min-w-0">
+            <h2 id="continue-heading" class="text-xl font-bold text-blue-950 dark:text-blue-100">Continue learning</h2>
+            <p class="mt-1 break-words text-sm leading-6 text-blue-800 dark:text-blue-200">{{ dashboard.continue_phase.label }}</p>
+        </div>
+        <a href="{{ dashboard.continue_phase.destination_url }}" class="inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">
+            Resume
+            <svg class="ml-2 h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
+            </svg>
+        </a>
     </div>
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-blue-500 dark:text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-    </svg>
-</a>
+</section>
+{% elif dashboard.is_program_complete and dashboard.phases %}
+<section class="mb-10 rounded-lg border border-green-200 bg-green-50 p-5 dark:border-green-800 dark:bg-green-950/30" aria-labelledby="complete-heading">
+    <h2 id="complete-heading" class="text-xl font-bold text-green-950 dark:text-green-100">You completed the program.</h2>
+    <p class="mt-2 text-sm leading-6 text-green-800 dark:text-green-200">Every phase verification is complete. Your dashboard remains available as a record of your work.</p>
+</section>
+{% elif dashboard.phases %}
+<section class="mb-10 rounded-lg border border-blue-200 bg-blue-50 p-5 dark:border-blue-800 dark:bg-blue-950/40" aria-labelledby="start-heading">
+    <div class="flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-center">
+        <div>
+            <h2 id="start-heading" class="text-xl font-bold text-blue-950 dark:text-blue-100">Start the curriculum</h2>
+            <p class="mt-1 text-sm leading-6 text-blue-800 dark:text-blue-200">Begin with Phase {{ dashboard.phases[0].order }}: {{ dashboard.phases[0].name }}.</p>
+        </div>
+        <a href="/phase/{{ dashboard.phases[0].order }}" class="inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">
+            Start Phase {{ dashboard.phases[0].order }}
+        </a>
+    </div>
+</section>
 {% endif %}
 
-{# ── Phase list ──
-   One state per phase (see PhaseProgress.status) and both counts as plain
-   text -- no per-row bar, so there's exactly one place (the hero above)
-   showing a percentage/bar for a given measure. #}
-<div class="space-y-3">
-    {% for phase in dashboard.phases %}
-    {% set p = phase.progress %}
-    <a href="/phase/{{ phase.order }}" class="block p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors {% if p and p.status == 'completed' %}border-l-3 border-l-green-500 dark:border-l-green-400{% elif p and p.status != 'not_started' %}border-l-3 border-l-blue-500 dark:border-l-blue-400{% endif %}">
-        <div class="flex items-center justify-between gap-3">
-            <div class="flex items-center gap-2.5 min-w-0">
-                <span class="flex items-center justify-center h-6 w-6 rounded-full text-xs font-semibold flex-shrink-0 {% if p and p.status == 'completed' %}bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400{% elif p and p.status != 'not_started' %}bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-400{% else %}bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500{% endif %}">{{ phase.order }}</span>
-                <h2 class="text-sm font-semibold text-gray-900 dark:text-white truncate">{{ phase.name }}</h2>
+{% if dashboard.phases %}
+<section class="mb-12" aria-labelledby="progress-heading">
+    <div class="flex flex-col justify-between gap-2 sm:flex-row sm:items-end">
+        <div>
+            <h2 id="progress-heading" class="text-xl font-bold text-gray-950 dark:text-white">Your progress</h2>
+            <p class="mt-1 text-sm leading-6 text-gray-600 dark:text-gray-400">
+                {{ dashboard.phases_completed }} of {{ dashboard.total_phases }} phases complete. Complete each phase's verification to progress.
+            </p>
+        </div>
+    </div>
+
+    <div class="mt-5 grid gap-6 border-y border-gray-200 py-6 dark:border-gray-700 sm:grid-cols-2 sm:gap-10">
+        <div>
+            <div class="flex items-baseline justify-between gap-4">
+                <p class="text-sm font-bold text-gray-950 dark:text-white">Verification progress</p>
+                <p class="text-sm font-bold text-blue-700 dark:text-blue-300">{{ dashboard.verification_percentage | round(0) | int }}%</p>
             </div>
-            <span class="text-xs font-medium shrink-0 {% if p and p.status == 'completed' %}text-green-600 dark:text-green-400{% else %}text-gray-500 dark:text-gray-400{% endif %}">
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Requirements verified</p>
+            <div
+                class="mt-3 h-2.5 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
+                role="progressbar"
+                aria-valuenow="{{ dashboard.verification_percentage | round(0) | int }}"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-label="Requirements verified: {{ dashboard.verification_percentage | round(0) | int }} percent"
+            >
+                <div class="h-full rounded-full {{ 'bg-green-500' if dashboard.is_program_complete else 'bg-blue-600' }} transition-all" style="width: {{ dashboard.verification_percentage }}%"></div>
+            </div>
+            <p class="sr-only">Verification progress — {{ dashboard.verification_percentage | round(0) | int }}% of requirements</p>
+        </div>
+
+        <div>
+            <div class="flex items-baseline justify-between gap-4">
+                <p class="text-sm font-bold text-gray-950 dark:text-white">Learning progress</p>
+                <p class="text-sm font-bold text-blue-700 dark:text-blue-300">{{ dashboard.learning_percentage | round(0) | int }}%</p>
+            </div>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Learning steps checked</p>
+            <div
+                class="mt-3 h-2.5 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
+                role="progressbar"
+                aria-valuenow="{{ dashboard.learning_percentage | round(0) | int }}"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-label="Learning steps checked: {{ dashboard.learning_percentage | round(0) | int }} percent"
+            >
+                <div class="h-full rounded-full bg-blue-400 transition-all dark:bg-blue-500" style="width: {{ dashboard.learning_percentage }}%"></div>
+            </div>
+            <p class="sr-only">Learning progress — {{ dashboard.learning_percentage | round(0) | int }}% of learning steps</p>
+        </div>
+    </div>
+</section>
+
+<section aria-labelledby="phase-progress-heading">
+    <div class="flex items-end justify-between gap-4">
+        <div>
+            <h2 id="phase-progress-heading" class="text-xl font-bold text-gray-950 dark:text-white">Phases</h2>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Open a phase to continue learning or complete verification.</p>
+        </div>
+        <a href="/curriculum" class="hidden min-h-11 items-center text-sm font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300 sm:inline-flex">
+            Full curriculum
+        </a>
+    </div>
+
+    <div class="mt-8">
+        {% for phase in dashboard.phases %}
+        {% set p = phase.progress %}
+        {% if loop.index0 == 0 or loop.index0 == 3 or loop.index0 == 6 %}
+        <div class="{% if not loop.first %}mt-10{% endif %} mb-2 flex items-center gap-4">
+            <h3 class="text-base font-bold text-gray-950 dark:text-white">
+                {% if loop.index0 == 0 %}Learn the systems{% elif loop.index0 == 3 %}Build and deploy{% else %}Secure and advance{% endif %}
+            </h3>
+            <div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>
+        </div>
+        {% endif %}
+
+        <a href="/phase/{{ phase.order }}" class="group grid min-h-11 grid-cols-[2.75rem_1fr] gap-4 {% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %} py-4 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 sm:grid-cols-[2.75rem_1fr_auto] sm:items-center">
+            {% if p and p.status == 'completed' %}
+            <span class="flex h-9 w-9 items-center justify-center rounded-full bg-green-100 text-xs font-bold text-green-800 dark:bg-green-950 dark:text-green-200">
+                {{ phase.order }}
+            </span>
+            {% elif p and p.status != 'not_started' %}
+            <span class="flex h-9 w-9 items-center justify-center rounded-full bg-blue-100 text-xs font-bold text-blue-800 dark:bg-blue-950 dark:text-blue-200">
+                {{ phase.order }}
+            </span>
+            {% else %}
+            <span class="flex h-9 w-9 items-center justify-center rounded-full bg-zinc-100 text-xs font-bold text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+                {{ phase.order }}
+            </span>
+            {% endif %}
+            <span class="min-w-0">
+                <span class="block text-sm font-bold text-gray-950 transition-colors group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ phase.name }}</span>
+                {% if p and (p.verification.requirements_required > 0 or p.learning.steps_required > 0) %}
+                <span class="mt-1 block text-xs leading-5 text-gray-500 dark:text-gray-400">
+                    {%- if p.verification.requirements_required > 0 -%}
+                    {{ p.verification.requirements_verified }}/{{ p.verification.requirements_required }} requirements verified
+                    {%- endif -%}
+                    {%- if p.verification.requirements_required > 0 and p.learning.steps_required > 0 %} · {% endif -%}
+                    {%- if p.learning.steps_required > 0 -%}
+                    {{ p.learning.steps_completed }}/{{ p.learning.steps_required }} steps checked
+                    {%- endif -%}
+                </span>
+                {% endif %}
+                <span class="mt-1 block text-xs font-bold sm:hidden {% if p and p.status == 'completed' %}text-green-700 dark:text-green-300{% elif p and p.status != 'not_started' %}text-blue-700 dark:text-blue-300{% else %}text-gray-500 dark:text-gray-400{% endif %}">
+                    {% if not p or p.status == 'not_started' %}
+                    Not started
+                    {% elif p.status == 'completed' %}
+                    Complete
+                    {% elif p.status == 'learning_complete' %}
+                    Ready for verification
+                    {% elif p.status == 'verification_complete' %}
+                    Steps remaining
+                    {% else %}
+                    In progress
+                    {% endif %}
+                </span>
+            </span>
+            <span class="hidden text-xs font-bold sm:block {% if p and p.status == 'completed' %}text-green-700 dark:text-green-300{% elif p and p.status != 'not_started' %}text-blue-700 dark:text-blue-300{% else %}text-gray-500 dark:text-gray-400{% endif %}">
                 {% if not p or p.status == 'not_started' %}
                 Not started
                 {% elif p.status == 'completed' %}
-                Complete ✓
+                Complete
                 {% elif p.status == 'learning_complete' %}
                 Ready for verification
                 {% elif p.status == 'verification_complete' %}
@@ -84,39 +173,50 @@
                 In progress
                 {% endif %}
             </span>
-        </div>
-        {% if p and (p.verification.requirements_required > 0 or p.learning.steps_required > 0) %}
-        <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
-            {%- if p.verification.requirements_required > 0 -%}
-            {{ p.verification.requirements_verified }}/{{ p.verification.requirements_required }} requirements verified
-            {%- endif -%}
-            {%- if p.verification.requirements_required > 0 and p.learning.steps_required > 0 %} · {% endif -%}
-            {%- if p.learning.steps_required > 0 -%}
-            {{ p.learning.steps_completed }}/{{ p.learning.steps_required }} steps checked
-            {%- endif -%}
-        </p>
-        {% endif %}
-    </a>
-    {% endfor %}
-</div>
+        </a>
+        {% endfor %}
+    </div>
 
-{# ── Need Help? ── #}
-<div class="mt-16 p-6 rounded-lg bg-gray-50 dark:bg-gray-800/50">
-    <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Need Help?</h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+    <a href="/curriculum" class="mt-6 inline-flex min-h-11 items-center text-sm font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300 sm:hidden">
+        Full curriculum
+    </a>
+</section>
+{% else %}
+<section class="rounded-lg border border-gray-200 bg-gray-50 p-8 dark:border-gray-700 dark:bg-gray-800/50" aria-labelledby="dashboard-empty-heading">
+    <h2 id="dashboard-empty-heading" class="text-xl font-bold text-gray-950 dark:text-white">Progress is temporarily unavailable.</h2>
+    <p class="mt-2 max-w-xl text-sm leading-6 text-gray-600 dark:text-gray-300">The curriculum did not load. Try again, or open the curriculum to keep learning.</p>
+    <div class="mt-5 flex flex-wrap gap-4">
+        <a href="/dashboard" hx-boost="false" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">Try again</a>
+        <a href="/curriculum" class="inline-flex min-h-11 items-center text-sm font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">Open curriculum</a>
+    </div>
+</section>
+{% endif %}
+
+<section class="mt-14 border-t border-gray-200 pt-8 dark:border-gray-700" aria-labelledby="help-heading">
+    <h2 id="help-heading" class="text-lg font-bold text-gray-950 dark:text-white">Need help?</h2>
+    <div class="mt-4 flex flex-wrap gap-3">
         {% for link in help_links %}
+        {% if link.label == "Discord" or link.label == "Report an Issue" %}
         <a
             href="{{ link.url }}"
             {% if link.label == "Report an Issue" %}data-report-issue data-issue-title="Issue: Dashboard" data-issue-labels="bug" data-issue-context="page=dashboard"{% endif %}
             target="_blank"
             rel="noopener noreferrer"
-            class="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-white dark:hover:bg-gray-800 transition-colors"
+            class="inline-flex min-h-11 items-center gap-2 rounded-md border border-gray-300 px-3 py-2 text-sm font-bold text-gray-700 transition-colors hover:border-blue-400 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:text-gray-200 dark:hover:border-blue-500 dark:hover:text-blue-300"
         >
             <span class="h-5 w-5 shrink-0 {{ link.color }}" aria-hidden="true">{{ link.icon | safe }}</span>
-            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ link.label }}</span>
+            <span>{% if link.label == "Discord" %}Ask on Discord{% else %}{{ link.label }}{% endif %}</span>
         </a>
+        {% endif %}
         {% endfor %}
     </div>
-</div>
-
+    <p class="mt-5 text-sm text-gray-500 dark:text-gray-400">
+        Updates:
+        {% for link in help_links %}
+        {% if link.label != "Discord" and link.label != "Report an Issue" %}
+        <a href="{{ link.url }}" target="_blank" rel="noopener noreferrer" class="ml-2 inline-flex min-h-11 items-center font-medium underline underline-offset-4 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:text-blue-300">{{ link.label }}</a>
+        {% endif %}
+        {% endfor %}
+    </p>
+</section>
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/home.html
+++ b/api/src/learn_to_cloud/templates/pages/home.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% set footer_margin = "mt-8" %}
 {% block title %}Learn to Cloud - Your Path to Cloud Computing{% endblock %}
 {% block description %}Learn cloud computing through a structured path of fundamentals, hands-on projects, and verified skills.{% endblock %}
 
@@ -24,59 +25,66 @@
                     </svg>
                 </a>
                 {% else %}
-                <a href="/auth/login" hx-boost="false" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-5 py-2.5 text-base font-semibold text-white shadow-sm shadow-blue-950/20 transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
-                    Start with GitHub
+                <a href="/curriculum" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-5 py-2.5 text-base font-semibold text-white shadow-sm shadow-blue-950/20 transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
+                    Explore the curriculum
                     <svg class="ml-2 h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
                     </svg>
                 </a>
                 {% endif %}
-                <a href="/curriculum" class="inline-flex min-h-11 items-center px-2 text-base font-semibold text-gray-700 underline decoration-gray-300 underline-offset-4 transition-colors hover:text-blue-700 hover:decoration-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-200 dark:decoration-gray-600 dark:hover:text-blue-300">
-                    Explore the curriculum
+                <a href="#journey-heading" class="inline-flex min-h-11 items-center px-2 text-base font-semibold text-gray-700 underline decoration-gray-300 underline-offset-4 transition-colors hover:text-blue-700 hover:decoration-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-200 dark:decoration-gray-600 dark:hover:text-blue-300">
+                    See the learning path
                 </a>
             </div>
-
-            <p class="mt-5 text-sm font-medium text-gray-500 dark:text-gray-400">
-                Start at Phase 0 <span class="mx-2 text-gray-300 dark:text-gray-600">·</span> Follow the path <span class="mx-2 text-gray-300 dark:text-gray-600">·</span> Verify your work
-            </p>
         </div>
 
-        <div class="relative mx-auto w-full max-w-sm" aria-label="Learning path: foundations, projects, deployment, and verified skills">
-            <div class="absolute bottom-8 left-[1.1875rem] top-8 w-px bg-blue-200 dark:bg-blue-800" aria-hidden="true"></div>
-            <ol class="relative space-y-2">
-                {% set path_steps = [
-                    ("Foundations", "Build the technical base"),
-                    ("Projects", "Practice with real systems"),
-                    ("Cloud", "Deploy and operate"),
-                    ("Proof", "Verify what you can do")
+        <div class="mx-auto w-full max-w-sm">
+            <h2 class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">A complete learning system.</h2>
+            <ul class="mt-5 divide-y divide-blue-100 border-y border-blue-100 dark:divide-blue-900 dark:border-blue-900">
+                {% set capabilities = [
+                    ("Curriculum", "Follow a phase-by-phase route from foundations to career."),
+                    ("Progress tracking", "Resume from your dashboard and see what is complete."),
+                    ("Hands-on labs", "Build with Linux, cloud CLIs, APIs, and infrastructure."),
+                    ("Verification", "Submit proof and get your work checked.")
                 ] %}
-                {% for title, detail in path_steps %}
-                <li class="grid grid-cols-[2.5rem_1fr] items-center gap-4 py-3">
-                    <span class="relative z-10 flex h-10 w-10 items-center justify-center rounded-full border-2 {% if loop.first %}border-blue-700 bg-blue-700 text-white dark:border-blue-400 dark:bg-blue-400 dark:text-blue-950{% else %}border-blue-200 bg-white text-blue-700 dark:border-blue-700 dark:bg-gray-900 dark:text-blue-300{% endif %}">
-                        {% if loop.last %}
-                        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="m5.5 10 3 3 6-6"/>
+                {% for title, detail in capabilities %}
+                <li class="grid grid-cols-[2.75rem_1fr] gap-4 py-4">
+                    <span class="flex h-10 w-10 items-center justify-center rounded-md bg-blue-50 text-blue-800 dark:bg-blue-950 dark:text-blue-200" aria-hidden="true">
+                        {% if loop.index == 1 %}
+                        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 4.5h4.25A2.75 2.75 0 0 1 11 7.25V16a2.75 2.75 0 0 0-2.75-2.75H4V4.5Zm12 0h-2.25A2.75 2.75 0 0 0 11 7.25V16a2.75 2.75 0 0 1 2.75-2.75H16V4.5Z"/>
+                        </svg>
+                        {% elif loop.index == 2 %}
+                        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 15V9m4 6V5m4 10v-4m4 4V7"/>
+                        </svg>
+                        {% elif loop.index == 3 %}
+                        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m7 5-4 5 4 5m6-10 4 5-4 5m-3.5 1.5 2-13"/>
                         </svg>
                         {% else %}
-                        <span class="text-xs font-bold">{{ loop.index }}</span>
+                        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M10 2.75 16 5v4.5c0 3.5-2.5 6.25-6 7.75-3.5-1.5-6-4.25-6-7.75V5l6-2.25Z"/>
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m7.25 10 1.75 1.75 3.75-4"/>
+                        </svg>
                         {% endif %}
                     </span>
                     <span>
                         <span class="block text-base font-bold text-gray-950 dark:text-white">{{ title }}</span>
-                        <span class="mt-0.5 block text-sm text-gray-500 dark:text-gray-400">{{ detail }}</span>
+                        <span class="mt-1 block text-sm leading-5 text-gray-600 dark:text-gray-400">{{ detail }}</span>
                     </span>
                 </li>
                 {% endfor %}
-            </ol>
+            </ul>
         </div>
     </div>
 </section>
 
 {% if phases %}
-<section class="py-16 sm:py-20" aria-labelledby="journey-heading">
+<section class="pb-0 pt-16 sm:pt-20" aria-labelledby="journey-heading">
     <div class="max-w-2xl">
         <h2 id="journey-heading" class="text-balance text-3xl font-bold tracking-[-0.025em] text-gray-950 dark:text-white sm:text-4xl">
-            One path. Skills that build on each other.
+            The curriculum, phase by phase.
         </h2>
         <p class="mt-4 text-lg leading-8 text-gray-600 dark:text-gray-300">
             Begin with the fundamentals, then use them to build, deploy, secure, and explain real cloud work.
@@ -127,7 +135,7 @@
     </div>
 </section>
 {% else %}
-<section class="py-16 sm:py-20" aria-labelledby="journey-heading">
+<section class="pb-0 pt-16 sm:pt-20" aria-labelledby="journey-heading">
     <div class="rounded-lg border border-gray-200 bg-gray-50 p-8 dark:border-gray-700 dark:bg-gray-800/50">
         <h2 id="journey-heading" class="text-2xl font-bold text-gray-950 dark:text-white">The learning path is temporarily unavailable.</h2>
         <p class="mt-3 max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-300">

--- a/api/src/learn_to_cloud/templates/pages/home.html
+++ b/api/src/learn_to_cloud/templates/pages/home.html
@@ -1,48 +1,147 @@
 {% extends "base.html" %}
 {% block title %}Learn to Cloud - Your Path to Cloud Computing{% endblock %}
+{% block description %}Learn cloud computing through a structured path of fundamentals, hands-on projects, and verified skills.{% endblock %}
 
 {% block content %}
-<div class="text-center py-8 sm:py-12">
-    <img src="{{ static_url('logo.svg') }}" alt="Learn to Cloud" class="h-24 sm:h-32 mx-auto mb-6">
-    <p class="mt-4 text-lg leading-8 text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-        A structured, hands-on guide to learning cloud computing. Follow the phases, complete the challenges, and prove your skills.
-    </p>
-    <div class="mt-6 flex items-center justify-center gap-x-6">
-        {% if user %}
-        <a href="/dashboard" class="rounded-md bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-blue-500">
-            Go to Dashboard →
-        </a>
-        {% else %}
-        <a href="/auth/login" hx-boost="false" class="rounded-md bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-blue-500">
-            Get Started →
-        </a>
-        {% endif %}
-    </div>
-</div>
+<section class="relative overflow-hidden border-b border-gray-200 pb-16 pt-6 dark:border-gray-700 sm:pb-20 sm:pt-12">
+    <div class="absolute right-0 top-8 -z-10 h-56 w-56 rounded-full bg-blue-100/70 blur-3xl dark:bg-blue-950/50" aria-hidden="true"></div>
 
-{% if phases %}
-<div class="mt-4">
-    <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-6 text-center">Your Journey</h2>
-    <div class="grid gap-3 sm:grid-cols-2">
-        {% for phase in phases %}
-        <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
-            <div class="flex items-center gap-2 mb-1">
-                <span class="text-sm font-medium text-gray-400 dark:text-gray-500">{{ phase.order }}</span>
-                <h3 class="text-base font-semibold text-gray-900 dark:text-white">
-                    {{ phase.name }}
-                </h3>
+    <div class="grid items-center gap-12 lg:grid-cols-[minmax(0,1.2fr)_minmax(17rem,0.8fr)]">
+        <div>
+            <h1 class="max-w-3xl text-balance text-4xl font-bold tracking-[-0.035em] text-gray-950 dark:text-white sm:text-6xl sm:leading-[1.05]">
+                From first command to production cloud system.
+            </h1>
+            <p class="mt-6 max-w-2xl text-lg leading-8 text-gray-600 dark:text-gray-300">
+                Build a Journal API, deploy it to your cloud, automate it, harden it, and prove your skills along the way.
+            </p>
+
+            <div class="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+                {% if user %}
+                <a href="/dashboard" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-5 py-2.5 text-base font-semibold text-white shadow-sm shadow-blue-950/20 transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
+                    Continue to your dashboard
+                    <svg class="ml-2 h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
+                    </svg>
+                </a>
+                {% else %}
+                <a href="/auth/login" hx-boost="false" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-5 py-2.5 text-base font-semibold text-white shadow-sm shadow-blue-950/20 transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
+                    Start with GitHub
+                    <svg class="ml-2 h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
+                    </svg>
+                </a>
+                {% endif %}
+                <a href="/curriculum" class="inline-flex min-h-11 items-center px-2 text-base font-semibold text-gray-700 underline decoration-gray-300 underline-offset-4 transition-colors hover:text-blue-700 hover:decoration-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-200 dark:decoration-gray-600 dark:hover:text-blue-300">
+                    Explore the curriculum
+                </a>
             </div>
-            <p class="text-sm leading-relaxed text-gray-500 dark:text-gray-400">
-                {{ phase.short_description | default(phase.description[:120] + '...' if phase.description | length > 120 else phase.description) }}
+
+            <p class="mt-5 text-sm font-medium text-gray-500 dark:text-gray-400">
+                Start at Phase 0 <span class="mx-2 text-gray-300 dark:text-gray-600">·</span> Follow the path <span class="mx-2 text-gray-300 dark:text-gray-600">·</span> Verify your work
             </p>
         </div>
+
+        <div class="relative mx-auto w-full max-w-sm" aria-label="Learning path: foundations, projects, deployment, and verified skills">
+            <div class="absolute bottom-8 left-[1.1875rem] top-8 w-px bg-blue-200 dark:bg-blue-800" aria-hidden="true"></div>
+            <ol class="relative space-y-2">
+                {% set path_steps = [
+                    ("Foundations", "Build the technical base"),
+                    ("Projects", "Practice with real systems"),
+                    ("Cloud", "Deploy and operate"),
+                    ("Proof", "Verify what you can do")
+                ] %}
+                {% for title, detail in path_steps %}
+                <li class="grid grid-cols-[2.5rem_1fr] items-center gap-4 py-3">
+                    <span class="relative z-10 flex h-10 w-10 items-center justify-center rounded-full border-2 {% if loop.first %}border-blue-700 bg-blue-700 text-white dark:border-blue-400 dark:bg-blue-400 dark:text-blue-950{% else %}border-blue-200 bg-white text-blue-700 dark:border-blue-700 dark:bg-gray-900 dark:text-blue-300{% endif %}">
+                        {% if loop.last %}
+                        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="m5.5 10 3 3 6-6"/>
+                        </svg>
+                        {% else %}
+                        <span class="text-xs font-bold">{{ loop.index }}</span>
+                        {% endif %}
+                    </span>
+                    <span>
+                        <span class="block text-base font-bold text-gray-950 dark:text-white">{{ title }}</span>
+                        <span class="mt-0.5 block text-sm text-gray-500 dark:text-gray-400">{{ detail }}</span>
+                    </span>
+                </li>
+                {% endfor %}
+            </ol>
+        </div>
+    </div>
+</section>
+
+{% if phases %}
+<section class="py-16 sm:py-20" aria-labelledby="journey-heading">
+    <div class="max-w-2xl">
+        <h2 id="journey-heading" class="text-balance text-3xl font-bold tracking-[-0.025em] text-gray-950 dark:text-white sm:text-4xl">
+            One path. Skills that build on each other.
+        </h2>
+        <p class="mt-4 text-lg leading-8 text-gray-600 dark:text-gray-300">
+            Begin with the fundamentals, then use them to build, deploy, secure, and explain real cloud work.
+        </p>
+    </div>
+
+    <div class="mt-12">
+        {% for phase in phases %}
+        {% if loop.index0 == 0 or loop.index0 == 3 or loop.index0 == 6 %}
+        <div class="{% if not loop.first %}mt-12{% endif %} mb-3 flex items-center gap-4" aria-hidden="true">
+            <p class="text-xs font-bold uppercase tracking-[0.16em] text-blue-700 dark:text-blue-300">
+                {% if loop.index0 == 0 %}Learn the systems{% elif loop.index0 == 3 %}Build and deploy{% else %}Secure and advance{% endif %}
+            </p>
+            <div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>
+        </div>
+        {% endif %}
+        <a href="/phase/{{ phase.order }}" class="group grid grid-cols-[3rem_1fr_auto] gap-4 border-b border-gray-200 py-6 transition-colors hover:border-blue-300 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:border-gray-700 dark:hover:border-blue-700 sm:grid-cols-[4rem_1fr_auto] sm:gap-6">
+            <span class="flex h-11 w-11 items-center justify-center rounded-full {% if loop.first %}bg-blue-700 text-white dark:bg-blue-400 dark:text-blue-950{% else %}bg-blue-50 text-blue-800 group-hover:bg-blue-100 group-hover:text-blue-900 dark:bg-blue-950 dark:text-blue-200 dark:group-hover:bg-blue-900 dark:group-hover:text-blue-100{% endif %} text-sm font-bold transition-colors">
+                {{ phase.order }}
+            </span>
+            <div class="min-w-0">
+                <div class="flex flex-wrap items-center gap-2">
+                    <h3 class="text-lg font-bold text-gray-950 dark:text-white">{{ phase.name }}</h3>
+                    {% if loop.first %}
+                    <span class="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-bold text-blue-800 dark:bg-blue-950 dark:text-blue-200">Start here</span>
+                    {% endif %}
+                </div>
+                <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
+                    {{ phase.short_description | default(phase.description[:160] + '...' if phase.description | length > 160 else phase.description) }}
+                </p>
+            </div>
+            <span class="mt-3 hidden text-blue-700 transition-transform group-hover:translate-x-1 dark:text-blue-300 sm:block" aria-hidden="true">
+                <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
+                </svg>
+            </span>
+        </a>
         {% endfor %}
     </div>
-    <div class="mt-6 text-center">
-        <a href="/curriculum" class="text-base font-medium text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300">
-            View full curriculum →
+
+    <div class="mt-10 flex flex-col items-start justify-between gap-5 border-t border-gray-200 pt-8 dark:border-gray-700 sm:flex-row sm:items-center">
+        <p class="max-w-xl text-base leading-7 text-gray-600 dark:text-gray-300">
+            Ready to see every topic, project, and verification challenge?
+        </p>
+        <a href="/curriculum" class="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-300 px-4 py-2.5 text-sm font-bold text-gray-900 transition-colors hover:border-blue-500 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:text-white dark:hover:border-blue-400 dark:hover:text-blue-300">
+            View the full curriculum
         </a>
     </div>
-</div>
+</section>
+{% else %}
+<section class="py-16 sm:py-20" aria-labelledby="journey-heading">
+    <div class="rounded-lg border border-gray-200 bg-gray-50 p-8 dark:border-gray-700 dark:bg-gray-800/50">
+        <h2 id="journey-heading" class="text-2xl font-bold text-gray-950 dark:text-white">The learning path is temporarily unavailable.</h2>
+        <p class="mt-3 max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-300">
+            The curriculum did not load. Try again, or visit the FAQ for more information about Learn to Cloud.
+        </p>
+        <div class="mt-5 flex flex-wrap items-center gap-4">
+            <a href="/" hx-boost="false" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
+                Try again
+            </a>
+            <a href="/faq" class="inline-flex min-h-11 items-center font-semibold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">
+                Visit the FAQ
+            </a>
+        </div>
+    </div>
+</section>
 {% endif %}
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/home.html
+++ b/api/src/learn_to_cloud/templates/pages/home.html
@@ -13,7 +13,7 @@
                 From first command to production cloud system.
             </h1>
             <p class="mt-6 max-w-2xl text-lg leading-8 text-gray-600 dark:text-gray-300">
-                Build a Journal API, deploy it to your cloud, automate it, harden it, and prove your skills along the way.
+                Build an API, deploy it to your cloud, automate it, harden it, and prove your skills along the way.
             </p>
 
             <div class="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:items-center">
@@ -25,16 +25,18 @@
                     </svg>
                 </a>
                 {% else %}
-                <a href="/curriculum" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-5 py-2.5 text-base font-semibold text-white shadow-sm shadow-blue-950/20 transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
-                    Explore the curriculum
+                <a href="#journey-heading" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-5 py-2.5 text-base font-semibold text-white shadow-sm shadow-blue-950/20 transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
+                    See the curriculum
                     <svg class="ml-2 h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
                     </svg>
                 </a>
                 {% endif %}
+                {% if user %}
                 <a href="#journey-heading" class="inline-flex min-h-11 items-center px-2 text-base font-semibold text-gray-700 underline decoration-gray-300 underline-offset-4 transition-colors hover:text-blue-700 hover:decoration-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-200 dark:decoration-gray-600 dark:hover:text-blue-300">
-                    See the learning path
+                    Review the curriculum
                 </a>
+                {% endif %}
             </div>
         </div>
 
@@ -101,7 +103,7 @@
             <div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>
         </div>
         {% endif %}
-        <a href="/phase/{{ phase.order }}" class="group grid grid-cols-[3rem_1fr_auto] gap-4 border-b border-gray-200 py-6 transition-colors hover:border-blue-300 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:border-gray-700 dark:hover:border-blue-700 sm:grid-cols-[4rem_1fr_auto] sm:gap-6">
+        <a href="/phase/{{ phase.order }}" class="group grid grid-cols-[3rem_1fr_auto] gap-4 {% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %} py-6 transition-colors hover:border-blue-300 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:hover:border-blue-700 sm:grid-cols-[4rem_1fr_auto] sm:gap-6">
             <span class="flex h-11 w-11 items-center justify-center rounded-full {% if loop.first %}bg-blue-700 text-white dark:bg-blue-400 dark:text-blue-950{% else %}bg-blue-50 text-blue-800 group-hover:bg-blue-100 group-hover:text-blue-900 dark:bg-blue-950 dark:text-blue-200 dark:group-hover:bg-blue-900 dark:group-hover:text-blue-100{% endif %} text-sm font-bold transition-colors">
                 {{ phase.order }}
             </span>
@@ -125,7 +127,7 @@
         {% endfor %}
     </div>
 
-    <div class="mt-10 flex flex-col items-start justify-between gap-5 border-t border-gray-200 pt-8 dark:border-gray-700 sm:flex-row sm:items-center">
+    <div class="mt-6 flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-center">
         <p class="max-w-xl text-base leading-7 text-gray-600 dark:text-gray-300">
             Ready to see every topic, project, and verification challenge?
         </p>

--- a/api/src/learn_to_cloud/templates/pages/phase.html
+++ b/api/src/learn_to_cloud/templates/pages/phase.html
@@ -1,14 +1,25 @@
 {% extends "base.html" %}
+{% set footer_margin = "mt-8" %}
 {% from "macros/badges.html" import status_pill %}
 {% block title %}{{ phase.name }} - Learn to Cloud{% endblock %}
 
 {% block content %}
-<div class="mb-8">
-    <div class="flex items-center gap-3 mb-2 flex-wrap">
-        <h1 class="text-3xl font-bold text-gray-900 dark:text-white">{{ phase.name }}</h1>
+<nav class="mb-6 flex min-h-11 flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400" aria-label="Breadcrumb">
+    <a href="/curriculum" class="inline-flex min-h-11 items-center font-medium hover:text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:text-blue-300">Curriculum</a>
+    <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m8 5 5 5-5 5"/>
+    </svg>
+    <span aria-current="page">Phase {{ phase.order }}</span>
+</nav>
+
+<header class="border-b border-gray-200 pb-10 dark:border-gray-700 sm:pb-12">
+    <div class="flex flex-wrap items-center gap-3">
+        <h1 class="text-balance text-3xl font-bold tracking-[-0.03em] text-gray-950 dark:text-white sm:text-4xl">
+            Phase {{ phase.order }}: {{ phase.name }}
+        </h1>
         {% if phase_progress %}
         {% if phase_progress.status == 'completed' %}
-        {{ status_pill("Phase complete ✓", "success") }}
+        {{ status_pill("Phase complete", "success") }}
         {% elif phase_progress.status == 'learning_complete' %}
         {{ status_pill("Ready for verification", "info") }}
         {% elif phase_progress.status == 'verification_complete' %}
@@ -16,10 +27,29 @@
         {% endif %}
         {% endif %}
     </div>
-    <div class="mt-2 text-gray-600 dark:text-gray-400 [&>p]:m-0 phase-description">{{ phase.description | md | safe }}</div>
+    <div class="phase-description mt-4 max-w-3xl text-base leading-7 text-gray-600 dark:text-gray-300 [&>p]:m-0">{{ phase.description | md | safe }}</div>
+
+    {% set next_topic = namespace(item=none) %}
+    {% for topic in topics %}
+    {% if next_topic.item is none and (not topic.progress or topic.progress.completed < topic.progress.total) %}
+    {% set next_topic.item = topic %}
+    {% endif %}
+    {% endfor %}
+
+    {% if next_topic.item %}
+    <div class="mt-7 flex flex-col items-start justify-between gap-4 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/40 sm:flex-row sm:items-center">
+        <div class="min-w-0">
+            <p class="text-sm font-bold text-blue-950 dark:text-blue-100">Continue learning</p>
+            <p class="mt-1 break-words text-sm text-blue-800 dark:text-blue-200">{{ next_topic.item.name }}</p>
+        </div>
+        <a href="/phase/{{ phase.order }}/{{ next_topic.item.slug }}" class="inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">
+            Open topic
+        </a>
+    </div>
+    {% endif %}
 
     {% if phase_progress %}
-    <div class="mt-4 space-y-2 max-w-md">
+    <div class="mt-6 grid gap-4 sm:grid-cols-2 sm:gap-8">
         {% if phase_progress.verification.requirements_required > 0 %}
         {% with
             value=phase_progress.verification.percentage,
@@ -42,20 +72,23 @@
         {% endif %}
     </div>
     {% endif %}
-</div>
+</header>
 
-<div class="mb-12">
-    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-4">Topics</h2>
-    <div class="space-y-3">
+<section class="pt-12 sm:pt-14" aria-labelledby="topics-heading">
+    <div>
+        <h2 id="topics-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Topics</h2>
+        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Work through the learning steps in order, then return here for verification.</p>
+    </div>
+
+    {% if topics %}
+    <div class="mt-6 border-y border-gray-200 dark:border-gray-700">
         {% for topic in topics %}
-        <a href="/phase/{{ phase.order }}/{{ topic.slug }}" class="flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-blue-500 dark:hover:border-blue-400 transition-colors">
-            <div class="flex items-center gap-3">
-                <span class="font-medium text-gray-900 dark:text-gray-100">{{ topic.name }}</span>
-            </div>
+        <a href="/phase/{{ phase.order }}/{{ topic.slug }}" class="group grid min-h-11 grid-cols-[2.75rem_1fr] gap-3 {% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %} py-4 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 sm:grid-cols-[2.75rem_1fr_auto] sm:items-center sm:gap-4">
+            <span class="flex h-9 w-9 items-center justify-center rounded-full bg-blue-50 text-xs font-bold text-blue-800 dark:bg-blue-950 dark:text-blue-200">{{ loop.index }}</span>
+            <span class="min-w-0 break-words text-sm font-bold text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ topic.name }}</span>
             {% if topic.progress %}
-            <span class="text-sm flex items-center gap-1.5 {% if topic.progress.completed == topic.progress.total and topic.progress.total > 0 %}text-green-600 dark:text-green-400 font-medium{% else %}text-gray-500 dark:text-gray-400{% endif %}">
+            <span class="col-start-2 text-xs font-bold sm:col-start-auto {% if topic.progress.completed == topic.progress.total and topic.progress.total > 0 %}text-green-700 dark:text-green-300{% else %}text-gray-500 dark:text-gray-400{% endif %}">
                 {% if topic.progress.completed == topic.progress.total and topic.progress.total > 0 %}
-                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
                 Complete
                 {% else %}
                 {{ topic.progress.completed }}/{{ topic.progress.total }} steps
@@ -65,54 +98,60 @@
         </a>
         {% endfor %}
     </div>
-</div>
+    {% else %}
+    <div class="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
+        <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">Topics for this phase are being prepared.</p>
+    </div>
+    {% endif %}
+</section>
 
 {% if requirements %}
-<div id="verification-section">
-    <h2 class="text-xl font-semibold text-gray-900 dark:text-white mb-4">Hands-on Verification</h2>
+<section id="verification-section" class="mt-14 border-t border-gray-200 pt-12 dark:border-gray-700 sm:mt-16 sm:pt-14" aria-labelledby="verification-heading">
+    <h2 id="verification-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Hands-on verification</h2>
+    <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">Submit proof of the work you completed in this phase. Requirements unlock in sequence.</p>
 
     {% if verification_locked %}
-    {# Phase verification is gated — prerequisite phase not yet complete #}
-    <div class="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-4 mb-4">
+    <div class="mb-6 mt-6 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
         <div class="flex items-start gap-3">
-            <span class="text-amber-500 dark:text-amber-400 text-lg mt-0.5" aria-hidden="true">🔒</span>
+            <svg class="mt-0.5 h-5 w-5 shrink-0 text-amber-700 dark:text-amber-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+                <rect x="4.5" y="8.5" width="11" height="8" rx="1.5"/>
+                <path stroke-linecap="round" d="M7 8.5V6a3 3 0 0 1 6 0v2.5"/>
+            </svg>
             <div>
-                <p class="text-sm font-medium text-amber-800 dark:text-amber-200">
-                    Phase {{ prerequisite_phase_id }} verification required
-                </p>
-                <p class="text-sm text-amber-700 dark:text-amber-300 mt-1">
-                    Complete all hands-on verifications in
-                    <a href="/phase/{{ prerequisite_phase_id }}" class="underline hover:no-underline font-medium">Phase {{ prerequisite_phase_id }}</a>
+                <p class="text-sm font-bold text-amber-950 dark:text-amber-100">Phase {{ prerequisite_phase_id }} verification required</p>
+                <p class="mt-1 text-sm leading-6 text-amber-800 dark:text-amber-200">
+                    Complete every hands-on verification in
+                    <a href="/phase/{{ prerequisite_phase_id }}" class="font-bold underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-700">Phase {{ prerequisite_phase_id }}</a>
                     before submitting here.
                 </p>
             </div>
         </div>
     </div>
-    <div class="space-y-2">
+    <div class="space-y-3">
         {% for req in requirements %}
         {% set card = card_contexts_by_req[req.slug] %}
         {% if card.card_state == 'passed' %}
-        {# Already validated before the phase was gated — keep showing it as
-           verified so the card matches the progress bar above. #}
         {% include "partials/verified_requirement_row.html" %}
         {% else %}
-        <div class="flex items-center gap-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 px-4 py-2.5 opacity-50">
-            <span class="text-gray-400 dark:text-gray-500" aria-hidden="true">🔒</span>
-            <span class="text-sm text-gray-500 dark:text-gray-400">{{ req.name }}</span>
+        <div class="flex min-h-11 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+            <svg class="h-5 w-5 shrink-0 text-gray-500 dark:text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+                <rect x="4.5" y="8.5" width="11" height="8" rx="1.5"/>
+                <path stroke-linecap="round" d="M7 8.5V6a3 3 0 0 1 6 0v2.5"/>
+            </svg>
+            <span class="min-w-0 flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">{{ req.name }}</span>
+            <span class="text-xs font-bold text-gray-500 dark:text-gray-400">Locked</span>
         </div>
         {% endif %}
         {% endfor %}
     </div>
     {% else %}
     {% set ns = namespace(found_active=false) %}
-    <div class="space-y-2">
+    <div class="mt-6 space-y-3">
         {% for req in requirements %}
         {% set card = card_contexts_by_req[req.slug] %}
         {% if card.card_state == 'passed' %}
-        {# Compact verified row, with expandable feedback explaining why it passed #}
         {% include "partials/verified_requirement_row.html" %}
         {% elif not ns.found_active %}
-        {# First incomplete — show the full interactive card #}
         {% set ns.found_active = true %}
         {% with
             requirement=card.requirement,
@@ -132,15 +171,23 @@
         {% include "partials/requirement_card.html" %}
         {% endwith %}
         {% else %}
-        {# Future requirements — compact, not-yet-reached row #}
-        <div class="flex items-center gap-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 px-4 py-2.5 opacity-50">
-            <span class="text-gray-400 dark:text-gray-500" aria-hidden="true">○</span>
-            <span class="text-sm text-gray-500 dark:text-gray-400">{{ req.name }}</span>
+        <div class="flex min-h-11 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+            <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-gray-400 text-xs text-gray-500 dark:border-gray-500 dark:text-gray-400" aria-hidden="true">{{ loop.index }}</span>
+            <span class="min-w-0 flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">{{ req.name }}</span>
+            <span class="text-xs font-bold text-gray-500 dark:text-gray-400">Up next</span>
         </div>
         {% endif %}
         {% endfor %}
     </div>
     {% endif %}
-</div>
+</section>
+{% endif %}
+
+{% if phase_progress and phase_progress.status == 'completed' %}
+<section class="mt-14 border-t border-gray-200 pt-8 dark:border-gray-700" aria-labelledby="phase-complete-heading">
+    <h2 id="phase-complete-heading" class="text-xl font-bold text-gray-950 dark:text-white">Phase complete</h2>
+    <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Your learning steps and verification work are complete.</p>
+    <a href="/dashboard" class="mt-4 inline-flex min-h-11 items-center font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">Return to dashboard</a>
+</section>
 {% endif %}
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/topic.html
+++ b/api/src/learn_to_cloud/templates/pages/topic.html
@@ -1,90 +1,109 @@
 {% extends "layouts/content_page.html" %}
+{% set footer_margin = "mt-8" %}
 {% block title %}{{ topic.name }} - Learn to Cloud{% endblock %}
 
 {% block breadcrumb %}
-<nav class="mb-4 text-sm text-gray-500 dark:text-gray-400">
-    <a href="/phase/{{ phase_id }}" class="hover:text-gray-700 dark:hover:text-gray-200">{{ phase_name }}</a>
-    <span class="mx-2">/</span>
-    <span class="text-gray-900 dark:text-gray-100">{{ topic.name }}</span>
+<nav class="mb-4 flex min-h-11 flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400" aria-label="Breadcrumb">
+    <a href="/curriculum" class="inline-flex min-h-11 items-center font-medium hover:text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:text-blue-300">Curriculum</a>
+    <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m8 5 5 5-5 5"/></svg>
+    <a href="/phase/{{ phase_id }}" class="inline-flex min-h-11 items-center font-medium hover:text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:text-blue-300">{{ phase_name }}</a>
+    <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m8 5 5 5-5 5"/></svg>
+    <span aria-current="page">{{ topic.name }}</span>
 </nav>
 {% endblock %}
 
 {% block page_header %}
-<h1 class="text-3xl font-bold text-gray-900 dark:text-white">{{ topic.name }}</h1>
+<h1 class="text-balance text-3xl font-bold tracking-[-0.03em] text-gray-950 dark:text-white sm:text-4xl">{{ topic.name }}</h1>
 {% if topic.description %}
-<p class="text-gray-600 dark:text-gray-400 mt-2">{{ topic.description }}</p>
+<p class="mt-3 max-w-3xl text-base leading-7 text-gray-600 dark:text-gray-300">{{ topic.description }}</p>
 {% endif %}
 
 {% if user and progress %}
-{% with
-    value=progress.percentage,
-    label=progress.completed ~ '/' ~ progress.total ~ ' steps checked',
-    complete=(progress.completed == progress.total and progress.total > 0),
-    aria_label='Learning steps checked: ' ~ progress.completed ~ ' of ' ~ progress.total,
-    id='topic-progress'
-%}
-{% include "partials/progress_bar.html" %}
-{% endwith %}
+<div class="mt-5 max-w-md">
+    {% with
+        value=progress.percentage,
+        label=progress.completed ~ '/' ~ progress.total ~ ' steps checked',
+        complete=(progress.completed == progress.total and progress.total > 0),
+        aria_label='Learning steps checked: ' ~ progress.completed ~ ' of ' ~ progress.total,
+        id='topic-progress'
+    %}
+    {% include "partials/progress_bar.html" %}
+    {% endwith %}
+</div>
 {% endif %}
 {% endblock %}
 
 {% block page_body %}
 {% if topic.learning_objectives %}
-<div class="mb-8 p-4 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800">
-    <h2 class="text-sm font-semibold text-blue-800 dark:text-blue-200 mb-2">Learning Objectives</h2>
-    <ul class="space-y-1">
+<section class="mb-10 border-y border-blue-100 py-5 dark:border-blue-900" aria-labelledby="objectives-heading">
+    <h2 id="objectives-heading" class="text-base font-bold text-blue-950 dark:text-blue-100">Learning objectives</h2>
+    <ul class="mt-3 space-y-2">
         {% for objective in topic.learning_objectives %}
-        <li class="text-sm text-blue-700 dark:text-blue-300 flex items-start gap-2">
-            <span class="text-blue-500 mt-0.5">•</span>
-            {{ objective.text }}
+        <li class="flex items-start gap-3 text-sm leading-6 text-blue-900 dark:text-blue-200">
+            <svg class="mt-1 h-4 w-4 shrink-0" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m5 10 3 3 7-7"/></svg>
+            <span>{{ objective.text }}</span>
         </li>
         {% endfor %}
     </ul>
-</div>
+</section>
 {% endif %}
 
-<!-- Expand / Collapse all -->
 {% if steps | length > 3 %}
-<div class="flex justify-end mb-3 gap-2" x-data>
+<div class="mb-4 flex flex-wrap justify-end gap-2" x-data>
     <button
-        @click="document.querySelectorAll('[x-data]').forEach(el => { if (el._x_dataStack && el._x_dataStack[0] && 'expanded' in el._x_dataStack[0]) el._x_dataStack[0].expanded = true })"
-        class="text-xs font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        type="button"
+        @click="document.querySelectorAll('#topic-steps [data-step]').forEach(el => { if (el._x_dataStack && el._x_dataStack[0]) el._x_dataStack[0].expanded = true })"
+        class="inline-flex min-h-11 items-center rounded-md px-3 text-sm font-bold text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
     >Expand all</button>
-    <span class="text-gray-300 dark:text-gray-600">|</span>
     <button
-        @click="document.querySelectorAll('[x-data]').forEach(el => { if (el._x_dataStack && el._x_dataStack[0] && 'expanded' in el._x_dataStack[0]) el._x_dataStack[0].expanded = false })"
-        class="text-xs font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 px-2 py-1 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        type="button"
+        @click="document.querySelectorAll('#topic-steps [data-step]').forEach(el => { if (el._x_dataStack && el._x_dataStack[0]) el._x_dataStack[0].expanded = false })"
+        class="inline-flex min-h-11 items-center rounded-md px-3 text-sm font-bold text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
     >Collapse all</button>
 </div>
 {% endif %}
 
-<div class="space-y-4">
+{% if steps %}
+<div id="topic-steps" class="space-y-4">
+    {% set ns = namespace(opened=false) %}
     {% for step in steps %}
-    {% with completed_steps=completed_steps %}
+    {% set step_complete = step.uuid in completed_steps %}
+    {% set expand_initially = not step_complete and not ns.opened %}
+    {% if expand_initially %}{% set ns.opened = true %}{% endif %}
+    {% with completed_steps=completed_steps, expand_initially=expand_initially %}
     {% include "partials/topic_step.html" %}
     {% endwith %}
     {% endfor %}
 </div>
+{% else %}
+<div class="rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
+    <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">Learning steps for this topic are being prepared.</p>
+</div>
+{% endif %}
 
-<div class="mt-12 flex items-center justify-between border-t border-gray-200 dark:border-gray-700 pt-6">
+<nav class="mt-12 grid gap-3 border-t border-gray-200 pt-6 dark:border-gray-700 sm:grid-cols-2" aria-label="Topic navigation">
     {% if prev_topic %}
-    <a href="{{ prev_topic.url }}" class="flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
-        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" /></svg>
-        {{ prev_topic.name }}
+    <a href="{{ prev_topic.url }}" class="group flex min-h-11 min-w-0 items-center gap-3 rounded-md p-3 text-left hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:bg-gray-800/50">
+        <svg class="h-5 w-5 shrink-0 text-gray-500 group-hover:text-blue-700 dark:text-gray-400 dark:group-hover:text-blue-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m12 5-5 5 5 5"/></svg>
+        <span class="min-w-0">
+            <span class="block text-xs font-bold text-gray-500 dark:text-gray-400">Previous topic</span>
+            <span class="mt-1 block break-words text-sm font-bold text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ prev_topic.name }}</span>
+        </span>
     </a>
     {% else %}
-    <div></div>
+    <span></span>
     {% endif %}
 
     {% if next_topic %}
-    <a href="{{ next_topic.url }}" class="flex items-center gap-2 text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
-        {{ next_topic.name }}
-        <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /></svg>
+    <a href="{{ next_topic.url }}" class="group flex min-h-11 min-w-0 items-center justify-end gap-3 rounded-md p-3 text-right hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:bg-gray-800/50 sm:col-start-2">
+        <span class="min-w-0">
+            <span class="block text-xs font-bold text-gray-500 dark:text-gray-400">Next topic</span>
+            <span class="mt-1 block break-words text-sm font-bold text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ next_topic.name }}</span>
+        </span>
+        <svg class="h-5 w-5 shrink-0 text-gray-500 group-hover:text-blue-700 dark:text-gray-400 dark:group-hover:text-blue-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m8 5 5 5-5 5"/></svg>
     </a>
-    {% else %}
-    <div></div>
     {% endif %}
-</div>
+</nav>
 
 <div class="mt-8 flex justify-center">
     <a
@@ -93,7 +112,7 @@
         data-issue-title="Issue with {{ topic.name }}"
         data-issue-labels="content"
         data-issue-context="phase={{ phase_id }}, topic={{ topic.slug }}"
-        class="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+        class="inline-flex min-h-11 items-center gap-2 rounded-md px-3 text-sm font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
         target="_blank"
         rel="noopener"
         hx-boost="false"

--- a/api/src/learn_to_cloud/templates/partials/footer.html
+++ b/api/src/learn_to_cloud/templates/partials/footer.html
@@ -1,4 +1,4 @@
-<footer class="border-t border-gray-200 dark:border-gray-700 mt-16">
+<footer class="border-t border-gray-200 dark:border-gray-700 {{ footer_margin | default('mt-16') }}">
     <div class="mx-auto max-w-content px-4 sm:px-6 lg:px-8 py-8">
         <p class="text-sm text-gray-500 dark:text-gray-400 text-center">
             &copy; {{ now.year }} Learn to Cloud

--- a/api/src/learn_to_cloud/templates/partials/navbar.html
+++ b/api/src/learn_to_cloud/templates/partials/navbar.html
@@ -1,20 +1,24 @@
-<nav class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+<nav class="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900" x-data="{ mobileOpen: false }">
     <div class="mx-auto max-w-content px-4 sm:px-6 lg:px-8">
         <div class="flex h-16 items-center justify-between">
-            <div class="flex items-center gap-8">
-                <a href="/" class="text-xl font-bold text-blue-600 dark:text-blue-400">
-                    ☁️ Learn to Cloud
+            <div class="flex min-w-0 items-center gap-8">
+                <a href="/" class="flex min-h-11 items-center gap-2 text-lg font-bold tracking-[-0.02em] text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">
+                    <svg class="h-7 w-7 shrink-0" viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M8.5 21.5h11a5 5 0 0 0 .8-9.94A7.25 7.25 0 0 0 6.65 10.1 5.75 5.75 0 0 0 8.5 21.5Z"/>
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M14 8.25v5.5m-3.25 3.5h6.5M14 13.75v3.5"/>
+                    </svg>
+                    <span class="truncate">Learn to Cloud</span>
                 </a>
                 <div class="hidden sm:flex items-center gap-4">
                     {% if user %}
-                    <a href="/dashboard" class="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
+                    <a href="/dashboard" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
                         Dashboard
                     </a>
                     {% endif %}
-                    <a href="/community" class="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
+                    <a href="/community" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
                         Community
                     </a>
-                    <a href="/faq" class="text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
+                    <a href="/faq" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
                         FAQ
                     </a>
                 </div>
@@ -25,7 +29,7 @@
 
                 {% if user %}
                 <div class="relative flex items-center gap-3" x-data="{ open: false }">
-                    <button @click="open = !open" class="flex items-center gap-2 cursor-pointer">
+                    <button @click="open = !open" class="flex min-h-11 cursor-pointer items-center gap-2 rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700">
                         {% if user.avatar_url %}
                         <img src="{{ user.avatar_url }}" alt="{{ user.github_username }}" class="h-8 w-8 rounded-full">
                         {% endif %}
@@ -40,20 +44,51 @@
                         x-cloak
                         class="absolute right-0 top-full mt-2 w-48 rounded-md bg-white dark:bg-gray-800 shadow-lg ring-1 ring-gray-200 dark:ring-gray-700 py-1 z-50"
                     >
-                        <a href="/account" @click="open = false" class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
+                        <a href="/account" @click="open = false" class="flex min-h-11 items-center px-4 text-sm text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:bg-gray-700">
                             Account
                         </a>
                         <div class="border-t border-gray-100 dark:border-gray-700 my-1"></div>
                         <form method="post" action="/auth/logout">
-                            <button type="submit" class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700">
+                            <button type="submit" class="min-h-11 w-full px-4 text-left text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white">
                                 Sign out
                             </button>
                         </form>
                     </div>
                 </div>
                 {% else %}
-                <a href="/auth/login" hx-boost="false" class="inline-flex items-center gap-2 rounded-md bg-gray-900 dark:bg-white px-3 py-2 text-sm font-semibold text-white dark:text-gray-900 hover:bg-gray-700 dark:hover:bg-gray-200">
+                <a href="/auth/login" hx-boost="false" class="hidden min-h-11 items-center gap-2 rounded-md bg-gray-900 px-3 py-2 text-sm font-semibold text-white hover:bg-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 sm:inline-flex">
                     <svg class="h-4 w-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                    Sign in with GitHub
+                </a>
+                {% endif %}
+
+                <button
+                    type="button"
+                    class="inline-flex h-11 w-11 items-center justify-center rounded-md text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white sm:hidden"
+                    @click="mobileOpen = !mobileOpen"
+                    :aria-expanded="mobileOpen"
+                    aria-controls="mobile-navigation"
+                    aria-label="Toggle navigation"
+                >
+                    <svg x-show="!mobileOpen" class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                        <path stroke-linecap="round" d="M4 7h16M4 12h16M4 17h16"/>
+                    </svg>
+                    <svg x-show="mobileOpen" x-cloak class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                        <path stroke-linecap="round" d="m6 6 12 12M18 6 6 18"/>
+                    </svg>
+                </button>
+            </div>
+        </div>
+
+        <div id="mobile-navigation" x-show="mobileOpen" x-collapse x-cloak class="border-t border-gray-200 py-3 dark:border-gray-700 sm:hidden">
+            <div class="grid gap-1">
+                {% if user %}
+                <a href="/dashboard" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">Dashboard</a>
+                {% endif %}
+                <a href="/community" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">Community</a>
+                <a href="/faq" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">FAQ</a>
+                {% if not user %}
+                <a href="/auth/login" hx-boost="false" class="mt-2 flex min-h-11 items-center justify-center rounded-md bg-gray-900 px-3 text-sm font-semibold text-white hover:bg-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200">
                     Sign in with GitHub
                 </a>
                 {% endif %}

--- a/api/src/learn_to_cloud/templates/partials/progress_bar.html
+++ b/api/src/learn_to_cloud/templates/partials/progress_bar.html
@@ -9,16 +9,16 @@
      id          – id attribute for HTMX OOB swaps
      oob         – if true, adds hx-swap-oob="true"
 #}
-<div{% if id %} id="{{ id }}"{% endif %}{% if oob %} hx-swap-oob="true"{% endif %} class="mt-4 flex items-center gap-3">
+<div{% if id %} id="{{ id }}"{% endif %}{% if oob %} hx-swap-oob="true"{% endif %} class="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
     <div
-        class="flex-1 max-w-xs h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden"
+        class="h-2 w-full max-w-xs overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700 sm:flex-1"
         role="progressbar"
         aria-valuenow="{{ value | round(0) | int }}"
         aria-valuemin="0"
         aria-valuemax="100"
         aria-label="{{ aria_label | default(label) }}"
     >
-        <div class="h-full {{ 'bg-green-500' if complete else 'bg-blue-600' }} rounded-full transition-all" style="width: {{ value }}%"></div>
+        <div class="h-full rounded-full {{ 'bg-green-500' if complete else 'bg-blue-600' }} transition-all" style="width: {{ value }}%"></div>
     </div>
-    <span class="text-sm font-medium text-gray-600 dark:text-gray-400">{{ label }}</span>
+    <span class="text-sm font-medium leading-5 text-gray-600 dark:text-gray-400">{{ label }}</span>
 </div>

--- a/api/src/learn_to_cloud/templates/partials/requirement_card.html
+++ b/api/src/learn_to_cloud/templates/partials/requirement_card.html
@@ -13,11 +13,11 @@
 {% from "macros/callouts.html" import banner %}
 <div id="requirement-{{ requirement.slug }}" class="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
     <div class="flex items-center justify-between mb-2">
-        <h4 class="font-medium text-gray-900 dark:text-gray-100">{{ requirement.name }}</h4>
+        <h3 class="font-medium text-gray-900 dark:text-gray-100">{{ requirement.name }}</h3>
         {% if card_state == 'passed' %}
-        {{ status_pill("✓ Verified", "success") }}
+        {{ status_pill("Verified", "success") }}
         {% elif card_state == 'unavailable' %}
-        {{ status_pill("⚠ Service unavailable", "warning") }}
+        {{ status_pill("Service unavailable", "warning") }}
         {% elif card_state == 'failed' %}
         {{ status_pill("Needs work", "error") }}
         {% endif %}
@@ -56,7 +56,7 @@
         hx-swap="outerHTML"
         hx-indicator="#spinner-{{ requirement.slug }}"
         hx-disabled-elt="find button[type='submit']"
-        class="{% if is_reflection or is_architecture %}flex flex-col gap-4{% else %}flex gap-2{% endif %}"
+        class="flex flex-col gap-3 {% if is_reflection or is_architecture %}gap-4{% else %}sm:flex-row sm:items-start{% endif %}"
     >
         <input type="hidden" name="requirement_slug" value="{{ requirement.slug }}">
 
@@ -109,7 +109,7 @@
             name="submitted_value"
             placeholder="{{ requirement.type_config.placeholder | default('Paste your completion token here') }}"
             value=""
-            class="flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+            class="min-h-11 flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             required
         >
         {% elif requirement.submission_type == 'deployed_api' %}
@@ -121,7 +121,7 @@
             name="submitted_value"
             placeholder="{{ requirement.type_config.placeholder | default('https://your-api.example.com') }}"
             value="{% if submission %}{{ submission.submitted_value }}{% endif %}"
-            class="flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+            class="min-h-11 flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
             required
         >
         {% elif derived_url %}
@@ -136,7 +136,7 @@
             value="{{ derived_url }}"
             readonly
             aria-readonly="true"
-            class="flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 cursor-default select-all focus:outline-hidden"
+            class="min-h-11 flex-1 cursor-default select-all rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-300"
         >
         {% else %}
         {# Fallback: requirement is misconfigured or the learner has no
@@ -150,13 +150,13 @@
             disabled
             aria-disabled="true"
             placeholder="Unable to auto-derive submission URL"
-            class="flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900 px-3 py-2 text-sm text-gray-500 cursor-not-allowed"
+            class="min-h-11 flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-900 px-3 py-2 text-sm text-gray-500 cursor-not-allowed"
         >
         {% endif %}
 
         <button
             type="submit"
-            class="inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500 disabled:opacity-50"
+            class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 disabled:opacity-50"
         >
             Verify
         </button>

--- a/api/src/learn_to_cloud/templates/partials/theme_toggle.html
+++ b/api/src/learn_to_cloud/templates/partials/theme_toggle.html
@@ -1,7 +1,7 @@
 <!-- Theme toggle — vanilla JS click via event delegation in base.html -->
 <button
     id="theme-toggle"
-    class="rounded-md p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+    class="inline-flex h-11 w-11 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
     :title="darkMode ? 'Switch to light mode' : 'Switch to dark mode'"
     :aria-label="darkMode ? 'Switch to light mode' : 'Switch to dark mode'"
     title="Toggle dark mode"

--- a/api/src/learn_to_cloud/templates/partials/topic_step.html
+++ b/api/src/learn_to_cloud/templates/partials/topic_step.html
@@ -1,14 +1,3 @@
-{# Single learning step — HTMX-swappable.
-
-Required context:
-- step (LearningStep — the Pydantic schema directly, no intermediate dict)
-- completed_steps (set of step UUIDs)
-- user (User | None — drives the checkbox affordance)
-
-Markdown is rendered via the ``md`` Jinja filter (memoized per-process);
-template fields like ``step.description``, ``tip.text`` etc. are raw
-markdown and the template owns the rendering call.
-#}
 {% from "macros/badges.html" import action_badge, step_number_badge %}
 {% from "macros/callouts.html" import tip_callout, done_when %}
 {% from "macros/code_block.html" import copy_code %}
@@ -16,72 +5,77 @@ markdown and the template owns the rendering call.
 
 {% set is_completed = step.uuid in completed_steps %}
 {% set has_body = step.description or step.code or step.options or step.checklist or step.tips or step.done_when %}
+{% set step_label = step.title or ('Step ' ~ step.order) %}
+{% set initially_open = expand_initially | default(not is_completed) %}
 
-<div id="step-{{ step.uuid }}"
-    class="rounded-xl border {% if is_completed %}border-green-200 bg-green-50/40 dark:border-green-800/50 dark:bg-green-900/10{% else %}border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800/50{% endif %} shadow-sm transition-colors"
-    x-data="{ expanded: {{ 'false' if is_completed else 'true' }} }"
+<section
+    id="step-{{ step.uuid }}"
+    data-step
+    class="rounded-lg border {% if is_completed %}border-green-200 bg-green-50/40 dark:border-green-800/50 dark:bg-green-950/20{% else %}border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800/50{% endif %}"
+    x-data="{ expanded: {{ 'true' if initially_open else 'false' }} }"
 >
-    <div
-        class="flex items-center gap-3 px-4 py-3 cursor-pointer select-none{% if has_body %} focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset{% endif %}"
-        {% if has_body %}
-        role="button"
-        tabindex="0"
-        :aria-expanded="expanded"
-        @keydown.enter.prevent="expanded = !expanded"
-        @keydown.space.prevent="expanded = !expanded"
-        {% endif %}
-        @click="expanded = !expanded"
-    >
+    <div class="flex items-start gap-2 p-3 sm:items-center">
         {% if user %}
-        <input
-            type="checkbox"
-            {% if is_completed %}checked{% endif %}
-            class="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500 cursor-pointer flex-shrink-0"
-            {% if is_completed %}
-            hx-delete="/htmx/steps/{{ step.uuid }}"
-            {% else %}
-            hx-post="/htmx/steps/complete"
-            hx-vals='{"step_uuid": "{{ step.uuid }}"}'
-            {% endif %}
-            hx-target="#step-{{ step.uuid }}"
-            hx-swap="outerHTML"
-            hx-disabled-elt="this"
-            @click.stop
-            @keydown.space.stop
-            @keydown.enter.stop
-        >
+        <label class="flex h-11 w-11 shrink-0 cursor-pointer items-center justify-center rounded-md hover:bg-gray-100 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-blue-700 dark:hover:bg-gray-800">
+            <span class="sr-only">Mark {{ step_label }} complete</span>
+            <input
+                type="checkbox"
+                {% if is_completed %}checked{% endif %}
+                aria-label="Mark {{ step_label }} complete"
+                class="h-5 w-5 cursor-pointer rounded border-gray-300 text-blue-600 focus:ring-3 focus:ring-blue-500"
+                {% if is_completed %}
+                hx-delete="/htmx/steps/{{ step.uuid }}"
+                {% else %}
+                hx-post="/htmx/steps/complete"
+                hx-vals='{"step_uuid": "{{ step.uuid }}"}'
+                {% endif %}
+                hx-target="#step-{{ step.uuid }}"
+                hx-swap="outerHTML"
+                hx-disabled-elt="this"
+                @keydown.space.stop
+                @keydown.enter.stop
+            >
+        </label>
         {% else %}
-        <div class="h-5 w-5 rounded border-2 border-gray-300 dark:border-gray-600 flex-shrink-0"></div>
+        <span class="flex h-11 w-11 shrink-0 items-center justify-center" aria-hidden="true">
+            <span class="h-5 w-5 rounded border-2 border-gray-300 dark:border-gray-600"></span>
+        </span>
         {% endif %}
 
-        {{ step_number_badge(step.order, is_completed) }}
+        <span class="mt-2.5 sm:mt-0">{{ step_number_badge(step.order, is_completed) }}</span>
 
-        <div class="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
-            {{ action_badge(step.action) }}
-            <span class="text-sm font-semibold {% if is_completed %}line-through text-gray-400 dark:text-gray-500{% else %}text-gray-900 dark:text-gray-100{% endif %}">
+        <div class="min-w-0 flex-1 py-2">
+            <div class="flex flex-wrap items-center gap-2">
+                {{ action_badge(step.action) }}
                 {% if step.title and step.url %}
-                <a href="{{ step.url }}" target="_blank" rel="noopener" hx-boost="false" class="underline hover:text-blue-600 dark:hover:text-blue-400" @click.stop>{{ step.title }}</a>
+                <a href="{{ step.url }}" target="_blank" rel="noopener" hx-boost="false" class="inline-flex min-h-11 items-center break-words text-sm font-bold underline underline-offset-4 hover:text-blue-700 focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:text-blue-300">{{ step.title }}</a>
                 {% elif step.title %}
-                {{ step.title }}
+                <h2 class="break-words text-sm font-bold {% if is_completed %}text-gray-500 line-through dark:text-gray-400{% else %}text-gray-950 dark:text-white{% endif %}">{{ step.title }}</h2>
                 {% endif %}
-            </span>
+            </div>
         </div>
 
         {% if has_body %}
-        <svg class="h-5 w-5 text-gray-400 dark:text-gray-500 flex-shrink-0 transition-transform duration-200" :class="expanded ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-        </svg>
+        <button
+            type="button"
+            class="flex h-11 w-11 shrink-0 items-center justify-center rounded-md text-gray-500 hover:bg-gray-100 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-blue-300"
+            @click="expanded = !expanded"
+            :aria-expanded="expanded"
+            aria-controls="step-{{ step.uuid }}-body"
+            aria-label="Toggle details for {{ step_label }}"
+        >
+            <svg class="h-5 w-5 transition-transform duration-200" :class="expanded ? 'rotate-180' : ''" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+            </svg>
+        </button>
         {% endif %}
     </div>
 
     {% if has_body %}
-    <div x-show="expanded" x-collapse>
-        <div class="px-4 pb-4 pl-[4.5rem]">
-
+    <div id="step-{{ step.uuid }}-body" x-show="expanded" x-collapse x-cloak>
+        <div class="px-4 pb-4 sm:pl-[5.75rem]">
             {% if step.description %}
-            <div class="text-sm text-gray-600 dark:text-gray-400 prose prose-sm dark:prose-invert max-w-none"
-                x-data="proseCopyButtons"
-            >
+            <div class="prose prose-sm max-w-none text-sm text-gray-600 dark:prose-invert dark:text-gray-400" x-data="proseCopyButtons">
                 {{ step.description | md | safe }}
             </div>
             {% endif %}
@@ -113,8 +107,7 @@ markdown and the template owns the rendering call.
                 {{ done_when(step.done_when | md) }}
             </div>
             {% endif %}
-
         </div>
     </div>
     {% endif %}
-</div>
+</section>

--- a/api/src/learn_to_cloud/templates/partials/verified_requirement_row.html
+++ b/api/src/learn_to_cloud/templates/partials/verified_requirement_row.html
@@ -13,7 +13,9 @@
 <div id="requirement-{{ card.requirement.slug }}">
     <div class="rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 px-4 py-2.5">
         <div class="flex items-center gap-3 flex-wrap">
-            <span class="text-green-600 dark:text-green-400" aria-hidden="true">✓</span>
+            <svg class="h-5 w-5 shrink-0 text-green-700 dark:text-green-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="m5 10 3 3 7-7"/>
+            </svg>
             <span class="text-sm font-medium text-green-800 dark:text-green-200">{{ card.requirement.name }}</span>
             <span class="sr-only">— Verified</span>
             {% if card.submission and card.submission.validated_at %}

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -220,8 +220,7 @@ class TestPhaseVerificationLocked:
 
         html = self._render_phase([req], {})
 
-        assert "🔒" in html
-        assert "opacity-50" in html
+        assert "Locked" in html
         assert "text-green-800 dark:text-green-200" not in html
 
     def test_mixed_shows_validated_complete_and_other_locked(self):
@@ -234,7 +233,7 @@ class TestPhaseVerificationLocked:
 
         assert 'id="requirement-security-scanning"' in html
         assert "text-green-800 dark:text-green-200" in html  # the validated one
-        assert "opacity-50" in html  # the locked one
+        assert "Locked" in html
 
 
 @pytest.mark.unit
@@ -399,6 +398,9 @@ def test_step_checkbox_keeps_keyboard_events_from_toggling_accordion():
     source, _, _ = loader.get_source(_ENV, "partials/topic_step.html")
     assert "@keydown.space.stop" in source
     assert "@keydown.enter.stop" in source
+    assert 'role="button"' not in source
+    assert 'aria-label="Mark {{ step_label }} complete"' in source
+    assert "x-collapse x-cloak" in source
 
 
 @pytest.mark.unit
@@ -453,6 +455,8 @@ def test_community_page_renders_safe_external_resource_links():
     for url in expected_links:
         assert f'href="{url}"' in html
     assert html.count('rel="noopener noreferrer"') >= len(expected_links)
+    assert "Verified learner progress is temporarily unavailable." in html
+    assert "Curriculum updates are temporarily unavailable." in html
     assert "Discord" in html
     assert "GitHub Discussions" in html
     assert "Follow @madebygps" in html

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -478,6 +478,80 @@ def test_dashboard_help_section_links_to_discord():
 
 
 @pytest.mark.unit
+class TestDashboardPrimaryState:
+    @staticmethod
+    def _dashboard(
+        *,
+        phases: list[object],
+        continue_phase: object | None = None,
+        is_program_complete: bool = False,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            phases=phases,
+            learning_percentage=0,
+            verification_percentage=0,
+            phases_completed=0,
+            total_phases=len(phases),
+            is_program_complete=is_program_complete,
+            continue_phase=continue_phase,
+        )
+
+    def test_fresh_learner_sees_start_state(self):
+        phase = SimpleNamespace(order=0, name="Prerequisites", progress=None)
+        html = _render(
+            "pages/dashboard.html",
+            dashboard=self._dashboard(phases=[phase]),
+            help_links=[],
+        )
+
+        assert "Start the curriculum" in html
+        assert "Resume" not in html
+
+    def test_returning_learner_sees_resume_state(self):
+        phase = SimpleNamespace(order=0, name="Prerequisites", progress=None)
+        continue_phase = SimpleNamespace(
+            destination_url="/phase/0/linux",
+            label="Phase 0: Prerequisites",
+        )
+        html = _render(
+            "pages/dashboard.html",
+            dashboard=self._dashboard(phases=[phase], continue_phase=continue_phase),
+            help_links=[],
+        )
+
+        assert "Continue learning" in html
+        assert 'href="/phase/0/linux"' in html
+
+    def test_completed_learner_sees_completion_state(self):
+        progress = SimpleNamespace(
+            status="completed",
+            verification=SimpleNamespace(
+                requirements_required=1,
+                requirements_verified=1,
+            ),
+            learning=SimpleNamespace(steps_required=1, steps_completed=1),
+        )
+        phase = SimpleNamespace(order=0, name="Prerequisites", progress=progress)
+        html = _render(
+            "pages/dashboard.html",
+            dashboard=self._dashboard(phases=[phase], is_program_complete=True),
+            help_links=[],
+        )
+
+        assert "You completed the program." in html
+
+    def test_missing_curriculum_sees_recovery_state(self):
+        html = _render(
+            "pages/dashboard.html",
+            dashboard=self._dashboard(phases=[]),
+            help_links=[],
+        )
+
+        assert "Progress is temporarily unavailable." in html
+        assert "Try again" in html
+
+
+@pytest.mark.unit
 def test_primary_links_are_in_navbar_and_footer_is_minimal():
     navbar = _render("partials/navbar.html")
     footer = _render("partials/footer.html")
@@ -599,7 +673,7 @@ class TestDashboardPhaseRow:
             requirements_required=1,
         )
         html = self._render_dashboard(progress)
-        assert "Complete ✓" in html
+        assert "Complete" in html
         assert "28/28 steps checked" in html
         assert "1/1 requirements verified" in html
         assert 'text-3xl font-bold text-white">' not in html

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -221,7 +221,15 @@ class TestPublicPageSmoke:
         assert "Hands-on labs" in response.text
         assert "The curriculum, phase by phase." in response.text
 
-    @pytest.mark.parametrize("path", ["/curriculum", "/faq", "/privacy", "/terms"])
+    async def test_curriculum_page_renders(self, anon_client: AsyncClient):
+        """GET /curriculum renders the phase hierarchy and progress CTA."""
+        response = await anon_client.get("/curriculum")
+        assert response.status_code == 200
+        assert "The complete cloud curriculum." in response.text
+        assert "Learn in sequence." in response.text
+        assert "Keep your place as you learn." in response.text
+
+    @pytest.mark.parametrize("path", ["/faq", "/privacy", "/terms"])
     async def test_public_page_renders(self, anon_client: AsyncClient, path: str):
         response = await anon_client.get(path)
         assert response.status_code == 200

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -216,7 +216,9 @@ class TestPublicPageSmoke:
         """GET / renders the home page template."""
         response = await anon_client.get("/")
         assert response.status_code == 200
-        assert "Learn to Cloud" in response.text
+        assert "From first command to production cloud system." in response.text
+        assert "Start with GitHub" in response.text
+        assert "One path. Skills that build on each other." in response.text
 
     @pytest.mark.parametrize("path", ["/curriculum", "/faq", "/privacy", "/terms"])
     async def test_public_page_renders(self, anon_client: AsyncClient, path: str):

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -217,8 +217,9 @@ class TestPublicPageSmoke:
         response = await anon_client.get("/")
         assert response.status_code == 200
         assert "From first command to production cloud system." in response.text
-        assert "Start with GitHub" in response.text
-        assert "One path. Skills that build on each other." in response.text
+        assert "Progress tracking" in response.text
+        assert "Hands-on labs" in response.text
+        assert "The curriculum, phase by phase." in response.text
 
     @pytest.mark.parametrize("path", ["/curriculum", "/faq", "/privacy", "/terms"])
     async def test_public_page_renders(self, anon_client: AsyncClient, path: str):

--- a/api/tests/services/test_dashboard_service.py
+++ b/api/tests/services/test_dashboard_service.py
@@ -163,6 +163,53 @@ class TestGetDashboardDataUnauthenticated:
 @pytest.mark.unit
 class TestGetDashboardDataAuthenticated:
     @pytest.mark.asyncio
+    async def test_zero_activity_has_no_continue_phase(self):
+        """A fresh learner sees the dashboard start state, not Resume."""
+        phases = (_make_phase(0), _make_phase(1))
+        user_progress = UserProgress(
+            user_id=42,
+            phases={
+                0: _make_phase_progress(0, steps_completed=0, steps_required=5),
+                1: _make_phase_progress(1, steps_completed=0, steps_required=5),
+            },
+            total_phases=2,
+        )
+        progress_data = PhaseProgressData(
+            learning=LearningProgress(steps_completed=0, steps_required=5),
+            verification=VerificationProgress(
+                requirements_verified=0, requirements_required=1
+            ),
+            is_complete=False,
+            status="not_started",
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.services.dashboard_service.get_curriculum_overview",
+                autospec=True,
+                return_value=phases,
+            ),
+            patch(
+                "learn_to_cloud.services.dashboard_service.fetch_user_progress",
+                autospec=True,
+                return_value=user_progress,
+            ),
+            patch(
+                "learn_to_cloud.services.dashboard_service.phase_progress_to_data",
+                autospec=True,
+                return_value=progress_data,
+            ),
+            patch(
+                "learn_to_cloud.services.dashboard_service.resolve_continue_destination",
+                new_callable=AsyncMock,
+            ) as resolve_destination,
+        ):
+            result = await get_dashboard_data(db=AsyncMock(), user_id=42)
+
+        assert result.continue_phase is None
+        resolve_destination.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_partial_progress_has_continue_phase(self):
         """User with incomplete phase 0 gets continue_phase pointing at the
         destination resolve_continue_destination computes for that phase."""


### PR DESCRIPTION
## Summary
- replace the generic homepage card grid with a product-specific cloud learning path
- clarify GitHub onboarding and preserve mobile access to Community and FAQ
- improve semantic headings, keyboard focus, touch targets, and curriculum recovery states

## Validation
- uv run poe check
- Impeccable detector: 0 findings