### PR TITLE
chore(telemetry): remove old verification events

### DIFF
--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -699,10 +699,6 @@ async def finalize_verification_attempt(
             session_maker=_get_session_maker(),
         )
         state = result.state
-        logger.info(
-            "verification.attempt.finalized",
-            extra={"attempt_id": str(state.id), "outcome": state.outcome},
-        )
         return _terminal_state_payload(state)
 
 
@@ -724,14 +720,6 @@ async def terminalize_verification_attempt(
             session_maker=_get_session_maker(),
         )
         state = result.state
-        logger.info(
-            "verification.attempt.terminalized",
-            extra={
-                "attempt_id": str(state.id),
-                "outcome": state.outcome,
-                "terminal_source": state.terminal_source,
-            },
-        )
         return _terminal_state_payload(state)
 
 


### PR DESCRIPTION
## Summary

This PR removes two old log events: `verification.attempt.finalized` and `verification.attempt.terminalized`.

They were kept temporarily while we moved the alerts to the new database-backed telemetry. Production now has the final five-alert configuration, and no alert uses these old events anymore.

The verification workflow does not change. Attempts are still saved and returned exactly as before. The official `verification.attempt.completed` event and the confirmed `verification.attempt.stuck` event remain.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.

N/A: no schema migration.