### PR TITLE
Remove Container Apps secret reads from Terraform plans

### DIFF
--- a/infra/CLEANUP.md
+++ b/infra/CLEANUP.md
@@ -104,6 +104,12 @@ about credentials in state, exposure defaults, and structure.
       1.14. Pinned to `~> 1.14`, and the CI/apply jobs to `~1.14`. The old `~1.5`
       workflow pin resolved to 1.5.x, which predates expression support in
       `import` block ids (added in 1.12).
+- [x] **Container Apps Job refresh reads secrets.** Replaced
+      `azurerm_container_app_job.migrations` with `azapi_resource` so refresh
+      uses the normal ARM resource read instead of
+      `Microsoft.App/jobs/listSecrets/action`. The state migration uses
+      `removed` + `import` and preserves the live job, managed identity,
+      registry identity, image rollout boundary, and runtime configuration.
 
 ## Tier 3 — Consistency
 
@@ -115,9 +121,11 @@ about credentials in state, exposure defaults, and structure.
       `AZURE_CONTAINER_REGISTRY_*` are SCREAMING_CASE among otherwise snake_case
       outputs, and `database_host` overlaps `postgres_server_name`. Normalize to
       snake_case and map names in the workflow instead.
-- [ ] **`schema_validation_enabled = false` is copy-pasted** onto all five
+- [ ] **`schema_validation_enabled = false` is copy-pasted** onto five
       `azapi_resource` blocks, including stable API versions that do not need it.
-- [ ] **`provider "azapi" {}` is empty.** Set `subscription_id` so it cannot drift
+      The Container Apps Job migration uses the stable schema with validation
+      enabled; clean up the older resources separately.
+- [x] **`provider "azapi" {}` is empty.** Set `subscription_id` so it cannot drift
       from the AzureRM provider.
 - [ ] **Duplicated and hardcoded values.** `https://learntocloud.guide` appears in
       both `container-apps.tf` (CORS) and `monitoring.tf` (web test); the
@@ -134,8 +142,10 @@ about credentials in state, exposure defaults, and structure.
 
 ## Related work
 
-- Issue #743 covers the secretless planning identity and the Container Apps
-  `ListSecrets` refresh problem. Note that `azurerm_container_app.api` hits the
-  same `ListSecrets` call on read as `azurerm_container_app_job.migrations`.
+- Issue #743 covers the secretless planning identity and the Container Apps Job
+  `ListSecrets` refresh problem. The first live read-only plan failed on the job
+  and Functions storage account, but did not report a corresponding denial for
+  `azurerm_container_app.api`; keep the API resource under observation when the
+  read-only plan is re-run.
 - PR #714 bumps AzureRM 4.81 to 5.0.1. Land the cleanup on 4.x first, then
   upgrade, so a provider major and a state migration never mix in one change.

