### PR TITLE
feat(monitoring): add verification system error coverage

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -248,8 +248,69 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_function
   name                = "alert-ltc-verification-functions-exceptions-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  description         = "Alert when verification Functions record non-learner API exceptions in a 5-minute window"
+  description         = "Alert when a non-HTTP verification Functions invocation remains failed after a 5-minute correlation delay"
   severity            = 1
+  enabled             = true
+  tags                = local.tags
+
+  scopes                = [azurerm_application_insights.main.id]
+  evaluation_frequency  = "PT5M"
+  window_duration       = "PT15M"
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query                   = <<-QUERY
+      let TerminalVerificationAttempts =
+          traces
+          | where timestamp > ago(15m)
+          | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
+              or cloud_RoleName has "verification-functions"
+              or cloud_RoleName has "func-ltc-verification"
+          | where message in ("verification.attempt.finalized", "verification.attempt.terminalized")
+          | project operation_Id;
+      let FunctionsHttp5xx =
+          requests
+          | where timestamp > ago(15m)
+          | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
+              or cloud_RoleName has "verification-functions"
+              or cloud_RoleName has "func-ltc-verification"
+          | where resultCode startswith "5"
+          | project operation_Id;
+      exceptions
+      | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
+          or cloud_RoleName has "verification-functions"
+          or cloud_RoleName has "func-ltc-verification"
+      | where isnotempty(operation_Id)
+      | where timestamp between (ago(15m) .. ago(5m))
+      | join kind=leftanti TerminalVerificationAttempts on operation_Id
+      | join kind=leftanti FunctionsHttp5xx on operation_Id
+      | summarize ExceptionRows = count() by operation_Id
+    QUERY
+    time_aggregation_method = "Count"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.critical.id]
+  }
+}
+
+# Learner-facing verification system failures cross two telemetry boundaries:
+# the API records a handled start failure before Functions can claim an attempt,
+# while Functions records an authoritative server_error after an attempt starts.
+# Both mean our system, not the learner's validation, prevented completion.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_system_error" {
+  name                = "alert-ltc-verification-system-error-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Alert on any handled Durable start failure or terminal verification server_error"
+  severity            = 2
   enabled             = true
   tags                = local.tags
 
@@ -260,23 +321,34 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_function
 
   criteria {
     query                   = <<-QUERY
-      let LearnerApiDependencyFailures =
-          dependencies
+      let DurableStartFailures =
+          traces
+          | where timestamp > ago(5m)
+          | extend ErrorType = tostring(customDimensions.error_type)
+          | where cloud_RoleName in ("learn-to-cloud-api", "ca-ltc-api-${var.environment}")
+              or cloud_RoleName has "learn-to-cloud-api"
+              or cloud_RoleName has "ca-ltc-api"
+          | where message == "htmx.submit.durable_start_failed"
+          | where ErrorType == "DurableVerificationStartError"
+          | project FailureKey = strcat("start:", operation_Id);
+      let TerminalServerErrors =
+          traces
+          | where timestamp > ago(5m)
+          | extend
+              Outcome = tostring(customDimensions.outcome),
+              AttemptId = tostring(customDimensions.attempt_id)
           | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
               or cloud_RoleName has "verification-functions"
               or cloud_RoleName has "func-ltc-verification"
-          | where type == "HTTP"
-          | where name in ("POST /entries", "GET /entries")
-              or name startswith "DELETE /entries/"
-          | project operation_Id, dependencySpanId = id;
-      exceptions
-      | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
-          or cloud_RoleName has "verification-functions"
-          or cloud_RoleName has "func-ltc-verification"
-      | join kind=leftanti LearnerApiDependencyFailures
-          on operation_Id, $left.operation_ParentId == $right.dependencySpanId
+          | where message in ("verification.attempt.finalized", "verification.attempt.terminalized")
+          | where Outcome == "server_error"
+          | where isnotempty(AttemptId)
+          | project FailureKey = strcat("attempt:", AttemptId);
+      union DurableStartFailures, TerminalServerErrors
+      | summarize ErrorCount = dcount(FailureKey)
     QUERY
-    time_aggregation_method = "Count"
+    time_aggregation_method = "Maximum"
+    metric_measure_column   = "ErrorCount"
     operator                = "GreaterThanOrEqual"
     threshold               = 1
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
@@ -276,6 +276,16 @@ class WebSettings(BaseSettings):
                     "SESSION__SECRET_KEY must be set to a secure random value "
                     "when ENVIRONMENT=production."
                 )
