### PR TITLE
Remove storage keys and secrets from Terraform state

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -349,7 +349,6 @@ jobs:
         env:
           TF_VAR_subscription_id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
           TF_VAR_github_client_id: ${{ secrets.TF_VAR_github_client_id }}
-          TF_VAR_smoke_test_token: ${{ secrets.SMOKE_TEST_TOKEN }}
           TF_VAR_postgres_entra_admin_object_id: ${{ vars.POSTGRES_ENTRA_ADMIN_OBJECT_ID }}
           TF_VAR_postgres_entra_admin_principal_name: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_NAME }}
           TF_VAR_postgres_entra_admin_principal_type: ${{ vars.POSTGRES_ENTRA_ADMIN_PRINCIPAL_TYPE || 'Group' }}
@@ -644,12 +643,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # The gate only runs once the shared secret exists in both places
-          # (the GitHub secret here and, via Terraform, the running app). Until
-          # then, warn loudly instead of blocking every deploy.
+          # The gate only runs once the shared secret exists in both places: the
+          # GitHub secret here and the smoke-test-token Key Vault secret the app
+          # reads. Until then, warn loudly instead of blocking every deploy.
           if [[ -z "${SMOKE_TEST_TOKEN:-}" ]]; then
             echo "::warning::SMOKE_TEST_TOKEN is not set — skipping the post-deploy verification smoke test."
-            echo "Set the SMOKE_TEST_TOKEN repository secret to activate this deploy gate."
+            echo "Set the SMOKE_TEST_TOKEN repository secret to the same value as the"
+            echo "smoke-test-token Key Vault secret to activate this deploy gate."
             exit 0
           fi
 
@@ -683,6 +683,6 @@ jobs:
 
           echo "ERROR: verification smoke test did not pass (last HTTP $code)."
           echo "401 means the app's SMOKE_TEST__TOKEN does not match this secret;"
-          echo "404 means the app has no token configured yet."
+          echo "check that the smoke-test-token Key Vault secret holds the same value."
           cat /tmp/smoke_body.txt || true
           exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
-          terraform_version: "~1.5"
+          terraform_version: "~1.14"
           terraform_wrapper: false
 
       - name: Terraform format check
@@ -328,7 +328,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
-          terraform_version: "~1.5"
+          terraform_version: "~1.14"
           terraform_wrapper: false
 
       - name: Azure CLI Login for deployment

--- a/infra/CLEANUP.md
+++ b/infra/CLEANUP.md
@@ -89,8 +89,10 @@ about credentials in state, exposure defaults, and structure.
       declare a null default and resolve the real default in `locals`. Put the
       default on the variable and drop the local, keeping the pattern only where
       the value genuinely varies per environment.
-- [ ] **`required_version = ">= 1.5.0"`** is unbounded while local and CI runs use
-      1.14. Pin a bounded constraint.
+- [x] **`required_version = ">= 1.5.0"`** was unbounded while local and CI runs used
+      1.14. Pinned to `~> 1.14`, and the CI/apply jobs to `~1.14`. The old `~1.5`
+      workflow pin resolved to 1.5.x, which predates expression support in
+      `import` block ids (added in 1.12).
 
 ## Tier 3 — Consistency
 

--- a/infra/CLEANUP.md
+++ b/infra/CLEANUP.md
@@ -29,6 +29,11 @@ about credentials in state, exposure defaults, and structure.
       the host starts. Fully key-free therefore requires moving the Function App
       to `azapi_resource`, which the repository already uses for Foundry and the
       Durable Task Scheduler.
+
+      **Resolved** by modelling the app with azapi and migrating state with
+      `removed` + `import`. One caveat to confirm at apply time: azapi PUTs only
+      the configured body, so compare the site's ARM properties before and after
+      the first apply to be sure the Web RP did not reset an omitted property.
 - [x] **`smoke_test_token` is an inline Container App secret.** `container-apps.tf`
       passes the raw value through `var.smoke_test_token` (supplied by CI as
       `TF_VAR_smoke_test_token`), so it lands in state in plaintext. Note that an

--- a/infra/CLEANUP.md
+++ b/infra/CLEANUP.md
@@ -8,7 +8,7 @@ about credentials in state, exposure defaults, and structure.
 
 ## Tier 1 — Security
 
