### PR TITLE
chore(monitoring): retire broad API 5xx alert

### DIFF
--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -9,8 +9,8 @@ Analytics workspace. Replace `dev` if the alert came from another environment.
 ### Meaning
 
 The API emitted `unhandled.exception`, which is the final FastAPI exception
-boundary. The exact event is stored in `AppExceptions.OuterMessage`. The broad
-API 5xx alert remains separate and may also fire.
+boundary. The exact event is stored in `AppExceptions.OuterMessage`. This exact
+detector replaces the retired broad API 5xx paging signal.
 
 ### First checks
 
@@ -62,8 +62,8 @@ revision, path, exception type, and first/last timestamps.
 
 Prefer rolling back the affected API revision when the failures began directly
 after a deployment. Do not suppress the exception or disable the alert. If a
-dependency is transiently unavailable, restore that dependency and confirm both
-the exact exception alert and broad 5xx alert recover.
+dependency is transiently unavailable, restore that dependency and confirm the
+exact exception alert returns to a healthy state.
 
 ## Telemetry pipeline failure
 

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -124,45 +124,6 @@ resource "azurerm_monitor_metric_alert" "availability" {
 # Log Alerts (scheduled query rules v2)
 # ---------------------------------------------------------------------------
 
-resource "azurerm_monitor_scheduled_query_rules_alert_v2" "api_5xx_errors" {
-  name                = "alert-ltc-api-5xx-${var.environment}"
-  resource_group_name = azurerm_resource_group.main.name
-  location            = azurerm_resource_group.main.location
-  description         = "Alert when API returns 3+ 5xx errors in a 5-minute window"
-  severity            = 1
-  enabled             = true
-  tags                = local.tags
-
-  scopes                = [azurerm_application_insights.main.id]
-  evaluation_frequency  = "PT5M"
-  window_duration       = "PT5M"
-  target_resource_types = ["microsoft.insights/components"]
-
-  criteria {
-    query                   = <<-QUERY
-      requests
-      | where cloud_RoleName in ("learn-to-cloud-api", "ca-ltc-api-${var.environment}")
-          or cloud_RoleName has "learn-to-cloud-api"
-          or cloud_RoleName has "ca-ltc-api"
-      | where resultCode startswith "5"
-      | summarize ErrorCount = count() by bin(timestamp, 5m)
-    QUERY
-    time_aggregation_method = "Maximum"
-    metric_measure_column   = "ErrorCount"
-    operator                = "GreaterThanOrEqual"
-    threshold               = 3
-
-    failing_periods {
-      minimum_failing_periods_to_trigger_alert = 2
-      number_of_evaluation_periods             = 3
-    }
-  }
-
-  action {
-    action_groups = [azurerm_monitor_action_group.critical.id]
-  }
-}
-
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "api_unhandled_exception" {
   name                = "alert-ltc-api-unhandled-exception-${var.environment}"
   resource_group_name = azurerm_resource_group.main.name


### PR DESCRIPTION
PR #770 deployed successfully and passed the production gate. The exact unhandled exception detector is enabled and healthy, so this PR removes only the duplicate broad API 5xx paging rule.

No application code or other alert behavior changes. The alert response guide now accurately reflects that the broad 5xx paging signal is retired.

Terraform plan:
- `0 to add, 0 to change, 1 to destroy`
- The only action is destroying `azurerm_monitor_scheduled_query_rules_alert_v2.api_5xx_errors`, named `alert-ltc-api-5xx-dev`.
- No replacements or other resource changes are planned.

Validation:
- `uv run poe check` passed
- `terraform validate` passed against the PR's exact remote head
- Azure-backed Terraform plan matched the intended single deletion

This PR has not been deployed.