### PR TITLE
feat(auth): require Entra smoke identity

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -638,11 +638,7 @@ jobs:
             --tail 100 --format text 2>&1 || true
           exit 1
 
-      # Transitional validation: prove the OIDC/Entra path works in production
-      # before a follow-up PR removes the shared-token fallback and makes this
-      # identity path the mandatory deployment gate.
-      - name: Validate Entra smoke authentication
-        continue-on-error: true
+      - name: Smoke test verification submit path
         env:
           SMOKE_SCOPE: ${{ needs.terraform.outputs.smoke_auth_scope }}
           SMOKE_URL: ${{ needs.terraform.outputs.api_url }}/internal/smoke/verification
@@ -668,63 +664,13 @@ jobs:
             echo "Attempt $i: HTTP $code"
 
             if [[ "$code" == "200" ]]; then
-              echo "Entra smoke authentication passed."
+              echo "Verification smoke test passed."
+              cat /tmp/entra_smoke_body.txt || true
               exit 0
             fi
             sleep 10
           done
 
-          echo "Entra smoke-auth validation returned HTTP $code."
-          cat /tmp/entra_smoke_body.txt || true
-          exit 1
-
-      - name: Smoke test verification submit path
-        env:
-          SMOKE_TEST_TOKEN: ${{ secrets.SMOKE_TEST_TOKEN }}
-          SMOKE_URL: ${{ needs.terraform.outputs.api_url }}/internal/smoke/verification
-        run: |
-          set -euo pipefail
-
-          # The gate only runs once the shared secret exists in both places: the
-          # GitHub secret here and the smoke-test-token Key Vault secret the app
-          # reads. Until then, warn loudly instead of blocking every deploy.
-          if [[ -z "${SMOKE_TEST_TOKEN:-}" ]]; then
-            echo "::warning::SMOKE_TEST_TOKEN is not set — skipping the post-deploy verification smoke test."
-            echo "Set the SMOKE_TEST_TOKEN repository secret to the same value as the"
-            echo "smoke-test-token Key Vault secret to activate this deploy gate."
-            exit 0
-          fi
-
-          echo "POSTing verification smoke check to $SMOKE_URL"
-
-          # Retry briefly: traffic can take a few seconds to fully shift to the
-          # freshly deployed revision after readiness reports healthy.
-          code=000
-          for i in {1..6}; do
-            code=$(curl -s -o /tmp/smoke_body.txt -w "%{http_code}" \
-              -X POST "$SMOKE_URL" \
-              -H "X-Smoke-Test-Token: $SMOKE_TEST_TOKEN" || echo 000)
-            echo "Attempt $i: HTTP $code"
-
-            if [[ "$code" == "200" ]]; then
-              echo "Verification smoke test passed."
-              cat /tmp/smoke_body.txt || true
-              exit 0
-            fi
-
-            # A 5xx means the verification submit code path is broken against the
-            # live database schema (the incident #432 class of failure). Fail now.
-            if [[ "$code" =~ ^5 ]]; then
-              echo "ERROR: smoke endpoint returned $code — verification submit path is broken."
-              cat /tmp/smoke_body.txt || true
-              exit 1
-            fi
-
-            sleep 5
-          done
-
           echo "ERROR: verification smoke test did not pass (last HTTP $code)."
-          echo "401 means the app's SMOKE_TEST__TOKEN does not match this secret;"
-          echo "check that the smoke-test-token Key Vault secret holds the same value."
-          cat /tmp/smoke_body.txt || true
+          cat /tmp/entra_smoke_body.txt || true
           exit 1

--- a/api/src/learn_to_cloud/routes/internal_routes.py
+++ b/api/src/learn_to_cloud/routes/internal_routes.py
@@ -2,7 +2,6 @@
 
 import base64
 import binascii
-import hmac
 import logging
 
 from fastapi import APIRouter, Header, HTTPException, Request
@@ -15,7 +14,6 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["internal"], include_in_schema=False)
 
