### PR TITLE
Add an interactive Azure alert audit canvas

### DIFF
--- a/.github/extensions/alert-audit/extension.mjs
+++ b/.github/extensions/alert-audit/extension.mjs
@@ -1,0 +1,173 @@
+import { createServer } from "node:http";
+
+import { createCanvas, joinSession } from "@github/copilot-sdk/extension";
+
+import { runAlertAudit, summarizeAudit } from "./lib/audit.mjs";
+import { renderHtml } from "./lib/renderer.mjs";
+
+const servers = new Map();
+
+function normalizeOptions(input = {}) {
+    return {
+        environment: input.environment ?? "dev",
+        resourceGroup: input.resourceGroup ?? "rg-ltc-dev",
+        lookbackHours: input.lookbackHours ?? 24,
+    };
+}
+
+function sendJson(res, status, value) {
+    res.writeHead(status, {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "no-store",
+    });
+    res.end(JSON.stringify(value));
+}
+
+async function refresh(entry) {
+    if (entry.refreshPromise) {
+        return entry.refreshPromise;
+    }
+
+    entry.refreshPromise = runAlertAudit(entry.options)
+        .then((snapshot) => {
+            entry.snapshot = snapshot;
+            return snapshot;
+        })
+        .finally(() => {
+            entry.refreshPromise = undefined;
+        });
+    return entry.refreshPromise;
+}
+
+async function startServer(options) {
+    const entry = {
+        options,
+        snapshot: undefined,
+        refreshPromise: undefined,
+        server: undefined,
+        url: undefined,
+    };
+
+    const server = createServer(async (req, res) => {
+        const url = new URL(req.url ?? "/", "http://127.0.0.1");
+
+        if (req.method === "GET" && url.pathname === "/") {
+            res.writeHead(200, {
+                "Content-Type": "text/html; charset=utf-8",
+                "Cache-Control": "no-store",
+                "Content-Security-Policy":
+                    "default-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'",
+            });
+            res.end(renderHtml(options));
+            return;
+        }
+
+        if (req.method === "GET" && url.pathname === "/api/snapshot") {
+            sendJson(res, 200, entry.snapshot ?? { status: "not-run" });
+            return;
+        }
+
+        if (req.method === "POST" && url.pathname === "/api/audit") {
+            try {
+                sendJson(res, 200, await refresh(entry));
+            } catch (error) {
+                sendJson(res, 500, {
+                    status: "error",
+                    error: error instanceof Error ? error.message : String(error),
+                });
+            }
+            return;
+        }
+
+        sendJson(res, 404, { error: "Not found" });
+    });
+
+    await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    entry.server = server;
+    entry.url = `http://127.0.0.1:${port}/`;
+    return entry;
+}
+
+const session = await joinSession({
+    canvases: [
+        createCanvas({
+            id: "alert-audit",
+            displayName: "Alert audit",
+            description:
+                "Compare Terraform-managed Azure Monitor alerts with live rules and recent firings.",
+            inputSchema: {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                    environment: {
+                        type: "string",
+                        minLength: 1,
+                        description: "Terraform environment name used in alert resource names.",
+                    },
+                    resourceGroup: {
+                        type: "string",
+                        minLength: 1,
+                        description: "Azure resource group containing the alert rules.",
+                    },
+                    lookbackHours: {
+                        type: "integer",
+                        minimum: 1,
+                        maximum: 168,
+                        description: "Recent fired-alert lookback window.",
+                    },
+                },
+            },
+            actions: [
+                {
+                    name: "refresh",
+                    description: "Refresh the Terraform and live Azure alert audit.",
+                    handler: async (ctx) => {
+                        const entry = servers.get(ctx.instanceId);
+                        if (!entry) {
+                            throw new Error(`Canvas instance ${ctx.instanceId} is not open`);
+                        }
+                        return summarizeAudit(await refresh(entry));
+                    },
+                },
+                {
+                    name: "get_summary",
+                    description: "Return a compact summary of the latest alert audit.",
+                    handler: async (ctx) => {
+                        const entry = servers.get(ctx.instanceId);
+                        if (!entry) {
+                            throw new Error(`Canvas instance ${ctx.instanceId} is not open`);
+                        }
+                        return summarizeAudit(entry.snapshot ?? (await refresh(entry)));
+                    },
+                },
+            ],
+            open: async (ctx) => {
+                let entry = servers.get(ctx.instanceId);
+                if (!entry) {
+                    entry = await startServer(normalizeOptions(ctx.input));
+                    servers.set(ctx.instanceId, entry);
+                }
+                return {
+                    title: `Alert audit · ${entry.options.environment}`,
+                    status: entry.snapshot ? entry.snapshot.verdict : "Ready to audit",
+                    url: entry.url,
+                };
+            },
+            onClose: async (ctx) => {
+                const entry = servers.get(ctx.instanceId);
+                if (!entry) {
+                    return;
+                }
+                servers.delete(ctx.instanceId);
+                await new Promise((resolve) => entry.server.close(resolve));
+            },
+        }),
+    ],
+});
+
+void session;

