### PR TITLE
Show recent community activity

### DIFF
--- a/api/alembic/versions/0056_add_community_activity_indexes.py
+++ b/api/alembic/versions/0056_add_community_activity_indexes.py
@@ -1,0 +1,75 @@
+"""add indexes for community activity aggregates
+
+Why this change: the public community page aggregates recent verification
+attempts by ``created_at`` and successful projects by ``completed_at``. These
+indexes keep the rolling activity query bounded as attempt history grows.
+
+Schema effect:
+- Adds an index on ``verification_attempts.created_at``.
+- Adds a partial succeeded-attempt index on ``(completed_at, requirement_uuid,
+  user_id)``.
+
+Both indexes are built concurrently so production verification writes remain
+available while the migration runs. The downgrade removes them concurrently.
+
+Revision ID: 0056_add_community_activity_indexes
+Revises: 0055_drop_legacy_curriculum_contract
+Create Date: 2026-08-25
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0056_add_community_activity_indexes"
+down_revision: str | None = "0055_drop_legacy_curriculum_contract"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEXES: tuple[tuple[str, str], ...] = (
+    (
+        "ix_verification_attempts_created_at",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "ix_verification_attempts_created_at "
+        "ON verification_attempts (created_at)",
+    ),
+    (
+        "ix_verification_attempts_succeeded_completed_requirement_user",
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+        "ix_verification_attempts_succeeded_completed_requirement_user "
+        "ON verification_attempts (completed_at, requirement_uuid, user_id) "
+        "WHERE outcome = 'succeeded'",
+    ),
+)
+
+
+def upgrade() -> None:
+    """Build community activity indexes without blocking verification writes."""
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '10min'")
+
+    with op.get_context().autocommit_block():
+        op.execute("SET lock_timeout = '5s'")
+        op.execute("SET statement_timeout = '10min'")
+        try:
+            for name, create_stmt in _INDEXES:
+                op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+                op.execute(create_stmt)
+        finally:
+            op.execute("RESET statement_timeout")
+            op.execute("RESET lock_timeout")
+
+
+def downgrade() -> None:
+    """Remove community activity indexes without blocking verification writes."""
+    with op.get_context().autocommit_block():
+        op.execute("SET lock_timeout = '5s'")
+        op.execute("SET statement_timeout = '10min'")
+        try:
+            for name, _ in reversed(_INDEXES):
+                op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+        finally:
+            op.execute("RESET statement_timeout")
+            op.execute("RESET lock_timeout")

--- a/api/src/learn_to_cloud/services/community_service.py
+++ b/api/src/learn_to_cloud/services/community_service.py
@@ -1,19 +1,7 @@
-"""Assemble aggregate data for the public community experience.
-
-The phase funnel and the graduate list come from a single completion
-aggregate (``VerificationAttemptRepository.list_phase_completions``) plus a
-total account count and one batched user load. Because phase submissions
-are gated on the previous phase, completions are nested (completers of
-phase N are a subset of phase N-1), so the funnel is monotone and
-"graduates" are simply the learners who appear in every completable phase.
-The latest-commit panel is fetched and cached separately via the shared GitHub
-helper.
-
-Completions come from succeeded ``verification_attempts`` and do not count
-learning steps.
-"""
+"""Assemble aggregate data for the public community experience."""
 
 import logging
+from datetime import timedelta
 
 from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
 from learn_to_cloud_shared.content_service import (
@@ -21,14 +9,16 @@ from learn_to_cloud_shared.content_service import (
     get_requirement_counts_by_phase,
 )
 from learn_to_cloud_shared.github_updates import get_latest_curriculum_commits
+from learn_to_cloud_shared.models import utcnow
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
 from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     VerificationAttemptRepository,
 )
 from learn_to_cloud_shared.schemas import (
+    CommunityActivity,
     CommunityMember,
     CommunityPageData,
-    FunnelLevel,
+    CommunityPhaseActivity,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,13 +29,11 @@ async def get_community_page_data(db: AsyncSession) -> CommunityPageData:
     """Build the aggregate community page payload."""
     phases = get_curriculum_overview()
     phase_names = {phase.order: phase.name for phase in phases}
-
     requirement_counts = get_requirement_counts_by_phase()
-    phase_order_by_requirement_uuid = (
-        get_curriculum_catalog().phase_order_by_requirement_uuid
-    )
-    completions = await VerificationAttemptRepository(db).list_phase_completions(
-        requirement_counts, phase_order_by_requirement_uuid
+    catalog = get_curriculum_catalog()
+    attempt_repository = VerificationAttemptRepository(db)
+    completions = await attempt_repository.list_phase_completions(
+        requirement_counts, catalog.phase_order_by_requirement_uuid
     )
 
     # Group completions into a per-phase set of completer ids.
@@ -58,31 +46,31 @@ async def get_community_page_data(db: AsyncSession) -> CommunityPageData:
         order for order, total in requirement_counts.items() if total > 0
     )
 
-    total_accounts = await UserRepository(db).count()
-
-    # Build the funnel top-down: total accounts, then each phase, tracking
-    # both share of total (bar width) and conversion from the level above.
-    funnel: list[FunnelLevel] = [
-        FunnelLevel(
-            label="Total accounts",
-            count=total_accounts,
-            pct_of_total=100.0,
-            pct_of_previous=None,
-            is_total=True,
+    activity_rows = await attempt_repository.get_community_activity(
+        since=utcnow() - timedelta(days=7),
+        phase_order_by_requirement_uuid=catalog.phase_order_by_requirement_uuid,
+    )
+    total_activity = next(
+        (row for row in activity_rows if row.phase_order is None),
+        None,
+    )
+    activity = CommunityActivity(
+        active_learners=total_activity.active_learners if total_activity else 0,
+        attempts=total_activity.attempts if total_activity else 0,
+        projects_verified=total_activity.projects_verified if total_activity else 0,
+    )
+    phase_activity = [
+        CommunityPhaseActivity(
+            phase_order=row.phase_order,
+            label=phase_names.get(row.phase_order, f"Phase {row.phase_order}"),
+            active_learners=row.active_learners,
+            attempts=row.attempts,
+            projects_verified=row.projects_verified,
         )
+        for row in activity_rows
+        if row.phase_order is not None
+        and (row.active_learners or row.projects_verified)
     ]
-    prev_count = total_accounts
-    for order in completable_orders:
-        count = len(completers_by_phase.get(order, set()))
-        funnel.append(
-            FunnelLevel(
-                label=f"Phase {order}: {phase_names.get(order, order)}",
-                count=count,
-                pct_of_total=(count / total_accounts * 100) if total_accounts else 0.0,
-                pct_of_previous=(count / prev_count * 100) if prev_count else None,
-            )
-        )
-        prev_count = count
 
     # Graduates completed every completable phase.
     graduate_ids: set[int] = set()
@@ -106,8 +94,8 @@ async def get_community_page_data(db: AsyncSession) -> CommunityPageData:
     repo_updates = await get_latest_curriculum_commits()
 
     return CommunityPageData(
-        total_accounts=total_accounts,
-        funnel=funnel,
+        activity=activity,
+        phase_activity=phase_activity,
         graduates=graduates,
         repo_updates=repo_updates,
     )

--- a/api/src/learn_to_cloud/templates/pages/community.html
+++ b/api/src/learn_to_cloud/templates/pages/community.html
@@ -38,43 +38,41 @@
     </ul>
 </section>
 
-<section class="pt-14 sm:pt-16" aria-labelledby="progress-heading">
+<section class="pt-14 sm:pt-16" aria-labelledby="activity-heading">
     <div class="max-w-2xl">
-        <h2 id="progress-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Verified progress across the curriculum</h2>
-        <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-300">
-            Each level counts learners who have verified every project in that phase. Later phases require the earlier work first.
-        </p>
+        <h2 id="activity-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">This week in the community</h2>
     </div>
 
-    {% if community.funnel %}
-    <ol class="mt-8 space-y-5">
-        {% for level in community.funnel %}
-        <li>
-            <div class="flex items-end justify-between gap-4">
-                <p class="min-w-0 text-sm {% if level.is_total %}font-bold text-gray-950 dark:text-white{% else %}font-medium text-gray-700 dark:text-gray-300{% endif %}">
-                    {{ level.label }}
-                </p>
-                <p class="shrink-0 text-right text-sm tabular-nums">
-                    <strong class="font-bold text-gray-950 dark:text-white">{{ level.count }}</strong>
-                    {% if level.is_total %}
-                    <span class="ml-1 text-gray-500 dark:text-gray-400">accounts</span>
-                    {% else %}
-                    <span class="ml-1 text-gray-500 dark:text-gray-400">{{ level.pct_of_total | round(1) }}%</span>
-                    {% endif %}
-                </p>
-            </div>
-            <div class="mt-2 h-2.5 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700" aria-hidden="true">
-                <div class="h-full rounded-full {% if level.is_total %}bg-blue-700 dark:bg-blue-400{% else %}bg-blue-500 dark:bg-blue-500{% endif %}" style="width: {{ level.pct_of_total | round(2) }}%"></div>
-            </div>
-            {% if not level.is_total and level.pct_of_previous is not none %}
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ level.pct_of_previous | round(0) | int }}% advanced from the previous phase</p>
-            {% endif %}
-        </li>
-        {% endfor %}
-    </ol>
+    {% if community.activity.active_learners or community.activity.projects_verified %}
+    <div class="mt-8 grid gap-6 rounded-lg border border-blue-200 bg-blue-50 p-6 dark:border-blue-900 dark:bg-blue-950/30 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+        <div>
+            <p class="text-4xl font-bold tracking-[-0.035em] text-gray-950 dark:text-white">{{ community.activity.active_learners }} learner{% if community.activity.active_learners != 1 %}s{% endif %}</p>
+            <p class="mt-2 text-lg font-bold tracking-[-0.02em] text-gray-950 dark:text-white">worked on {{ community.activity.attempts }} verification{% if community.activity.attempts != 1 %}s{% endif %} in the past 7 days.</p>
+        </div>
+        <div class="border-t border-blue-200 pt-5 dark:border-blue-900 sm:border-l sm:border-t-0 sm:pl-6 sm:pt-0">
+            <p class="text-3xl font-bold tracking-[-0.035em] text-blue-700 dark:text-blue-300">{{ community.activity.projects_verified }}</p>
+            <p class="mt-1 text-sm leading-5 text-gray-600 dark:text-gray-300">projects verified</p>
+        </div>
+    </div>
+
+    {% if community.phase_activity %}
+    <div class="mt-10 max-w-3xl">
+        <h3 class="text-lg font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Where learners are working</h3>
+        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">Active learners and newly verified projects in the past 7 days.</p>
+        <ul class="mt-4 border-y border-gray-200 dark:border-gray-700">
+            {% for phase in community.phase_activity %}
+            <li class="grid gap-1 border-b border-gray-200 py-4 last:border-b-0 sm:grid-cols-[minmax(11rem,1fr)_minmax(11rem,1fr)_auto] sm:items-center sm:gap-4">
+                <p class="font-bold text-gray-950 dark:text-white">{{ phase.label }}</p>
+                <p class="text-sm text-gray-600 dark:text-gray-300">{{ phase.active_learners }} learner{% if phase.active_learners != 1 %}s{% endif %} &middot; {{ phase.attempts }} attempt{% if phase.attempts != 1 %}s{% endif %}</p>
+                <p class="text-sm font-bold text-blue-700 dark:text-blue-300">{{ phase.projects_verified }} verified</p>
+            </li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
     {% else %}
     <div class="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
-        <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">Verified learner progress is temporarily unavailable.</p>
+        <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">No verification activity has been recorded in the past 7 days.</p>
     </div>
     {% endif %}
 </section>

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -404,15 +404,19 @@ def test_step_checkbox_keeps_keyboard_events_from_toggling_accordion():
 
 
 @pytest.mark.unit
-def test_community_page_renders_public_progress_and_canonical_footer_link():
+def test_community_page_renders_activity_and_canonical_footer_link():
     community = SimpleNamespace(
-        funnel=[
+        activity=SimpleNamespace(
+            active_learners=42,
+            attempts=75,
+            projects_verified=20,
+        ),
+        phase_activity=[
             SimpleNamespace(
-                label="Total accounts",
-                count=42,
-                pct_of_total=100.0,
-                pct_of_previous=None,
-                is_total=True,
+                label="Starting from Zero",
+                active_learners=30,
+                attempts=50,
+                projects_verified=12,
             )
         ],
         graduates=[],
@@ -427,15 +431,25 @@ def test_community_page_renders_public_progress_and_canonical_footer_link():
     )
 
     assert "Learn to Cloud community" in html
-    assert "Total accounts" in html
     assert "42" in html
+    assert "This week in the community" in html
+    assert "Starting from Zero" in html
     assert 'href="/community"' in html
     assert 'href="/stats"' not in html
 
 
 @pytest.mark.unit
 def test_community_page_renders_safe_external_resource_links():
-    community = SimpleNamespace(funnel=[], graduates=[], repo_updates=[])
+    community = SimpleNamespace(
+        activity=SimpleNamespace(
+            active_learners=0,
+            attempts=0,
+            projects_verified=0,
+        ),
+        phase_activity=[],
+        graduates=[],
+        repo_updates=[],
+    )
 
     html = _render(
         "pages/community.html",
@@ -455,7 +469,7 @@ def test_community_page_renders_safe_external_resource_links():
     for url in expected_links:
         assert f'href="{url}"' in html
     assert html.count('rel="noopener noreferrer"') >= len(expected_links)
-    assert "Verified learner progress is temporarily unavailable." in html
+    assert "No verification activity has been recorded in the past 7 days." in html
     assert "Curriculum updates are temporarily unavailable." in html
     assert "Discord" in html
     assert "GitHub Discussions" in html

--- a/api/tests/services/test_community_service.py
+++ b/api/tests/services/test_community_service.py
@@ -66,12 +66,12 @@ async def test_graduates_are_full_curriculum_completers(
     assert [member.github_username for member in community.graduates] == ["grad"]
 
 
-async def test_funnel_uses_authoritative_attempts_and_excludes_empty_phases(
+async def test_activity_uses_authoritative_attempts_and_current_phase_mapping(
     db_session: AsyncSession,
 ) -> None:
     counts = get_requirement_counts_by_phase()
     first_completable = min(order for order, count in counts.items() if count > 0)
-    db_session.add(User(id=60003, github_username="funnel"))
+    db_session.add(User(id=60003, github_username="activity"))
     await db_session.flush()
     await _complete_phase(db_session, user_id=60003, phase_order=first_completable)
 
@@ -81,7 +81,8 @@ async def test_funnel_uses_authoritative_attempts_and_excludes_empty_phases(
     ):
         community = await get_community_page_data(db_session)
 
-    assert community.total_accounts == 1
-    assert community.funnel[0].label == "Total accounts"
-    assert community.funnel[1].count == 1
-    assert len(community.funnel) == 1 + sum(count > 0 for count in counts.values())
+    assert community.activity.active_learners == 1
+    assert community.activity.attempts == counts[first_completable]
+    assert community.activity.projects_verified == counts[first_completable]
+    assert len(community.phase_activity) == 1
+    assert community.phase_activity[0].phase_order == first_completable

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -161,6 +161,14 @@ class VerificationAttempt(TimestampMixin, Base):
             "requirement_uuid",
             text("created_at DESC"),
         ),
+        Index("ix_verification_attempts_created_at", "created_at"),
+        Index(
+            "ix_verification_attempts_succeeded_completed_requirement_user",
+            "completed_at",
+            "requirement_uuid",
+            "user_id",
+            postgresql_where=text("outcome = 'succeeded'"),
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
@@ -13,8 +13,10 @@ from sqlalchemy import (
     and_,
     column,
     func,
+    literal,
     select,
     text,
+    union_all,
     update,
     values,
 )
@@ -110,6 +112,16 @@ class FinalizeResult:
 
     won: bool
     state: AttemptTerminalState
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityActivityRow:
+    """Aggregate verification activity for the community page."""
+
+    phase_order: int | None
+    active_learners: int
+    attempts: int
+    projects_verified: int
 
 
 class AttemptAlreadyGoneError(Exception):
@@ -720,4 +732,111 @@ class VerificationAttemptRepository:
             (row.phase_order, row.user_id)
             for row in result.all()
             if row.validated >= completable[row.phase_order]
+        ]
+
+    async def get_community_activity(
+        self,
+        *,
+        since: datetime,
+        phase_order_by_requirement_uuid: Mapping[UUID, int],
+    ) -> list[CommunityActivityRow]:
+        """Aggregate recent attempts and verified projects by current phase."""
+        requirement_phase_rows = list(
+            phase_order_by_requirement_uuid.items(),
+        )
+        if not requirement_phase_rows:
+            return []
+
+        requirement_phase_map = values(
+            column("requirement_uuid", Uuid(as_uuid=True)),
+            column("phase_order", Integer),
+            name="community_requirement_phase_map",
+        ).data(requirement_phase_rows)
+        mapped_attempts = (
+            select(
+                requirement_phase_map.c.phase_order,
+                VerificationAttempt.user_id,
+                VerificationAttempt.requirement_uuid,
+                VerificationAttempt.outcome,
+                VerificationAttempt.created_at,
+                VerificationAttempt.completed_at,
+            )
+            .select_from(VerificationAttempt)
+            .join(
+                requirement_phase_map,
+                VerificationAttempt.requirement_uuid
+                == requirement_phase_map.c.requirement_uuid,
+            )
+            .subquery("mapped_attempts")
+        )
+        recent_attempts = (
+            mapped_attempts.select()
+            .where(
+                mapped_attempts.c.created_at >= since,
+            )
+            .subquery("recent_attempts")
+        )
+        recent_verified_projects = (
+            select(
+                mapped_attempts.c.phase_order,
+                mapped_attempts.c.user_id,
+                mapped_attempts.c.requirement_uuid,
+            )
+            .where(
+                mapped_attempts.c.outcome == VerificationAttemptOutcome.SUCCEEDED.value,
+                mapped_attempts.c.completed_at >= since,
+            )
+            .distinct()
+            .subquery("recent_verified_projects")
+        )
+        zero = literal(0, type_=Integer)
+        total_phase_order = literal(None, type_=Integer)
+        activity_rows = union_all(
+            select(
+                total_phase_order.label("phase_order"),
+                func.count(func.distinct(recent_attempts.c.user_id)).label(
+                    "active_learners"
+                ),
+                func.count().label("attempts"),
+                zero.label("projects_verified"),
+            ),
+            select(
+                recent_attempts.c.phase_order,
+                func.count(func.distinct(recent_attempts.c.user_id)).label(
+                    "active_learners"
+                ),
+                func.count().label("attempts"),
+                zero.label("projects_verified"),
+            ).group_by(recent_attempts.c.phase_order),
+            select(
+                total_phase_order.label("phase_order"),
+                zero.label("active_learners"),
+                zero.label("attempts"),
+                func.count().label("projects_verified"),
+            ).select_from(recent_verified_projects),
+            select(
+                recent_verified_projects.c.phase_order,
+                zero.label("active_learners"),
+                zero.label("attempts"),
+                func.count().label("projects_verified"),
+            ).group_by(recent_verified_projects.c.phase_order),
+        ).subquery("community_activity_rows")
+        result = await self.db.execute(
+            select(
+                activity_rows.c.phase_order,
+                func.sum(activity_rows.c.active_learners).label("active_learners"),
+                func.sum(activity_rows.c.attempts).label("attempts"),
+                func.sum(activity_rows.c.projects_verified).label("projects_verified"),
+            )
+            .group_by(activity_rows.c.phase_order)
+            .order_by(activity_rows.c.phase_order)
+        )
+        return [
+            CommunityActivityRow(
+                phase_order=row.phase_order,
+                active_learners=int(row.active_learners),
+                attempts=int(row.attempts),
+                projects_verified=int(row.projects_verified),
+            )
+            for row in result.all()
         ]

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -704,19 +704,22 @@ class CommunityMember(FrozenModel):
     avatar_url: str | None = None
 
 
-class FunnelLevel(FrozenModel):
-    """One level of the community progress funnel.
+class CommunityActivity(FrozenModel):
+    """Recent verification activity across the current curriculum."""
 
