### PR TITLE
Keep telemetry failures nonfatal

### DIFF
--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -52,7 +52,7 @@ from learn_to_cloud.routes.health_routes import get_code_alembic_head
 # See: https://learn.microsoft.com/en-us/troubleshoot/azure/azure-monitor/
 #      app-insights/telemetry/opentelemetry-troubleshooting-python
 configure_logging()
-configure_observability(fail_on_azure_error=True)
+configure_observability()
 logger = logging.getLogger(__name__)
 
 

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -77,7 +77,7 @@ def _patch_startup_dependencies(test_settings):
         yield
 
 
-def test_observability_fails_fast_before_fastapi_construction():
+def test_observability_is_configured_before_fastapi_construction():
     tree = ast.parse(inspect.getsource(main_module))
     configure_call: ast.Call | None = None
     app_assignment_line: int | None = None
@@ -98,11 +98,8 @@ def test_observability_fails_fast_before_fastapi_construction():
     assert configure_call is not None
     assert app_assignment_line is not None
     assert configure_call.lineno < app_assignment_line
-    assert len(configure_call.keywords) == 1
-    keyword = configure_call.keywords[0]
-    assert keyword.arg == "fail_on_azure_error"
-    assert isinstance(keyword.value, ast.Constant)
-    assert keyword.value.value is True
+    assert not configure_call.args
+    assert not configure_call.keywords
 
 
 def test_exception_handlers_are_registered_for_their_dispatch_types():

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -68,18 +68,19 @@ exact exception alert returns to a healthy state.
 
 ### Meaning
 
-The API could not configure Azure Monitor once, or the main Azure Monitor
-exporter logged at least three non-retryable transmission records in 15 minutes.
-This signal does **not** prove permanent telemetry loss or an Azure service
-fault. QuickPulse (Live Metrics) diagnostics are intentionally excluded.
+The API could not configure an OpenTelemetry destination once, or the main Azure
+Monitor exporter logged at least three non-retryable transmission records in 15
+minutes. The API continues serving when this alert fires; monitoring is
+degraded. This signal does **not** prove permanent telemetry loss or an Azure
+service fault. QuickPulse (Live Metrics) diagnostics are intentionally excluded.
 
 ### First checks
 
 1. Open the Log Analytics workspace used by the Container Apps environment.
-2. Identify whether the signal is configuration failure or repeated main
-   exporter transmission failure.
-3. Check the API revision, replica, connection-string reference, outbound
-   connectivity, and Azure Monitor service health.
+2. Identify whether the signal is a missing destination, a setup exception, or
+   repeated main exporter transmission failure.
+3. Check the API revision, replica, telemetry destination configuration,
+   outbound connectivity, and Azure Monitor service health.
 
 ### Detailed Kusto
 
@@ -92,7 +93,8 @@ ContainerAppConsoleLogs_CL
 | extend ParsedLog = parse_json(Log_s)
 | extend
     Event = tostring(ParsedLog.event),
-    Logger = tostring(ParsedLog.logger)
+    Logger = tostring(ParsedLog.logger),
+    Reason = tostring(ParsedLog.reason)
 | extend
     IsConfigureFailure = Event == "telemetry.configure.failed",
     IsMainExporterFailure =
@@ -105,31 +107,34 @@ ContainerAppConsoleLogs_CL
     ContainerGroupName_s,
     Event,
     Logger,