-- [ ] **Function storage uses an access key.** `functions.tf` sets
+- [x] **Function storage uses an access key.** `functions.tf` sets
       `storage_authentication_type = "StorageAccountConnectionString"` and
       `storage_access_key = azurerm_storage_account.verification_functions.primary_access_key`,
       which writes a reusable storage key into Terraform state and forces the
@@ -29,7 +29,7 @@ about credentials in state, exposure defaults, and structure.
       the host starts. Fully key-free therefore requires moving the Function App
       to `azapi_resource`, which the repository already uses for Foundry and the
       Durable Task Scheduler.
-- [ ] **`smoke_test_token` is an inline Container App secret.** `container-apps.tf`
+- [x] **`smoke_test_token` is an inline Container App secret.** `container-apps.tf`
       passes the raw value through `var.smoke_test_token` (supplied by CI as
       `TF_VAR_smoke_test_token`), so it lands in state in plaintext. Note that an
       `azurerm_key_vault_secret` resource would not help — that also stores the
@@ -49,14 +49,21 @@ about credentials in state, exposure defaults, and structure.
       `variables.tf` precondition only rejects it in `prod`, and CI never sets
       `TF_VAR_durable_task_scheduler_ip_allowlist`, so the open default is what
       dev actually runs. Same networking dependency as the item above.
-- [ ] **Key Vault reference identity is implicit.** `key-vault.tf` grants
+- [x] **Key Vault reference identity is implicit.** `key-vault.tf` grants
       `Key Vault Secrets User` to the Functions app's *system-assigned* identity
       while the app otherwise runs as its user-assigned identity. Key Vault
       references only resolve because the reference identity is unset and
       defaults to system-assigned. `azurerm_function_app_flex_consumption` has no
       `key_vault_reference_identity_id` argument in either 4.81 or 5.0.1, so
       making this explicit needs `azapi` — the same conclusion as the storage
-      item above.
+      item above. Resolved by the same azapi migration: the app now runs with
+      the user-assigned identity only, and keyVaultReferenceIdentity points at
+      it explicitly.
+
+- [ ] **Disable Shared Key on the Functions storage account.** Now that nothing
+      requests a key, set `shared_access_key_enabled = false`. Do this only
+      after an apply has confirmed the identity-based host storage works, so the
+      change is independently revertable.
 - [x] **Diagnostic settings.** Added for Key Vault, the container registry,
       PostgreSQL, and the Functions storage blob service. None of these resource
       types expose Azure Monitor category groups, so categories are named

