### PR TITLE
chore(monitoring): replace noisy verification alerts

### DIFF
--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -163,166 +163,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "api_5xx_errors" {
   }
 }
 
-resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_functions_5xx_errors" {
-  name                = "alert-ltc-verification-functions-5xx-${var.environment}"
-  resource_group_name = azurerm_resource_group.main.name
-  location            = azurerm_resource_group.main.location
-  description         = "Alert when verification Functions return any 5xx errors in a 5-minute window"
-  severity            = 1
-  enabled             = true
-  tags                = local.tags
-
-  scopes                = [azurerm_application_insights.main.id]
-  evaluation_frequency  = "PT5M"
-  window_duration       = "PT5M"
-  target_resource_types = ["microsoft.insights/components"]
-
-  criteria {
-    query                   = <<-QUERY
-      requests
-      | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
-          or cloud_RoleName has "verification-functions"
-          or cloud_RoleName has "func-ltc-verification"
-      | where resultCode startswith "5"
-    QUERY
-    time_aggregation_method = "Count"
-    operator                = "GreaterThanOrEqual"
-    threshold               = 1
-
-    failing_periods {
-      minimum_failing_periods_to_trigger_alert = 1
-      number_of_evaluation_periods             = 1
-    }
-  }
-
-  action {
-    action_groups = [azurerm_monitor_action_group.critical.id]
-  }
-}
-
-resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_functions_exceptions" {
-  name                = "alert-ltc-verification-functions-exceptions-${var.environment}"
-  resource_group_name = azurerm_resource_group.main.name
-  location            = azurerm_resource_group.main.location
-  description         = "Alert when a non-HTTP verification Functions invocation remains failed after a 5-minute correlation delay"
-  severity            = 1
-  enabled             = true
-  tags                = local.tags
-
-  scopes                = [azurerm_application_insights.main.id]
-  evaluation_frequency  = "PT5M"
-  window_duration       = "PT15M"
-  target_resource_types = ["microsoft.insights/components"]
-
-  criteria {
-    query                   = <<-QUERY
-      let TerminalVerificationAttempts =
-          traces
-          | where timestamp > ago(15m)
-          | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
-              or cloud_RoleName has "verification-functions"
-              or cloud_RoleName has "func-ltc-verification"
-          | where message in ("verification.attempt.finalized", "verification.attempt.terminalized")
-          | project operation_Id;
-      let FunctionsHttp5xx =
-          requests
-          | where timestamp > ago(15m)
-          | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
-              or cloud_RoleName has "verification-functions"
-              or cloud_RoleName has "func-ltc-verification"
-          | where resultCode startswith "5"
-          | project operation_Id;
-      exceptions
-      | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
-          or cloud_RoleName has "verification-functions"
-          or cloud_RoleName has "func-ltc-verification"
-      | where isnotempty(operation_Id)
-      | where timestamp between (ago(15m) .. ago(5m))
-      | join kind=leftanti TerminalVerificationAttempts on operation_Id
-      | join kind=leftanti FunctionsHttp5xx on operation_Id
-      | summarize ExceptionRows = count() by operation_Id
-    QUERY
-    time_aggregation_method = "Count"
-    operator                = "GreaterThanOrEqual"
-    threshold               = 1
-
-    failing_periods {
-      minimum_failing_periods_to_trigger_alert = 1
-      number_of_evaluation_periods             = 1
-    }
-  }
-
-  action {
-    action_groups = [azurerm_monitor_action_group.critical.id]
-  }
-}
-
-# Learner-facing verification system failures cross two telemetry boundaries:
-# the API records a handled start failure before Functions can claim an attempt,
-# while Functions records an authoritative server_error after an attempt starts.
-# Both mean our system, not the learner's validation, prevented completion.
-resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_system_error" {
-  name                = "alert-ltc-verification-system-error-${var.environment}"
-  resource_group_name = azurerm_resource_group.main.name
-  location            = azurerm_resource_group.main.location
-  description         = "Alert on any handled Durable start failure or terminal verification server_error"
-  severity            = 2
-  enabled             = true
-  tags                = local.tags
-
-  scopes                = [azurerm_application_insights.main.id]
-  evaluation_frequency  = "PT5M"
-  window_duration       = "PT5M"
-  target_resource_types = ["microsoft.insights/components"]
-
-  criteria {
-    query                   = <<-QUERY
-      let DurableStartFailures =
-          traces
-          | where timestamp > ago(5m)
-          | extend ErrorType = tostring(customDimensions.error_type)
-          | where cloud_RoleName in ("learn-to-cloud-api", "ca-ltc-api-${var.environment}")
-              or cloud_RoleName has "learn-to-cloud-api"
-              or cloud_RoleName has "ca-ltc-api"
-          | where message == "htmx.submit.durable_start_failed"
-          | where ErrorType == "DurableVerificationStartError"
-          | project FailureKey = strcat("start:", operation_Id);
-      let TerminalServerErrors =
-          traces
-          | where timestamp > ago(5m)
-          | extend
-              Outcome = tostring(customDimensions.outcome),
-              AttemptId = tostring(customDimensions.attempt_id)
-          | where cloud_RoleName in ("learn-to-cloud-verification-functions", "func-ltc-verification-${var.environment}")
-              or cloud_RoleName has "verification-functions"
-              or cloud_RoleName has "func-ltc-verification"
-          | where message in ("verification.attempt.finalized", "verification.attempt.terminalized")
-          | where Outcome == "server_error"
-          | where isnotempty(AttemptId)
-          | project FailureKey = strcat("attempt:", AttemptId);
-      union DurableStartFailures, TerminalServerErrors
-      | summarize ErrorCount = dcount(FailureKey)
-    QUERY
-    time_aggregation_method = "Maximum"
-    metric_measure_column   = "ErrorCount"
-    operator                = "GreaterThanOrEqual"
-    threshold               = 1
-
-    failing_periods {
-      minimum_failing_periods_to_trigger_alert = 1
-      number_of_evaluation_periods             = 1
-    }
-  }
-
-  action {
-    action_groups = [azurerm_monitor_action_group.critical.id]
-  }
-}
-
-# Additive replacement for verification_system_error during the telemetry
-# migration. It evaluates in shadow mode without an action group until cutover,
-# and only uses canonical events emitted after PostgreSQL accepts the first
-# terminal result for an attempt.
+# Page only for the final outcome PostgreSQL accepted for an attempt.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_system_error" {
   name                = "alert-ltc-verification-attempt-system-error-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name