+    Reason,
     Log_s
 | order by TimeGenerated desc
 ```
 
 ### Likely causes
 
-- An invalid or unavailable Application Insights connection string prevented API
-  startup telemetry configuration.
+- `telemetry_destination_missing` means neither an Application Insights
+  connection string nor an OTLP endpoint was configured.
+- An invalid telemetry configuration or an SDK setup exception prevented
+  telemetry initialization.
 - Network, DNS, TLS, throttling, or authentication conditions blocked exporter
   transmission.
 - A payload was rejected as non-retryable by the ingestion endpoint.
 
 ### Escalation
 
-Escalate when configuration failures block a new API revision, exporter failures
-continue for more than 30 minutes, or the telemetry gap prevents incident
-response. Include revision names, timestamps, exporter logger, and the exact
-error text without including connection strings.
+Escalate when setup failures persist, exporter failures continue for more than
+30 minutes, or the telemetry gap prevents incident response. Include revision
+names, timestamps, the `reason` value, exporter logger, and the exact error
+text without including connection strings.
 
 ### Safe recovery
 
-Correct the secret reference, managed configuration, or outbound connectivity,
-then restart or roll forward the affected revision. Do not rotate or expose the
-connection string unless investigation confirms it is invalid. Confirm new
-traces, requests, exceptions, logs, and metrics arrive after recovery.
+Correct the telemetry destination configuration or outbound connectivity. Do
+not rotate or expose the connection string unless investigation confirms it is
+invalid. Confirm new traces, requests, exceptions, logs, and metrics arrive
+after recovery.
 
 ## Schema drift
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/logger.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/logger.py
@@ -1,7 +1,6 @@
-"""Centralized stdlib logging configuration.
+"""Centralized JSON stdout logging configuration.
 
-Simple JSON logging for Azure Container Apps, human-readable console for
-local dev. Azure Monitor/OpenTelemetry setup lives in ``core.observability``.
+Azure Monitor/OpenTelemetry setup lives in ``core.observability``.
 
 Usage::
 
@@ -21,7 +20,7 @@ _APP_HANDLER_NAME = "learn_to_cloud.stdout"
 
 
 def _json_formatter() -> JsonFormatter:
-    """Create the production JSON formatter."""
+    """Create the shared JSON formatter."""
     return JsonFormatter(
         ["levelname", "name", "message"],
         rename_fields={
@@ -37,8 +36,6 @@ def _json_formatter() -> JsonFormatter:
 
 def configure_logging() -> None:
     """Configure stdlib logging. Call once at application startup."""
-    is_production = bool(os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING"))
-    use_json = is_production and os.getenv("LOG_FORMAT", "").lower() != "console"
     level = getattr(
         logging,
         os.environ.get("LOG_LEVEL", "INFO").upper(),
@@ -53,11 +50,7 @@ def configure_logging() -> None:
 
     console = logging.StreamHandler(sys.stdout)
     console.set_name(_APP_HANDLER_NAME)
-    console.setFormatter(
-        _json_formatter()
-        if use_json
-        else logging.Formatter("%(levelname)-5s [%(name)s] %(message)s")
-    )
+    console.setFormatter(_json_formatter())
     root.addHandler(console)
     root.setLevel(level)
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
@@ -147,7 +147,7 @@ def _configure_otlp(resource: Resource) -> None:
         raise ValueError(f"Unsupported OTLP protocol: {protocol}")
 
 
-def configure_observability(*, fail_on_azure_error: bool = False) -> None:
+def configure_observability() -> None:
     """Set up the OTel telemetry pipeline."""
     global _telemetry_enabled
 
@@ -164,11 +164,13 @@ def configure_observability(*, fail_on_azure_error: bool = False) -> None:
         elif otlp_endpoint:
             _configure_otlp(resource)
         else:
+            logger.error(
+                "telemetry.configure.failed",
+                extra={"reason": "telemetry_destination_missing"},
+            )
             return
     except Exception:
         logger.exception("telemetry.configure.failed")
-        if conn_str and fail_on_azure_error:
-            raise
         return
 
     _telemetry_enabled = True

--- a/packages/learn-to-cloud-shared/tests/test_logger.py
+++ b/packages/learn-to-cloud-shared/tests/test_logger.py
@@ -10,8 +10,6 @@ Tests the stdlib-based logging configuration:
 import io
 import json
 import logging
-import os
-from unittest.mock import patch
 
 import pytest
 from pythonjsonlogger.json import JsonFormatter
@@ -217,16 +215,15 @@ class TestConfigureLogging:
         assert len(handlers) == 1
         assert handlers[0] is not first_handler
 
-    def test_json_format_when_app_insights_set(self):
-        with patch.dict(
-            os.environ,
-            {
-                "LOG_FORMAT": "",
-                "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test",
-            },
-        ):
-            configure_logging()
-            assert isinstance(_app_handlers()[0].formatter, JsonFormatter)
+    def test_json_format_without_telemetry_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.delenv("APPLICATIONINSIGHTS_CONNECTION_STRING", raising=False)
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+        configure_logging()
+
+        assert isinstance(_app_handlers()[0].formatter, JsonFormatter)
 
     def test_preserves_external_handlers(self):
         """Handlers not owned by the app should survive configure_logging()."""
@@ -239,21 +236,14 @@ class TestConfigureLogging:
         assert external_handler in root.handlers
 
     def test_child_logger_output_does_not_auto_add_github_username(self):
-        with patch.dict(
-            os.environ,
-            {
-                "LOG_FORMAT": "",
-                "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test",
-            },
-        ):
-            configure_logging()
-            stream = io.StringIO()
-            _app_handlers()[0].setStream(stream)
+        configure_logging()
+        stream = io.StringIO()
+        _app_handlers()[0].setStream(stream)
 
-            child_logger = logging.getLogger("test.child")
-            child_logger.setLevel(logging.NOTSET)
-            child_logger.propagate = True
-            child_logger.info("child.event")
+        child_logger = logging.getLogger("test.child")
+        child_logger.setLevel(logging.NOTSET)
+        child_logger.propagate = True
+        child_logger.info("child.event")
 
         parsed = json.loads(stream.getvalue())
 

--- a/packages/learn-to-cloud-shared/tests/test_observability.py
+++ b/packages/learn-to-cloud-shared/tests/test_observability.py
@@ -19,7 +19,9 @@ def _restore_telemetry_flag():
 
 
 @pytest.mark.unit
-def test_configure_observability_noops_without_exporter_env():
+def test_configure_observability_logs_missing_destination(
+    caplog: pytest.LogCaptureFixture,
+):
     with (
         patch.dict("os.environ", {}, clear=True),
         patch(
@@ -29,6 +31,7 @@ def test_configure_observability_noops_without_exporter_env():
         patch(
             "learn_to_cloud_shared.core.observability.HTTPXClientInstrumentor"
         ) as httpx_instrumentor,
+        caplog.at_level("ERROR"),
     ):
         observability.configure_observability()
 
@@ -36,6 +39,14 @@ def test_configure_observability_noops_without_exporter_env():
     otlp.assert_not_called()
     httpx_instrumentor.assert_not_called()
     assert observability._telemetry_enabled is False
+    records = [
+        record
+        for record in caplog.records
+        if record.message == "telemetry.configure.failed"
+    ]
+    assert len(records) == 1
+    assert records[0].__dict__["reason"] == "telemetry_destination_missing"
+    assert records[0].exc_info is None
 
 
 @pytest.mark.unit
@@ -178,26 +189,35 @@ def test_configure_observability_azure_failure_is_nonfatal_by_default(
 
 
 @pytest.mark.unit
-def test_configure_observability_azure_failure_reraises_when_opted_in():
+def test_configure_observability_otlp_failure_is_nonfatal(
+    caplog: pytest.LogCaptureFixture,
+):
     with (
         patch.dict(
             "os.environ",
-            {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"},
+            {"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"},
             clear=True,
         ),
         patch(
-            "learn_to_cloud_shared.core.observability._configure_azure_monitor",
+            "learn_to_cloud_shared.core.observability._configure_otlp",
             side_effect=RuntimeError("boom"),
         ),
         patch(
             "learn_to_cloud_shared.core.observability.HTTPXClientInstrumentor"
         ) as httpx_instrumentor,
-        pytest.raises(RuntimeError, match="boom"),
+        caplog.at_level("ERROR"),
     ):
-        observability.configure_observability(fail_on_azure_error=True)
+        observability.configure_observability()
 
     httpx_instrumentor.assert_not_called()
     assert observability._telemetry_enabled is False
+    records = [
+        record
+        for record in caplog.records
+        if record.message == "telemetry.configure.failed"
+    ]
+    assert len(records) == 1
+    assert records[0].exc_info is not None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Telemetry setup failures no longer prevent the API from starting. The API writes structured console events so the existing telemetry alert detects missing configuration or setup problems while users continue to be served.

Logs are JSON everywhere, including local development, so Container Apps can always query the same fields. The alert runbook now explains missing telemetry destinations, setup errors, and repeated exporter transmission failures.

Validated with the repository quality gate and targeted logger, observability, and API startup tests.