--- a/infra/CLEANUP.md
+++ b/infra/CLEANUP.md
@@ -1,0 +1,116 @@
+# Terraform cleanup backlog
+
+Tracked findings from a full review of `infra/`. Ordered by priority. Check items
+off as they land; each tier is intended to ship as its own pull request.
+
+`terraform fmt` is clean and the module layout is sensible — everything below is
+about credentials in state, exposure defaults, and structure.
+
+## Tier 1 — Security
+
+- [ ] **Function storage uses an access key.** `functions.tf` sets
+      `storage_authentication_type = "StorageAccountConnectionString"` and
+      `storage_access_key = azurerm_storage_account.verification_functions.primary_access_key`,
+      which writes a reusable storage key into Terraform state and forces the
+      planning identity to hold `listKeys`.
+
+      **Blocked on a provider limitation.** Switching to
+      `storage_authentication_type = "UserAssignedIdentity"` fixes the
+      *deployment* container only. AzureRM always writes the host storage
+      setting from a key-based connection string, in both 4.81 and 5.0.1:
+      `function_app_flex_consumption_resource.go:450` builds
+      `StorageStringFmt` (`...;AccountKey=%s;...`) from `storage_access_key`
+      regardless of the authentication type, and
+      `helpers/function_app_schema.go:2114` writes that value to
+      `AzureWebJobsStorage` unconditionally. With the key removed the app would
+      receive `AccountKey=` and the Functions host would fail to resolve the
+      connection. The provider's own acceptance tests
+      (`storageUserAssignedIdentity1`) only assert the resource exists, not that
+      the host starts. Fully key-free therefore requires moving the Function App
+      to `azapi_resource`, which the repository already uses for Foundry and the
+      Durable Task Scheduler.
+- [ ] **`smoke_test_token` is an inline Container App secret.** `container-apps.tf`
+      passes the raw value through `var.smoke_test_token` (supplied by CI as
+      `TF_VAR_smoke_test_token`), so it lands in state in plaintext. Note that an
+      `azurerm_key_vault_secret` resource would not help — that also stores the
+      value in state. The fix is to stop routing the token through Terraform:
+      create the Key Vault secret out of band, exactly like the other four
+      secrets, reference it with `key_vault_secret_id`, and delete the variable.
+      This also removes the two `dynamic` blocks and the `!= ""` special-casing.
+- [ ] **PostgreSQL is reachable from all of Azure.** `database.tf` combines
+      `public_network_access_enabled = true` with an `AllowAzureServices`
+      (`0.0.0.0`) firewall rule, so any Azure tenant can reach the server and
+      Entra-only authentication is the sole control. **Depends on a networking
+      decision:** the Container Apps environment and the Flex Consumption app
+      both egress from dynamic public IPs today, so there is no address range to
+      allow-list. Closing this requires VNet integration, or a NAT gateway for a
+      stable egress address, or private networking.
+- [ ] **Durable Task Scheduler allowlist defaults to `0.0.0.0/0`.** The
+      `variables.tf` precondition only rejects it in `prod`, and CI never sets
+      `TF_VAR_durable_task_scheduler_ip_allowlist`, so the open default is what
+      dev actually runs. Same networking dependency as the item above.
+- [ ] **Key Vault reference identity is implicit.** `key-vault.tf` grants
+      `Key Vault Secrets User` to the Functions app's *system-assigned* identity
+      while the app otherwise runs as its user-assigned identity. Key Vault
+      references only resolve because the reference identity is unset and
+      defaults to system-assigned. `azurerm_function_app_flex_consumption` has no
+      `key_vault_reference_identity_id` argument in either 4.81 or 5.0.1, so
+      making this explicit needs `azapi` — the same conclusion as the storage
+      item above.
+- [x] **Diagnostic settings.** Added for Key Vault, the container registry,
+      PostgreSQL, and the Functions storage blob service. None of these resource
+      types expose Azure Monitor category groups, so categories are named
+      explicitly.
+- [ ] **No network restrictions.** Key Vault and the Functions storage account
+      both allow public network access with no `network_acls`. Blocked on the
+      same networking decision as the PostgreSQL item.
+
+## Tier 2 — Structure
+
+- [ ] **`provider.tf` holds four unrelated concerns:** the `terraform` block, the
+      provider configurations, a real resource (`random_string.suffix`), and a
+      30-line `locals`. Split into `versions.tf`, `providers.tf`, and `locals.tf`.
+- [ ] **`monitoring.tf` is 479 lines** with eight near-identical
+      `azurerm_monitor_scheduled_query_rules_alert_v2` blocks. Collapse them into
+      a `for_each` over a locals map of alert definitions.
+- [ ] **`default = null` + `coalesce()` indirection.** Roughly ten variables
+      declare a null default and resolve the real default in `locals`. Put the
+      default on the variable and drop the local, keeping the pattern only where
+      the value genuinely varies per environment.
+- [ ] **`required_version = ">= 1.5.0"`** is unbounded while local and CI runs use
+      1.14. Pin a bounded constraint.
+
+## Tier 3 — Consistency
+
+- [ ] **`local.suffix` is applied inconsistently.** Key Vault, PostgreSQL, ACR,
+      Log Analytics, App Insights, storage, and Foundry include it; the Container
+      App, migration job, Function App, service plan, Container App environment,
+      and action group do not. Pick one rule and document it.
+- [ ] **`outputs.tf` mixes conventions.** `AZURE_RESOURCE_GROUP` and
+      `AZURE_CONTAINER_REGISTRY_*` are SCREAMING_CASE among otherwise snake_case
+      outputs, and `database_host` overlaps `postgres_server_name`. Normalize to
+      snake_case and map names in the workflow instead.
+- [ ] **`schema_validation_enabled = false` is copy-pasted** onto all five
+      `azapi_resource` blocks, including stable API versions that do not need it.
+- [ ] **`provider "azapi" {}` is empty.** Set `subscription_id` so it cannot drift
+      from the AzureRM provider.
+- [ ] **Duplicated and hardcoded values.** `https://learntocloud.guide` appears in
+      both `container-apps.tf` (CORS) and `monitoring.tf` (web test); the
+      verification Entra client ID and the dashboard reader group object ID are
+      hardcoded in `provider.tf` locals and `variables.tf` defaults.
+- [ ] **`ignore_changes = all` on `random_string.suffix`** is broader than needed
+      for an already-stable value.
+- [ ] **Redundant `depends_on`.** `container-apps.tf` and `migrations.tf` both
+      declare an explicit dependency on
+      `azurerm_postgresql_flexible_server_database.main`, which is already
+      implicit through env var references. Keep only the role-assignment entries.
+- [ ] **No Terraform checks in the quality gate.** Add `terraform validate` and a
+      linter (`tflint`, optionally `checkov`) to the `poe` tasks and CI.
+
+## Related work
+
+- Issue #743 covers the secretless planning identity and the Container Apps
+  `ListSecrets` refresh problem. Note that `azurerm_container_app.api` hits the
+  same `ListSecrets` call on read as `azurerm_container_app_job.migrations`.
+- PR #714 bumps AzureRM 4.81 to 5.0.1. Land the cleanup on 4.x first, then
+  upgrade, so a provider major and a state migration never mix in one change.

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -82,16 +82,14 @@ resource "azurerm_container_app" "api" {
     key_vault_secret_id = "${azurerm_key_vault.main.vault_uri}secrets/labs-verification-secret"
   }
 