--- a/infra/migrate-container-app-job.tf
+++ b/infra/migrate-container-app-job.tf
@@ -14,5 +14,5 @@ removed {
 
 import {
   to = azapi_resource.migrations
-  id = "${azurerm_resource_group.main.id}/providers/Microsoft.App/jobs/job-ltc-migrations-${var.environment}?api-version=2024-03-01"
+  id = "${azurerm_resource_group.main.id}/providers/Microsoft.App/jobs/job-ltc-migrations-${var.environment}?api-version=${local.migration_job_api_version}"
 }

--- a/infra/migrate-container-app-job.tf
+++ b/infra/migrate-container-app-job.tf
@@ -1,0 +1,18 @@
+# State migration for the database migration job, moving it from
+# azurerm_container_app_job to azapi without recreating the live resource. The
+# removed block drops only the old Terraform address; the import adopts the
+# existing ARM resource at its new address.
+#
+# Delete this file after the migration has been applied to every environment.
+removed {
+  from = azurerm_container_app_job.migrations
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = azapi_resource.migrations
+  id = "${azurerm_resource_group.main.id}/providers/Microsoft.App/jobs/job-ltc-migrations-${var.environment}?api-version=2024-03-01"
+}

--- a/infra/migrations.tf
+++ b/infra/migrations.tf
@@ -3,7 +3,8 @@
 # even though this job has no secrets. A normal ARM GET is sufficient for this
 # resource and keeps the PR planning identity strictly read-only.
 locals {
-  migration_job_resource_type = "Microsoft.App/jobs@2024-03-01"
+  migration_job_api_version   = "2024-03-01"
+  migration_job_resource_type = "Microsoft.App/jobs@${local.migration_job_api_version}"
   migration_job_configuration = {
     triggerType       = "Manual"
     replicaTimeout    = 1800

--- a/infra/migrations.tf
+++ b/infra/migrations.tf
@@ -1,67 +1,87 @@
-resource "azurerm_container_app_job" "migrations" {
-  name                         = "job-ltc-migrations-${var.environment}"
-  location                     = azurerm_resource_group.main.location
-  resource_group_name          = azurerm_resource_group.main.name
-  container_app_environment_id = azurerm_container_app_environment.main.id
-  replica_timeout_in_seconds   = 1800
-  replica_retry_limit          = 0
-  tags                         = local.tags
-
-  lifecycle {
-    ignore_changes = [
-      template[0].container[0].image,
+# Modelled with azapi rather than azurerm_container_app_job because the
+# AzureRM provider calls Microsoft.App/jobs/listSecrets/action on every refresh,
+# even though this job has no secrets. A normal ARM GET is sufficient for this
+# resource and keeps the PR planning identity strictly read-only.
+locals {
+  migration_job_resource_type = "Microsoft.App/jobs@2024-03-01"
+  migration_job_configuration = {
+    triggerType       = "Manual"
+    replicaTimeout    = 1800
+    replicaRetryLimit = 0
+    manualTriggerConfig = {
+      parallelism            = 1
+      replicaCompletionCount = 1
+    }
+    registries = [
+      {
+        server   = azurerm_container_registry.main.login_server
+        identity = azurerm_user_assigned_identity.migrations.id
+      },
     ]
   }
+}
+
+resource "azapi_resource" "migrations" {
+  type      = local.migration_job_resource_type
+  name      = "job-ltc-migrations-${var.environment}"
+  parent_id = azurerm_resource_group.main.id
+  location  = azurerm_resource_group.main.location
+  tags      = local.tags
 
   identity {
     type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.migrations.id]
   }
 
-  registry {
-    server   = azurerm_container_registry.main.login_server
-    identity = azurerm_user_assigned_identity.migrations.id
-  }
+  body = {
+    properties = {
+      environmentId = azurerm_container_app_environment.main.id
 
-  manual_trigger_config {
-    parallelism              = 1
-    replica_completion_count = 1
-  }
+      configuration = local.migration_job_configuration
 
-  template {
-    container {
-      name    = "migrations"
-      image   = "mcr.microsoft.com/k8se/quickstart:latest"
-      command = ["python"]
-      args    = ["scripts/run_migrations.py"]
-      cpu     = 0.5
-      memory  = "1Gi"
-
-      env {
-        name  = "DATABASE__HOST"
-        value = azurerm_postgresql_flexible_server.main.fqdn
-      }
-
-      env {
-        name  = "DATABASE__USER"
-        value = local.migration_postgres_role
-      }
-
-      env {
-        name  = "DATABASE__NAME"
-        value = azurerm_postgresql_flexible_server_database.main.name
-      }
-
-      env {
-        name  = "AZURE_CLIENT_ID"
-        value = azurerm_user_assigned_identity.migrations.client_id
-      }
-
-      env {
-        name  = "POSTGRES_VERIFICATION_FUNCTIONS_ROLE"
-        value = local.verification_functions_postgres_role
+      template = {
+        containers = [
+          {
+            name    = "migrations"
+            image   = "${azurerm_container_registry.main.login_server}/migrations:latest"
+            command = ["python"]
+            args    = ["scripts/run_migrations.py"]
+            resources = {
+              cpu    = 0.5
+              memory = "1Gi"
+            }
+            env = [
+              {
+                name  = "DATABASE__HOST"
+                value = azurerm_postgresql_flexible_server.main.fqdn
+              },
+              {
+                name  = "DATABASE__USER"
+                value = local.migration_postgres_role
+              },
+              {
+                name  = "DATABASE__NAME"
+                value = azurerm_postgresql_flexible_server_database.main.name
+              },
+              {
+                name  = "AZURE_CLIENT_ID"
+                value = azurerm_user_assigned_identity.migrations.client_id
+              },
+              {
+                name  = "POSTGRES_VERIFICATION_FUNCTIONS_ROLE"
+                value = local.verification_functions_postgres_role
+              },
+            ]
+          },
+        ]
       }
     }
+  }
+
+  lifecycle {
+    # Deploy updates the image to the immutable commit tag after Terraform has
+    # run. Infrastructure plans must preserve that independently managed tag.
+    ignore_changes = [body.properties.template.containers[0].image]
   }
 
   depends_on = [

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -77,7 +77,7 @@ output "api_container_app_name" {
 
 output "migration_job_name" {
   description = "Container Apps Job name used to run database migrations"
-  value       = azurerm_container_app_job.migrations.name
+  value       = azapi_resource.migrations.name
 }
 
 output "migration_identity_client_id" {

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -38,7 +38,9 @@ provider "azurerm" {
   storage_use_azuread = true
 }
 
-provider "azapi" {}
+provider "azapi" {
+  subscription_id = var.subscription_id
+}
 
 resource "random_string" "suffix" {
   length  = 6

--- a/infra/tests/secretless_planning.tftest.hcl
+++ b/infra/tests/secretless_planning.tftest.hcl
@@ -1,0 +1,59 @@
+mock_provider "azurerm" {
+  mock_data "azurerm_client_config" {
+    defaults = {
+      client_id       = "00000000-0000-0000-0000-000000000003"
+      object_id       = "00000000-0000-0000-0000-000000000004"
+      subscription_id = "00000000-0000-0000-0000-000000000001"
+      tenant_id       = "00000000-0000-0000-0000-000000000005"
+    }
+  }
+
+  mock_resource "azurerm_resource_group" {
+    override_during = plan
+    defaults = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/rg-ltc-dev"
+    }
+  }
+}
+mock_provider "azapi" {}
+mock_provider "random" {}
+
+variables {
+  subscription_id                     = "00000000-0000-0000-0000-000000000001"
+  postgres_entra_admin_object_id      = "00000000-0000-0000-0000-000000000002"
+  postgres_entra_admin_principal_name = "Learn to Cloud PostgreSQL Admins"
+  github_client_id                    = "test-github-client-id"
+}
+
+run "secretless_planning_invariants" {
+  command = plan
+
+  plan_options {
+    target = [
+      azurerm_storage_account.verification_functions,
+      azapi_resource.verification_functions,
+    ]
+  }
+
+  assert {
+    condition     = azurerm_storage_account.verification_functions.shared_access_key_enabled == false
+    error_message = "The Functions storage account must keep Shared Key disabled."
+  }
+
+  assert {
+    condition     = azapi_resource.verification_functions.body.properties.functionAppConfig.deployment.storage.authentication.type == "UserAssignedIdentity"
+    error_message = "Function deployment storage must use the user-assigned identity."
+  }
+
+  assert {
+    condition = !contains(
+      [
+        for setting in azapi_resource.verification_functions.body.properties.siteConfig.appSettings :
+        setting.name
+      ],
+      "AzureWebJobsStorage",
+    )
+    error_message = "The Function App must not use a connection-string AzureWebJobsStorage setting."
+  }
+
+}


### PR DESCRIPTION
## Summary

- model the database migration Container Apps Job with AzAPI so Terraform refresh uses a normal ARM GET instead of `Microsoft.App/jobs/listSecrets/action`
- migrate the existing job between Terraform resource addresses with `removed` and `import`, preserving the live resource and deployment-managed image
- pin the AzAPI provider to the configured subscription and add regression coverage and cleanup documentation

## Root cause

The AzureRM Container Apps Job resource calls `Microsoft.App/jobs/listSecrets/action` during refresh even though the migration job contains no secrets. The intentionally read-only OIDC planning identity in #742 must not receive that action, so refresh-enabled plans could not complete.

## Validation

- `terraform -chdir=infra fmt -check -recursive`
- `terraform -chdir=infra validate`
- `terraform -chdir=infra test -no-color` — 1 passed
- live dev refresh plan — 1 import, 0 add, 0 change, 0 destroy
- `uv run poe check` — 544 passed, 1 skipped; Functions: 20 passed
- refreshed GitHub checks — Terraform CI, dependency review, and CodeQL passed

## Rollout

The first apply performs only the Terraform state migration. After it lands, #742 should be updated from `main` and its protected read-only OIDC plan re-run to provide the final acceptance proof. The temporary migration file can be removed after every environment has adopted the new resource address.

Addresses #743.
