### PR TITLE
feat(auth): add Entra smoke authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -321,6 +321,7 @@ jobs:
       migration_postgres_role: ${{ steps.tf-outputs.outputs.migration_postgres_role }}
       verification_functions_postgres_role: ${{ steps.tf-outputs.outputs.verification_functions_postgres_role }}
       api_url: ${{ steps.tf-outputs.outputs.api_url }}
+      smoke_auth_scope: ${{ steps.tf-outputs.outputs.smoke_auth_scope }}
       verification_functions_name: ${{ steps.tf-outputs.outputs.verification_functions_name }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -373,6 +374,7 @@ jobs:
           echo "migration_postgres_role=$(terraform output -raw migration_postgres_role)" >> "$GITHUB_OUTPUT"
           echo "verification_functions_postgres_role=$(terraform output -raw verification_functions_postgres_role)" >> "$GITHUB_OUTPUT"
           echo "api_url=$(terraform output -raw api_url)" >> "$GITHUB_OUTPUT"
+          echo "smoke_auth_scope=$(terraform output -raw smoke_auth_scope)" >> "$GITHUB_OUTPUT"
           echo "verification_functions_name=$(terraform output -raw verification_functions_name)" >> "$GITHUB_OUTPUT"
 
   # -----------------------------------------------------------------------
@@ -635,6 +637,36 @@ jobs:
             --name "$APP_NAME" --resource-group "$RG" --revision "$REVISION" \
             --tail 100 --format text 2>&1 || true
           exit 1
+
+      # Transitional validation: prove the OIDC/Entra path works in production
+      # before a follow-up PR removes the shared-token fallback and makes this
+      # identity path the mandatory deployment gate.
+      - name: Validate Entra smoke authentication
+        continue-on-error: true
+        env:
+          SMOKE_SCOPE: ${{ needs.terraform.outputs.smoke_auth_scope }}
+          SMOKE_URL: ${{ needs.terraform.outputs.api_url }}/internal/smoke/verification
+        run: |
+          set -euo pipefail
+
+          access_token=$(az account get-access-token \
+            --scope "$SMOKE_SCOPE" \
+            --query accessToken \
+            --output tsv)
+          echo "::add-mask::$access_token"
+
+          code=$(curl --silent --output /tmp/entra_smoke_body.txt \
+            --write-out "%{http_code}" \
+            --request POST "$SMOKE_URL" \
+            --header "Authorization: Bearer $access_token")
+
+          if [[ "$code" != "200" ]]; then
+            echo "Entra smoke-auth validation returned HTTP $code."
+            cat /tmp/entra_smoke_body.txt || true
+            exit 1
+          fi
+
+          echo "Entra smoke authentication passed."
 
       - name: Smoke test verification submit path
         env:

--- a/api/src/learn_to_cloud/routes/internal_routes.py
+++ b/api/src/learn_to_cloud/routes/internal_routes.py
@@ -1,14 +1,12 @@
-"""Internal operational endpoints.
+"""Internal operational endpoints."""
 
-These routes are not part of the user-facing product. They support
-deployment and monitoring tooling and are gated by a shared secret so
-they are only reachable where that secret is configured.
-"""
-
+import base64
+import binascii
 import hmac
 import logging
 
 from fastapi import APIRouter, Header, HTTPException, Request
+from pydantic import BaseModel, ValidationError
 from starlette import status
 
 from learn_to_cloud.services.submissions_service import run_submit_smoke_check
@@ -18,12 +16,82 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["internal"], include_in_schema=False)
 
 _SMOKE_TOKEN_HEADER = "X-Smoke-Test-Token"
