### PR TITLE
feat(monitoring): add canonical verification alerts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,6 +66,13 @@ Keep docstrings short and useful. One line is enough for most functions.
 - Answering a question is not permission to be verbose. Lead with the direct concise answer. Add detail only if asked for additional context or explanation.
 - Don't teach or give multiple framings unless asked.
 
+## Pull Request Descriptions
+
+- Write PR descriptions in plain language that a learner can understand.
+- Lead with what changes, why it is needed, and what effect it has.
+- Avoid unexplained jargon. If a technical term is necessary, define it immediately with a concrete explanation.
+- Describe rollout states plainly. For example, say "the alert is evaluated but sends no notifications" instead of relying on "shadow mode."
+
 ## Research
 
 If you need to research something that is Azure related always use the azure-skills plugin.

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -954,6 +954,40 @@ class _ReconcileSummary:
 
     candidate_count: int
     terminalized_count: int
+    stuck_count: int
+
+
+async def _emit_stuck_if_active(
+    attempt_id: UUID,
+    *,
+    durable_status: str | None,
+    reason: str,
+    cutoff: datetime,
+    reference: datetime,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> bool:
+    """Emit a stuck event only after PostgreSQL confirms the row is still stale."""
+    async with session_maker() as db:
+        current = await VerificationAttemptRepository(db).get_status(attempt_id)
+    if current is None or current.outcome is not None:
+        return False
+    age_anchor = current.started_at or current.created_at
+    if age_anchor >= cutoff:
+        return False
+
+    logger.warning(
+        "verification.attempt.stuck",
+        extra={
+            "attempt_id": str(attempt_id),
+            "verification.attempt.id": str(attempt_id),
+            "verification.failure.stage": "reconciliation",
+            "verification.retryable": True,
+            "durable_status": durable_status,
+            "stuck_reason": reason,
+            "attempt_age_seconds": int((reference - age_anchor).total_seconds()),
+        },
+    )
+    return True
 
 
 async def _reconcile_stale_attempts(
@@ -984,6 +1018,7 @@ async def _reconcile_stale_attempts(
     )
 
     terminalized = 0
+    stuck = 0
     for attempt in stale:
         instance_id = str(attempt.id)
         try:
@@ -993,10 +1028,26 @@ async def _reconcile_stale_attempts(
                 "verification.reconciler.status_query_failed",
                 extra={"attempt_id": instance_id},
             )
+            stuck += await _emit_stuck_if_active(
+                attempt.id,
+                durable_status=None,
+                reason="status_query_failed",
+                cutoff=cutoff,
+                reference=reference,
+                session_maker=session_maker,
+            )
             continue
         status_name = _runtime_status_name(status)
         decision = reconcile_decision(status_name)
         if decision is None:
+            stuck += await _emit_stuck_if_active(
+                attempt.id,
+                durable_status=status_name,
+                reason="active_beyond_limit",
+                cutoff=cutoff,
+                reference=reference,
+                session_maker=session_maker,
+            )
             continue
         if status_name is None:
             try:
@@ -1006,10 +1057,26 @@ async def _reconcile_stale_attempts(
                     "verification.reconciler.status_recheck_failed",
                     extra={"attempt_id": instance_id},
                 )
+                stuck += await _emit_stuck_if_active(
+                    attempt.id,
+                    durable_status=None,
+                    reason="status_recheck_failed",
+                    cutoff=cutoff,
+                    reference=reference,
+                    session_maker=session_maker,
+                )
                 continue
             confirmed_name = _runtime_status_name(confirmed_status)
             decision = reconcile_decision(confirmed_name)
             if decision is None:
+                stuck += await _emit_stuck_if_active(
+                    attempt.id,
+                    durable_status=confirmed_name,
+                    reason="active_beyond_limit",
+                    cutoff=cutoff,
+                    reference=reference,
+                    session_maker=session_maker,
+                )
                 continue
             status_name = confirmed_name
         result = await terminalize_attempt(
@@ -1037,11 +1104,13 @@ async def _reconcile_stale_attempts(
         extra={
             "candidate_count": len(stale),
             "terminalized_count": terminalized,
+            "stuck_count": stuck,
         },
     )
     return _ReconcileSummary(
         candidate_count=len(stale),
         terminalized_count=terminalized,
+        stuck_count=stuck,
     )
 
 

--- a/apps/verification-functions/tests/test_attempt_orchestrations.py
+++ b/apps/verification-functions/tests/test_attempt_orchestrations.py
@@ -443,11 +443,35 @@ class _CapturingRepo:
         _CapturingRepo.captured_cutoff = cutoff
         return _CapturingRepo.rows
 
+    async def get_status(self, attempt_id):
+        return next(
+            (row for row in _CapturingRepo.rows if row.id == attempt_id),
+            None,
+        )
+
+
+class _TerminalOnRecheckRepo(_CapturingRepo):
+    async def get_status(self, attempt_id):
+        row = await super().get_status(attempt_id)
+        if row is None:
+            return None
+        return AttemptStatusRow(
+            id=row.id,
+            user_id=row.user_id,
+            requirement_uuid=row.requirement_uuid,
+            outcome="succeeded",
+            started_at=row.started_at,
+            created_at=row.created_at,
+        )
+
 
 class TestReconciler:
     pytestmark = pytest.mark.asyncio
 
-    async def test_maps_statuses_and_skips_healthy(self) -> None:
+    async def test_maps_statuses_and_reports_stuck_healthy_attempt(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         failed = uuid4()
         terminated = uuid4()
         completed = uuid4()
@@ -475,6 +499,10 @@ class TestReconciler:
         with (
             patch.object(function_app, "VerificationAttemptRepository", _CapturingRepo),
             patch.object(function_app, "terminalize_attempt", new=AsyncMock()) as term,
+            caplog.at_level(
+                "WARNING",
+                logger="function_app",
+            ),
         ):
             summary = await function_app._reconcile_stale_attempts(
                 client,
@@ -486,6 +514,7 @@ class TestReconciler:
 
         assert summary.candidate_count == 5
         assert summary.terminalized_count == 4
+        assert summary.stuck_count == 1
         assert _CapturingRepo.captured_cutoff == stale_cutoff(now, 30)
 
         terminalized = {
@@ -496,6 +525,13 @@ class TestReconciler:
         assert terminalized[completed] is VerificationAttemptOutcome.SERVER_ERROR
         assert terminalized[missing] is VerificationAttemptOutcome.SERVER_ERROR
         assert running not in terminalized
+        stuck_record = next(
+            record
+            for record in caplog.records
+            if record.message == "verification.attempt.stuck"
+        )
+        assert stuck_record.__dict__["verification.attempt.id"] == str(running)
+        assert stuck_record.durable_status == "Running"
 
     async def test_rechecks_missing_status_before_terminalizing(self) -> None:
         attempt_id = uuid4()
@@ -514,7 +550,42 @@ class TestReconciler:
                 now=now,
             )
         assert summary.terminalized_count == 0
+        assert summary.stuck_count == 1
         term.assert_not_awaited()
+
+    async def test_does_not_report_stuck_after_database_finalization(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        attempt_id = uuid4()
+        now = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        _CapturingRepo.rows = [_status_row(attempt_id, now - timedelta(hours=2))]
+        client = _FakeClient(
+            statuses={
+                str(attempt_id): _FakeStatus(_FakeRuntimeStatus("Running")),
+            }
+        )
+
+        with (
+            patch.object(
+                function_app,
+                "VerificationAttemptRepository",
+                _TerminalOnRecheckRepo,
+            ),
+            caplog.at_level("WARNING", logger="function_app"),
+        ):
+            summary = await function_app._reconcile_stale_attempts(
+                client,
+                session_maker=_session_maker,
+                stale_attempt_min_age_minutes=30,
+                batch_limit=50,
+                now=now,
+            )
+
+        assert summary.stuck_count == 0
+        assert not any(
+            record.message == "verification.attempt.stuck" for record in caplog.records
+        )
 
 
 class _MissingThenRunningClient:

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -319,6 +319,102 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_system_e
   }
 }
 
+# Additive replacement for verification_system_error during the telemetry
+# migration. It evaluates in shadow mode without an action group until cutover,
+# and only uses canonical events emitted after PostgreSQL accepts the first
+# terminal result for an attempt.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_system_error" {
+  name                = "alert-ltc-verification-attempt-system-error-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Alert when a saved verification attempt outcome is server_error"
+  severity            = 2
+  enabled             = true
+  tags                = local.tags
+
+  scopes                = [azurerm_application_insights.main.id]
+  evaluation_frequency  = "PT5M"
+  window_duration       = "PT5M"
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query                   = <<-QUERY
+      traces
+      | where cloud_RoleName in (
+          "learn-to-cloud-api",
+          "ca-ltc-api-${var.environment}",
+          "learn-to-cloud-verification-functions",
+          "func-ltc-verification-${var.environment}"
+        )
+          or cloud_RoleName has "learn-to-cloud-api"
+          or cloud_RoleName has "ca-ltc-api"
+          or cloud_RoleName has "verification-functions"
+          or cloud_RoleName has "func-ltc-verification"
+      | where message == "verification.attempt.completed"
+      | extend
+          Outcome = tostring(customDimensions["verification.outcome"]),
+          AttemptId = tostring(customDimensions["verification.attempt.id"])
+      | where Outcome == "server_error"
+      | where isnotempty(AttemptId)
+      | summarize ErrorCount = dcount(AttemptId) by bin(timestamp, 5m)
+    QUERY
+    time_aggregation_method = "Maximum"
+    metric_measure_column   = "ErrorCount"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+}
+
+# The reconciler emits this event only after a final database read confirms the
+# attempt is still active beyond its allowed duration. It also starts in shadow
+# mode so deploying it cannot duplicate the existing verification pages.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_stuck" {
+  name                = "alert-ltc-verification-attempt-stuck-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Alert when a verification attempt remains active beyond its maximum duration"
+  severity            = 2
+  enabled             = true
+  tags                = local.tags
+
+  scopes                = [azurerm_application_insights.main.id]
+  evaluation_frequency  = "PT5M"
+  window_duration       = "PT15M"
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query                   = <<-QUERY
+      traces
+      | where cloud_RoleName in (
+          "learn-to-cloud-verification-functions",
+          "func-ltc-verification-${var.environment}"
+        )
+          or cloud_RoleName has "verification-functions"
+          or cloud_RoleName has "func-ltc-verification"
+      | where message == "verification.attempt.stuck"
+      | extend AttemptId = tostring(customDimensions["verification.attempt.id"])
+      | where isnotempty(AttemptId)
+      | summarize StuckCount = dcount(AttemptId) by bin(timestamp, 5m)
+    QUERY
+    time_aggregation_method = "Maximum"
+    metric_measure_column   = "StuckCount"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+}
+
 # Tier 3 follow-up from the #432 post-mortem: page if the production DB's
 # applied Alembic head ever falls out of sync with the head baked into the
 # deployed code (manual psql access, a half-applied migration, a future


### PR DESCRIPTION
## What this PR does

This PR adds two new Azure Monitor alert rules for verification attempts:

1. **Verification system error:** detects when PostgreSQL saves the official final result as `server_error`.
2. **Stuck verification attempt:** detects when an attempt has run too long and the recovery process confirms it is still unfinished.

The new rules use the verification result saved in PostgreSQL instead of treating unrelated Azure Functions host or lifecycle errors as verification failures.

## Why the new alerts will not email yet

The two rules will be deployed and evaluated, but they will not have a notification group attached. This is sometimes called "shadow mode." In plain language: **Azure will test the rules, but they cannot send emails or page anyone.**

The existing verification alerts remain active while we confirm that the two new rules detect the right events. A later PR will remove the old noisy alerts and connect these new rules to notifications.

## Deployment status

PR #761 is deployed, and its new completion event has been confirmed in Application Insights. The Azure-backed Terraform plan for this PR creates exactly two alert rules: **2 added, 0 changed, 0 destroyed**.

After this PR deploys, we will observe the two rules before making them responsible for notifications.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.

N/A: no schema migration.