-  # The smoke-test token is the single source of truth for the post-deploy
-  # verification smoke endpoint and is supplied directly from a GitHub Actions
-  # secret (not Key Vault), so it is set inline here. Only created when a
-  # token is provided so applies without the secret stay valid.
-  dynamic "secret" {
-    for_each = var.smoke_test_token != "" ? [1] : []
-    content {
-      name  = "smoke-test-token"
-      value = var.smoke_test_token
-    }
+  # The smoke-test token gates the post-deploy verification smoke endpoint
+  # (POST /internal/smoke/verification). Like every other secret here it is
+  # created out of band in Key Vault, so its value never passes through
+  # Terraform variables or state.
+  secret {
+    name                = "smoke-test-token"
+    identity            = azurerm_user_assigned_identity.api.id
+    key_vault_secret_id = "${azurerm_key_vault.main.vault_uri}secrets/smoke-test-token"
   }
 
   ingress {
@@ -164,12 +162,9 @@ resource "azurerm_container_app" "api" {
         secret_name = "ctf-master-secret"
       }
 
-      dynamic "env" {
-        for_each = var.smoke_test_token != "" ? [1] : []
-        content {
-          name        = "SMOKE_TEST__TOKEN"
-          secret_name = "smoke-test-token"
-        }
+      env {
+        name        = "SMOKE_TEST__TOKEN"
+        secret_name = "smoke-test-token"
       }
 
       env {

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -184,7 +184,7 @@ resource "azurerm_container_app" "api" {
 
       env {
         name  = "VERIFICATION_FUNCTIONS__BASE_URL"
-        value = "https://${azurerm_function_app_flex_consumption.verification.default_hostname}"
+        value = "https://${azapi_resource.verification_functions.output.properties.defaultHostName}"
       }
 
       env {

--- a/infra/diagnostics.tf
+++ b/infra/diagnostics.tf
@@ -1,0 +1,52 @@
+# None of these resource types expose Azure Monitor category groups, so each log
+// category is named explicitly.
+resource "azurerm_monitor_diagnostic_setting" "key_vault" {
+  name                       = "diag-to-log-analytics"
+  target_resource_id         = azurerm_key_vault.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "AuditEvent"
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "container_registry" {
+  name                       = "diag-to-log-analytics"
+  target_resource_id         = azurerm_container_registry.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "ContainerRegistryLoginEvents"
+  }
+
+  enabled_log {
+    category = "ContainerRegistryRepositoryEvents"
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "postgres" {
+  name                       = "diag-to-log-analytics"
+  target_resource_id         = azurerm_postgresql_flexible_server.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "PostgreSQLLogs"
+  }
+}
+
+# Data-plane reads and writes against the deployment container. This is the only
+# audit trail for the Functions storage account, so it stays on even though the
+# account is expected to be low traffic.
+resource "azurerm_monitor_diagnostic_setting" "verification_functions_storage_blob" {
+  name                       = "diag-to-log-analytics"
+  target_resource_id         = "${azurerm_storage_account.verification_functions.id}/blobServices/default"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "StorageWrite"
+  }
+
+  enabled_log {
+    category = "StorageDelete"
+  }
+}

--- a/infra/functions.tf
+++ b/infra/functions.tf
@@ -92,78 +92,133 @@ resource "azurerm_role_assignment" "verification_functions_foundry" {
   skip_service_principal_aad_check = true
 }
 
-resource "azurerm_function_app_flex_consumption" "verification" {
-  name                = "func-ltc-verification-${var.environment}"
-  resource_group_name = azurerm_resource_group.main.name
-  location            = azurerm_resource_group.main.location
-  service_plan_id     = azurerm_service_plan.verification_functions.id
-  https_only          = true
-  tags                = local.tags
 
-  storage_container_type      = "blobContainer"
-  storage_container_endpoint  = "${azurerm_storage_account.verification_functions.primary_blob_endpoint}${azurerm_storage_container.verification_functions_deployments.name}"
-  storage_authentication_type = "StorageAccountConnectionString"
-  storage_access_key          = azurerm_storage_account.verification_functions.primary_access_key
-  runtime_name                = "python"
-  runtime_version             = "3.13"
+# The Functions host and the deployment process both reach the storage account
+# with the app's user-assigned identity, so no account key is ever issued.
+# Blob Data Owner (not Contributor) is required: the host manages its own
+# containers and takes blob leases for singleton coordination.
+resource "azurerm_role_assignment" "verification_functions_storage_blob" {
+  scope                            = azurerm_storage_account.verification_functions.id
+  role_definition_name             = "Storage Blob Data Owner"
+  principal_id                     = azurerm_user_assigned_identity.verification_functions.principal_id
+  principal_type                   = "ServicePrincipal"
+  skip_service_principal_aad_check = true
+}
 
-  identity {
-    type         = "SystemAssigned, UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.verification_functions.id]
-  }
+resource "azurerm_role_assignment" "verification_functions_storage_queue" {
+  scope                            = azurerm_storage_account.verification_functions.id
+  role_definition_name             = "Storage Queue Data Contributor"
+  principal_id                     = azurerm_user_assigned_identity.verification_functions.principal_id
+  principal_type                   = "ServicePrincipal"
+  skip_service_principal_aad_check = true
+}
 
-  auth_settings_v2 {
-    auth_enabled           = true
-    runtime_version        = "~1"
-    require_authentication = true
-    unauthenticated_action = "Return401"
-    require_https          = true
-
-    active_directory_v2 {
-      client_id            = local.verification_functions_auth_client_id
-      tenant_auth_endpoint = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/v2.0"
-      allowed_audiences = [
-        local.verification_functions_auth_client_id,
-        local.verification_functions_auth_audience,
-      ]
-      allowed_applications = [
-        azurerm_user_assigned_identity.api.client_id,
-      ]
-      allowed_identities = [
-        azurerm_user_assigned_identity.api.principal_id,
-      ]
-    }
-
-    login {}
-  }
-
-  app_settings = {
+locals {
+  # AzureWebJobsStorage is configured with the identity-based __ properties
+  # instead of a connection string, so no storage key exists in state or in the
+  # app configuration. Secrets stay as Key Vault references, which the app
+  # resolves with keyVaultReferenceIdentity.
+  verification_functions_app_settings = {
+    APPLICATIONINSIGHTS_CONNECTION_STRING    = azurerm_application_insights.main.connection_string
     AZURE_CLIENT_ID                          = azurerm_user_assigned_identity.verification_functions.client_id
+    AzureWebJobsStorage__blobServiceUri      = azurerm_storage_account.verification_functions.primary_blob_endpoint
+    AzureWebJobsStorage__queueServiceUri     = azurerm_storage_account.verification_functions.primary_queue_endpoint
+    AzureWebJobsStorage__tableServiceUri     = azurerm_storage_account.verification_functions.primary_table_endpoint
+    AzureWebJobsStorage__credential          = "managedidentity"
+    AzureWebJobsStorage__clientId            = azurerm_user_assigned_identity.verification_functions.client_id
     DATABASE__URL                            = ""
-    ENABLE_INSTRUMENTATION                   = "true"
+    DATABASE__HOST                           = azurerm_postgresql_flexible_server.main.fqdn
+    DATABASE__NAME                           = azurerm_postgresql_flexible_server_database.main.name
+    DATABASE__USER                           = local.verification_functions_postgres_role
     DURABLE_TASK_SCHEDULER_CONNECTION_STRING = "Endpoint=${azapi_resource.verification_scheduler.output.properties.endpoint};Authentication=ManagedIdentity;ClientID=${azurerm_user_assigned_identity.verification_functions.client_id}"
-    OAUTH__CLIENT_ID                         = var.github_client_id
-    OAUTH__CLIENT_SECRET                     = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-client-secret)"
-    GITHUB__TOKEN                            = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-token)"
+    ENABLE_INSTRUMENTATION                   = "true"
     FOUNDRY_MODEL_DEPLOYMENT_NAME            = azapi_resource.foundry_model_deployment.name
     FOUNDRY_PROJECT_ENDPOINT                 = local.foundry_project_endpoint
+    GITHUB__TOKEN                            = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-token)"
     LABS__VERIFICATION_SECRET                = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=labs-verification-secret)"
+    OAUTH__CLIENT_ID                         = var.github_client_id
+    OAUTH__CLIENT_SECRET                     = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-client-secret)"
     OTEL_SERVICE_NAME                        = "learn-to-cloud-verification-functions"
-    DATABASE__NAME                           = azurerm_postgresql_flexible_server_database.main.name
-    DATABASE__HOST                           = azurerm_postgresql_flexible_server.main.fqdn
-    DATABASE__USER                           = local.verification_functions_postgres_role
     SESSION__SECRET_KEY                      = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=session-secret-key)"
     TASKHUB_NAME                             = local.verification_functions_task_hub_name
   }
+}
 
-  site_config {
-    application_insights_connection_string = azurerm_application_insights.main.connection_string
-    minimum_tls_version                    = "1.2"
+# Modelled with azapi rather than azurerm_function_app_flex_consumption because
+# that resource always derives the AzureWebJobsStorage setting from a key-based
+# connection string, regardless of storage_authentication_type, and exposes no
+# way to set keyVaultReferenceIdentity. See infra/CLEANUP.md.
+resource "azapi_resource" "verification_functions" {
+  type      = "Microsoft.Web/sites@2024-04-01"
+  name      = "func-ltc-verification-${var.environment}"
+  parent_id = azurerm_resource_group.main.id
+  location  = azurerm_resource_group.main.location
+  tags      = local.tags
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.verification_functions.id]
   }
+
+  body = {
+    kind = "functionapp,linux"
+    properties = {
+      serverFarmId        = azurerm_service_plan.verification_functions.id
+      httpsOnly           = true
+      publicNetworkAccess = "Enabled"
+
+      # Key Vault references resolve through the same identity the app runs as,
+      # rather than the platform default of the system-assigned identity.
+      keyVaultReferenceIdentity = azurerm_user_assigned_identity.verification_functions.id
+
+      functionAppConfig = {
+        deployment = {
+          storage = {
+            type  = "blobContainer"
+            value = "${azurerm_storage_account.verification_functions.primary_blob_endpoint}${azurerm_storage_container.verification_functions_deployments.name}"
+            authentication = {
+              type                           = "UserAssignedIdentity"
+              userAssignedIdentityResourceId = azurerm_user_assigned_identity.verification_functions.id
+            }
+          }
+        }
+
+        runtime = {
+          name    = "python"
+          version = "3.13"
+        }
+
+        scaleAndConcurrency = {
+          instanceMemoryMB     = 2048
+          maximumInstanceCount = 100
+        }
+      }
+
+      siteConfig = {
+        minTlsVersion    = "1.2"
+        scmMinTlsVersion = "1.2"
+        ftpsState        = "FtpsOnly"
+
+        appSettings = [
+          for name, value in local.verification_functions_app_settings : {
+            name  = name
+            value = value
+          }
+        ]
+      }
+    }
+  }
+
+  # ARM returns the service plan ID with different casing than it accepts.
+  ignore_casing             = true
+  response_export_values    = ["properties.defaultHostName"]
+  schema_validation_enabled = false
 
   depends_on = [
     azurerm_role_assignment.verification_functions_durable_task,
     azurerm_role_assignment.verification_functions_foundry,
+    azurerm_role_assignment.verification_functions_storage_blob,
+    azurerm_role_assignment.verification_functions_storage_queue,
     azapi_resource.foundry_model_deployment,
     azurerm_postgresql_flexible_server_database.main,
   ]
@@ -174,4 +229,56 @@ resource "azurerm_function_app_flex_consumption" "verification" {
       error_message = "verification_functions_auth_client_id must be set for this environment."
     }
   }
+}
+
+resource "azapi_resource" "verification_functions_auth" {
+  type      = "Microsoft.Web/sites/config@2024-04-01"
+  name      = "authsettingsV2"
+  parent_id = azapi_resource.verification_functions.id
+
+  body = {
+    properties = {
+      globalValidation = {
+        requireAuthentication       = true
+        unauthenticatedClientAction = "Return401"
+      }
+
+      httpSettings = {
+        requireHttps = true
+      }
+
+      identityProviders = {
+        azureActiveDirectory = {
+          enabled = true
+          registration = {
+            clientId     = local.verification_functions_auth_client_id
+            openIdIssuer = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/v2.0"
+          }
+          validation = {
+            allowedAudiences = [
+              local.verification_functions_auth_client_id,
+              local.verification_functions_auth_audience,
+            ]
+            defaultAuthorizationPolicy = {
+              allowedApplications = [
+                azurerm_user_assigned_identity.api.client_id,
+              ]
+              allowedPrincipals = {
+                identities = [
+                  azurerm_user_assigned_identity.api.principal_id,
+                ]
+              }
+            }
+          }
+        }
+      }
+
+      platform = {
+        enabled        = true
+        runtimeVersion = "~1"
+      }
+    }
+  }
+
+  schema_validation_enabled = false
 }

