### PR TITLE
Harden API telemetry and alert coverage

### DIFF
--- a/api/src/learn_to_cloud/core/ratelimit.py
+++ b/api/src/learn_to_cloud/core/ratelimit.py
@@ -29,10 +29,7 @@ limiter = Limiter(
 )
 
 
-def rate_limit_exceeded_handler(request: Request, exc: Exception) -> Response:
-    if not isinstance(exc, RateLimitExceeded):
-        return JSONResponse(status_code=500, content={"detail": "Unexpected error"})
-
+def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Response:
     return JSONResponse(
         status_code=429,
         content={

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -5,7 +5,6 @@ import logging
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
 
 import fastapi
 from fastapi import Request
@@ -28,7 +27,6 @@ from learn_to_cloud_shared.core.logger import configure_logging
 from learn_to_cloud_shared.core.observability import configure_observability
 from slowapi.errors import RateLimitExceeded
 from starlette.middleware.sessions import SessionMiddleware
-from starlette.types import ExceptionHandler
 
 from learn_to_cloud.core.auth import init_oauth
 from learn_to_cloud.core.middleware import (
@@ -56,57 +54,6 @@ from learn_to_cloud.routes.health_routes import get_code_alembic_head
 configure_logging()
 configure_observability(fail_on_azure_error=True)
 logger = logging.getLogger(__name__)
-
-
-async def not_found_handler(
-    request: Request, exc: Exception
-) -> HTMLResponse | JSONResponse:
-    """Render nice 404 page for browsers, JSON for API clients."""
-    if request.url.path.startswith("/api/"):
-        return JSONResponse(
-            status_code=404,
-            content={"detail": "Not found"},
-        )
-    return templates.TemplateResponse(
-        request,
-        "pages/404.html",
-        {"user": None, "now": datetime.now(UTC)},
-        status_code=404,
-    )
-
-
-async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
-    """Last-resort handler for unhandled exceptions."""
-    logger.exception(
-        "unhandled.exception",
-        extra={
-            "exc_type": type(exc).__name__,
-            "path": request.url.path,
-            "method": request.method,
-        },
-    )
-    return JSONResponse(
-        status_code=500,
-        content={"detail": "An unexpected error occurred. Please try again."},
-    )
-
-
-async def validation_exception_handler(
-    request: Request, exc: RequestValidationError
-) -> JSONResponse:
-    """Handler for request validation errors."""
-    logger.warning(
-        "request.validation_error",
-        extra={
-            "path": request.url.path,
-            "method": request.method,
-            "error_count": len(exc.errors()),
-        },
-    )
-    return JSONResponse(
-        status_code=422,
-        content={"detail": exc.errors()},
-    )
 
 
 @asynccontextmanager
@@ -194,16 +141,62 @@ app = fastapi.FastAPI(
 )
 
 app.state.limiter = limiter
-app.add_exception_handler(
-    RateLimitExceeded,
-    cast(ExceptionHandler, rate_limit_exceeded_handler),
-)
-app.add_exception_handler(
-    RequestValidationError,
-    cast(ExceptionHandler, validation_exception_handler),
-)
-app.add_exception_handler(404, not_found_handler)
-app.add_exception_handler(Exception, global_exception_handler)
+app.exception_handler(RateLimitExceeded)(rate_limit_exceeded_handler)
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Handler for request validation errors."""
+    logger.warning(
+        "request.validation_error",
+        extra={
+            "path": request.url.path,
+            "method": request.method,
+            "error_count": len(exc.errors()),
+        },
+    )
+    return JSONResponse(
+        status_code=422,
+        content={"detail": exc.errors()},
+    )
+
+
+@app.exception_handler(404)
+async def not_found_handler(
+    request: Request, exc: Exception
+) -> HTMLResponse | JSONResponse:
+    """Render nice 404 page for browsers, JSON for API clients."""
+    if request.url.path.startswith("/api/"):
+        return JSONResponse(
+            status_code=404,
+            content={"detail": "Not found"},
+        )
+    return templates.TemplateResponse(
+        request,
+        "pages/404.html",
+        {"user": None, "now": datetime.now(UTC)},
+        status_code=404,
+    )
+
+
+@app.exception_handler(Exception)
+async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Last-resort handler for unhandled exceptions."""
+    logger.exception(
+        "unhandled.exception",
+        extra={
+            "exc_type": type(exc).__name__,
+            "path": request.url.path,
+            "method": request.method,
+        },
+    )
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "An unexpected error occurred. Please try again."},
+    )
+
 
 app.add_middleware(UserTrackingMiddleware)
 app.add_middleware(

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -5,6 +5,7 @@ import logging
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 import fastapi
 from fastapi import Request
@@ -27,6 +28,7 @@ from learn_to_cloud_shared.core.logger import configure_logging
 from learn_to_cloud_shared.core.observability import configure_observability
 from slowapi.errors import RateLimitExceeded
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.types import ExceptionHandler
 
 from learn_to_cloud.core.auth import init_oauth
 from learn_to_cloud.core.middleware import (
@@ -52,7 +54,7 @@ from learn_to_cloud.routes.health_routes import get_code_alembic_head
 # See: https://learn.microsoft.com/en-us/troubleshoot/azure/azure-monitor/
 #      app-insights/telemetry/opentelemetry-troubleshooting-python
 configure_logging()
-configure_observability()
+configure_observability(fail_on_azure_error=True)
 logger = logging.getLogger(__name__)
 
 
@@ -90,12 +92,9 @@ async def global_exception_handler(request: Request, exc: Exception) -> JSONResp
 
 
 async def validation_exception_handler(
-    request: Request, exc: Exception
+    request: Request, exc: RequestValidationError
 ) -> JSONResponse:
     """Handler for request validation errors."""
-    if not isinstance(exc, RequestValidationError):
-        return JSONResponse(status_code=500, content={"detail": "Unexpected error"})
-
     logger.warning(
         "request.validation_error",
         extra={
@@ -195,8 +194,14 @@ app = fastapi.FastAPI(
 )
 
 app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
-app.add_exception_handler(RequestValidationError, validation_exception_handler)
+app.add_exception_handler(
+    RateLimitExceeded,
+    cast(ExceptionHandler, rate_limit_exceeded_handler),
+)
+app.add_exception_handler(
+    RequestValidationError,
+    cast(ExceptionHandler, validation_exception_handler),
+)
 app.add_exception_handler(404, not_found_handler)
 app.add_exception_handler(Exception, global_exception_handler)
 

--- a/api/tests/core/test_ratelimit.py
+++ b/api/tests/core/test_ratelimit.py
@@ -86,13 +86,3 @@ class TestRateLimitExceededHandler:
         body = json.loads(bytes(response.body))
         assert "Rate limit exceeded" in body["detail"]
         assert "retry_after" in body
-
-    def test_handles_non_rate_limit_exception(self):
-        request = MagicMock(spec=Request)
-        exc = ValueError("something else")
-
-        response = rate_limit_exceeded_handler(request, exc)
-
-        assert response.status_code == 500
-        body = json.loads(bytes(response.body))
-        assert body["detail"] == "Unexpected error"

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -8,13 +8,25 @@ packaged artifact must abort application startup (not merely mark
 
 from __future__ import annotations
 
+import ast
+import inspect
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from learn_to_cloud_shared.content_catalog import CurriculumCatalogError
+from slowapi.errors import RateLimitExceeded
 
-from learn_to_cloud.main import lifespan
+from learn_to_cloud import main as main_module
+from learn_to_cloud.core.ratelimit import rate_limit_exceeded_handler
+from learn_to_cloud.main import (
+    app,
+    global_exception_handler,
+    lifespan,
+    validation_exception_handler,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -27,6 +39,21 @@ def _fake_catalog(
     catalog.artifact_schema_version = artifact_schema_version
     catalog.content_hash = "deadbeef"
     return catalog
+
+
+def _request(path: str = "/api/test", method: str = "GET") -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "path": path,
+            "headers": [],
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+            "scheme": "http",
+        }
+    )
 
 
 @pytest.fixture
@@ -48,6 +75,98 @@ def _patch_startup_dependencies(test_settings):
         patch("learn_to_cloud.main.dispose_engine", new=AsyncMock()),
     ):
         yield
+
+
+def test_observability_fails_fast_before_fastapi_construction():
+    tree = ast.parse(inspect.getsource(main_module))
+    configure_call: ast.Call | None = None
+    app_assignment_line: int | None = None
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == "configure_observability"
+        ):
+            configure_call = node.value
+        elif isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "app"
+            for target in node.targets
+        ):
+            app_assignment_line = node.lineno
+
+    assert configure_call is not None
+    assert app_assignment_line is not None
+    assert configure_call.lineno < app_assignment_line
+    assert len(configure_call.keywords) == 1
+    keyword = configure_call.keywords[0]
+    assert keyword.arg == "fail_on_azure_error"
+    assert isinstance(keyword.value, ast.Constant)
+    assert keyword.value.value is True
+
+
+def test_exception_handlers_are_registered_for_their_dispatch_types():
+    assert app.exception_handlers[RateLimitExceeded] is rate_limit_exceeded_handler
+    assert (
+        app.exception_handlers[RequestValidationError] is validation_exception_handler
+    )
+    assert app.exception_handlers[Exception] is global_exception_handler
+
+
+@pytest.mark.asyncio
+async def test_global_exception_handler_logs_once_and_returns_500(
+    caplog: pytest.LogCaptureFixture,
+):
+    request = _request(path="/api/crash", method="POST")
+
+    with caplog.at_level("ERROR", logger="learn_to_cloud.main"):
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError as exc:
+            response = await global_exception_handler(request, exc)
+
+    assert response.status_code == 500
+    assert json.loads(bytes(response.body)) == {
+        "detail": "An unexpected error occurred. Please try again."
+    }
+    records = [
+        record for record in caplog.records if record.message == "unhandled.exception"
+    ]
+    assert len(records) == 1
+    record = records[0]
+    assert record.exc_info is not None
+    assert record.__dict__["exc_type"] == "RuntimeError"
+    assert record.__dict__["path"] == "/api/crash"
+    assert record.__dict__["method"] == "POST"
+
+
+@pytest.mark.asyncio
+async def test_validation_exception_handler_preserves_422_response():
+    exc = RequestValidationError(
+        [
+            {
+                "type": "missing",
+                "loc": ("body", "name"),
+                "msg": "Field required",
+                "input": {},
+            }
+        ]
+    )
+
+    response = await validation_exception_handler(
+        _request(path="/api/users", method="POST"),
+        exc,
+    )
+
+    assert response.status_code == 422
+    assert json.loads(bytes(response.body))["detail"] == [
+        {
+            "type": "missing",
+            "loc": ["body", "name"],
+            "msg": "Field required",
+            "input": {},
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -1,0 +1,304 @@
+# Alert response guides
+
+These guides cover the first response to production alerts. Run queries in the
+Application Insights **Logs** blade unless a section says to use the Log
+Analytics workspace. Replace `dev` if the alert came from another environment.
+
+## Unhandled API exception
+
+### Meaning
+
+The API emitted `unhandled.exception`, which is the final FastAPI exception
+boundary. The exact event is stored in `AppExceptions.OuterMessage`. The broad
+API 5xx alert remains separate and may also fire.
+
+### First checks
+
+1. Note the alert time, affected revision, exception type, request path, and HTTP
+   method.
+2. Check whether the same operation ID has a failed request or dependency.
+3. Compare the first occurrence with the latest API deployment time.
+
+### Detailed Kusto
+
+```kusto
+exceptions
+| where timestamp > ago(2h)
+| where cloud_RoleName == "learn-to-cloud-api"
+| where outerMessage == "unhandled.exception"
+| project
+    timestamp,
+    operation_Id,
+    cloud_RoleInstance,
+    type,
+    outerMessage,
+    innermostMessage,
+    details
+| order by timestamp desc
+```
+
+Correlate an occurrence with its request and dependencies:
+
+```kusto
+let OperationId = "<operation-id>";
+union requests, dependencies, exceptions, traces
+| where operation_Id == OperationId
+| order by timestamp asc
+```
+
+### Likely causes
+
+- An unexpected application exception escaped its route or service boundary.
+- A new revision introduced an incompatible configuration or dependency.
+- A downstream service returned a condition the API did not handle.
+
+### Escalation
+
+Escalate immediately if exceptions continue, affect authentication or data
+integrity, or coincide with availability failures. Include the operation ID,
+revision, path, exception type, and first/last timestamps.
+
+### Safe recovery
+
+Prefer rolling back the affected API revision when the failures began directly
+after a deployment. Do not suppress the exception or disable the alert. If a
+dependency is transiently unavailable, restore that dependency and confirm both
+the exact exception alert and broad 5xx alert recover.
+
+## Telemetry pipeline failure
+
+### Meaning
+
+The API could not configure Azure Monitor once, or the main Azure Monitor
+exporter logged at least three non-retryable transmission records in 15 minutes.
+This signal does **not** prove permanent telemetry loss or an Azure service
+fault. QuickPulse (Live Metrics) diagnostics are intentionally excluded.
+
+### First checks
+
+1. Open the Log Analytics workspace used by the Container Apps environment.
+2. Identify whether the signal is configuration failure or repeated main
+   exporter transmission failure.
+3. Check the API revision, replica, connection-string reference, outbound
+   connectivity, and Azure Monitor service health.
+
+### Detailed Kusto
+
+```kusto
+let Environment = "dev";
+ContainerAppConsoleLogs_CL
+| where TimeGenerated > ago(2h)
+| where ContainerAppName_s == strcat("ca-ltc-api-", Environment)
+| where ContainerName_s == "api"
+| extend ParsedLog = parse_json(Log_s)
+| extend
+    Event = tostring(ParsedLog.event),
+    Logger = tostring(ParsedLog.logger)
+| extend
+    IsConfigureFailure = Event == "telemetry.configure.failed",
+    IsMainExporterFailure =
+        Logger == "azure.monitor.opentelemetry.exporter.export._base"
+        and Log_s contains "Envelopes could not be exported and are not retryable:"
+| where IsConfigureFailure or IsMainExporterFailure
+| project
+    TimeGenerated,
+    RevisionName_s,
+    ContainerGroupName_s,
+    Event,
+    Logger,
+    Log_s
+| order by TimeGenerated desc
+```
+
+### Likely causes
+
+- An invalid or unavailable Application Insights connection string prevented API
+  startup telemetry configuration.
+- Network, DNS, TLS, throttling, or authentication conditions blocked exporter
+  transmission.
+- A payload was rejected as non-retryable by the ingestion endpoint.
+
+### Escalation
+
+Escalate when configuration failures block a new API revision, exporter failures
+continue for more than 30 minutes, or the telemetry gap prevents incident
+response. Include revision names, timestamps, exporter logger, and the exact
+error text without including connection strings.
+
+### Safe recovery
+
+Correct the secret reference, managed configuration, or outbound connectivity,
+then restart or roll forward the affected revision. Do not rotate or expose the
+connection string unless investigation confirms it is invalid. Confirm new
+traces, requests, exceptions, logs, and metrics arrive after recovery.
+
+## Schema drift
+
+### Meaning
+
+Three consecutive evaluations found either a mismatch between the database
+Alembic head and the code head, or a failure while checking that relationship.
+
+### First checks
+
+1. Distinguish `health.ready.schema_drift` from
+   `health.ready.schema_drift_check_failed`.
+2. Check the deployed API revision and the latest migration job result.
+3. Compare the database revision with the Alembic head in the deployed code.
+
+### Detailed Kusto
+
+```kusto
+traces
+| where timestamp > ago(2h)
+| where cloud_RoleName in ("learn-to-cloud-api", "ca-ltc-api-dev")
+    or cloud_RoleName has "learn-to-cloud-api"
+    or cloud_RoleName has "ca-ltc-api"
+| where message in (
+    "health.ready.schema_drift",
+    "health.ready.schema_drift_check_failed"
+)
+| project timestamp, message, severityLevel, customDimensions
+| order by timestamp desc
+```
+
+### Likely causes
+
+- The application image deployed before its migration completed.
+- A migration failed or was only partially applied.
+- The database was changed manually.
+- The readiness check could not query the migration table.
+
+### Escalation
+
+Escalate immediately for migration failure, manual schema change, or any evidence
+of data corruption. Include current/code revision values, migration job output,
+API revision, and the exact readiness event.
+
+### Safe recovery
+
+Use the normal migration job to apply a verified forward migration. Never edit
+the Alembic version table merely to clear the alert. If the check itself failed,
+restore database connectivity or permissions, then wait for three clean
+evaluations.
+
+## Verification final failures
+
+### Meaning
+
+A verification attempt reached a final persisted outcome of `server_error` or
+`cancelled`. The alert counts distinct attempt IDs and does not page for learner
+validation failures.
+
+### First checks
+
+1. Capture the attempt ID and final outcome.
+2. Correlate the attempt across API and verification Functions telemetry.
+3. Check Durable Functions status, dependencies, and the persisted attempt row.
+
+### Detailed Kusto
+
+```kusto
+traces
+| where timestamp > ago(2h)
+| where cloud_RoleName in (
+    "learn-to-cloud-api",
+    "ca-ltc-api-dev",
+    "learn-to-cloud-verification-functions",
+    "func-ltc-verification-dev"
+)
+    or cloud_RoleName has "learn-to-cloud-api"
+    or cloud_RoleName has "verification-functions"
+| where message == "verification.attempt.completed"
+| extend
+    Outcome = tostring(customDimensions["verification.outcome"]),
+    AttemptId = tostring(customDimensions["verification.attempt.id"])
+| where Outcome in ("server_error", "cancelled")
+| project timestamp, AttemptId, Outcome, cloud_RoleName, customDimensions
+| order by timestamp desc
+```
+
+### Likely causes
+
+- A verification dependency or orchestration activity failed.
+- The orchestration was cancelled during shutdown or recovery.
+- Persisting or reading the final state failed.
+
+### Escalation
+
+Escalate when multiple learners are affected, the same stage repeatedly fails,
+or retries produce another system outcome. Include attempt IDs, outcomes,
+failure stage, dependency errors, and orchestration status.
+
+### Safe recovery
+
+Fix the underlying dependency or code path before asking the learner to retry.
+Do not rewrite a final outcome. Use established replay/reset procedures only
+after confirming they are safe for that attempt.
+
+## Verification active beyond limit
+
+### Meaning
+
+The reconciler confirmed an attempt is still active beyond its allowed duration,
+or it could not reliably query/recheck Durable status. The emitted event remains
+`verification.attempt.stuck`; the alert dimension is limited to:
+`active_beyond_limit`, `status_query_failed`, and `status_recheck_failed`.
+
+### First checks
+
+1. Use the alert dimension to identify the bounded stuck reason.
+2. Capture attempt ID, Durable status, and attempt age from the matching record.
+3. Check the verification Functions revision, host health, storage, and Durable
+   task hub.
+
+### Detailed Kusto
+
+```kusto
+traces
+| where timestamp > ago(4h)
+| where cloud_RoleName in (
+    "learn-to-cloud-verification-functions",
+    "func-ltc-verification-dev"
+)
+    or cloud_RoleName has "verification-functions"
+    or cloud_RoleName has "func-ltc-verification"
+| where message == "verification.attempt.stuck"
+| extend
+    AttemptId = tostring(customDimensions["verification.attempt.id"]),
+    DurableStatus = tostring(customDimensions["durable_status"]),
+    AttemptAgeSeconds = toint(customDimensions["attempt_age_seconds"]),
+    StuckReason = tostring(customDimensions["stuck_reason"])
+| where StuckReason in (
+    "active_beyond_limit",
+    "status_query_failed",
+    "status_recheck_failed"
+)
+| project
+    timestamp,
+    AttemptId,
+    DurableStatus,
+    AttemptAgeSeconds,
+    StuckReason,
+    cloud_RoleInstance
+| order by timestamp desc
+```
+
+### Likely causes
+
+- An orchestration or activity is genuinely running beyond its limit.
+- Durable storage or the management endpoint could not answer a status query.
+- A race occurred while the reconciler rechecked a terminal transition.
+
+### Escalation
+
+Escalate when age keeps increasing, multiple attempts share the same reason, or
+status queries fail across replicas. Include attempt IDs, bounded reason,
+Durable status, age, revision, and storage/host errors.
+
+### Safe recovery
+
+Restore task-hub or host connectivity before changing attempt state. Terminate
+or reset an orchestration only after confirming the attempt ID and persisted
+state, and use the application's established recovery path rather than editing
+Durable storage directly.

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -163,12 +163,97 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "api_5xx_errors" {
   }
 }
 
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "api_unhandled_exception" {
+  name                = "alert-ltc-api-unhandled-exception-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Alert on the first exact unhandled API exception. Response guide: https://github.com/learntocloud/learn-to-cloud-app/blob/main/docs/runbooks/alerts.md#unhandled-api-exception"
+  severity            = 1
+  enabled             = true
+  tags                = local.tags
+
+  scopes                = [azurerm_application_insights.main.id]
+  evaluation_frequency  = "PT5M"
+  window_duration       = "PT5M"
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query                   = <<-QUERY
+      exceptions
+      | where cloud_RoleName == "learn-to-cloud-api"
+      | where outerMessage == "unhandled.exception"
+      | summarize CrashCount = count() by bin(timestamp, 5m)
+    QUERY
+    time_aggregation_method = "Maximum"
+    metric_measure_column   = "CrashCount"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.critical.id]
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "api_telemetry_pipeline_failure" {
+  name                = "alert-ltc-api-telemetry-pipeline-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Detects API telemetry setup or transmission failures; it does not prove permanent telemetry loss or an Azure service fault. Response guide: https://github.com/learntocloud/learn-to-cloud-app/blob/main/docs/runbooks/alerts.md#telemetry-pipeline-failure"
+  severity            = 1
+  enabled             = true
+  tags                = local.tags
+
+  scopes                = [azurerm_log_analytics_workspace.main.id]
+  evaluation_frequency  = "PT5M"
+  window_duration       = "PT15M"
+  target_resource_types = ["Microsoft.OperationalInsights/workspaces"]
+
+  criteria {
+    query                   = <<-QUERY
+      ContainerAppConsoleLogs_CL
+      | where ContainerAppName_s == "ca-ltc-api-${var.environment}"
+      | where ContainerName_s == "api"
+      | extend ParsedLog = parse_json(Log_s)
+      | extend
+          Event = tostring(ParsedLog.event),
+          Logger = tostring(ParsedLog.logger)
+      | extend
+          IsConfigureFailure = Event == "telemetry.configure.failed",
+          IsMainExporterFailure = Logger == "azure.monitor.opentelemetry.exporter.export._base"
+            and Log_s contains "Envelopes could not be exported and are not retryable:"
+      | where IsConfigureFailure or IsMainExporterFailure
+      | summarize
+          ConfigureFailureCount = countif(IsConfigureFailure),
+          ExportFailureCount = countif(IsMainExporterFailure)
+      | where ConfigureFailureCount >= 1 or ExportFailureCount >= 3
+    QUERY
+    time_aggregation_method = "Count"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.critical.id]
+  }
+}
+
 # Page only for the final outcome PostgreSQL accepted for an attempt.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_system_error" {
   name                = "alert-ltc-verification-attempt-system-error-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  description         = "Alert when a saved verification attempt outcome is server_error"
+  description         = "Alert when a saved verification attempt outcome is server_error or cancelled. Response guide: https://github.com/learntocloud/learn-to-cloud-app/blob/main/docs/runbooks/alerts.md#verification-final-failures"
   severity            = 2
   enabled             = true
   tags                = local.tags
@@ -195,7 +280,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
       | extend
           Outcome = tostring(customDimensions["verification.outcome"]),
           AttemptId = tostring(customDimensions["verification.attempt.id"])
-      | where Outcome == "server_error"
+      | where Outcome in ("server_error", "cancelled")
       | where isnotempty(AttemptId)
       | summarize ErrorCount = dcount(AttemptId) by bin(timestamp, 5m)
     QUERY
@@ -215,13 +300,13 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
   }
 }
 
-# The reconciler emits this event only after a final database read confirms the
-# attempt is still active beyond its allowed duration.
+# Keep the existing Terraform address and Azure resource name to avoid an alert
+# replacement gap; the operator-facing description uses the clearer wording.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_stuck" {
   name                = "alert-ltc-verification-attempt-stuck-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  description         = "Alert when a verification attempt remains active beyond its maximum duration"
+  description         = "Alert when verification is active beyond its allowed limit. Response guide: https://github.com/learntocloud/learn-to-cloud-app/blob/main/docs/runbooks/alerts.md#verification-active-beyond-limit"
   severity            = 2
   enabled             = true
   tags                = local.tags
@@ -241,14 +326,33 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
           or cloud_RoleName has "verification-functions"
           or cloud_RoleName has "func-ltc-verification"
       | where message == "verification.attempt.stuck"
-      | extend AttemptId = tostring(customDimensions["verification.attempt.id"])
+      | extend
+          AttemptId = tostring(customDimensions["verification.attempt.id"]),
+          DurableStatus = tostring(customDimensions["durable_status"]),
+          AttemptAgeSeconds = toint(customDimensions["attempt_age_seconds"]),
+          StuckReason = tostring(customDimensions["stuck_reason"])
       | where isnotempty(AttemptId)
-      | summarize StuckCount = dcount(AttemptId) by bin(timestamp, 5m)
+      | where StuckReason in (
+          "active_beyond_limit",
+          "status_query_failed",
+          "status_recheck_failed"
+        )
+      | summarize arg_max(timestamp, DurableStatus, AttemptAgeSeconds) by AttemptId, StuckReason
+      | project timestamp, AttemptId, DurableStatus, AttemptAgeSeconds, StuckReason
     QUERY
-    time_aggregation_method = "Maximum"
-    metric_measure_column   = "StuckCount"
+    time_aggregation_method = "Count"
     operator                = "GreaterThanOrEqual"
     threshold               = 1
+
+    dimension {
+      name     = "StuckReason"
+      operator = "Include"
+      values = [
+        "active_beyond_limit",
+        "status_query_failed",
+        "status_recheck_failed",
+      ]
+    }
 
     failing_periods {
       minimum_failing_periods_to_trigger_alert = 1
@@ -272,8 +376,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "schema_drift" {
   name                = "alert-ltc-schema-drift-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
-  description         = "Alert when the deployed DB's Alembic head diverges from the deployed code's Alembic head for more than 10 minutes"
-  severity            = 2
+  description         = "Alert when schema drift or the schema drift check persists for three evaluations. Response guide: https://github.com/learntocloud/learn-to-cloud-app/blob/main/docs/runbooks/alerts.md#schema-drift"
+  severity            = 1
   enabled             = true
   tags                = local.tags
 
@@ -288,7 +392,10 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "schema_drift" {
       | where cloud_RoleName in ("learn-to-cloud-api", "ca-ltc-api-${var.environment}")
           or cloud_RoleName has "learn-to-cloud-api"
           or cloud_RoleName has "ca-ltc-api"
-      | where message has "health.ready.schema_drift"
+      | where message in (
+          "health.ready.schema_drift",
+          "health.ready.schema_drift_check_failed"
+        )
     QUERY
     time_aggregation_method = "Count"
     operator                = "GreaterThanOrEqual"

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
@@ -15,6 +15,7 @@ import os
 from typing import Any
 
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.sdk.resources import Resource
 
 from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE
 
@@ -23,7 +24,25 @@ logger = logging.getLogger(__name__)
 _telemetry_enabled: bool = False
 
 
-def _configure_azure_monitor() -> None:
+def _build_resource() -> Resource:
+    """Build the shared identity attached to every telemetry signal."""
+    attributes = {
+        "service.name": os.getenv("OTEL_SERVICE_NAME") or APP_LOGGER_NAMESPACE,
+    }
+
+    if revision := os.getenv("CONTAINER_APP_REVISION"):
+        attributes["service.version"] = revision
+
+    instance_id = os.getenv("CONTAINER_APP_REPLICA_NAME") or os.getenv(
+        "WEBSITE_INSTANCE_ID"
+    )
+    if instance_id:
+        attributes["service.instance.id"] = instance_id
+
+    return Resource(attributes=attributes)
+
+
+def _configure_azure_monitor(resource: Resource) -> None:
     """Set up the Azure Monitor exporter for production."""
     from azure.monitor.opentelemetry import (
         configure_azure_monitor as _configure_azure_monitor_sdk,
@@ -32,10 +51,11 @@ def _configure_azure_monitor() -> None:
     _configure_azure_monitor_sdk(
         enable_live_metrics=True,
         logger_name=APP_LOGGER_NAMESPACE,
+        resource=resource,
     )
 
 
-def _configure_otlp_grpc() -> None:
+def _configure_otlp_grpc(resource: Resource) -> None:
     """Set up OTLP gRPC exporter."""
     from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
         OTLPLogExporter,
@@ -47,10 +67,15 @@ def _configure_otlp_grpc() -> None:
         OTLPSpanExporter,
     )
 
-    _configure_otlp_exporters(OTLPSpanExporter, OTLPLogExporter, OTLPMetricExporter)
+    _configure_otlp_exporters(
+        OTLPSpanExporter,
+        OTLPLogExporter,
+        OTLPMetricExporter,
+        resource,
+    )
 
 
-def _configure_otlp_http() -> None:
+def _configure_otlp_http(resource: Resource) -> None:
     """Set up OTLP HTTP/protobuf exporter."""
     from opentelemetry.exporter.otlp.proto.http._log_exporter import (
         OTLPLogExporter,
@@ -62,19 +87,25 @@ def _configure_otlp_http() -> None:
         OTLPSpanExporter,
     )
 
-    _configure_otlp_exporters(OTLPSpanExporter, OTLPLogExporter, OTLPMetricExporter)
+    _configure_otlp_exporters(
+        OTLPSpanExporter,
+        OTLPLogExporter,
+        OTLPMetricExporter,
+        resource,
+    )
 
 
 def _configure_otlp_exporters(
     span_exporter_cls: type[Any],
     log_exporter_cls: type[Any],
     metric_exporter_cls: type[Any],
+    resource: Resource,
 ) -> None:
     from opentelemetry.instrumentation.logging.handler import LoggingHandler
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-    provider = TracerProvider()
+    provider = TracerProvider(resource=resource)
     provider.add_span_processor(BatchSpanProcessor(span_exporter_cls()))
 
     from opentelemetry import trace
@@ -86,7 +117,7 @@ def _configure_otlp_exporters(
     from opentelemetry.sdk._logs import LoggerProvider
     from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
-    log_provider = LoggerProvider()
+    log_provider = LoggerProvider(resource=resource)
     log_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter_cls()))
     set_logger_provider(log_provider)
     logging.getLogger().addHandler(LoggingHandler(logger_provider=log_provider))
@@ -100,22 +131,23 @@ def _configure_otlp_exporters(
             metric_readers=[
                 PeriodicExportingMetricReader(metric_exporter_cls()),
             ],
+            resource=resource,
         )
     )
 
 
-def _configure_otlp() -> None:
+def _configure_otlp(resource: Resource) -> None:
     """Set up OTLP exporter for local dev (Aspire, Jaeger, etc.)."""
     protocol = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc").lower()
     if protocol == "grpc":
-        _configure_otlp_grpc()
+        _configure_otlp_grpc(resource)
     elif protocol in {"http/protobuf", "http"}:
-        _configure_otlp_http()
+        _configure_otlp_http(resource)
     else:
         raise ValueError(f"Unsupported OTLP protocol: {protocol}")
 
 
-def configure_observability() -> None:
+def configure_observability(*, fail_on_azure_error: bool = False) -> None:
     """Set up the OTel telemetry pipeline."""
     global _telemetry_enabled
 
@@ -124,16 +156,19 @@ def configure_observability() -> None:
 
     conn_str = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
     otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    resource = _build_resource()
 
     try:
         if conn_str:
-            _configure_azure_monitor()
+            _configure_azure_monitor(resource)
         elif otlp_endpoint:
-            _configure_otlp()
+            _configure_otlp(resource)
         else:
             return
-    except Exception as exc:
-        logger.warning("telemetry.configure.failed", extra={"error": str(exc)})
+    except Exception:
+        logger.exception("telemetry.configure.failed")
+        if conn_str and fail_on_azure_error:
+            raise
         return
 
     _telemetry_enabled = True

--- a/packages/learn-to-cloud-shared/tests/test_observability.py
+++ b/packages/learn-to-cloud-shared/tests/test_observability.py
@@ -1,9 +1,10 @@
 """Unit tests for observability instrumentation helpers."""
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from opentelemetry.sdk.resources import Resource
 
 from learn_to_cloud_shared.core import observability
 
@@ -38,12 +39,65 @@ def test_configure_observability_noops_without_exporter_env():
 
 
 @pytest.mark.unit
+def test_build_resource_uses_logger_namespace_without_platform_values():
+    with patch.dict("os.environ", {}, clear=True):
+        resource = observability._build_resource()
+
+    assert resource.attributes["service.name"] == "learn_to_cloud"
+    assert "service.version" not in resource.attributes
+    assert "service.instance.id" not in resource.attributes
+
+
+@pytest.mark.unit
+def test_build_resource_maps_container_app_identity():
+    with patch.dict(
+        "os.environ",
+        {
+            "OTEL_SERVICE_NAME": "learn-to-cloud-api",
+            "CONTAINER_APP_REVISION": "ca-ltc-api--rev42",
+            "CONTAINER_APP_REPLICA_NAME": "ca-ltc-api--rev42-abc",
+            "WEBSITE_INSTANCE_ID": "function-instance",
+        },
+        clear=True,
+    ):
+        resource = observability._build_resource()
+
+    assert resource.attributes["service.name"] == "learn-to-cloud-api"
+    assert resource.attributes["service.version"] == "ca-ltc-api--rev42"
+    assert resource.attributes["service.instance.id"] == "ca-ltc-api--rev42-abc"
+
+
+@pytest.mark.unit
+def test_build_resource_maps_function_instance_identity():
+    with patch.dict(
+        "os.environ",
+        {
+            "OTEL_SERVICE_NAME": "learn-to-cloud-verification-functions",
+            "WEBSITE_INSTANCE_ID": "function-instance",
+        },
+        clear=True,
+    ):
+        resource = observability._build_resource()
+
+    assert (
+        resource.attributes["service.name"] == "learn-to-cloud-verification-functions"
+    )
+    assert resource.attributes["service.instance.id"] == "function-instance"
+    assert "service.version" not in resource.attributes
+
+
+@pytest.mark.unit
 def test_configure_observability_uses_azure_monitor_when_connection_string_set():
+    resource = MagicMock(spec=Resource)
     with (
         patch.dict(
             "os.environ",
             {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"},
             clear=True,
+        ),
+        patch(
+            "learn_to_cloud_shared.core.observability._build_resource",
+            return_value=resource,
         ),
         patch(
             "learn_to_cloud_shared.core.observability._configure_azure_monitor"
@@ -55,7 +109,7 @@ def test_configure_observability_uses_azure_monitor_when_connection_string_set()
     ):
         observability.configure_observability()
 
-    azure_monitor.assert_called_once_with()
+    azure_monitor.assert_called_once_with(resource)
     otlp.assert_not_called()
     httpx_instrumentor.return_value.instrument.assert_called_once_with()
     assert observability._telemetry_enabled is True
@@ -63,11 +117,16 @@ def test_configure_observability_uses_azure_monitor_when_connection_string_set()
 
 @pytest.mark.unit
 def test_configure_observability_uses_otlp_when_endpoint_set():
+    resource = MagicMock(spec=Resource)
     with (
         patch.dict(
             "os.environ",
             {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"},
             clear=True,
+        ),
+        patch(
+            "learn_to_cloud_shared.core.observability._build_resource",
+            return_value=resource,
         ),
         patch(
             "learn_to_cloud_shared.core.observability._configure_azure_monitor"
@@ -80,13 +139,15 @@ def test_configure_observability_uses_otlp_when_endpoint_set():
         observability.configure_observability()
 
     azure_monitor.assert_not_called()
-    otlp.assert_called_once_with()
+    otlp.assert_called_once_with(resource)
     httpx_instrumentor.return_value.instrument.assert_called_once_with()
     assert observability._telemetry_enabled is True
 
 
 @pytest.mark.unit
-def test_configure_observability_does_not_enable_telemetry_after_failure():
+def test_configure_observability_azure_failure_is_nonfatal_by_default(
+    caplog: pytest.LogCaptureFixture,
+):
     with (
         patch.dict(
             "os.environ",
@@ -100,10 +161,41 @@ def test_configure_observability_does_not_enable_telemetry_after_failure():
         patch(
             "learn_to_cloud_shared.core.observability.HTTPXClientInstrumentor"
         ) as httpx_instrumentor,
+        caplog.at_level("ERROR"),
     ):
         observability.configure_observability()
 
-    azure_monitor.assert_called_once_with()
+    azure_monitor.assert_called_once()
+    httpx_instrumentor.assert_not_called()
+    assert observability._telemetry_enabled is False
+    records = [
+        record
+        for record in caplog.records
+        if record.message == "telemetry.configure.failed"
+    ]
+    assert len(records) == 1
+    assert records[0].exc_info is not None
+
+
+@pytest.mark.unit
+def test_configure_observability_azure_failure_reraises_when_opted_in():
+    with (
+        patch.dict(
+            "os.environ",
+            {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"},
+            clear=True,
+        ),
+        patch(
+            "learn_to_cloud_shared.core.observability._configure_azure_monitor",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch(
+            "learn_to_cloud_shared.core.observability.HTTPXClientInstrumentor"
+        ) as httpx_instrumentor,
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        observability.configure_observability(fail_on_azure_error=True)
+
     httpx_instrumentor.assert_not_called()
     assert observability._telemetry_enabled is False
 
@@ -128,21 +220,23 @@ def test_configure_observability_noops_when_already_enabled():
 
 @pytest.mark.unit
 def test_configure_azure_monitor_uses_distro_instrumentation_defaults():
+    resource = observability._build_resource()
     with patch(
         "azure.monitor.opentelemetry.configure_azure_monitor"
     ) as configure_azure_monitor:
-        observability._configure_azure_monitor()
+        observability._configure_azure_monitor(resource)
 
     configure_azure_monitor.assert_called_once()
     kwargs = configure_azure_monitor.call_args.kwargs
     assert kwargs["enable_live_metrics"] is True
     assert kwargs["logger_name"] == "learn_to_cloud"
     assert "instrumentation_options" not in kwargs
-    assert "resource" not in kwargs
+    assert kwargs["resource"] is resource
 
 
 @pytest.mark.unit
 def test_configure_otlp_uses_env_driven_exporter_defaults():
+    resource = observability._build_resource()
     with (
         patch(
             "opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter"
@@ -173,16 +267,18 @@ def test_configure_otlp_uses_env_driven_exporter_defaults():
             "learn_to_cloud_shared.core.observability.logging.getLogger"
         ) as get_logger,
     ):
-        observability._configure_otlp()
+        observability._configure_otlp(resource)
 
     span_exporter.assert_called_once_with()
     span_processor.assert_called_once_with(span_exporter.return_value)
+    tracer_provider.assert_called_once_with(resource=resource)
     tracer_provider.return_value.add_span_processor.assert_called_once_with(
         span_processor.return_value
     )
     set_tracer_provider.assert_called_once_with(tracer_provider.return_value)
     log_exporter.assert_called_once_with()
     log_processor.assert_called_once_with(log_exporter.return_value)
+    logger_provider.assert_called_once_with(resource=resource)
     logger_provider.return_value.add_log_record_processor.assert_called_once_with(
         log_processor.return_value
     )
@@ -195,12 +291,16 @@ def test_configure_otlp_uses_env_driven_exporter_defaults():
     )
     metric_exporter.assert_called_once_with()
     metric_reader.assert_called_once_with(metric_exporter.return_value)
-    meter_provider.assert_called_once_with(metric_readers=[metric_reader.return_value])
+    meter_provider.assert_called_once_with(
+        metric_readers=[metric_reader.return_value],
+        resource=resource,
+    )
     set_meter_provider.assert_called_once_with(meter_provider.return_value)
 
 
 @pytest.mark.unit
 def test_configure_otlp_uses_http_exporters_when_protocol_is_http():
+    resource = observability._build_resource()
     with (
         patch.dict(
             "os.environ",
@@ -236,16 +336,18 @@ def test_configure_otlp_uses_http_exporters_when_protocol_is_http():
             "learn_to_cloud_shared.core.observability.logging.getLogger"
         ) as get_logger,
     ):
-        observability._configure_otlp()
+        observability._configure_otlp(resource)
 
     span_exporter.assert_called_once_with()
     span_processor.assert_called_once_with(span_exporter.return_value)
+    tracer_provider.assert_called_once_with(resource=resource)
     tracer_provider.return_value.add_span_processor.assert_called_once_with(
         span_processor.return_value
     )
     set_tracer_provider.assert_called_once_with(tracer_provider.return_value)
     log_exporter.assert_called_once_with()
     log_processor.assert_called_once_with(log_exporter.return_value)
+    logger_provider.assert_called_once_with(resource=resource)
     logger_provider.return_value.add_log_record_processor.assert_called_once_with(
         log_processor.return_value
     )
@@ -258,7 +360,10 @@ def test_configure_otlp_uses_http_exporters_when_protocol_is_http():
     )
     metric_exporter.assert_called_once_with()
     metric_reader.assert_called_once_with(metric_exporter.return_value)
-    meter_provider.assert_called_once_with(metric_readers=[metric_reader.return_value])
+    meter_provider.assert_called_once_with(
+        metric_readers=[metric_reader.return_value],
+        resource=resource,
+    )
     set_meter_provider.assert_called_once_with(meter_provider.return_value)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -334,7 +334,7 @@ wheels = [
 
 [[package]]
 name = "azure-monitor-opentelemetry-exporter"
-version = "1.0.0b55"
+version = "1.0.0b56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "azure-core" },
@@ -344,9 +344,9 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "psutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/21/178fed00e9738e4c953e147d46f5f803bfeb3fde50b11efdb99ae016f05f/azure_monitor_opentelemetry_exporter-1.0.0b55.tar.gz", hash = "sha256:6701307124e5eeb1837b269ddafab0affb69020fdb842d7c5ff1a3122514595a", size = 342308, upload-time = "2026-07-01T23:59:14.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/0e/c74f9bf0b071f5e13c93c285d585ddc96de43658076733cab039844c198a/azure_monitor_opentelemetry_exporter-1.0.0b56.tar.gz", hash = "sha256:d645e2dbde68123a1c0ab6a5705424bae5bbda53495f2cd8be1bb2a78e9f31d3", size = 355000, upload-time = "2026-08-05T22:49:43.804Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/80/c1e58ea1c7dd7452579ab98912e9a3aa9a5fdb22f24a676f3cdaac3ab096/azure_monitor_opentelemetry_exporter-1.0.0b55-py2.py3-none-any.whl", hash = "sha256:5f0bcfcfd36d82f3f55cf5fe894ea05c5c0a32d2e38adf571eaa0e2b655aeb9e", size = 251064, upload-time = "2026-07-01T23:59:16.305Z" },
+    { url = "https://files.pythonhosted.org/packages/09/fa/d56f55dae96b8c7ee675ffedbacdb65fd28c5cf00d5134e0fd69aeaea5d1/azure_monitor_opentelemetry_exporter-1.0.0b56-py2.py3-none-any.whl", hash = "sha256:9d006bef633fed895333c6b632eda21411acf5eedcfc396f2813c6d11515278c", size = 255013, upload-time = "2026-08-05T22:49:45.219Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

This Deployment 1 change makes API telemetry identify the running service, revision, and instance consistently across Azure Monitor and local OpenTelemetry exporters. The API now refuses to start when Azure Monitor setup fails, while verification Functions keep their existing non-blocking behavior.

It also adds two focused alerts: one for exact unhandled API exceptions and one for repeated telemetry setup or transmission failures. Schema drift and verification alerts now match the approved failure states more precisely, and a new response guide gives operators the checks and recovery steps for each alert.

The verification active-beyond-limit alert keeps its existing Terraform address and Azure resource name. Only its description and query change, avoiding a replacement gap while exposing the bounded stuck reason as the sole alert dimension.

## Safe overlap

This is Deployment 1 only. The existing broad API 5xx alert remains enabled and unchanged, so the new exact crash alert overlaps with it during production validation. Deployment 2 is not included.

## Validation

- `uv run poe check`
- `terraform -chdir=infra validate`
- Azure-backed Terraform plan: 2 alerts added, 3 alerts updated in place, 0 resources destroyed or replaced
- `azure-monitor-opentelemetry` remains `1.8.9`; only its compatible exporter lock moved from `1.0.0b55` to `1.0.0b56`