### PR TITLE
Use Entra ID for storage data-plane reads

### DIFF
--- a/infra/CLEANUP.md
+++ b/infra/CLEANUP.md
@@ -71,6 +71,15 @@ about credentials in state, exposure defaults, and structure.
       remains in app settings. `azurerm_storage_container` uses
       `storage_account_id`, so it goes through the management plane and keeps
       working without the key.
+
+      `azurerm_storage_account` itself still reads queue properties over the
+      data plane, which 403s once the key is gone, so the provider needs
+      `storage_use_azuread = true`. That makes the read use Entra ID, which
+      requires a data-plane role: the CI identities are granted
+      `Storage Queue Data Contributor` (apply) and `Storage Queue Data Reader`
+      (plan) on the account. These are granted out of band, alongside the OIDC
+      federation and the subscription Contributor/Reader assignments, because
+      Terraform cannot refresh this resource without them.
 - [x] **Diagnostic settings.** Added for Key Vault, the container registry,
       PostgreSQL, and the Functions storage blob service. None of these resource
       types expose Azure Monitor category groups, so categories are named

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -32,6 +32,10 @@ provider "azurerm" {
     }
   }
   subscription_id = var.subscription_id
+
+  # The Functions storage account has Shared Key disabled, so data-plane reads
+  # (queue properties) must use Entra ID.
+  storage_use_azuread = true
 }
 
 provider "azapi" {}


### PR DESCRIPTION
## Fixes the broken apply from #746

The apply in #746 failed, and left `main` unable to run Terraform at all.

`azurerm_storage_account` reads queue properties over the **data plane**. Once Shared Key was disabled that read returns:

```
403 Key based authentication is not permitted on this storage account.
KeyBasedAuthenticationNotPermitted
```

The ARM update itself succeeded, so the account had the key disabled while state still recorded it as enabled — and refresh failed before it could reconcile. Every subsequent plan hit the same error, confirmed locally as well as in CI.

## The fix

`storage_use_azuread = true` on the azurerm provider, which switches data-plane reads to Entra ID.

That requires a data-plane role, which neither CI identity had. Owner and Contributor do not grant data-plane access. Granted on the storage account only:

| Identity | Role |
| --- | --- |
| `learn-to-cloud-sp` (apply, `refs/heads/main`) | Storage Queue Data Contributor |
| `github-learntocloud-terraform-plan` (plan) | Storage Queue Data Reader |

These are granted out of band, alongside the OIDC federation and the existing subscription Contributor/Reader assignments, because Terraform cannot refresh this resource without them. Codifying them would be circular.

I verified the **read-only** role is sufficient for the plan path, so the read-only planning identity from #743 keeps its read-only posture.

## Verification

Local plan against dev, with the key already disabled in Azure:

```
Plan: 0 to add, 1 to change, 0 to destroy.
```

The refresh now reconciles the storage account cleanly. The one remaining change is pre-existing action-group email drift from a local, gitignored `terraform.tfvars`, which does not appear in CI.