+            if not self.verification_functions.base_url:
+                raise ValueError(
+                    "VERIFICATION_FUNCTIONS__BASE_URL must be set "
+                    "when ENVIRONMENT=production."
+                )
+            if not self.verification_functions.token_scope:
+                raise ValueError(
+                    "VERIFICATION_FUNCTIONS__TOKEN_SCOPE must be set "
+                    "when ENVIRONMENT=production."
+                )
         return self
 
     @property

--- a/packages/learn-to-cloud-shared/tests/core/test_config.py
+++ b/packages/learn-to-cloud-shared/tests/core/test_config.py
@@ -13,6 +13,7 @@ from learn_to_cloud_shared.core.config import (
     LabsConfig,
     OAuthConfig,
     SessionConfig,
+    VerificationFunctionsConfig,
     WebSecurityConfig,
     WebSettings,
     WorkerSettings,
@@ -103,9 +104,39 @@ class TestWebSettingsValidation:
             environment="production",
             oauth=OAuthConfig(client_id="id", client_secret="secret"),
             session=SessionConfig(secret_key="a-real-secret-not-the-default"),
+            verification_functions=VerificationFunctionsConfig(
+                base_url="https://functions.example.test",
+                token_scope="api://verification/.default",
+            ),
         )
         assert s.environment is Environment.PRODUCTION
         assert s.is_development is False
+
+    def test_production_requires_verification_functions_base_url(self):
+        with pytest.raises(ValidationError, match="VERIFICATION_FUNCTIONS__BASE_URL"):
+            WebSettings(
+                database=DatabaseConfig(url="postgresql+asyncpg://localhost/test"),
+                environment="production",
+                oauth=OAuthConfig(client_id="id", client_secret="secret"),
+                session=SessionConfig(secret_key="a-real-secret-not-the-default"),
+                verification_functions=VerificationFunctionsConfig(
+                    token_scope="api://verification/.default"
+                ),
+            )
+
+    def test_production_requires_verification_functions_token_scope(self):
+        with pytest.raises(
+            ValidationError, match="VERIFICATION_FUNCTIONS__TOKEN_SCOPE"
+        ):
+            WebSettings(
+                database=DatabaseConfig(url="postgresql+asyncpg://localhost/test"),
+                environment="production",
+                oauth=OAuthConfig(client_id="id", client_secret="secret"),
+                session=SessionConfig(secret_key="a-real-secret-not-the-default"),
+                verification_functions=VerificationFunctionsConfig(
+                    base_url="https://functions.example.test"
+                ),
+            )
 
 
 @pytest.mark.unit
@@ -153,6 +184,10 @@ class TestAllowedOrigins:
             environment="production",
             oauth=OAuthConfig(client_id="id", client_secret="secret"),
             session=SessionConfig(secret_key="prod-secret"),
+            verification_functions=VerificationFunctionsConfig(
+                base_url="https://functions.example.test",
+                token_scope="api://verification/.default",
+            ),
         )
         assert "http://localhost:3000" not in s.allowed_origins
 


### PR DESCRIPTION
## Summary

- add a unified verification system-error alert covering handled API start failures and terminal Functions `server_error` outcomes
- correlate Functions exceptions with terminal attempts and HTTP 5xx telemetry after a five-minute grace period, suppressing unowned host lifecycle noise
- fail production startup when required verification Functions settings are missing

## Deployment boundary

This PR adds replacement coverage without removing any existing alerts. Redundant alert removal will follow only after this alert deploys successfully.

## Validation

- `uv run poe check`
- `terraform -chdir=infra fmt -check -recursive`
- `terraform -chdir=infra validate`
- `terraform -chdir=infra test -no-color`
- live KQL validation for both revised queries
- fresh API `/health`, `/ready`, and OpenAPI smoke test
- Azure-backed plan at head `9cc8659c960427c172fcf2c9f36e260f60494ad1`: **1 to add, 1 to change, 0 to destroy**
  - create `verification_system_error`
  - update `verification_functions_exceptions` in place