### PR TITLE
refactor(verification): make saved outcomes authoritative

### DIFF
--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -32,6 +32,10 @@ from learn_to_cloud_shared.submission_derivation import (
     derive_submission_value,
     is_derivable,
 )
+from learn_to_cloud_shared.verification_attempt_executor import (
+    terminalize_unstarted_verification_attempt,
+    terminalize_verification_attempt,
+)
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -47,6 +51,7 @@ from learn_to_cloud.rendering.context import (
     build_requirement_card_context,
 )
 from learn_to_cloud.services.durable_verification_client import (
+    DurableVerificationAuthError,
     DurableVerificationConfigError,
     DurableVerificationStartError,
     DurableVerificationStatusError,
@@ -202,44 +207,41 @@ async def _terminalize_failed_attempt(
     session_maker = request.app.state.session_maker
     attempt_id = UUID(token_data.job_id)
     async with session_maker() as session:
-        attempt_repo = VerificationAttemptRepository(session)
-        attempt = await attempt_repo.get_status(attempt_id)
-        if attempt is None:
+        if await VerificationAttemptRepository(session).get_status(attempt_id) is None:
             return False
 
-        cancelled = status in {"terminated", "canceled"}
-        result = await attempt_repo.finalize(
-            attempt_id,
-            outcome="cancelled" if cancelled else "server_error",
-            error_code="cancelled" if cancelled else "server_error",
-            validation_message=(
-                "Verification was cancelled."
-                if cancelled
-                else "Verification failed before recording a result."
-            ),
-            terminal_source="poller",
-            feedback_json=None,
-        )
-        if not result.won:
-            logger.info(
-                "verification.poller.finalize_skipped",
-                extra={
-                    "attempt_id": str(attempt_id),
-                    "runtime_status": status,
-                    "outcome": result.state.outcome,
-                },
-            )
-            return False
-        await session.commit()
+    cancelled = status in {"terminated", "canceled"}
+    result = await terminalize_verification_attempt(
+        attempt_id,
+        outcome="cancelled" if cancelled else "server_error",
+        error_code="cancelled" if cancelled else "server_error",
+        validation_message=(
+            "Verification was cancelled."
+            if cancelled
+            else "Verification failed before recording a result."
+        ),
+        terminal_source="poller",
+        session_maker=session_maker,
+    )
+    if not result.won:
         logger.info(
-            "verification.poller.attempt_terminalized",
+            "verification.poller.finalize_skipped",
             extra={
                 "attempt_id": str(attempt_id),
                 "runtime_status": status,
                 "outcome": result.state.outcome,
-                "cas_won": result.won,
             },
         )
+        return False
+    logger.info(
+        "verification.poller.attempt_terminalized",
+        extra={
+            "attempt_id": str(attempt_id),
+            "runtime_status": status,
+            "outcome": result.state.outcome,
+            "cas_won": result.won,
+        },
+    )
     return True
 
 
@@ -286,9 +288,9 @@ async def _log_attempt_completion(
         "terminal_source": state.terminal_source if state else None,
     }
     if state is None or state.outcome == "server_error":
-        logger.warning("verification.attempt.completed", extra=extra)
+        logger.warning("verification.attempt.observed", extra=extra)
     else:
-        logger.info("verification.attempt.completed", extra=extra)
+        logger.info("verification.attempt.observed", extra=extra)
 
 
 async def _render_step_toggle(
@@ -526,8 +528,9 @@ async def _start_async_attempt_and_render(
     original start never actually succeeded, the poller will see a 404
     from Durable and surface the error so the user can retry.
 
-    On a Durable start-call failure that never reached Functions, deletes the
-    just-created attempt so it does not block the learner's retry.
+    On a Durable start-call failure that never reached Functions, terminalizes
+    the just-created attempt so it remains in the outcome ledger without
+    blocking the learner's retry.
     """
     try:
         if attempt_submission.created:
@@ -549,15 +552,27 @@ async def _start_async_attempt_and_render(
 
     except (
         DurableVerificationConfigError,
+        DurableVerificationAuthError,
         DurableVerificationStartError,
     ) as exc:
-        record_span_exception(exc)
+        exception_attributes: dict[str, str | bool | int] = {
+            "verification.attempt.id": str(attempt_submission.attempt_id),
+            "verification.failure.kind": exc.failure_kind.value,
+            "verification.retryable": exc.retryable,
+        }
+        if exc.status_code is not None:
+            exception_attributes["http.response.status_code"] = exc.status_code
+        record_span_exception(exc, exception_attributes)
         logger.exception(
             "htmx.submit.durable_start_failed",
             extra={
                 "user_id": user_id,
                 "requirement_slug": requirement_slug,
+                "attempt_id": str(attempt_submission.attempt_id),
                 "error_type": type(exc).__name__,
+                "failure_kind": exc.failure_kind.value,
+                "retryable": exc.retryable,
+                "status_code": exc.status_code,
                 "error_message": str(exc),
                 "error_cause": (
                     f"{type(exc.__cause__).__name__}: {exc.__cause__}"
@@ -566,18 +581,14 @@ async def _start_async_attempt_and_render(
                 ),
             },
         )
-        # Only an unclaimed attempt is safe to remove. A timeout can happen
-        # after Functions has claimed and started it, in which case the row
-        # must remain for the orchestration to finalize.
-        async with session_maker() as write_session:
-            await VerificationAttemptRepository(write_session).delete_active(
-                attempt_submission.attempt_id,
-            )
-            await write_session.commit()
-        # A config error means the verification service is misconfigured on our
-        # side, so retrying will never help. A start error is usually a
-        # transient hiccup in the Functions app, so retrying is worth it.
-        if isinstance(exc, DurableVerificationConfigError):
+        await terminalize_unstarted_verification_attempt(
+            attempt_submission.attempt_id,
+            error_code=exc.error_code,
+            validation_message="Verification could not be started.",
+            terminal_source="api_start_failure",
+            session_maker=session_maker,
+        )
+        if not exc.retryable:
             return render_card(
                 server_error=True,
                 server_error_message=_DURABLE_UNAVAILABLE_ERROR_MESSAGE,
@@ -614,20 +625,29 @@ async def htmx_verification_attempt_status(
 
     try:
         durable_status = await get_verification_attempt_status(token_data.instance_id)
-    except (DurableVerificationConfigError, DurableVerificationStatusError) as exc:
+    except (
+        DurableVerificationAuthError,
+        DurableVerificationConfigError,
+        DurableVerificationStatusError,
+    ) as exc:
         record_span_exception(
             exc,
             {
                 "user.id": user_id,
-                "verification.job_id": str(token_data.job_id),
+                "verification.attempt.id": str(token_data.job_id),
+                "verification.failure.kind": exc.failure_kind.value,
+                "verification.retryable": exc.retryable,
             },
         )
         logger.warning(
             "verification.status.durable_read_failed",
             extra={
                 "user_id": user_id,
-                "job_id": token_data.job_id,
+                "attempt_id": token_data.job_id,
                 "error_type": type(exc).__name__,
+                "failure_kind": exc.failure_kind.value,
+                "retryable": exc.retryable,
+                "status_code": exc.status_code,
             },
         )
         return _status_error_response(
@@ -675,7 +695,7 @@ async def htmx_verification_attempt_status(
         "verification.status.unexpected_durable_status",
         extra={
             "user_id": user_id,
-            "job_id": token_data.job_id,
+            "attempt_id": token_data.job_id,
             "runtime_status": durable_status.runtime_status,
         },
     )

--- a/api/src/learn_to_cloud/services/durable_verification_client.py
+++ b/api/src/learn_to_cloud/services/durable_verification_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any
 from uuid import UUID
 
@@ -12,20 +13,102 @@ from learn_to_cloud_shared.core.azure_auth import get_token as get_azure_token
 from learn_to_cloud_shared.core.config import get_web_settings
 
 
-class DurableVerificationConfigError(Exception):
+class DurableFailureKind(StrEnum):
+    """Stable categories for verification service failures."""
+
+    CONFIGURATION = "configuration"
+    AUTHENTICATION = "authentication"
+    TRANSPORT = "transport"
+    HTTP_RETRYABLE = "http_retryable"
+    HTTP_REJECTED = "http_rejected"
+    PROTOCOL = "protocol"
+
+
+class DurableVerificationError(Exception):
+    """Structured verification service failure."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_kind: DurableFailureKind,
+        retryable: bool,
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.failure_kind = failure_kind
+        self.retryable = retryable
+        self.status_code = status_code
+
+    @property
+    def error_code(self) -> str:
+        return f"durable_{self.failure_kind.value}_error"
+
+
+class DurableVerificationConfigError(DurableVerificationError):
     """Raised when the Durable starter endpoint is not configured."""
 
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            message,
+            failure_kind=DurableFailureKind.CONFIGURATION,
+            retryable=False,
+        )
 
-class DurableVerificationStartError(Exception):
+
+class DurableVerificationStartError(DurableVerificationError):
     """Raised when the Durable starter rejects or fails a start request."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_kind: DurableFailureKind = DurableFailureKind.TRANSPORT,
+        retryable: bool = True,
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            failure_kind=failure_kind,
+            retryable=retryable,
+            status_code=status_code,
+        )
 
-class DurableVerificationStatusError(Exception):
+
+class DurableVerificationStatusError(DurableVerificationError):
     """Raised when Durable status cannot be fetched or parsed."""
 
+    def __init__(
+        self,
+        message: str,
+        *,
+        failure_kind: DurableFailureKind = DurableFailureKind.TRANSPORT,
+        retryable: bool = True,
+        status_code: int | None = None,
+    ) -> None:
+        super().__init__(
+            message,
+            failure_kind=failure_kind,
+            retryable=retryable,
+            status_code=status_code,
+        )
 
-class DurableVerificationAuthError(Exception):
+
+class DurableVerificationAuthError(DurableVerificationError):
     """Raised when a verification Function access token cannot be acquired."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            message,
+            failure_kind=DurableFailureKind.AUTHENTICATION,
+            retryable=False,
+        )
+
+
+def _http_failure_kind(status_code: int) -> tuple[DurableFailureKind, bool]:
+    if status_code in {408, 425, 429} or status_code >= 500:
+        return DurableFailureKind.HTTP_RETRYABLE, True
+    return DurableFailureKind.HTTP_REJECTED, False
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,24 +134,36 @@ async def _post_start_request(
         async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.post(url, headers=headers)
     except httpx.HTTPError as exc:
-        raise DurableVerificationStartError("Durable starter request failed.") from exc
+        raise DurableVerificationStartError(
+            "Durable starter request failed.",
+            failure_kind=DurableFailureKind.TRANSPORT,
+            retryable=True,
+        ) from exc
 
     if response.status_code >= 400:
+        failure_kind, retryable = _http_failure_kind(response.status_code)
         raise DurableVerificationStartError(
-            f"Durable starter returned HTTP {response.status_code}"
+            f"Durable starter returned HTTP {response.status_code}",
+            failure_kind=failure_kind,
+            retryable=retryable,
+            status_code=response.status_code,
         )
 
     try:
         payload = response.json()
     except ValueError as exc:
         raise DurableVerificationStartError(
-            "Durable starter returned invalid JSON."
+            "Durable starter returned invalid JSON.",
+            failure_kind=DurableFailureKind.PROTOCOL,
+            retryable=False,
         ) from exc
 
     instance_id = payload.get("id")
     if not isinstance(instance_id, str) or not instance_id:
         raise DurableVerificationStartError(
-            "Durable starter response did not include an instance ID."
+            "Durable starter response did not include an instance ID.",
+            failure_kind=DurableFailureKind.PROTOCOL,
+            retryable=False,
         )
 
     return DurableStartResult(instance_id=instance_id)
@@ -106,24 +201,36 @@ async def get_verification_attempt_status(
         async with httpx.AsyncClient(timeout=timeout) as client:
             response = await client.get(url, headers=headers)
     except httpx.HTTPError as exc:
-        raise DurableVerificationStatusError("Durable status request failed.") from exc
+        raise DurableVerificationStatusError(
+            "Durable status request failed.",
+            failure_kind=DurableFailureKind.TRANSPORT,
+            retryable=True,
+        ) from exc
 
     if response.status_code >= 400:
+        failure_kind, retryable = _http_failure_kind(response.status_code)
         raise DurableVerificationStatusError(
-            f"Durable status returned HTTP {response.status_code}"
+            f"Durable status returned HTTP {response.status_code}",
+            failure_kind=failure_kind,
+            retryable=retryable,
+            status_code=response.status_code,
         )
 
     try:
         payload = response.json()
     except ValueError as exc:
         raise DurableVerificationStatusError(
-            "Durable status returned invalid JSON."
+            "Durable status returned invalid JSON.",
+            failure_kind=DurableFailureKind.PROTOCOL,
+            retryable=False,
         ) from exc
 
     runtime_status = payload.get("runtimeStatus")
     if not isinstance(runtime_status, str) or not runtime_status:
         raise DurableVerificationStatusError(
-            "Durable status response did not include runtimeStatus."
+            "Durable status response did not include runtimeStatus.",
+            failure_kind=DurableFailureKind.PROTOCOL,
+            retryable=False,
         )
 
     return DurableStatusResult(

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -320,20 +320,11 @@ class TestHtmxSubmitVerification:
         # Should render a server error card, not crash
         assert result is not None
 
-    async def test_durable_start_failure_deletes_attempt(self):
-        """When Durable's start_new call fails before reaching Functions, the
-        route deletes the just-created attempt instead of marking it terminal,
-        freeing the active slot so the user can retry immediately."""
+    async def test_durable_start_failure_terminalizes_attempt(self):
+        """A failed pre-start attempt remains in the outcome ledger."""
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
         attempt_submission = _mock_attempt_submission(created=True)
-        write_session = AsyncMock()
-        request.app.state.session_maker.return_value.__aenter__.return_value = (
-            write_session
-        )
-        attempt_repo = MagicMock()
-        attempt_repo.delete_active = AsyncMock(return_value=True)
-
         with (
             patch(
                 "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
@@ -356,9 +347,10 @@ class TestHtmxSubmitVerification:
                 side_effect=DurableVerificationStartError("boom"),
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
-                return_value=attempt_repo,
-            ),
+                "learn_to_cloud.routes.htmx_routes."
+                "terminalize_unstarted_verification_attempt",
+                new_callable=AsyncMock,
+            ) as terminalize,
         ):
             result = await htmx_submit_verification(
                 request,
@@ -368,10 +360,13 @@ class TestHtmxSubmitVerification:
             )
 
         assert isinstance(result, HTMLResponse)
-        attempt_repo.delete_active.assert_awaited_once_with(
-            attempt_submission.attempt_id
+        terminalize.assert_awaited_once_with(
+            attempt_submission.attempt_id,
+            error_code="durable_transport_error",
+            validation_message="Verification could not be started.",
+            terminal_source="api_start_failure",
+            session_maker=request.app.state.session_maker,
         )
-        write_session.commit.assert_awaited_once()
 
     async def test_durable_config_error_does_not_invite_immediate_retry(
         self, _patch_templates
@@ -381,13 +376,6 @@ class TestHtmxSubmitVerification:
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
         attempt_submission = _mock_attempt_submission(created=True)
-        write_session = AsyncMock()
-        request.app.state.session_maker.return_value.__aenter__.return_value = (
-            write_session
-        )
-        attempt_repo = MagicMock()
-        attempt_repo.delete_active = AsyncMock(return_value=True)
-
         with (
             patch(
                 "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
@@ -410,9 +398,10 @@ class TestHtmxSubmitVerification:
                 side_effect=DurableVerificationConfigError("not configured"),
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
-                return_value=attempt_repo,
-            ),
+                "learn_to_cloud.routes.htmx_routes."
+                "terminalize_unstarted_verification_attempt",
+                new_callable=AsyncMock,
+            ) as terminalize,
         ):
             result = await htmx_submit_verification(
                 request,
@@ -422,10 +411,7 @@ class TestHtmxSubmitVerification:
             )
 
         assert isinstance(result, HTMLResponse)
-        # The in-flight slot is still freed so a later (post-fix) retry works.
-        attempt_repo.delete_active.assert_awaited_once_with(
-            attempt_submission.attempt_id
-        )
+        terminalize.assert_awaited_once()
         _, _, context = _patch_templates.TemplateResponse.call_args.args
         assert context["server_error"] is True
         assert context["server_error_retryable"] is False
@@ -442,13 +428,6 @@ class TestHtmxSubmitVerification:
         request = _mock_request()
         current_user = AuthenticatedUser(user_id=1, github_username="user")
         attempt_submission = _mock_attempt_submission(created=True)
-        write_session = AsyncMock()
-        request.app.state.session_maker.return_value.__aenter__.return_value = (
-            write_session
-        )
-        attempt_repo = MagicMock()
-        attempt_repo.delete_active = AsyncMock(return_value=False)
-
         with (
             patch(
                 "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
@@ -471,9 +450,10 @@ class TestHtmxSubmitVerification:
                 side_effect=DurableVerificationStartError("boom"),
             ),
             patch(
-                "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
-                return_value=attempt_repo,
-            ),
+                "learn_to_cloud.routes.htmx_routes."
+                "terminalize_unstarted_verification_attempt",
+                new_callable=AsyncMock,
+            ) as terminalize,
         ):
             await htmx_submit_verification(
                 request,
@@ -485,9 +465,7 @@ class TestHtmxSubmitVerification:
         _, _, context = _patch_templates.TemplateResponse.call_args.args
         assert context["server_error"] is True
         assert context["server_error_retryable"] is True
-        attempt_repo.delete_active.assert_awaited_once_with(
-            attempt_submission.attempt_id
-        )
+        terminalize.assert_awaited_once()
 
     async def test_async_submit_still_returns_processing_card(self):
         """Regression: async submissions must keep using the
@@ -792,7 +770,7 @@ class TestHtmxVerificationAttemptStatus:
             )
 
         record = next(
-            r for r in caplog.records if r.message == "verification.attempt.completed"
+            r for r in caplog.records if r.message == "verification.attempt.observed"
         )
         # A server_error is the case an operator most needs to find, so it must
         # not be buried at INFO.
@@ -874,18 +852,20 @@ class TestHtmxVerificationAttemptStatus:
                 autospec=True,
             ) as mock_repository_class,
             patch(
+                "learn_to_cloud.routes.htmx_routes.terminalize_verification_attempt",
+                new_callable=AsyncMock,
+                return_value=MagicMock(
+                    won=True,
+                    state=MagicMock(outcome="server_error"),
+                ),
+            ) as terminalize,
+            patch(
                 "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
                 return_value=MagicMock(),
             ),
         ):
             mock_repository = mock_repository_class.return_value
             mock_repository.get_status = AsyncMock(return_value=MagicMock())
-            mock_repository.finalize = AsyncMock(
-                return_value=MagicMock(
-                    won=True,
-                    state=MagicMock(outcome="server_error"),
-                )
-            )
             result = await htmx_verification_attempt_status(
                 request,
                 token="signed-token",
@@ -893,15 +873,14 @@ class TestHtmxVerificationAttemptStatus:
             )
 
         assert isinstance(result, HTMLResponse)
-        mock_repository.finalize.assert_awaited_once_with(
+        terminalize.assert_awaited_once_with(
             job_id,
             outcome="server_error",
             error_code="server_error",
             validation_message="Verification failed before recording a result.",
             terminal_source="poller",
-            feedback_json=None,
+            session_maker=request.app.state.session_maker,
         )
-        mock_session.commit.assert_awaited_once()
         _, _, context = _patch_templates.TemplateResponse.call_args.args
         assert context["server_error"] is True
         assert context["server_error_retryable"] is False
@@ -942,18 +921,20 @@ class TestHtmxVerificationAttemptStatus:
                 autospec=True,
             ) as mock_repository_class,
             patch(
+                "learn_to_cloud.routes.htmx_routes.terminalize_verification_attempt",
+                new_callable=AsyncMock,
+                return_value=MagicMock(
+                    won=True,
+                    state=MagicMock(outcome="cancelled"),
+                ),
+            ) as terminalize,
+            patch(
                 "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
                 return_value=MagicMock(),
             ),
         ):
             mock_repository = mock_repository_class.return_value
             mock_repository.get_status = AsyncMock(return_value=MagicMock())
-            mock_repository.finalize = AsyncMock(
-                return_value=MagicMock(
-                    won=True,
-                    state=MagicMock(outcome="cancelled"),
-                )
-            )
             result = await htmx_verification_attempt_status(
                 request,
                 token="signed-token",
@@ -961,13 +942,13 @@ class TestHtmxVerificationAttemptStatus:
             )
 
         assert isinstance(result, HTMLResponse)
-        mock_repository.finalize.assert_awaited_once_with(
+        terminalize.assert_awaited_once_with(
             job_id,
             outcome="cancelled",
             error_code="cancelled",
             validation_message="Verification was cancelled.",
             terminal_source="poller",
-            feedback_json=None,
+            session_maker=request.app.state.session_maker,
         )
 
     async def test_failed_status_reloads_when_attempt_was_already_finalized(self):
@@ -999,15 +980,17 @@ class TestHtmxVerificationAttemptStatus:
                 "learn_to_cloud.routes.htmx_routes.VerificationAttemptRepository",
                 autospec=True,
             ) as mock_attempt_repository_class,
-        ):
-            attempt_repo = mock_attempt_repository_class.return_value
-            attempt_repo.get_status = AsyncMock(return_value=MagicMock())
-            attempt_repo.finalize = AsyncMock(
+            patch(
+                "learn_to_cloud.routes.htmx_routes.terminalize_verification_attempt",
+                new_callable=AsyncMock,
                 return_value=MagicMock(
                     won=False,
                     state=MagicMock(outcome="succeeded"),
-                )
-            )
+                ),
+            ),
+        ):
+            attempt_repo = mock_attempt_repository_class.return_value
+            attempt_repo.get_status = AsyncMock(return_value=MagicMock())
 
             result = await htmx_verification_attempt_status(
                 request,

--- a/api/tests/services/test_durable_verification_client.py
+++ b/api/tests/services/test_durable_verification_client.py
@@ -9,6 +9,7 @@ import pytest
 from azure.core.exceptions import ClientAuthenticationError
 
 from learn_to_cloud.services.durable_verification_client import (
+    DurableFailureKind,
     DurableVerificationAuthError,
     DurableVerificationConfigError,
     DurableVerificationStartError,
@@ -96,9 +97,58 @@ async def test_start_http_error_raises_start_error() -> None:
             "learn_to_cloud.services.durable_verification_client.httpx.AsyncClient",
             return_value=context_manager,
         ),
-        pytest.raises(DurableVerificationStartError, match="HTTP 500"),
+        pytest.raises(DurableVerificationStartError, match="HTTP 500") as caught,
     ):
         await start_verification_attempt_orchestration(uuid4())
+    assert caught.value.failure_kind is DurableFailureKind.HTTP_RETRYABLE
+    assert caught.value.retryable is True
+    assert caught.value.status_code == 500
+
+
+async def test_start_rejected_http_error_is_not_retryable() -> None:
+    _, context_manager = _async_client(httpx.Response(400, json={"error": "boom"}))
+
+    with (
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_web_settings",
+            return_value=_settings(),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_azure_token",
+            new=AsyncMock(return_value=_TOKEN),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.httpx.AsyncClient",
+            return_value=context_manager,
+        ),
+        pytest.raises(DurableVerificationStartError) as caught,
+    ):
+        await start_verification_attempt_orchestration(uuid4())
+    assert caught.value.failure_kind is DurableFailureKind.HTTP_REJECTED
+    assert caught.value.retryable is False
+
+
+async def test_start_invalid_json_is_protocol_error() -> None:
+    _, context_manager = _async_client(httpx.Response(202, content=b"not json"))
+
+    with (
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_web_settings",
+            return_value=_settings(),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.get_azure_token",
+            new=AsyncMock(return_value=_TOKEN),
+        ),
+        patch(
+            "learn_to_cloud.services.durable_verification_client.httpx.AsyncClient",
+            return_value=context_manager,
+        ),
+        pytest.raises(DurableVerificationStartError) as caught,
+    ):
+        await start_verification_attempt_orchestration(uuid4())
+    assert caught.value.failure_kind is DurableFailureKind.PROTOCOL
+    assert caught.value.retryable is False
 
 
 async def test_gets_attempt_status() -> None:

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -514,6 +514,7 @@ async def get_verification_attempt_status(
         except ValueError:
             return _json_response({"error": "invalid_instance_id"}, status_code=400)
 
+        _set_verification_span_attributes(attempt_id=instance_id)
         status = await client.get_status(
             instance_id,
             show_history=False,
@@ -577,6 +578,7 @@ def _finalize_attempt_step(
 def _terminalize_attempt_step(
     context: df.DurableOrchestrationContext,
     attempt_id: str,
+    failure_stage: str,
 ):
     """Convert an authoritative orchestration failure into a terminal outcome.
 
@@ -594,7 +596,7 @@ def _terminalize_attempt_step(
                 "outcome": "server_error",
                 "error_code": "server_error",
                 "validation_message": "Verification could not be completed.",
-                "terminal_source": "orchestrator_exception",
+                "terminal_source": f"orchestrator_{failure_stage}_exception",
             },
         )
     )
@@ -614,6 +616,7 @@ def _run_attempt_orchestration(context: df.DurableOrchestrationContext):
     attempt_id = _attempt_id_from_input(context)
     _set_verification_span_attributes(attempt_id=attempt_id)
     context.set_custom_status({"step": "preparing", "attempt_id": attempt_id})
+    failure_stage = "prepare"
     try:
         preparation = yield context.call_activity_with_retry(
             "prepare_verification_attempt",
@@ -630,11 +633,16 @@ def _run_attempt_orchestration(context: df.DurableOrchestrationContext):
             prepared_payload=prepared_attempt_payload,
             prepared_attempt=prepared_attempt,
         )
+        failure_stage = "verification"
         run_result = yield from _verify_step(context, outcome)
+        failure_stage = "grading"
         run_result = yield from _llm_grading_step(context, outcome, run_result)
+        failure_stage = "finalization"
         return (yield from _finalize_attempt_step(context, outcome, run_result))
     except Exception:
-        return (yield from _terminalize_attempt_step(context, attempt_id))
+        return (
+            yield from _terminalize_attempt_step(context, attempt_id, failure_stage)
+        )
 
 
 @app.orchestration_trigger(context_name="context")
@@ -686,10 +694,11 @@ async def finalize_verification_attempt(
     with _attached_invocation_context(context):
         run_result = VerificationRunResult.from_payload(_activity_payload(run_payload))
         _set_attempt_span_attributes(run_result.attempt)
-        state = await finalize_attempt(
+        result = await finalize_attempt(
             run_result,
             session_maker=_get_session_maker(),
         )
+        state = result.state
         logger.info(
             "verification.attempt.finalized",
             extra={"attempt_id": str(state.id), "outcome": state.outcome},
@@ -706,7 +715,7 @@ async def terminalize_verification_attempt(
     with _attached_invocation_context(context):
         data = _activity_payload(input_payload)
         attempt_id = UUID(str(data["attempt_id"]))
-        state = await terminalize_attempt(
+        result = await terminalize_attempt(
             attempt_id,
             outcome=str(data["outcome"]),
             error_code=str(data["error_code"]),
@@ -714,6 +723,7 @@ async def terminalize_verification_attempt(
             terminal_source=str(data["terminal_source"]),
             session_maker=_get_session_maker(),
         )
+        state = result.state
         logger.info(
             "verification.attempt.terminalized",
             extra={
@@ -1002,7 +1012,7 @@ async def _reconcile_stale_attempts(
             if decision is None:
                 continue
             status_name = confirmed_name
-        await terminalize_attempt(
+        result = await terminalize_attempt(
             attempt.id,
             outcome=decision.outcome,
             error_code=decision.error_code,
@@ -1010,6 +1020,8 @@ async def _reconcile_stale_attempts(
             terminal_source=decision.terminal_source,
             session_maker=session_maker,
         )
+        if not result.won:
+            continue
         terminalized += 1
         logger.info(
             "verification.reconciler.terminalized",

--- a/apps/verification-functions/tests/test_attempt_orchestrations.py
+++ b/apps/verification-functions/tests/test_attempt_orchestrations.py
@@ -186,6 +186,9 @@ class TestAttemptOrchestration:
             ("activity_with_retry", "prepare_verification_attempt"),
             ("activity_with_retry", "terminalize_verification_attempt"),
         ]
+        assert calls[-1].payload["terminal_source"] == (
+            "orchestrator_prepare_exception"
+        )
         assert result == {"attempt_id": "a-1", "outcome": "server_error"}
 
     def test_verify_failure_terminalizes(self) -> None:
@@ -203,6 +206,9 @@ class TestAttemptOrchestration:
             ("activity_with_retry", "execute_requirement_verification"),
             ("activity_with_retry", "terminalize_verification_attempt"),
         ]
+        assert calls[-1].payload["terminal_source"] == (
+            "orchestrator_verification_exception"
+        )
 
 
 class TestVersionedOrchestratorRegistered:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
@@ -12,7 +12,6 @@ from sqlalchemy import (
     Uuid,
     and_,
     column,
-    delete,
     func,
     select,
     text,
@@ -124,10 +123,9 @@ class AttemptAlreadyValidatedError(Exception):
 class VerificationAttemptRepository:
     """Data access for verification attempts.
 
-    Most methods here run under the Functions role's narrowed column
-    grants (see migration 0051). :meth:`create_or_get_active` and
-    :meth:`delete_active` are the API-side submission-creation path and run
-    under the API's normal (unrestricted) role instead.
+    Most methods here run under the Functions role's narrowed column grants
+    (see migration 0051). :meth:`create_or_get_active` is the API-side
+    submission-creation path and runs under the API's normal role instead.
     """
 
     def __init__(self, db: AsyncSession) -> None:
@@ -213,23 +211,6 @@ class VerificationAttemptRepository:
         self.db.add(attempt)
         await self.db.flush()
         return attempt, True
-
-    async def delete_active(self, attempt_id: UUID) -> bool:
-        """Delete an attempt that never started, freeing its active slot.
-
-        Used only when the API's own Durable start call fails before
-        reaching Functions (a config error, or a transport error before the
-        request landed) -- the attempt never ran, so nothing about it is
-        worth retaining. The lifecycle guards preserve rows already claimed
-        by Functions or terminalized by an authoritative writer.
-        """
-        stmt = delete(VerificationAttempt).where(
-            VerificationAttempt.id == attempt_id,
-            VerificationAttempt.outcome.is_(None),
-            VerificationAttempt.started_at.is_(None),
-        )
-        result = await self.db.execute(stmt)
-        return (getattr(result, "rowcount", 0) or 0) > 0
 
     async def _acquire_submission_lock(
         self, user_id: int, requirement_uuid: UUID
@@ -464,6 +445,73 @@ class VerificationAttemptRepository:
         if existing is None:
             raise AttemptAlreadyGoneError(str(attempt_id))
         return FinalizeResult(won=False, state=existing)
+
+    async def finalize_unstarted(
+        self,
+        attempt_id: UUID,
+        *,
+        outcome: VerificationAttemptOutcome | str,
+        error_code: str,
+        validation_message: str,
+        terminal_source: str,
+        completed_at: datetime | None = None,
+    ) -> FinalizeResult | None:
+        """Finalize only while an attempt is both active and unclaimed."""
+        normalized_outcome = (
+            outcome.value
+            if isinstance(outcome, VerificationAttemptOutcome)
+            else VerificationAttemptOutcome(outcome).value
+        )
+        now = completed_at or utcnow()
+        stmt = (
+            update(VerificationAttempt)
+            .where(
+                VerificationAttempt.id == attempt_id,
+                VerificationAttempt.outcome.is_(None),
+                VerificationAttempt.started_at.is_(None),
+            )
+            .values(
+                outcome=normalized_outcome,
+                error_code=error_code,
+                validation_message=validation_message,
+                terminal_source=terminal_source,
+                feedback_json=None,
+                completed_at=now,
+                updated_at=now,
+            )
+            .returning(
+                VerificationAttempt.id,
+                VerificationAttempt.outcome,
+                VerificationAttempt.error_code,
+                VerificationAttempt.validation_message,
+                VerificationAttempt.terminal_source,
+                VerificationAttempt.completed_at,
+            )
+        )
+        result = await self.db.execute(stmt)
+        row = result.one_or_none()
+        if row is not None:
+            return FinalizeResult(
+                won=True,
+                state=AttemptTerminalState(
+                    id=row.id,
+                    outcome=row.outcome,
+                    error_code=row.error_code,
+                    validation_message=row.validation_message,
+                    terminal_source=row.terminal_source,
+                    completed_at=row.completed_at,
+                ),
+            )
+
+        existing = await self.get_status(attempt_id)
+        if existing is None:
+            raise AttemptAlreadyGoneError(str(attempt_id))
+        if existing.outcome is None:
+            return None
+        terminal = await self.get_terminal_state(attempt_id)
+        if terminal is None:
+            raise AttemptAlreadyGoneError(str(attempt_id))
+        return FinalizeResult(won=False, state=terminal)
 
     # Authoritative progress, gating, card, and stats reads.
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
@@ -21,6 +21,7 @@ Trust boundary and idempotency:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -30,6 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from learn_to_cloud_shared.models import VerificationAttemptOutcome
 from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     AttemptTerminalState,
+    FinalizeResult,
     VerificationAttemptRepository,
 )
 from learn_to_cloud_shared.submission_values import (
@@ -52,6 +54,7 @@ from learn_to_cloud_shared.verification_workflow import (
 )
 
 tracer = trace.get_tracer(__name__)
+logger = logging.getLogger(__name__)
 
 _SNAPSHOT_SOURCE_SUBMITTED = "submitted"
 _ORCHESTRATOR_TERMINAL_SOURCE = "orchestrator"
@@ -162,7 +165,7 @@ async def finalize_verification_attempt(
     run_result: VerificationRunResult,
     *,
     session_maker: async_sessionmaker[AsyncSession],
-) -> AttemptTerminalState:
+) -> FinalizeResult:
     """Persist an attempt's real verification outcome via compare-and-set."""
     run_result = run_result.without_transport_data()
     attempt = run_result.attempt
@@ -199,7 +202,7 @@ async def terminalize_verification_attempt(
     validation_message: str,
     terminal_source: str,
     session_maker: async_sessionmaker[AsyncSession],
-) -> AttemptTerminalState:
+) -> FinalizeResult:
     """Compare-and-set a failure/cancellation outcome.
 
     Used by the orchestrator's exception path and the stale-attempt
@@ -221,6 +224,38 @@ async def terminalize_verification_attempt(
     )
 
 
+async def terminalize_unstarted_verification_attempt(
+    attempt_id: UUID,
+    *,
+    error_code: str,
+    validation_message: str,
+    terminal_source: str,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> FinalizeResult | None:
+    """Terminalize a pre-start failure without racing a Functions claim."""
+    with tracer.start_as_current_span(
+        "terminalize_unstarted_verification_attempt",
+        attributes={"verification.attempt.id": str(attempt_id)},
+    ) as span:
+        async with session_maker() as db:
+            result = await VerificationAttemptRepository(db).finalize_unstarted(
+                attempt_id,
+                outcome=VerificationAttemptOutcome.SERVER_ERROR,
+                error_code=error_code,
+                validation_message=validation_message,
+                terminal_source=terminal_source,
+            )
+            if result is not None:
+                await db.commit()
+        span.set_attribute(
+            "verification.finalization.disposition",
+            "claimed" if result is None else ("written" if result.won else "existing"),
+        )
+        if result is not None:
+            _log_canonical_completion(result)
+        return result
+
+
 async def _finalize(
     attempt_id: UUID,
     *,
@@ -230,7 +265,7 @@ async def _finalize(
     validation_message: str | None,
     terminal_source: str,
     feedback_json: list[dict] | None,
-) -> AttemptTerminalState:
+) -> FinalizeResult:
     with tracer.start_as_current_span(
         "finalize_verification_attempt",
         attributes={
@@ -249,6 +284,60 @@ async def _finalize(
                 feedback_json=feedback_json,
             )
             await db.commit()
-        span.set_attribute("verification.cas_won", result.won)
+        span.set_attribute(
+            "verification.finalization.disposition",
+            "written" if result.won else "existing",
+        )
+        _log_canonical_completion(result)
 
-        return result.state
+        return result
+
+
+def _failure_stage(state: AttemptTerminalState) -> str | None:
+    if state.outcome not in {VerificationAttemptOutcome.SERVER_ERROR.value}:
+        return None
+    source = state.terminal_source or ""
+    if source.startswith("orchestrator_"):
+        return source.removeprefix("orchestrator_").removesuffix("_exception")
+    if source in {"start_failure", "api_start_failure"}:
+        return "start"
+    if source == "poller":
+        return "status"
+    if source == "reconciler":
+        return "reconciliation"
+    if source == _ORCHESTRATOR_TERMINAL_SOURCE:
+        return "verification"
+    return None
+
+
+def _is_retryable(state: AttemptTerminalState) -> bool:
+    if state.outcome != VerificationAttemptOutcome.SERVER_ERROR.value:
+        return False
+    return state.error_code not in {
+        "durable_authentication_error",
+        "durable_configuration_error",
+        "durable_http_rejected_error",
+        "durable_protocol_error",
+    }
+
+
+def _log_canonical_completion(result: FinalizeResult) -> None:
+    if not result.won:
+        return
+    state = result.state
+    extra: dict[str, object] = {
+        "verification.attempt.id": str(state.id),
+        "verification.outcome": state.outcome,
+        "verification.error.code": state.error_code,
+        "verification.terminal.source": state.terminal_source,
+        "verification.retryable": _is_retryable(state),
+    }
+    failure_stage = _failure_stage(state)
+    if failure_stage is not None:
+        extra["verification.failure.stage"] = failure_stage
+    log = (
+        logger.warning
+        if state.outcome == VerificationAttemptOutcome.SERVER_ERROR.value
+        else logger.info
+    )
+    log("verification.attempt.completed", extra=extra)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
@@ -28,6 +28,7 @@ from uuid import UUID
 from opentelemetry import trace
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE
 from learn_to_cloud_shared.models import VerificationAttemptOutcome
 from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     AttemptTerminalState,
@@ -54,7 +55,7 @@ from learn_to_cloud_shared.verification_workflow import (
 )
 
 tracer = trace.get_tracer(__name__)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(f"{APP_LOGGER_NAMESPACE}.verification_attempt_executor")
 
 _SNAPSHOT_SOURCE_SUBMITTED = "submitted"
 _ORCHESTRATOR_TERMINAL_SOURCE = "orchestrator"

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
@@ -369,48 +369,112 @@ async def test_create_or_get_active_serializes_concurrent_submits(
     assert count == 1
 
 
-async def test_delete_active_removes_non_terminal_attempt(
+async def test_finalize_unstarted_terminalizes_active_attempt(
     session_maker: async_sessionmaker[AsyncSession], user: int
 ) -> None:
     attempt_id = await _insert_attempt(session_maker)
 
     async with session_maker() as db:
-        deleted = await VerificationAttemptRepository(db).delete_active(attempt_id)
+        result = await VerificationAttemptRepository(db).finalize_unstarted(
+            attempt_id,
+            outcome="server_error",
+            error_code="durable_transport_error",
+            validation_message="Verification could not be started.",
+            terminal_source="api_start_failure",
+        )
         await db.commit()
-    assert deleted is True
+    assert result is not None
+    assert result.won is True
+    assert result.state.outcome == "server_error"
 
     async with session_maker() as db:
         status = await VerificationAttemptRepository(db).get_status(attempt_id)
-    assert status is None
+    assert status is not None
+    assert status.outcome == "server_error"
 
 
-async def test_delete_active_refuses_terminal_attempt(
+async def test_finalize_unstarted_returns_existing_terminal_attempt(
     session_maker: async_sessionmaker[AsyncSession], user: int
 ) -> None:
     attempt_id = await _insert_attempt(session_maker, outcome="succeeded")
 
     async with session_maker() as db:
-        deleted = await VerificationAttemptRepository(db).delete_active(attempt_id)
-    assert deleted is False
+        result = await VerificationAttemptRepository(db).finalize_unstarted(
+            attempt_id,
+            outcome="server_error",
+            error_code="durable_transport_error",
+            validation_message="Verification could not be started.",
+            terminal_source="api_start_failure",
+        )
+    assert result is not None
+    assert result.won is False
+    assert result.state.outcome == "succeeded"
 
     async with session_maker() as db:
         status = await VerificationAttemptRepository(db).get_status(attempt_id)
     assert status is not None
 
 
-async def test_delete_active_refuses_claimed_attempt(
+async def test_finalize_unstarted_refuses_claimed_attempt(
     session_maker: async_sessionmaker[AsyncSession], user: int
 ) -> None:
     attempt_id = await _insert_attempt(session_maker, started_at=utcnow())
 
     async with session_maker() as db:
-        deleted = await VerificationAttemptRepository(db).delete_active(attempt_id)
-    assert deleted is False
+        result = await VerificationAttemptRepository(db).finalize_unstarted(
+            attempt_id,
+            outcome="server_error",
+            error_code="durable_transport_error",
+            validation_message="Verification could not be started.",
+            terminal_source="api_start_failure",
+        )
+    assert result is None
 
     async with session_maker() as db:
         status = await VerificationAttemptRepository(db).get_status(attempt_id)
     assert status is not None
     assert status.started_at is not None
+
+
+async def test_new_submission_follows_terminalized_pre_start_attempt(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement_uuid = uuid4()
+    first_id = await _insert_attempt(
+        session_maker,
+        requirement_uuid=requirement_uuid,
+    )
+    async with session_maker() as db:
+        result = await VerificationAttemptRepository(db).finalize_unstarted(
+            first_id,
+            outcome="server_error",
+            error_code="durable_transport_error",
+            validation_message="Verification could not be started.",
+            terminal_source="api_start_failure",
+        )
+        await db.commit()
+    assert result is not None and result.won
+
+    second_id = uuid4()
+    async with session_maker() as db:
+        attempt, created = await VerificationAttemptRepository(db).create_or_get_active(
+            **_create_kwargs(
+                id=second_id,
+                requirement_uuid=requirement_uuid,
+                submitted_value=_submitted_value(),
+            )
+        )
+        await db.commit()
+
+    assert created is True
+    assert attempt.id == second_id
+    async with session_maker() as db:
+        count = await db.scalar(
+            select(func.count())
+            .select_from(VerificationAttempt)
+            .where(VerificationAttempt.requirement_uuid == requirement_uuid)
+        )
+    assert count == 2
 
 
 # Progress, gating, card, and stats reads

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
@@ -1,5 +1,6 @@
 """Integration tests for verification-attempt execution."""
 
+import logging
 from uuid import uuid4
 
 import pytest
@@ -109,6 +110,7 @@ async def test_prepare_rejects_reconstructed_attempt(
 
 async def test_finalize_is_compare_and_set_idempotent(
     session_maker: async_sessionmaker[AsyncSession],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     attempt = await _create_attempt(session_maker)
     preparation = await prepare_verification_attempt(
@@ -122,14 +124,30 @@ async def test_finalize_is_compare_and_set_idempotent(
         ),
     )
 
-    first = await finalize_verification_attempt(run_result, session_maker=session_maker)
-    second = await finalize_verification_attempt(
-        run_result, session_maker=session_maker
-    )
+    with caplog.at_level(
+        logging.INFO,
+        logger="learn_to_cloud_shared.verification_attempt_executor",
+    ):
+        first = await finalize_verification_attempt(
+            run_result, session_maker=session_maker
+        )
+        second = await finalize_verification_attempt(
+            run_result, session_maker=session_maker
+        )
 
-    assert first.outcome == "succeeded"
-    assert second.outcome == "succeeded"
-    assert first.completed_at == second.completed_at
+    assert first.won is True
+    assert second.won is False
+    assert first.state.outcome == "succeeded"
+    assert second.state.outcome == "succeeded"
+    assert first.state.completed_at == second.state.completed_at
+    records = [
+        record
+        for record in caplog.records
+        if record.message == "verification.attempt.completed"
+    ]
+    assert len(records) == 1
+    assert records[0].__dict__["verification.attempt.id"] == str(attempt.id)
+    assert records[0].__dict__["verification.outcome"] == "succeeded"
 
 
 async def test_terminalize_records_cancelled_outcome(
@@ -137,7 +155,7 @@ async def test_terminalize_records_cancelled_outcome(
 ) -> None:
     attempt = await _create_attempt(session_maker)
 
-    state = await terminalize_verification_attempt(
+    result = await terminalize_verification_attempt(
         attempt.id,
         outcome="cancelled",
         error_code="cancelled",
@@ -146,5 +164,6 @@ async def test_terminalize_records_cancelled_outcome(
         session_maker=session_maker,
     )
 
-    assert state.outcome == "cancelled"
-    assert state.error_code == "cancelled"
+    assert result.won is True
+    assert result.state.outcome == "cancelled"
+    assert result.state.error_code == "cancelled"

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
@@ -126,7 +126,7 @@ async def test_finalize_is_compare_and_set_idempotent(
 
     with caplog.at_level(
         logging.INFO,
-        logger="learn_to_cloud_shared.verification_attempt_executor",
+        logger="learn_to_cloud.verification_attempt_executor",
     ):
         first = await finalize_verification_attempt(
             run_result, session_maker=session_maker


### PR DESCRIPTION
## Summary

- emit `verification.attempt.completed` only when PostgreSQL accepts the first terminal result
- correlate start/status diagnostics with `attempt_id` and structured retryability metadata
- retain failed pre-start attempts as guarded terminal rows instead of deleting them
- rename the API poller's read-back event to `verification.attempt.observed`

## Stack

Bottom layer of stack #763. PR #762 adds shadow alerts on top of this telemetry contract.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.

N/A: no schema migration.