--- a/.github/extensions/alert-audit/lib/audit.mjs
+++ b/.github/extensions/alert-audit/lib/audit.mjs
@@ -1,0 +1,284 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+const MONITORING_PATH = resolve(REPO_ROOT, "infra/monitoring.tf");
+
+function extractValue(body, key) {
+    const match = body.match(new RegExp(`^\\s*${key}\\s*=\\s*("?)([^"\\n]+)\\1`, "m"));
+    return match?.[2]?.trim();
+}
+
+function extractQuery(body) {
+    return body.match(/query\s*=\s*<<-\w+\n([\s\S]*?)\n\s*\w+\n/)?.[1]?.trim() ?? null;
+}
+
+function parseBoolean(value) {
+    if (value === "true") {
+        return true;
+    }
+    if (value === "false") {
+        return false;
+    }
+    return null;
+}
+
+function parseNumber(value) {
+    if (value === undefined) {
+        return null;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function resolveName(value, environment) {
+    return value?.replaceAll("${var.environment}", environment) ?? null;
+}
+
+export function parseDeclaredAlerts(source, environment) {
+    const matches = [
+        ...source.matchAll(
+            /^resource "(azurerm_monitor_(?:metric_alert|scheduled_query_rules_alert_v2))" "([^"]+)" \{/gm,
+        ),
+    ];
+
+    return matches.map((match, index) => {
+        const end = matches[index + 1]?.index ?? source.length;
+        const body = source.slice(match.index, end);
+        const type = match[1] === "azurerm_monitor_metric_alert" ? "metric" : "scheduled-query";
+        const name = resolveName(extractValue(body, "name"), environment);
+        const actionAttached =
+            body.includes("action_group_id") || body.includes("action_groups");
+
+        return {
+            terraformId: match[2],
+            type,
+            name,
+            description: extractValue(body, "description") ?? null,
+            severity: parseNumber(extractValue(body, "severity")),
+            enabled: parseBoolean(extractValue(body, "enabled")),
+            frequency:
+                extractValue(body, type === "metric" ? "frequency" : "evaluation_frequency") ??
+                null,
+            window:
+                extractValue(body, type === "metric" ? "window_size" : "window_duration") ??
+                null,
+            operator: extractValue(body, "operator") ?? null,
+            threshold: parseNumber(extractValue(body, "threshold")),
+            minimumFailingPeriods: parseNumber(
+                extractValue(body, "minimum_failing_periods_to_trigger_alert"),
+            ),
+            evaluationPeriods: parseNumber(extractValue(body, "number_of_evaluation_periods")),
+            actionAttached,
+            query: extractQuery(body),
+        };
+    });
+}
+
+async function runAz(args) {
+    const { stdout } = await execFileAsync("az", args, {
+        timeout: 30_000,
+        maxBuffer: 5 * 1024 * 1024,
+        env: { ...process.env, AZURE_CORE_ONLY_SHOW_ERRORS: "true" },
+    });
+    return JSON.parse(stdout);
+}
+
+function errorMessage(error) {
+    if (!(error instanceof Error)) {
+        return String(error);
+    }
+    const stderr = "stderr" in error && typeof error.stderr === "string" ? error.stderr.trim() : "";
+    return stderr || error.message;
+}
+
+async function getLiveAzureState(resourceGroup, lookbackHours) {
+    const account = await runAz([
+        "account",
+        "show",
+        "--query",
+        "{subscriptionId:id,subscriptionName:name,tenantId:tenantId}",
+        "--output",
+        "json",
+    ]);
+    const base =
+        `https://management.azure.com/subscriptions/${account.subscriptionId}` +
+        `/resourceGroups/${encodeURIComponent(resourceGroup)}/providers/Microsoft.Insights`;
+    const timeRange = lookbackHours <= 1 ? "1h" : lookbackHours <= 24 ? "1d" : "7d";
+    const alertsUrl =
+        `https://management.azure.com/subscriptions/${account.subscriptionId}` +
+        `/providers/Microsoft.AlertsManagement/alerts?api-version=2019-03-01` +
+        `&timeRange=${timeRange}&targetResourceGroup=${encodeURIComponent(resourceGroup)}`;
+
+    const [metricResult, scheduledResult, firedResult] = await Promise.allSettled([
+        runAz(["rest", "--method", "get", "--url", `${base}/metricAlerts?api-version=2018-03-01`]),
+        runAz([
+            "rest",
+            "--method",
+            "get",
+            "--url",
+            `${base}/scheduledQueryRules?api-version=2023-12-01`,
+        ]),
+        runAz(["rest", "--method", "get", "--url", alertsUrl]),
+    ]);
+
+    const errors = [];
+    const valueOrEmpty = (result, label) => {
+        if (result.status === "fulfilled") {
+            return result.value.value ?? [];
+        }
+        errors.push(`${label}: ${errorMessage(result.reason)}`);
+        return [];
+    };
+
+    return {
+        account,
+        rules: [
+            ...valueOrEmpty(metricResult, "Metric alerts"),
+            ...valueOrEmpty(scheduledResult, "Scheduled query rules"),
+        ],
+        fired: valueOrEmpty(firedResult, "Fired alerts"),
+        errors,
+    };
+}
+
+function normalizedName(value) {
+    return value?.toLowerCase() ?? "";
+}
+
+function liveRuleEnabled(rule) {
+    if (typeof rule.properties?.enabled === "boolean") {
+        return rule.properties.enabled;
+    }
+    return rule.properties?.enabled === "true";
+}
+
+function firedRuleName(alert) {
+    const essentials = alert.properties?.essentials ?? {};
+    return essentials.alertRule ?? essentials.alertRuleName ?? alert.name ?? "";
+}
+
+function buildFindings(declared, liveRules, fired, liveErrors) {
+    const liveByName = new Map(liveRules.map((rule) => [normalizedName(rule.name), rule]));
+    const declaredNames = new Set(declared.map((rule) => normalizedName(rule.name)));
+    const firedCounts = new Map();
+
+    for (const alert of fired) {
+        const name = normalizedName(firedRuleName(alert));
+        firedCounts.set(name, (firedCounts.get(name) ?? 0) + 1);
+    }
+
+    const rows = declared.map((rule) => {
+        const live = liveByName.get(normalizedName(rule.name));
+        const issues = [];
+        if (!rule.actionAttached) {
+            issues.push("No action group in Terraform");
+        }
+        if (rule.enabled !== true) {
+            issues.push("Disabled in Terraform");
+        }
+        if (!rule.description) {
+            issues.push("Missing description");
+        }
+        if (!live && liveErrors.length === 0) {
+            issues.push("Missing from Azure");
+        }
+        if (live && !liveRuleEnabled(live)) {
+            issues.push("Disabled in Azure");
+        }
+
+        return {
+            ...rule,
+            live: Boolean(live),
+            liveEnabled: live ? liveRuleEnabled(live) : null,
+            firedCount: firedCounts.get(normalizedName(rule.name)) ?? 0,
+            issues,
+            status:
+                issues.length > 0
+                    ? "action-needed"
+                    : liveErrors.length > 0
+                      ? "unknown"
+                      : "healthy",
+        };
+    });
+
+    const stale = liveRules
+        .filter((rule) => !declaredNames.has(normalizedName(rule.name)))
+        .map((rule) => ({
+            name: rule.name,
+            enabled: liveRuleEnabled(rule),
+            type: rule.type ?? "Azure Monitor rule",
+        }));
+
+    return { rows, stale };
+}
+
+function calculateVerdict(rows, stale, errors) {
+    if (rows.some((row) => row.status === "action-needed")) {
+        return "Action needed";
+    }
+    if (errors.length > 0) {
+        return "Unknown";
+    }
+    if (stale.length > 0) {
+        return "Review";
+    }
+    return "Healthy";
+}
+
+export async function runAlertAudit({ environment, resourceGroup, lookbackHours }) {
+    const source = await readFile(MONITORING_PATH, "utf8");
+    const declared = parseDeclaredAlerts(source, environment);
+    let live = {
+        account: null,
+        rules: [],
+        fired: [],
+        errors: [],
+    };
+
+    try {
+        live = await getLiveAzureState(resourceGroup, lookbackHours);
+    } catch (error) {
+        live.errors.push(`Azure discovery: ${errorMessage(error)}`);
+    }
+
+    const { rows, stale } = buildFindings(declared, live.rules, live.fired, live.errors);
+    return {
+        status: "complete",
+        generatedAt: new Date().toISOString(),
+        environment,
+        resourceGroup,
+        lookbackHours,
+        source: "infra/monitoring.tf",
+        subscription: live.account?.subscriptionName ?? null,
+        verdict: calculateVerdict(rows, stale, live.errors),
+        counts: {
+            declared: rows.length,
+            live: live.rules.length,
+            fired: live.fired.length,
+            actionNeeded: rows.filter((row) => row.status === "action-needed").length,
+            stale: stale.length,
+        },
+        alerts: rows,
+        stale,
+        errors: live.errors,
+    };
+}
+
+export function summarizeAudit(snapshot) {
+    return {
+        verdict: snapshot.verdict,
+        generatedAt: snapshot.generatedAt,
+        resourceGroup: snapshot.resourceGroup,
+        counts: snapshot.counts,
+        actionNeeded: snapshot.alerts
+            .filter((alert) => alert.issues.length > 0)
+            .map((alert) => ({ name: alert.name, issues: alert.issues })),
+        stale: snapshot.stale,
+        errors: snapshot.errors,
+    };
+}

