### PR TITLE
Reduce verification alert noise

### DIFF
--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -692,7 +692,17 @@ async def finalize_verification_attempt(
         )
         logger.info(
             "verification.attempt.finalized",
-            extra={"attempt_id": str(state.id), "outcome": state.outcome},
+            extra={
+                "attempt_id": str(state.id),
+                "outcome": state.outcome,
+                "error_code": state.error_code,
+                "terminal_source": state.terminal_source,
+                "requirement_slug": run_result.attempt.requirement.slug,
+                "submission_type": run_result.attempt.requirement.submission_type.value,
+                "verification_completed": (
+                    run_result.validation_result.verification_completed
+                ),
+            },
         )
         return _terminal_state_payload(state)
 
@@ -719,6 +729,7 @@ async def terminalize_verification_attempt(
             extra={
                 "attempt_id": str(state.id),
                 "outcome": state.outcome,
+                "error_code": state.error_code,
                 "terminal_source": state.terminal_source,
             },
         )
@@ -883,7 +894,13 @@ async def _start_attempt_orchestration(
 
         logger.error(
             "verification.attempt.start.failed",
-            extra={"attempt_id": instance_id, "error": str(exc)},
+            extra={
+                "attempt_id": instance_id,
+                "outcome": "server_error",
+                "error_code": "server_error",
+                "terminal_source": "start_failure",
+                "error": str(exc),
+            },
         )
         await terminalize_attempt(
             attempt_uuid,
@@ -1017,6 +1034,8 @@ async def _reconcile_stale_attempts(
                 "attempt_id": str(attempt.id),
                 "durable_status": status_name,
                 "outcome": decision.outcome.value,
+                "error_code": decision.error_code,
+                "terminal_source": decision.terminal_source,
             },
         )
 

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -248,7 +248,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_function
   name                = "alert-ltc-verification-functions-exceptions-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  description         = "Alert when verification Functions record non-learner API exceptions in a 5-minute window"
+  description         = "Alert when verification Functions record unhandled exceptions outside expected HTTP dependency failures"
   severity            = 1
   enabled             = true
   tags                = local.tags
@@ -260,25 +260,159 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_function
 
   criteria {
     query                   = <<-QUERY
-      let LearnerApiDependencyFailures =
+      let ExpectedDependencyFailures =
           dependencies
           | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
               or cloud_RoleName has "verification-functions"
               or cloud_RoleName has "func-ltc-verification"
           | where type == "HTTP"
-          | where name in ("POST /entries", "GET /entries")
-              or name startswith "DELETE /entries/"
+          | where (name in ("POST /entries", "GET /entries")
+                  or name startswith "DELETE /entries/")
+              or target in~ ("github.com", "api.github.com")
           | project operation_Id, dependencySpanId = id;
       exceptions
       | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
           or cloud_RoleName has "verification-functions"
           or cloud_RoleName has "func-ltc-verification"
-      | join kind=leftanti LearnerApiDependencyFailures
+      | join kind=leftanti ExpectedDependencyFailures
           on operation_Id, $left.operation_ParentId == $right.dependencySpanId
+      | summarize arg_max(timestamp, type) by operation_Id
+      | project OperationId = operation_Id, ExceptionType = type
     QUERY
     time_aggregation_method = "Count"
     operator                = "GreaterThanOrEqual"
     threshold               = 1
+
+    dimension {
+      name     = "OperationId"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "ExceptionType"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.critical.id]
+  }
+}
+
+# Dependency instrumentation records every failed retry as an exception, even
+# when the validator handles it and a later attempt succeeds. The severity-1
+# exception rule excludes those spans. Alert separately on the persisted final
+# outcome so only exhausted or authoritative failures notify operators.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_server_errors" {
+  name                = "alert-ltc-verification-attempt-server-errors-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Alert when a verification attempt finishes with a server-side error"
+  severity            = 2
+  enabled             = true
+  tags                = local.tags
+
+  scopes                = [azurerm_application_insights.main.id]
+  evaluation_frequency  = "PT5M"
+  window_duration       = "PT5M"
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query                   = <<-QUERY
+      let ServerErrorAttempts =
+          traces
+          | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
+              or cloud_RoleName has "verification-functions"
+              or cloud_RoleName has "func-ltc-verification"
+          | where message in (
+              "verification.attempt.finalized",
+              "verification.attempt.terminalized",
+              "verification.attempt.start.failed",
+              "verification.reconciler.terminalized"
+          )
+          | extend
+              AttemptId = tostring(customDimensions.attempt_id),
+              Outcome = iff(
+                  message == "verification.attempt.start.failed",
+                  "server_error",
+                  tostring(customDimensions.outcome)
+              ),
+              RequirementSlug = coalesce(tostring(customDimensions.requirement_slug), "unknown"),
+              SubmissionType = coalesce(tostring(customDimensions.submission_type), "unknown"),
+              TerminalSource = coalesce(tostring(customDimensions.terminal_source), "validator"),
+              OperationId = operation_Id,
+              FailureEvent = message
+          | where Outcome == "server_error"
+          | summarize arg_max(timestamp, *) by AttemptId;
+      let FailedDependencies =
+          dependencies
+          | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
+              or cloud_RoleName has "verification-functions"
+              or cloud_RoleName has "func-ltc-verification"
+          | where success == false
+          | summarize arg_max(timestamp, target, type) by operation_Id
+          | project
+              OperationId = operation_Id,
+              UpstreamService = iff(isempty(target), type, target);
+      ServerErrorAttempts
+      | join kind=leftouter FailedDependencies on OperationId
+      | extend UpstreamService = coalesce(UpstreamService, "internal")
+      | project
+          AttemptId,
+          OperationId,
+          Outcome,
+          UpstreamService,
+          FailureEvent,
+          RequirementSlug,
+          SubmissionType,
+          TerminalSource
+    QUERY
+    time_aggregation_method = "Count"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+
+    dimension {
+      name     = "AttemptId"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "OperationId"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "Outcome"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "UpstreamService"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "FailureEvent"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    dimension {
+      name     = "RequirementSlug"
+      operator = "Include"
+      values   = ["*"]
+    }
 
     failing_periods {
       minimum_failing_periods_to_trigger_alert = 1


### PR DESCRIPTION
## Summary
- enrich terminal verification telemetry with persisted failure context
- exclude expected handled HTTP dependency failures from the exception alert
- alert separately when verification attempts persist a final server error

## Validation
- `uv run poe check`
- Terraform 1.5.7 `fmt -check` and `validate`