--- a/infra/key-vault.tf
+++ b/infra/key-vault.tf
@@ -22,7 +22,7 @@ resource "azurerm_role_assignment" "api_key_vault_secrets_user" {
 resource "azurerm_role_assignment" "verification_functions_key_vault_secrets_user" {
   scope                            = azurerm_key_vault.main.id
   role_definition_name             = "Key Vault Secrets User"
-  principal_id                     = azurerm_function_app_flex_consumption.verification.identity[0].principal_id
+  principal_id                     = azurerm_user_assigned_identity.verification_functions.principal_id
   principal_type                   = "ServicePrincipal"
   skip_service_principal_aad_check = true
 }

--- a/infra/migrate-functions.tf
+++ b/infra/migrate-functions.tf
@@ -1,0 +1,23 @@
+# State migration for the verification Function App, moving it from
+# azurerm_function_app_flex_consumption to azapi without recreating the live
+# app. The removed block drops the old address from state only; the import
+# blocks adopt the existing site and its auth configuration.
+#
+# Delete this file once the migration has been applied to every environment.
+removed {
+  from = azurerm_function_app_flex_consumption.verification
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = azapi_resource.verification_functions
+  id = "${azurerm_resource_group.main.id}/providers/Microsoft.Web/sites/func-ltc-verification-${var.environment}"
+}
+
+import {
+  to = azapi_resource.verification_functions_auth
+  id = "${azurerm_resource_group.main.id}/providers/Microsoft.Web/sites/func-ltc-verification-${var.environment}/config/authsettingsV2"
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -102,12 +102,12 @@ output "migration_postgres_role" {
 
 output "verification_functions_name" {
   description = "Azure Functions app name used for Durable verification jobs"
-  value       = azurerm_function_app_flex_consumption.verification.name
+  value       = azapi_resource.verification_functions.name
 }
 
 output "verification_functions_url" {
   description = "Azure Functions app URL used by the API Durable client"
-  value       = "https://${azurerm_function_app_flex_consumption.verification.default_hostname}"
+  value       = "https://${azapi_resource.verification_functions.output.properties.defaultHostName}"
 }
 
 output "verification_functions_auth_scope" {

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,5 +1,6 @@
 terraform {
-  required_version = ">= 1.5.0"
+  # >= 1.12 is required for expressions in import block ids.
+  required_version = "~> 1.14"
 
   required_providers {
     azurerm = {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -165,19 +165,6 @@ variable "github_client_id" {
   type        = string
 }
 
-variable "smoke_test_token" {
-  description = <<-EOT
-    Shared secret for the post-deploy verification smoke endpoint
-    (POST /internal/smoke/verification). When set, it is delivered to the API
-    Container App as the SMOKE_TEST__TOKEN secret so the app can validate smoke
-    requests. When empty, the endpoint stays disabled (returns 404). Sourced
-    from the SMOKE_TEST_TOKEN GitHub Actions secret via TF_VAR_smoke_test_token.
-  EOT
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
 variable "verification_functions_auth_client_id" {
   description = "Client ID of the pre-created Entra app registration."
   type        = string


### PR DESCRIPTION
## What

The first three security items from a full review of `infra/`. The review itself is recorded in `infra/CLEANUP.md`, which tracks the remaining structural and consistency work.

### Diagnostic settings

No `azurerm_monitor_diagnostic_setting` existed anywhere. Added them for Key Vault, the container registry, PostgreSQL, and the Functions blob service. None of those resource types expose Azure Monitor category groups, so each log category is named explicitly, verified against the live subscription.

### Smoke-test token

The token was passed through `TF_VAR_smoke_test_token` and set inline on the API Container App, which would have written it to state in plaintext. An `azurerm_key_vault_secret` resource would do the same, so the value no longer passes through Terraform at all: it is created out of band in Key Vault like the other four application secrets and referenced by `key_vault_secret_id`. This also removes the two `dynamic` blocks and the empty-string special-casing.

The GitHub `SMOKE_TEST_TOKEN` secret was never set, so the gate was dormant and nothing had reached state yet.

### Key-free Function App

`azurerm_function_app_flex_consumption` cannot express a key-free Flex Consumption app. It builds `AzureWebJobsStorage` from a key-based connection string regardless of `storage_authentication_type` (`function_app_flex_consumption_resource.go:450` and `helpers/function_app_schema.go:2114`), and has no `keyVaultReferenceIdentity` argument. Both are true in 4.81 and 5.0.1. So a reusable storage key and a deployment connection string ended up in state and in app configuration.

The app is now modelled with `azapi`, matching the existing Foundry and Durable Task Scheduler resources:

- deployment storage authenticates with the user-assigned identity
- `AzureWebJobsStorage` uses the identity-based `__blobServiceUri` / `__queueServiceUri` / `__tableServiceUri` / `__credential` / `__clientId` settings
- `keyVaultReferenceIdentity` points at the user-assigned identity, so the system-assigned identity is no longer needed and Key Vault access follows the identity the app actually runs as
- Storage Blob Data Owner and Storage Queue Data Contributor replace the key
- `auth_settings_v2` becomes a `Microsoft.Web/sites/config` child resource

## Migration safety

State moves with `removed` + `import` in `infra/migrate-functions.tf`, so the live app is adopted rather than recreated. Plan against dev:

```
Plan: 2 to import, 7 to add, 4 to change, 1 to destroy.
```

The single destroy is the Key Vault role assignment being replaced to move from the system-assigned to the user-assigned principal. Nothing else is recreated.

Delete `infra/migrate-functions.tf` once this has been applied to every environment.

## Follow-up before merge

`azapi` PUTs only the configured body, unlike the read-modify-write that azurerm performs. The properties that matter are set explicitly (`httpsOnly`, `publicNetworkAccess`, `minTlsVersion`, `scmMinTlsVersion`, `ftpsState`), but the first apply should be followed by an ARM before/after diff on the site to confirm the Web RP did not reset an omitted property, and by a check that the Functions host starts with identity-based storage.

Disabling Shared Key on the storage account is deliberately left as a separate follow-up so it stays independently revertable.

## Verification

- `terraform fmt -check`, `terraform validate`, and `terraform plan` against dev
- `uv run poe check`
