### PR TITLE
Add secure Azure-backed Terraform plans for pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
 
 defaults:
   run:
@@ -58,6 +57,7 @@ jobs:
     outputs:
       deploy: ${{ steps.filter.outputs.deploy }}
       code: ${{ steps.filter.outputs.code }}
+      terraform: ${{ steps.filter.outputs.terraform }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -82,6 +82,10 @@ jobs:
               - 'packages/learn-to-cloud-shared/**'
               - 'pyproject.toml'
               - 'uv.lock'
+            terraform:
+              - 'infra/**'
+              - '.github/workflows/deploy.yml'
+              - '.github/workflows/terraform-plan.yml'
 
   # -----------------------------------------------------------------------
   # Dependency Review — block PRs that introduce vulnerable dependencies
@@ -100,7 +104,7 @@ jobs:
   # -----------------------------------------------------------------------
   terraform-ci:
     needs: [changes]
-    if: needs.changes.outputs.deploy == 'true'
+    if: needs.changes.outputs.terraform == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -122,9 +126,6 @@ jobs:
 
       - name: Terraform validate
         run: terraform validate
-
-      - name: Terraform tests
-        run: terraform test -no-color
 
   # -----------------------------------------------------------------------
   # CI — lint, type-check, test (runs on push AND PR)
@@ -287,7 +288,7 @@ jobs:
       - name: Check Terraform CI result
         run: |
           if [[ "${{ needs.terraform-ci.result }}" =~ ^(success|skipped)$ ]]; then
-            echo "Terraform CI passed or was skipped (no deploy changes)"
+            echo "Terraform CI passed or was skipped (no Terraform changes)"
           else
             echo "Terraform CI failed: ${{ needs.terraform-ci.result }}"
             exit 1
@@ -301,6 +302,9 @@ jobs:
     needs: [ci, changes]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
     env:
       ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -384,6 +388,9 @@ jobs:
     if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy == 'true') && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     needs: [terraform, changes]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