-    ``pct_of_total`` is relative to total accounts (drives the funnel
-    width); ``pct_of_previous`` is the conversion from the level above
-    (``None`` for the top level).
-    """
+    active_learners: int
+    attempts: int
+    projects_verified: int
 
+
+class CommunityPhaseActivity(FrozenModel):
+    """Recent verification activity for one curriculum phase."""
+
+    phase_order: int
     label: str
-    count: int
-    pct_of_total: float
-    pct_of_previous: float | None = None
-    is_total: bool = False
+    active_learners: int
+    attempts: int
+    projects_verified: int
 
 
 class RepoUpdate(FrozenModel):
@@ -738,8 +741,8 @@ class RepoUpdate(FrozenModel):
 class CommunityPageData(FrozenModel):
     """Aggregate data shown on the public community page."""
 
-    total_accounts: int
-    funnel: list[FunnelLevel]
+    activity: CommunityActivity
+    phase_activity: list[CommunityPhaseActivity]
     graduates: list[CommunityMember]
     repo_updates: list[RepoUpdate]
 

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
@@ -52,6 +52,7 @@ async def _insert_attempt(
     attempt_id: UUID | None = None,
     requirement_uuid: UUID | None = None,
     created_at=None,
+    completed_at=None,
     started_at=None,
     outcome: str | None = None,
 ) -> UUID:
@@ -66,13 +67,65 @@ async def _insert_attempt(
             submitted_value="https://github.com/attemptrepo/repo",
             started_at=started_at,
             outcome=outcome,
-            completed_at=utcnow() if outcome is not None else None,
+            completed_at=completed_at or (utcnow() if outcome is not None else None),
         )
         if created_at is not None:
             attempt.created_at = created_at
         db.add(attempt)
         await db.commit()
     return attempt_id
+
+
+async def test_community_activity_uses_distinct_projects_and_completion_time(
+    session_maker: async_sessionmaker[AsyncSession],
+    user: int,
+) -> None:
+    now = utcnow()
+    current_requirement = uuid4()
+    completed_after_window_requirement = uuid4()
+
+    await _insert_attempt(
+        session_maker,
+        requirement_uuid=current_requirement,
+        created_at=now - timedelta(days=1),
+        completed_at=now - timedelta(hours=1),
+        outcome="succeeded",
+    )
+    await _insert_attempt(
+        session_maker,
+        requirement_uuid=current_requirement,
+        created_at=now - timedelta(hours=2),
+        completed_at=now - timedelta(hours=1),
+        outcome="succeeded",
+    )
+    await _insert_attempt(
+        session_maker,
+        requirement_uuid=completed_after_window_requirement,
+        created_at=now - timedelta(days=8),
+        completed_at=now - timedelta(hours=1),
+        outcome="succeeded",
+    )
+
+    async with session_maker() as db:
+        activity = await VerificationAttemptRepository(db).get_community_activity(
+            since=now - timedelta(days=7),
+            phase_order_by_requirement_uuid={
+                current_requirement: 1,
+                completed_after_window_requirement: 1,
+            },
+        )
+
+    summary = next(row for row in activity if row.phase_order is None)
+    phase = next(row for row in activity if row.phase_order == 1)
+    assert summary.active_learners == 1
+    assert summary.attempts == 2
+    assert summary.projects_verified == 2
+    assert phase == summary.__class__(
+        phase_order=1,
+        active_learners=1,
+        attempts=2,
+        projects_verified=2,
+    )
 
 
 def _submitted_value(


### PR DESCRIPTION
## Summary

The community page made active learner work look quiet because it only emphasized completed phases against total accounts. This replaces that funnel with a rolling 7-day view of active learners, verification attempts, uniquely verified learner-project pairs, and current activity by phase.

The data comes from `verification_attempts`: attempts use `created_at`, while verified projects use `completed_at` and distinct `(user_id, requirement_uuid)` pairs so retries do not inflate progress. The migration adds concurrent indexes for these rolling aggregates.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.

N/A - the migration adds query-performance indexes only; the application data model is unchanged.