### PR TITLE
fix(infra): separate Container App probes

### DIFF
--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -199,7 +199,7 @@ resource "azurerm_container_app" "api" {
 
       readiness_probe {
         transport               = "HTTP"
-        path                    = "/health"
+        path                    = "/ready"
         port                    = 8000
         interval_seconds        = 30
         timeout                 = 5
@@ -208,7 +208,7 @@ resource "azurerm_container_app" "api" {
 
       startup_probe {
         transport               = "HTTP"
-        path                    = "/health"
+        path                    = "/ready"
         port                    = 8000
         interval_seconds        = 10
         timeout                 = 5


### PR DESCRIPTION
## Summary
- keep the liveness probe on `/health`
- move readiness and startup probes to `/ready`
- retain the existing 300-second startup budget

This prevents Azure from routing traffic or completing startup before database-backed readiness succeeds, while liveness remains independent of downstream dependencies.

## Validation
- `terraform -chdir=infra fmt -check`
- `terraform -chdir=infra validate`
- `terraform -chdir=infra test`
- `uv run poe check`