--- a/.github/extensions/alert-audit/lib/renderer.mjs
+++ b/.github/extensions/alert-audit/lib/renderer.mjs
@@ -1,0 +1,222 @@
+function escapeHtml(value) {
+    return String(value)
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#039;");
+}
+
+export function renderHtml(options) {
+    const environment = escapeHtml(options.environment);
+    const resourceGroup = escapeHtml(options.resourceGroup);
+    const lookbackHours = escapeHtml(options.lookbackHours);
+
+    return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Alert audit</title>
+  <style>
+    :root { color-scheme: light dark; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--background-color-default, #fff);
+      color: var(--text-color-default, #1f2328);
+      font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+      font-size: var(--text-body-medium, 14px);
+      line-height: var(--leading-body-medium, 20px);
+    }
+    main { max-width: 1180px; margin: 0 auto; padding: 24px; }
+    header { display: flex; gap: 20px; justify-content: space-between; align-items: flex-start; }
+    h1 {
+      margin: 0 0 6px;
+      font-size: var(--text-title-large, 26px);
+      line-height: var(--leading-title-large, 32px);
+    }
+    h2 { margin: 28px 0 12px; font-size: var(--text-title-medium, 18px); }
+    p { margin: 0; color: var(--text-color-muted, #59636e); }
+    button {
+      border: 1px solid var(--border-color-default, #d1d9e0);
+      border-radius: 6px;
+      padding: 7px 14px;
+      background: var(--true-color-blue, #0969da);
+      color: var(--color-white, #fff);
+      font: inherit;
+      font-weight: var(--font-weight-semibold, 600);
+      cursor: pointer;
+    }
+    button:disabled { opacity: .55; cursor: wait; }
+    .meta { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+    .chip, .badge {
+      display: inline-flex;
+      align-items: center;
+      border: 1px solid var(--border-color-default, #d1d9e0);
+      border-radius: 999px;
+      padding: 2px 8px;
+      font-size: var(--text-body-small, 12px);
+      white-space: nowrap;
+    }
+    .summary {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(100px, 1fr));
+      gap: 10px;
+      margin-top: 22px;
+    }
+    .stat, .panel {
+      border: 1px solid var(--border-color-default, #d1d9e0);
+      border-radius: 8px;
+      background: var(--background-color-muted, rgba(127,127,127,.04));
+    }
+    .stat { padding: 14px; }
+    .stat strong { display: block; font-size: 22px; line-height: 28px; }
+    .stat span { color: var(--text-color-muted, #59636e); }
+    .panel { overflow: hidden; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td {
+      padding: 11px 12px;
+      text-align: left;
+      vertical-align: top;
+      border-bottom: 1px solid var(--border-color-default, #d1d9e0);
+    }
+    th { color: var(--text-color-muted, #59636e); font-size: 12px; font-weight: 600; }
+    tr:last-child td { border-bottom: 0; }
+    code {
+      font-family: var(--font-mono, "SFMono-Regular", Consolas, monospace);
+      font-size: var(--text-code-inline, 12px);
+    }
+    .healthy { color: var(--true-color-green, #1a7f37); }
+    .review, .unknown { color: var(--true-color-yellow, #9a6700); }
+    .action-needed, .error { color: var(--true-color-red, #cf222e); }
+    .issues { margin: 4px 0 0; padding-left: 18px; color: var(--true-color-red, #cf222e); }
+    .empty, .loading { padding: 28px; text-align: center; color: var(--text-color-muted, #59636e); }
+    .errors {
+      padding: 12px 16px;
+      border: 1px solid var(--true-color-red-muted, #ff818266);
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--true-color-red, #cf222e) 8%, transparent);
+    }
+    .errors ul { margin: 6px 0 0; padding-left: 20px; }
+    @media (max-width: 760px) {
+      header { display: block; }
+      button { margin-top: 16px; }
+      .summary { grid-template-columns: repeat(2, 1fr); }
+      .panel { overflow-x: auto; }
+      table { min-width: 820px; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <div>
+      <h1>Alert audit</h1>
+      <p>Terraform intent compared with live Azure Monitor rules and recent firings.</p>
+      <div class="meta">
+        <span class="chip">Environment: <strong>&nbsp;${environment}</strong></span>
+        <span class="chip">Resource group: <strong>&nbsp;${resourceGroup}</strong></span>
+        <span class="chip">Lookback: <strong>&nbsp;${lookbackHours}h</strong></span>
+      </div>
+    </div>
+    <button id="refresh" type="button">Refresh audit</button>
+  </header>
+
+  <section id="content" aria-live="polite">
+    <div class="panel loading">Reading Terraform and Azure Monitor…</div>
+  </section>
+</main>
+<script>
+  const content = document.querySelector("#content");
+  const refreshButton = document.querySelector("#refresh");
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function statusClass(value) {
+    return String(value).toLowerCase().replaceAll(" ", "-");
+  }
+
+  function render(snapshot) {
+    const errors = snapshot.errors?.length
+      ? \`<div class="errors"><strong>Live Azure data is incomplete.</strong><ul>\${snapshot.errors
+          .map((error) => \`<li>\${escapeHtml(error)}</li>\`).join("")}</ul></div>\`
+      : "";
+    const rows = snapshot.alerts.map((alert) => {
+      const issues = alert.issues.length
+        ? \`<ul class="issues">\${alert.issues.map((issue) => \`<li>\${escapeHtml(issue)}</li>\`).join("")}</ul>\`
+        : "";
+      const live = snapshot.errors.length
+        ? "Unknown"
+        : alert.live
+          ? alert.liveEnabled ? "Enabled" : "Disabled"
+          : "Missing";
+      return \`<tr>
+        <td><strong>\${escapeHtml(alert.name)}</strong><br><code>\${escapeHtml(alert.terraformId)}</code>\${issues}</td>
+        <td><span class="badge \${statusClass(alert.status)}">\${escapeHtml(alert.status)}</span></td>
+        <td>\${escapeHtml(live)}</td>
+        <td>Sev \${escapeHtml(alert.severity)}</td>
+        <td>\${escapeHtml(alert.frequency)} / \${escapeHtml(alert.window)}</td>
+        <td>\${escapeHtml(alert.operator)} \${escapeHtml(alert.threshold)}</td>
+        <td>\${escapeHtml(alert.firedCount)}</td>
+      </tr>\`;
+    }).join("");
+    const stale = snapshot.stale.length
+      ? \`<h2>Live rules not declared here</h2><div class="panel"><table>
+          <thead><tr><th>Name</th><th>State</th><th>Azure type</th></tr></thead>
+          <tbody>\${snapshot.stale.map((rule) => \`<tr><td>\${escapeHtml(rule.name)}</td>
+            <td>\${rule.enabled ? "Enabled" : "Disabled"}</td><td><code>\${escapeHtml(rule.type)}</code></td></tr>\`).join("")}</tbody>
+        </table></div>\`
+      : "";
+
+    content.innerHTML = \`
+      <div class="summary">
+        <div class="stat"><strong class="\${statusClass(snapshot.verdict)}">\${escapeHtml(snapshot.verdict)}</strong><span>Verdict</span></div>
+        <div class="stat"><strong>\${snapshot.counts.declared}</strong><span>Declared</span></div>
+        <div class="stat"><strong>\${snapshot.counts.live}</strong><span>Live</span></div>
+        <div class="stat"><strong>\${snapshot.counts.fired}</strong><span>Fired in \${snapshot.lookbackHours}h</span></div>
+        <div class="stat"><strong>\${snapshot.counts.actionNeeded + snapshot.counts.stale}</strong><span>Needs review</span></div>
+      </div>
+      <h2>Managed alerts</h2>
+      \${errors}
+      <div class="panel" style="margin-top: \${errors ? "12px" : "0"}">
+        <table>
+          <thead><tr><th>Alert</th><th>Audit</th><th>Azure</th><th>Severity</th><th>Frequency / window</th><th>Trigger</th><th>Firings</th></tr></thead>
+          <tbody>\${rows}</tbody>
+        </table>
+      </div>
+      \${stale}
+      <p style="margin-top:12px">Source: <code>\${escapeHtml(snapshot.source)}</code> · Updated \${new Date(snapshot.generatedAt).toLocaleString()}</p>\`;
+  }
+
+  async function refresh() {
+    refreshButton.disabled = true;
+    refreshButton.textContent = "Refreshing…";
+    try {
+      const response = await fetch("/api/audit", { method: "POST" });
+      const snapshot = await response.json();
+      if (!response.ok) {
+        throw new Error(snapshot.error ?? "Audit failed");
+      }
+      render(snapshot);
+    } catch (error) {
+      content.innerHTML = \`<div class="errors"><strong>Audit failed.</strong><div>\${escapeHtml(error.message)}</div></div>\`;
+    } finally {
+      refreshButton.disabled = false;
+      refreshButton.textContent = "Refresh audit";
+    }
+  }
+
+  refreshButton.addEventListener("click", refresh);
+  refresh();
+</script>
+</body>
+</html>`;
+}


### PR DESCRIPTION
## What changes

Adds a project canvas that compares the Azure Monitor alerts declared in `infra/monitoring.tf` with the rules currently deployed in Azure.

The canvas shows whether each rule exists and is enabled, how often it evaluates, its trigger and severity, and how many alert instances fired recently. It also flags missing rules, live rules that are not declared in Terraform, missing notification action groups, and Azure query failures.

## Why

Issue #767 calls for an evidence-based alert audit. This gives maintainers a repeatable, read-only view instead of requiring several manual Azure CLI queries.

## Current production result

The canvas found five declared rules and five matching live rules. All are enabled, no stale rules were found, and no alerts fired in the last 24 hours.

Closes #767