-          terraform_version: "~1.5"
+          terraform_version: "1.16.1"
           terraform_wrapper: false
 
       - name: Azure login for read-only planning

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -2,7 +2,7 @@ name: Terraform PR Plan
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feat/secure-terraform-pr-plan]
 
 permissions:
   contents: read

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,167 @@
+name: Terraform PR Plan
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: terraform-plan-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      terraform: ${{ steps.filter.outputs.terraform }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Detect Terraform changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+        id: filter
+        with:
+          filters: |
+            terraform:
+              - 'infra/**'
+              - '.github/workflows/terraform-plan.yml'
+
+  terraform-plan:
+    needs: [changes]
+    if: needs.changes.outputs.terraform == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: terraform-plan
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: infra
+    env:
+      ARM_CLIENT_ID: ${{ vars.AZURE_TERRAFORM_PLAN_CLIENT_ID }}
+      ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      ARM_USE_OIDC: true
+      TF_VAR_environment: ${{ vars.AZURE_ENV_NAME }}
+      TF_VAR_github_client_id: ${{ vars.TERRAFORM_GITHUB_CLIENT_ID }}
+      TF_VAR_location: ${{ vars.AZURE_LOCATION }}
+      TF_VAR_postgres_entra_admin_object_id: ${{ vars.POSTGRES_ENTRA_ADMIN_OBJECT_ID }}
+      TF_VAR_postgres_entra_admin_principal_name: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME }}
+      TF_VAR_postgres_entra_admin_principal_type: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE }}
+      TF_VAR_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+        with:
+          terraform_version: "~1.5"
+          terraform_wrapper: false
+
+      - name: Azure login for read-only planning
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
+        with:
+          client-id: ${{ vars.AZURE_TERRAFORM_PLAN_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Terraform init
+        run: terraform init -input=false -backend-config="key=learn-to-cloud-${TF_VAR_environment}.tfstate"
+
+      - name: Create read-only plan
+        run: |
+          set +e
+          terraform plan \
+            -input=false \
+            -lock=false \
+            -out=tfplan \
+            -json > "$RUNNER_TEMP/terraform-plan-events.json"
+          status=$?
+          set -e
+
+          if [ "$status" -ne 0 ]; then
+            echo "::error::Terraform plan failed. Diagnostic summaries follow; full plan output is intentionally suppressed."
+            jq -r '
+              select(.type == "diagnostic")
+              | "\(.diagnostic.severity): \(.diagnostic.summary)"
+            ' "$RUNNER_TEMP/terraform-plan-events.json" | sort -u >&2
+            exit "$status"
+          fi
+
+      - name: Report aggregate resource actions
+        run: |
+          terraform show -json tfplan > "$RUNNER_TEMP/tfplan.json"
+
+          counts=$(jq -c '
+            [.resource_changes[]? | .change.actions] as $actions
+            | {
+                create:  [$actions[] | select(. == ["create"])] | length,
+                update:  [$actions[] | select(. == ["update"])] | length,
+                replace: [$actions[] | select((index("create") != null) and (index("delete") != null))] | length,
+                delete:  [$actions[] | select(. == ["delete"])] | length
+              }
+          ' "$RUNNER_TEMP/tfplan.json")
+
+          create=$(jq -r '.create' <<< "$counts")
+          update=$(jq -r '.update' <<< "$counts")
+          replace=$(jq -r '.replace' <<< "$counts")
+          delete=$(jq -r '.delete' <<< "$counts")
+
+          {
+            echo "## Terraform plan summary"
+            echo
+            echo "| Create | Update | Replace | Delete |"
+            echo "|------:|------:|--------:|-------:|"
+            echo "| $create | $update | $replace | $delete |"
+            echo
+            echo "The saved plan and full plan output are intentionally not published."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Terraform actions: create=$create update=$update replace=$replace delete=$delete"
+
+          if [ "$replace" -gt 0 ] || [ "$delete" -gt 0 ]; then
+            echo "::error::Terraform proposes $replace replacement(s) and $delete deletion(s). Explicit review is required."
+            exit 1
+          fi
+
+  terraform-plan-status:
+    if: always()
+    needs: [changes, terraform-plan]
+    runs-on: ubuntu-latest
+    env:
+      CHANGES_RESULT: ${{ needs.changes.result }}
+      PLAN_RESULT: ${{ needs.terraform-plan.result }}
+      TERRAFORM_CHANGED: ${{ needs.changes.outputs.terraform }}
+      HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+      BASE_REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Check Terraform plan result
+        run: |
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "Terraform change detection failed: $CHANGES_RESULT" >&2
+            exit 1
+          fi
+
+          if [ "$TERRAFORM_CHANGED" != "true" ]; then
+            echo "Terraform plan skipped because no Terraform files changed."
+            exit 0
+          fi
+
+          if [ "$HEAD_REPOSITORY" != "$BASE_REPOSITORY" ]; then
+            echo "Azure-backed Terraform plans are not permitted for fork pull requests." >&2
+            exit 1
+          fi
+
+          if [ "$PLAN_RESULT" != "success" ]; then
+            echo "Terraform plan failed or was not approved: $PLAN_RESULT" >&2
+            exit 1
+          fi
+
+          echo "Terraform plan passed."

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -73,7 +73,11 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Terraform init
-        run: terraform init -input=false -backend-config="key=learn-to-cloud-${TF_VAR_environment}.tfstate"
+        run: |
+          terraform init \
+            -input=false \
+            -backend-config="key=learn-to-cloud-${TF_VAR_environment}.tfstate" \
+            -backend-config="use_azuread_auth=true"
 
       - name: Create read-only plan
         run: |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -144,6 +144,16 @@ Azure CLI, Terraform, `jq`, and `psql` are not required for normal API
 development. They are required for infrastructure plans, deployment
 diagnostics, Azure-backed verification, and production database queries.
 
+Run the offline Terraform checks before opening an infrastructure pull request:
+
+```bash
+uv run poe terraform-check
+```
+
+See [Terraform validation and deployment](terraform.md) for the distinction
+between local validation, reviewer-approved pull-request plans, and production
+apply.
+
 #### Copilot and browser tooling
 
 Install the browser tooling used by the dog-food agent:
@@ -180,6 +190,9 @@ uv run poe test
 
 # Everything above, in order. Run this before opening a pull request.
 uv run poe check
+
+# Terraform formatting and backendless validation.
+uv run poe terraform-check
 ```
 
 Continuous integration runs the exact same `uv run poe` tasks, so a green

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,0 +1,73 @@
+# Terraform validation and deployment
+
+Terraform changes pass through three separate checks. Each check has different
+credentials and provides a different level of confidence.
+
+| Stage | Command or workflow | Azure access | Purpose |
+|-------|---------------------|--------------|---------|
+| Local and offline CI | `uv run poe terraform-check` | None | Check formatting, initialize providers without the backend, and validate configuration |
+| Pull-request plan | `Terraform PR Plan` | Read-only | Compare the proposed configuration with remote state and current Azure resources |
+| Main deployment | `Deploy` | Contributor | Create a fresh locked plan and apply it after merge |
+
+Offline validation cannot detect resource drift or show whether Terraform will
+create, update, replace, or delete existing resources. The pull-request plan
+fills that gap, but it still cannot guarantee that Azure will accept an apply.
+Policy, quota, naming availability, write permissions, and service-specific
+validation can still reject changes after merge.
+
+## Pull-request plan security
+
+The Azure-backed plan runs only for same-repository pull requests that change
+`infra/**` or the plan workflow. Fork pull requests fail the stable
+`terraform-plan-status` check and never request Azure credentials.
+
+The plan job:
+
+- waits for approval through the protected `terraform-plan` environment
+- requests an OIDC token only after approval
+- uses a dedicated Entra application with subscription `Reader`
+- has `Storage Blob Data Reader` only on the Terraform state container
+- runs with `-lock=false`, so it does not need state-write or lease permissions
+- receives configuration identifiers through environment variables, not
+  application secrets
+- publishes only aggregate create, update, replace, and delete counts
+- fails when any replacement or deletion is proposed
+
+The saved plan, plan JSON, remote state, and full plan output remain only on the
+ephemeral GitHub-hosted runner and are never uploaded or added to the pull
+request.
+
+## One-time repository setup
+
+An Azure and repository administrator can create the read-only identity,
+configure its OIDC trust and role assignments, and protect the GitHub
+environment with:
+
+```bash
+scripts/configure-terraform-plan.sh \
+  GITHUB_OAUTH_CLIENT_ID \
+  madebygps \
+  rishabkumar7
+```
+
+Reviewers must have access to the repository. Self-approval is disabled, so a
+pull-request author cannot approve their own plan even when they are listed.
+The GitHub OAuth client ID is configuration rather than a secret, but it must
+match the value used by the deployed Terraform state so the plan does not
+report a false application update.
+
+The script copies the existing Azure environment and PostgreSQL administrator
+repository variables into the protected environment. It does not copy or
+create GitHub Actions secrets.
+
+After the workflow has reported once, add `terraform-plan-status` to the active
+`main` branch ruleset's required status checks. This check succeeds immediately
+for pull requests without Terraform changes and gates infrastructure pull
+requests on the approved Azure-backed plan.
+
+## Production apply
+
+The existing `Deploy` workflow remains the only path that applies Terraform. It
+runs on `main`, authenticates with the deployment identity, creates a new plan
+with state locking immediately before apply, and never reuses a pull-request
+plan.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,17 @@ uv pip install --python "$tmpdir/venv/bin/python" "$wheel"
 "$tmpdir/venv/bin/python" -m learn_to_cloud_shared.runtime_package_check
 """
 
+[tool.poe.tasks.terraform-check]
+help = "Run Terraform formatting and backendless validation"
+shell = """
+set -eu
+tf_data_dir=$(mktemp -d)
+trap 'rm -rf "$tf_data_dir"' EXIT
+terraform -chdir=infra fmt -check -recursive
+TF_DATA_DIR="$tf_data_dir" terraform -chdir=infra init -backend=false -input=false
+TF_DATA_DIR="$tf_data_dir" terraform -chdir=infra validate
+"""
+
 [tool.poe.tasks.check]
 help = "Run the full quality gate: static checks, package smoke, then tests"
 sequence = ["static", "package-smoke", "test"]

--- a/scripts/configure-terraform-plan.sh
+++ b/scripts/configure-terraform-plan.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 GITHUB_OAUTH_CLIENT_ID REVIEWER_LOGIN..." >&2
+  exit 2
+fi
+
+github_client_id=$1
+shift
+reviewer_logins=("$@")
+repository=${REPOSITORY:-learntocloud/learn-to-cloud-app}
+environment_name=${TERRAFORM_PLAN_ENVIRONMENT:-terraform-plan}
+application_name=${TERRAFORM_PLAN_APPLICATION_NAME:-github-learntocloud-terraform-plan}
+state_resource_group=${TF_STATE_RESOURCE_GROUP:-rg-terraform-state}
+state_storage_account=${TF_STATE_STORAGE_ACCOUNT:-stterraformstateb1ac9ddc}
+state_container=${TF_STATE_CONTAINER:-tfstate}
+federated_credential_name=github-${environment_name}
+
+for command in az gh jq; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "Required command not found: $command" >&2
+    exit 1
+  fi
+done
+
+az account show >/dev/null
+gh auth status >/dev/null
+
+subscription_id=${AZURE_SUBSCRIPTION_ID:-$(az account show --query id -o tsv)}
+tenant_id=$(az account show --query tenantId -o tsv)
+subscription_scope="/subscriptions/$subscription_id"
+container_scope="${subscription_scope}/resourceGroups/${state_resource_group}/providers/Microsoft.Storage/storageAccounts/${state_storage_account}/blobServices/default/containers/${state_container}"
+oidc_subject="repo:${repository}:environment:${environment_name}"
+
+repo_variable() {
+  local name=$1
+  local value
+
+  if ! value=$(gh variable get "$name" --repo "$repository" --json value --jq .value 2>/dev/null); then
+    echo "Repository variable $name is required before configuring the plan environment." >&2
+    exit 1
+  fi
+
+  if [ -z "$value" ]; then
+    echo "Repository variable $name must not be empty." >&2
+    exit 1
+  fi
+
+  printf '%s' "$value"
+}
+
+app_matches=$(az ad app list --display-name "$application_name" --query "length(@)" -o tsv)
+if [ "$app_matches" -gt 1 ]; then
+  echo "Multiple Entra applications are named $application_name; resolve the duplicate before continuing." >&2
+  exit 1
+fi
+
+if [ "$app_matches" -eq 0 ]; then
+  app_id=$(az ad app create --display-name "$application_name" --sign-in-audience AzureADMyOrg --query appId -o tsv)
+else
+  app_id=$(az ad app list --display-name "$application_name" --query "[0].appId" -o tsv)
+fi
+
+if ! service_principal_id=$(az ad sp show --id "$app_id" --query id -o tsv 2>/dev/null); then
+  az ad sp create --id "$app_id" --output none
+  for _ in {1..12}; do
+    if service_principal_id=$(az ad sp show --id "$app_id" --query id -o tsv 2>/dev/null); then
+      break
+    fi
+    sleep 5
+  done
+fi
+
+if [ -z "${service_principal_id:-}" ]; then
+  echo "The Entra service principal was created but did not become readable in time." >&2
+  exit 1
+fi
+
+credential=$(az ad app federated-credential list \
+  --id "$app_id" \
+  --query "[?name=='${federated_credential_name}'] | [0]" \
+  -o json)
+
+if [ -z "$(jq -r '.name // empty' <<< "$credential")" ]; then
+  credential_parameters=$(jq -cn \
+    --arg name "$federated_credential_name" \
+    --arg subject "$oidc_subject" \
+    '{
+      name: $name,
+      issuer: "https://token.actions.githubusercontent.com",
+      subject: $subject,
+      description: "Read-only Terraform plans approved through the GitHub environment",
+      audiences: ["api://AzureADTokenExchange"]
+    }')
+  az ad app federated-credential create \
+    --id "$app_id" \
+    --parameters "$credential_parameters" \
+    --output none
+elif ! jq -e \
+  --arg subject "$oidc_subject" \
+  '.issuer == "https://token.actions.githubusercontent.com"
+    and .subject == $subject
+    and (.audiences == ["api://AzureADTokenExchange"])' <<< "$credential" >/dev/null; then
+  echo "Federated credential $federated_credential_name exists with unexpected trust settings." >&2
+  exit 1
+fi
+
+ensure_role_assignment() {
+  local role=$1
+  local scope=$2
+  local assignment_count
+
+  assignment_count=$(az role assignment list \
+    --assignee-object-id "$service_principal_id" \
+    --role "$role" \
+    --scope "$scope" \
+    --query "length(@)" \
+    -o tsv)
+
+  if [ "$assignment_count" -eq 0 ]; then
+    az role assignment create \
+      --assignee-object-id "$service_principal_id" \
+      --assignee-principal-type ServicePrincipal \
+      --role "$role" \
+      --scope "$scope" \
+      --output none
+  fi
+}
+
+ensure_role_assignment Reader "$subscription_scope"
+ensure_role_assignment "Storage Blob Data Reader" "$container_scope"
+
+reviewers='[]'
+for reviewer_login in "${reviewer_logins[@]}"; do
+  reviewer_id=$(gh api "users/$reviewer_login" --jq .id)
+  reviewers=$(jq -c \
+    --argjson reviewer_id "$reviewer_id" \
+    '. + [{type: "User", id: $reviewer_id}]' <<< "$reviewers")
+done
+
+environment_parameters=$(jq -cn \
+  --argjson reviewers "$reviewers" \
+  '{
+    wait_timer: 0,
+    prevent_self_review: true,
+    reviewers: $reviewers,
+    deployment_branch_policy: null
+  }')
+environment_file=$(mktemp)
+trap 'rm -f "$environment_file"' EXIT
+printf '%s' "$environment_parameters" > "$environment_file"
+gh api \
+  --method PUT \
+  "repos/${repository}/environments/${environment_name}" \
+  --input "$environment_file" \
+  >/dev/null
+
+environment_variables=(
+  "AZURE_TERRAFORM_PLAN_CLIENT_ID=$app_id"
+  "AZURE_TENANT_ID=$tenant_id"
+  "AZURE_SUBSCRIPTION_ID=$subscription_id"
+  "AZURE_ENV_NAME=$(repo_variable AZURE_ENV_NAME)"
+  "AZURE_LOCATION=$(repo_variable AZURE_LOCATION)"
+  "TERRAFORM_GITHUB_CLIENT_ID=$github_client_id"
+  "POSTGRES_ENTRA_ADMIN_OBJECT_ID=$(repo_variable POSTGRES_ENTRA_ADMIN_OBJECT_ID)"
+  "POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME=$(repo_variable POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME)"
+  "POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE=$(repo_variable POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE)"
+)
+
+for variable in "${environment_variables[@]}"; do
+  name=${variable%%=*}
+  value=${variable#*=}
+  gh variable set "$name" \
+    --repo "$repository" \
+    --env "$environment_name" \
+    --body "$value"
+done
+
+cat <<EOF
+Terraform plan access configured.
+
+Entra application: $application_name
+Client ID: $app_id
+OIDC subject: $oidc_subject
+Azure roles:
+  Reader at $subscription_scope
+  Storage Blob Data Reader at $container_scope
+
+Add terraform-plan-status to the main branch ruleset's required status checks.
+EOF


### PR DESCRIPTION
Closes #741

## What changes

This adds reviewer-approved Terraform plans against the real Azure subscription and remote state before infrastructure changes merge.

The workflow uses a dedicated Microsoft Entra identity with GitHub OIDC and read-only permissions. It reports only aggregate create, update, replace, and delete counts; it does not publish the saved plan, state, or full plan output.

It also:

- keeps fast offline Terraform checks for pull requests
- adds `uv run poe terraform-check` for local validation
- narrows Terraform CI to relevant files
- blocks fork pull requests before Azure authentication
- fails when a plan proposes a replacement or deletion
- documents the difference between offline validation, pull-request planning, and the fresh locked plan used for production apply
- includes an idempotent bootstrap script for the planning identity, OIDC federation, protected GitHub Environment, repository variables, and scoped RBAC

## Current stack

#807 removes the final AzureRM `listSecrets` refresh dependency by moving the existing API Container App to AzAPI without recreation.

The temporary `feat/secure-terraform-pr-plan` pull-request target exists only so #807 can use this branch's protected planning workflow. Remove that temporary target after #807 is merged into this branch, then rerun the final protected plan before merging to `main`.

## Security boundary

- subscription `Reader`
- state-container `Storage Blob Data Reader`
- narrowly scoped storage data-plane read access required for provider refresh
- no `listKeys`, `listSecrets`, Contributor, state-write, or lease permissions
- `id-token: write` scoped to the protected plan job
- no application secrets, saved plans, state, or full plan output are published

## Deployment order

1. Review and merge #807 into this branch.
2. Remove the temporary stack-only workflow trigger.
3. Approve and run the final protected read-only plan.
4. Merge this PR to `main` only after the plan is green.
5. Confirm the production deployment applies the state migrations without replacement.
6. Remove temporary migration files in a later cleanup after state adoption is confirmed.