@@ -369,11 +210,13 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
     }
   }
 
+  action {
+    action_groups = [azurerm_monitor_action_group.critical.id]
+  }
 }
 
 # The reconciler emits this event only after a final database read confirms the
-# attempt is still active beyond its allowed duration. It also starts in shadow
-# mode so deploying it cannot duplicate the existing verification pages.
+# attempt is still active beyond its allowed duration.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_stuck" {
   name                = "alert-ltc-verification-attempt-stuck-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name
@@ -413,6 +256,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
     }
   }
 
+  action {
+    action_groups = [azurerm_monitor_action_group.critical.id]
+  }
 }
 
 # Tier 3 follow-up from the #432 post-mortem: page if the production DB's


### PR DESCRIPTION
## Summary

This PR switches verification notifications from three old, noisy alert rules to the two new rules we have been testing.

It removes alerts that treated Azure Functions HTTP errors, host exceptions, and mixed diagnostic events as learner verification failures. Those signals could email us even when no saved verification attempt had failed.

It connects these two replacement rules to the critical notification group:

1. **Verification system error:** emails when PostgreSQL saves a verification attempt's official final result as `server_error`.
2. **Stuck verification attempt:** emails when an attempt has run too long and the recovery process confirms it is still unfinished.

After deployment, production will have five alerts total: availability, API errors, database schema drift, verification system errors, and stuck verification attempts.

This PR is intentionally a draft. Do not merge it until we review the new rules' evaluation results.

## Terraform plan

The Azure-backed plan matches the intended cutover:

- **0 alerts added**
- **2 alerts updated:** connect the two replacement rules to email notifications
- **3 alerts destroyed:** remove the old verification Functions HTTP, exception, and mixed system-error rules
- no replacements and no unrelated infrastructure changes

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.

N/A: no schema migration.