+_SMOKE_ROLE = "Smoke.Trigger"
+_APP_ID_CLAIMS = {
+    "appid",
+    "azp",
+    "http://schemas.microsoft.com/identity/claims/appid",
+}
+_ROLE_CLAIMS = {
+    "roles",
+    "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
+}
+
+
+class _ClientPrincipalClaim(BaseModel):
+    typ: str
+    val: str
+
+
+class _ClientPrincipal(BaseModel):
+    auth_typ: str
+    claims: list[_ClientPrincipalClaim]
+    role_typ: str = ""
+
+
+def _require_smoke_principal(encoded_principal: str, expected_client_id: str) -> None:
+    """Authorize an identity already validated by Container Apps Easy Auth."""
+    if not expected_client_id:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Smoke-test identity is not configured.",
+        )
+
+    try:
+        principal_json = base64.b64decode(encoded_principal, validate=True)
+        principal = _ClientPrincipal.model_validate_json(principal_json)
+    except (binascii.Error, UnicodeDecodeError, ValidationError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authenticated principal.",
+        ) from exc
+
+    if principal.auth_typ != "aad":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Smoke test requires Microsoft Entra authentication.",
+        )
+
+    claims: dict[str, set[str]] = {}
+    for claim in principal.claims:
+        claims.setdefault(claim.typ, set()).add(claim.val)
+
+    caller_ids = set().union(*(claims.get(name, set()) for name in _APP_ID_CLAIMS))
+    if expected_client_id not in caller_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Caller is not authorized to run smoke tests.",
+        )
+
+    role_claims = _ROLE_CLAIMS | ({principal.role_typ} if principal.role_typ else set())
+    roles = set().union(*(claims.get(name, set()) for name in role_claims))
+    if _SMOKE_ROLE not in roles:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Caller lacks the smoke-test role.",
+        )
 
 
 @router.post("/internal/smoke/verification")
 async def smoke_verification(
     request: Request,
     x_smoke_test_token: str | None = Header(default=None, alias=_SMOKE_TOKEN_HEADER),
+    x_ms_client_principal: str | None = Header(
+        default=None, alias="X-MS-CLIENT-PRINCIPAL"
+    ),
+    x_ms_client_principal_id: str | None = Header(
+        default=None, alias="X-MS-CLIENT-PRINCIPAL-ID"
+    ),
 ) -> dict[str, str]:
     """Post-deploy smoke check for the verification submit code path.
 
@@ -32,21 +100,24 @@ async def smoke_verification(
     code does not match the migrated database schema fails here instead of
     silently returning 500s to real users (see incident #432).
 
-    Returns 200 when the read path runs cleanly. Returns 503 when it does
-    not, which fails the post-deploy smoke step in CI. The endpoint is
-    disabled (404) unless ``SMOKE_TEST__TOKEN`` is configured, and rejects
-    requests (401) whose ``X-Smoke-Test-Token`` header does not match it.
+    During the workload-identity rollout, requests may authenticate through
+    Container Apps Easy Auth or the existing shared-token fallback.
     """
-    configured_token = request.app.state.settings.smoke_test.token
+    smoke_settings = request.app.state.settings.smoke_test
+    configured_token = smoke_settings.token
+    valid_legacy_token = bool(configured_token) and hmac.compare_digest(
+        x_smoke_test_token or "", configured_token
+    )
 
-    if not configured_token:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-
-    provided = x_smoke_test_token or ""
-    if not hmac.compare_digest(provided, configured_token):
+    if x_ms_client_principal and x_ms_client_principal_id:
+        _require_smoke_principal(
+            x_ms_client_principal,
+            smoke_settings.allowed_client_id,
+        )
+    elif not valid_legacy_token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid smoke-test token.",
+            detail="Smoke-test authentication required.",
         )
 
     try:
@@ -55,7 +126,7 @@ async def smoke_verification(
         logger.exception("internal.smoke.verification.failed")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=f"Verification smoke check failed: {type(exc).__name__}: {exc}",
+            detail="Verification smoke check failed.",
         ) from exc
 
     logger.info(

--- a/api/tests/routes/test_internal_routes.py
+++ b/api/tests/routes/test_internal_routes.py
@@ -1,5 +1,7 @@
 """Unit tests for internal operational routes."""
 
+import base64
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -8,48 +10,58 @@ from fastapi import HTTPException
 from learn_to_cloud.routes.internal_routes import smoke_verification
 
 
-def _request_with_token(configured: str) -> MagicMock:
-    """Build a mock request whose app carries the given configured token."""
+def _request_with_auth(*, token: str = "", allowed_client_id: str = "") -> MagicMock:
     request = MagicMock()
-    request.app.state.settings.smoke_test.token = configured
+    request.app.state.settings.smoke_test.token = token
+    request.app.state.settings.smoke_test.allowed_client_id = allowed_client_id
     request.app.state.session_maker = MagicMock()
     return request
+
+
+def _principal(*, app_id: str, roles: list[str]) -> str:
+    claims = [{"typ": "azp", "val": app_id}]
+    claims.extend({"typ": "roles", "val": role} for role in roles)
+    payload = {
+        "auth_typ": "aad",
+        "claims": claims,
+        "name_typ": "name",
+        "role_typ": "roles",
+    }
+    return base64.b64encode(json.dumps(payload).encode()).decode()
 
 
 @pytest.mark.unit
 class TestSmokeVerificationEndpoint:
     """Tests for POST /internal/smoke/verification."""
 
-    async def test_returns_404_when_token_not_configured(self):
-        """The endpoint is disabled (404) when no token is configured."""
-        request = _request_with_token("")
+    async def test_returns_401_when_authentication_missing(self):
+        request = _request_with_auth()
 
         with pytest.raises(HTTPException) as exc_info:
-            await smoke_verification(request, x_smoke_test_token="anything")
-
-        assert exc_info.value.status_code == 404
-
-    async def test_returns_401_when_header_missing(self):
-        """A missing token header is rejected with 401."""
-        request = _request_with_token("expected-secret")
-
-        with pytest.raises(HTTPException) as exc_info:
-            await smoke_verification(request, x_smoke_test_token=None)
+            await smoke_verification(
+                request,
+                x_smoke_test_token=None,
+                x_ms_client_principal=None,
+                x_ms_client_principal_id=None,
+            )
 
         assert exc_info.value.status_code == 401
 
     async def test_returns_401_when_header_mismatch(self):
-        """A wrong token header is rejected with 401."""
-        request = _request_with_token("expected-secret")
+        request = _request_with_auth(token="expected-secret")
 
         with pytest.raises(HTTPException) as exc_info:
-            await smoke_verification(request, x_smoke_test_token="wrong-secret")
+            await smoke_verification(
+                request,
+                x_smoke_test_token="wrong-secret",
+                x_ms_client_principal=None,
+                x_ms_client_principal_id=None,
+            )
 
         assert exc_info.value.status_code == 401
 
     async def test_returns_200_when_token_matches_and_check_passes(self):
-        """A matching token runs the read-only check and returns ok."""
-        request = _request_with_token("expected-secret")
+        request = _request_with_auth(token="expected-secret")
 
         with patch(
             "learn_to_cloud.routes.internal_routes.run_submit_smoke_check",
@@ -57,15 +69,68 @@ class TestSmokeVerificationEndpoint:
             return_value={"requirement_slug": "phase0-req"},
         ) as mock_check:
             result = await smoke_verification(
-                request, x_smoke_test_token="expected-secret"
+                request,
+                x_smoke_test_token="expected-secret",
+                x_ms_client_principal=None,
+                x_ms_client_principal_id=None,
             )
 
         assert result == {"status": "ok", "requirement_slug": "phase0-req"}
         mock_check.assert_awaited_once_with(request.app.state.session_maker)
 
+    async def test_returns_200_for_authorized_entra_principal(self):
+        client_id = "80656257-8f52-4889-95c4-d594c29c82ae"
+        request = _request_with_auth(allowed_client_id=client_id)
+
+        with patch(
+            "learn_to_cloud.routes.internal_routes.run_submit_smoke_check",
+            new_callable=AsyncMock,
+            return_value={"requirement_slug": "phase0-req"},
+        ):
+            result = await smoke_verification(
+                request,
+                x_smoke_test_token=None,
+                x_ms_client_principal=_principal(
+                    app_id=client_id, roles=["Smoke.Trigger"]
+                ),
+                x_ms_client_principal_id="deployment-service-principal",
+            )
+
+        assert result == {"status": "ok", "requirement_slug": "phase0-req"}
+
+    @pytest.mark.parametrize(
+        ("principal", "expected_status"),
+        [
+            ("not-base64", 401),
+            (_principal(app_id="other-client", roles=["Smoke.Trigger"]), 403),
+            (
+                _principal(
+                    app_id="80656257-8f52-4889-95c4-d594c29c82ae",
+                    roles=[],
+                ),
+                403,
+            ),
+        ],
+    )
+    async def test_rejects_invalid_entra_principal(
+        self, principal: str, expected_status: int
+    ):
+        request = _request_with_auth(
+            allowed_client_id="80656257-8f52-4889-95c4-d594c29c82ae"
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await smoke_verification(
+                request,
+                x_smoke_test_token=None,
+                x_ms_client_principal=principal,
+                x_ms_client_principal_id="deployment-service-principal",
+            )
+
+        assert exc_info.value.status_code == expected_status
+
     async def test_returns_503_when_check_raises(self):
-        """A failing read path surfaces as 503 so CI fails the deploy."""
-        request = _request_with_token("expected-secret")
+        request = _request_with_auth(token="expected-secret")
 
         with patch(
             "learn_to_cloud.routes.internal_routes.run_submit_smoke_check",
@@ -73,7 +138,12 @@ class TestSmokeVerificationEndpoint:
             side_effect=RuntimeError("schema mismatch"),
         ):
             with pytest.raises(HTTPException) as exc_info:
-                await smoke_verification(request, x_smoke_test_token="expected-secret")
+                await smoke_verification(
+                    request,
+                    x_smoke_test_token="expected-secret",
+                    x_ms_client_principal=None,
+                    x_ms_client_principal_id=None,
+                )
 
         assert exc_info.value.status_code == 503
-        assert "RuntimeError" in exc_info.value.detail
+        assert exc_info.value.detail == "Verification smoke check failed."

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -168,6 +168,11 @@ resource "azurerm_container_app" "api" {
       }
 
       env {
+        name  = "SMOKE_TEST__ALLOWED_CLIENT_ID"
+        value = local.smoke_auth_allowed_client_id
+      }
+
+      env {
         name  = "APPLICATIONINSIGHTS_CONNECTION_STRING"
         value = azurerm_application_insights.main.connection_string
       }
@@ -232,4 +237,63 @@ resource "azurerm_container_app" "api" {
     azurerm_role_assignment.api_key_vault_secrets_user,
     azurerm_postgresql_flexible_server_database.main,
   ]
+}
+
+# The app remains public, but Easy Auth validates any bearer token presented to
+# it and strips client-supplied identity headers. The smoke route then requires
+# the validated deployment identity and its Smoke.Trigger app role.
+resource "azapi_resource" "api_auth" {
+  type      = "Microsoft.App/containerApps/authConfigs@2025-01-01"
+  name      = "current"
+  parent_id = azurerm_container_app.api.id
+
+  body = {
+    properties = {
+      globalValidation = {
+        unauthenticatedClientAction = "AllowAnonymous"
+      }
+
+      httpSettings = {
+        requireHttps = true
+      }
+
+      identityProviders = {
+        azureActiveDirectory = {
+          enabled = true
+          registration = {
+            clientId     = local.smoke_auth_client_id
+            openIdIssuer = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/v2.0"
+          }
+          validation = {
+            allowedAudiences = [
+              local.smoke_auth_client_id,
+              local.smoke_auth_audience,
+            ]
+            defaultAuthorizationPolicy = {
+              allowedApplications = [
+                local.smoke_auth_allowed_client_id,
+              ]
+            }
+          }
+        }
+      }
+
+      platform = {
+        enabled        = true
+        runtimeVersion = "~1"
+      }
+    }
+  }
+
+  schema_validation_enabled = false
+
+  lifecycle {
+    precondition {
+      condition = (
+        length(trimspace(local.smoke_auth_client_id)) > 0
+        && length(trimspace(local.smoke_auth_allowed_client_id)) > 0
+      )
+      error_message = "Smoke-test Entra client IDs must be configured for this environment."
+    }
+  }
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -75,6 +75,11 @@ output "api_container_app_name" {
   value       = azurerm_container_app.api.name
 }
 
+output "smoke_auth_scope" {
+  description = "Microsoft Entra token scope used by the deployment smoke test"
+  value       = local.smoke_auth_scope
+}
+
 output "migration_job_name" {
   description = "Container Apps Job name used to run database migrations"
   value       = azurerm_container_app_job.migrations.name

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -78,8 +78,25 @@ locals {
     lookup(local.verification_functions_auth_client_ids, var.environment, ""),
   )
   verification_functions_auth_scope = "${local.verification_functions_auth_audience}/.default"
-  suffix                            = random_string.suffix.result
-  resource_group_name               = "rg-ltc-${var.environment}"
+  smoke_auth_app_name               = "ltc-smoke-api-${var.environment}"
+  smoke_auth_audience               = "api://${local.smoke_auth_app_name}"
+  smoke_auth_client_ids = {
+    dev = "64227d45-f58e-4956-ba5a-d04e281fa1a1"
+  }
+  smoke_auth_client_id = coalesce(
+    var.smoke_auth_client_id,
+    lookup(local.smoke_auth_client_ids, var.environment, ""),
+  )
+  smoke_auth_allowed_client_ids = {
+    dev = "80656257-8f52-4889-95c4-d594c29c82ae"
+  }
+  smoke_auth_allowed_client_id = coalesce(
+    var.smoke_auth_allowed_client_id,
+    lookup(local.smoke_auth_allowed_client_ids, var.environment, ""),
+  )
+  smoke_auth_scope    = "${local.smoke_auth_audience}/.default"
+  suffix              = random_string.suffix.result
+  resource_group_name = "rg-ltc-${var.environment}"
   tags = {
     environment = var.environment
     project     = "learntocloud"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -180,6 +180,36 @@ variable "verification_functions_auth_client_id" {
   }
 }
 
+variable "smoke_auth_client_id" {
+  description = "Client ID of the pre-created Entra smoke API app registration."
+  type        = string
+  default     = null
+
+  validation {
+    condition = (
+      var.smoke_auth_client_id == null
+      ? true
+      : length(trimspace(var.smoke_auth_client_id)) > 0
+    )
+    error_message = "smoke_auth_client_id must be non-empty when set."
+  }
+}
+
+variable "smoke_auth_allowed_client_id" {
+  description = "Client ID of the deployment identity allowed to run smoke tests."
+  type        = string
+  default     = null
+
+  validation {
+    condition = (
+      var.smoke_auth_allowed_client_id == null
+      ? true
+      : length(trimspace(var.smoke_auth_allowed_client_id)) > 0
+    )
+    error_message = "smoke_auth_allowed_client_id must be non-empty when set."
+  }
+}
+
 variable "environment" {
   description = "Environment name (dev, staging, prod)"
   type        = string

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
@@ -148,14 +148,10 @@ class SessionConfig(FrozenConfig):
 
 
 class SmokeTestConfig(FrozenConfig):
-    """Post-deploy smoke-test config.
-
-    ``token`` gates the internal verification smoke endpoint. When empty
-    (the default), the endpoint is disabled and returns 404, so the
-    diagnostic surface only exists where the secret is configured.
-    """
+    """Post-deploy smoke-test authorization config."""
 
     token: str = ""
+    allowed_client_id: str = ""
 
 
 class CorsConfig(FrozenConfig):


### PR DESCRIPTION
## Summary

- add a dedicated Microsoft Entra workload-identity path for the deployment smoke endpoint
- configure Container Apps Easy Auth to validate the smoke API audience and allow only the existing GitHub deployment identity
- require the `Smoke.Trigger` application role in the API while retaining the legacy shared-token fallback during rollout
- add a non-blocking deployment check that requests a short-lived smoke token through the existing GitHub OIDC login

## Rollout boundary

This PR establishes and observes the new authentication path without making it the mandatory gate yet. After one successful deployment proves token issuance, Easy Auth validation, caller authorization, and header handling, a follow-up PR will remove the shared-token fallback and make Entra authentication mandatory.

The dedicated single-tenant `ltc-smoke-api-dev` registration, `Smoke.Trigger` application role, assignment-required service principal, and role assignment to the existing deployment identity were created out of band before this PR.

## Security

- no new client secret or persistent access token
- tenant-pinned v2 issuer and dedicated audience
- Entra app-role assignment required
- Easy Auth allowed-application filtering
- API verifies authenticated caller client ID and `Smoke.Trigger` role
- internal failures return a generic 503 while full details remain in server telemetry

## Validation

- `uv run poe check`
- focused API and shared configuration tests
- Terraform formatting, validation, and tests
- Entra registration and app-role assignment inspected after creation
- Azure-backed plan at head `9b173368d74930cc41cf99821f8e1c3b586affc6`: **1 to add, 1 to change, 0 to destroy**
  - create the Container Apps `authConfigs/current` child resource
  - update the API Container App in place with the allowed deployment client ID
  - expose the non-sensitive smoke API scope output