-_SMOKE_TOKEN_HEADER = "X-Smoke-Test-Token"
 _SMOKE_ROLE = "Smoke.Trigger"
 _APP_ID_CLAIMS = {
     "appid",
@@ -85,7 +83,6 @@ def _require_smoke_principal(encoded_principal: str, expected_client_id: str) ->
 @router.post("/internal/smoke/verification")
 async def smoke_verification(
     request: Request,
-    x_smoke_test_token: str | None = Header(default=None, alias=_SMOKE_TOKEN_HEADER),
     x_ms_client_principal: str | None = Header(
         default=None, alias="X-MS-CLIENT-PRINCIPAL"
     ),
@@ -100,21 +97,17 @@ async def smoke_verification(
     code does not match the migrated database schema fails here instead of
     silently returning 500s to real users (see incident #432).
 
-    During the workload-identity rollout, requests may authenticate through
-    Container Apps Easy Auth or the existing shared-token fallback.
+    Container Apps Easy Auth validates the deployment identity before the
+    route authorizes its application ID and Smoke.Trigger role.
     """
     smoke_settings = request.app.state.settings.smoke_test
-    configured_token = smoke_settings.token
-    valid_legacy_token = bool(configured_token) and hmac.compare_digest(
-        x_smoke_test_token or "", configured_token
-    )
 
     if x_ms_client_principal and x_ms_client_principal_id:
         _require_smoke_principal(
             x_ms_client_principal,
             smoke_settings.allowed_client_id,
         )
-    elif not valid_legacy_token:
+    else:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Smoke-test authentication required.",

--- a/api/tests/routes/test_internal_routes.py
+++ b/api/tests/routes/test_internal_routes.py
@@ -10,9 +10,8 @@ from fastapi import HTTPException
 from learn_to_cloud.routes.internal_routes import smoke_verification
 
 
-def _request_with_auth(*, token: str = "", allowed_client_id: str = "") -> MagicMock:
+def _request_with_auth(*, allowed_client_id: str = "") -> MagicMock:
     request = MagicMock()
-    request.app.state.settings.smoke_test.token = token
     request.app.state.settings.smoke_test.allowed_client_id = allowed_client_id
     request.app.state.session_maker = MagicMock()
     return request
@@ -40,43 +39,11 @@ class TestSmokeVerificationEndpoint:
         with pytest.raises(HTTPException) as exc_info:
             await smoke_verification(
                 request,
-                x_smoke_test_token=None,
                 x_ms_client_principal=None,
                 x_ms_client_principal_id=None,
             )
 
         assert exc_info.value.status_code == 401
-
-    async def test_returns_401_when_header_mismatch(self):
-        request = _request_with_auth(token="expected-secret")
-
-        with pytest.raises(HTTPException) as exc_info:
-            await smoke_verification(
-                request,
-                x_smoke_test_token="wrong-secret",
-                x_ms_client_principal=None,
-                x_ms_client_principal_id=None,
-            )
-
-        assert exc_info.value.status_code == 401
-
-    async def test_returns_200_when_token_matches_and_check_passes(self):
-        request = _request_with_auth(token="expected-secret")
-
-        with patch(
-            "learn_to_cloud.routes.internal_routes.run_submit_smoke_check",
-            new_callable=AsyncMock,
-            return_value={"requirement_slug": "phase0-req"},
-        ) as mock_check:
-            result = await smoke_verification(
-                request,
-                x_smoke_test_token="expected-secret",
-                x_ms_client_principal=None,
-                x_ms_client_principal_id=None,
-            )
-
-        assert result == {"status": "ok", "requirement_slug": "phase0-req"}
-        mock_check.assert_awaited_once_with(request.app.state.session_maker)
 
     async def test_returns_200_for_authorized_entra_principal(self):
         client_id = "80656257-8f52-4889-95c4-d594c29c82ae"
@@ -89,7 +56,6 @@ class TestSmokeVerificationEndpoint:
         ):
             result = await smoke_verification(
                 request,
-                x_smoke_test_token=None,
                 x_ms_client_principal=_principal(
                     app_id=client_id, roles=["Smoke.Trigger"]
                 ),
@@ -122,7 +88,6 @@ class TestSmokeVerificationEndpoint:
         with pytest.raises(HTTPException) as exc_info:
             await smoke_verification(
                 request,
-                x_smoke_test_token=None,
                 x_ms_client_principal=principal,
                 x_ms_client_principal_id="deployment-service-principal",
             )
@@ -130,7 +95,8 @@ class TestSmokeVerificationEndpoint:
         assert exc_info.value.status_code == expected_status
 
     async def test_returns_503_when_check_raises(self):
-        request = _request_with_auth(token="expected-secret")
+        client_id = "80656257-8f52-4889-95c4-d594c29c82ae"
+        request = _request_with_auth(allowed_client_id=client_id)
 
         with patch(
             "learn_to_cloud.routes.internal_routes.run_submit_smoke_check",
@@ -140,9 +106,10 @@ class TestSmokeVerificationEndpoint:
             with pytest.raises(HTTPException) as exc_info:
                 await smoke_verification(
                     request,
-                    x_smoke_test_token="expected-secret",
-                    x_ms_client_principal=None,
-                    x_ms_client_principal_id=None,
+                    x_ms_client_principal=_principal(
+                        app_id=client_id, roles=["Smoke.Trigger"]
+                    ),
+                    x_ms_client_principal_id="deployment-service-principal",
                 )
 
         assert exc_info.value.status_code == 503

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -82,16 +82,6 @@ resource "azurerm_container_app" "api" {
     key_vault_secret_id = "${azurerm_key_vault.main.vault_uri}secrets/labs-verification-secret"
   }
 
-  # The smoke-test token gates the post-deploy verification smoke endpoint
-  # (POST /internal/smoke/verification). Like every other secret here it is
-  # created out of band in Key Vault, so its value never passes through
-  # Terraform variables or state.
-  secret {
-    name                = "smoke-test-token"
-    identity            = azurerm_user_assigned_identity.api.id
-    key_vault_secret_id = "${azurerm_key_vault.main.vault_uri}secrets/smoke-test-token"
-  }
-
   ingress {
     external_enabled = true
     target_port      = 8000
@@ -160,11 +150,6 @@ resource "azurerm_container_app" "api" {
       env {
         name        = "LABS__VERIFICATION_SECRET"
         secret_name = "ctf-master-secret"
-      }
-
-      env {
-        name        = "SMOKE_TEST__TOKEN"
-        secret_name = "smoke-test-token"
       }
 
       env {

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
@@ -150,7 +150,6 @@ class SessionConfig(FrozenConfig):
 class SmokeTestConfig(FrozenConfig):
     """Post-deploy smoke-test authorization config."""
 
-    token: str = ""
     allowed_client_id: str = ""
 
 


### PR DESCRIPTION
## Summary
- make the short-lived Entra workload token smoke check a mandatory deployment gate
- remove the legacy shared-token authorization path from the API
- remove the smoke token from application configuration and Container Apps secret references
- remove the unused legacy workflow step and tests

## Rollout evidence
The transitional deployment completed successfully and the Entra-authenticated smoke request returned HTTP 200. Public `/health` and `/ready` remained HTTP 200, while unauthenticated and forged-principal smoke requests returned HTTP 401.

## Validation
- `uv run --directory api pytest tests/routes/test_internal_routes.py -q`
- `terraform -chdir=infra fmt -check`
- `terraform -chdir=infra validate`
- `terraform -chdir=infra test`
- `uv run poe check`