### PR TITLE
Implement safe LLM grading telemetry

### DIFF
--- a/api/src/learn_to_cloud/core/middleware.py
+++ b/api/src/learn_to_cloud/core/middleware.py
@@ -79,7 +79,6 @@ class UserTrackingMiddleware:
 
         session = scope.get("session", {})
         user_id = session.get("user_id")
-        github_username = session.get("github_username")
 
         if user_id is not None:
             session_id = session.get(SESSION_ID_KEY)
@@ -89,12 +88,6 @@ class UserTrackingMiddleware:
             span = trace.get_current_span()
             if span.is_recording():
                 span.set_attribute("enduser.id", str(user_id))
-                span.set_attribute("app.user_id", str(user_id))
                 span.set_attribute("enduser.pseudo.id", session_id)
-                span.set_attribute("app.session_id", session_id)
-                span.set_attribute("ai.session.id", session_id)
-                if github_username:
-                    span.set_attribute("enduser.name", github_username)
-                    span.set_attribute("app.github_username", github_username)
 
         await self.app(scope, receive, send)

--- a/api/tests/core/test_middleware.py
+++ b/api/tests/core/test_middleware.py
@@ -7,7 +7,7 @@ Tests ASGI middleware:
 - UserTrackingMiddleware sets OTel span attributes for authenticated users
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -169,10 +169,10 @@ class TestUserTrackingMiddleware:
 
         await middleware(scope, _noop_receive, _noop_send)
 
-        mock_span.set_attribute.assert_any_call("enduser.id", "42")
-        mock_span.set_attribute.assert_any_call("app.user_id", "42")
-        mock_span.set_attribute.assert_any_call("enduser.name", "testuser")
-        mock_span.set_attribute.assert_any_call("app.github_username", "testuser")
+        assert mock_span.set_attribute.call_args_list == [
+            call("enduser.id", "42"),
+            call("enduser.pseudo.id", scope["session"]["session_id"]),
+        ]
 
     @patch("learn_to_cloud.core.middleware.trace", autospec=True)
     async def test_sets_session_attributes_when_session_id_present(self, mock_trace):
@@ -191,9 +191,10 @@ class TestUserTrackingMiddleware:
 
         await middleware(scope, _noop_receive, _noop_send)
 
-        mock_span.set_attribute.assert_any_call("enduser.pseudo.id", "session-123")
-        mock_span.set_attribute.assert_any_call("app.session_id", "session-123")
-        mock_span.set_attribute.assert_any_call("ai.session.id", "session-123")
+        assert mock_span.set_attribute.call_args_list == [
+            call("enduser.id", "42"),
+            call("enduser.pseudo.id", "session-123"),
+        ]
 
     @patch("learn_to_cloud.core.middleware.trace", autospec=True)
     @patch("learn_to_cloud.core.middleware.new_session_id", autospec=True)
@@ -213,11 +214,10 @@ class TestUserTrackingMiddleware:
 
         await middleware(scope, _noop_receive, _noop_send)
 
-        mock_span.set_attribute.assert_any_call("enduser.id", "42")
-        mock_span.set_attribute.assert_any_call("app.user_id", "42")
-        mock_span.set_attribute.assert_any_call(
-            "enduser.pseudo.id", "generated-session"
-        )
+        assert mock_span.set_attribute.call_args_list == [
+            call("enduser.id", "42"),
+            call("enduser.pseudo.id", "generated-session"),
+        ]
         assert scope["session"]["session_id"] == "generated-session"
 
     @patch("learn_to_cloud.core.middleware.trace", autospec=True)

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -49,6 +49,7 @@ from learn_to_cloud_shared.verification.llm_grading import (
 )
 from learn_to_cloud_shared.verification.engine import run_profile
 from learn_to_cloud_shared.verification_workflow import (
+    LLM_ERROR_TYPES,
     PreparedVerificationAttempt,
     VerificationRunResult,
     outcome_for_validation,
@@ -58,10 +59,15 @@ from opentelemetry import trace as otel_trace
 from opentelemetry.propagate import extract
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from verification_agents import (
-    CONTENT_FILTER_MARKER,
+    ContentFilteredError,
+    LLM_OUTCOME_CONTENT_FILTERED,
+    LLM_OUTCOME_ERROR,
+    LLM_OUTCOME_SUCCESS,
+    LLMGradingError,
     grade_evidence,
     missing_grading_config,
 )
+from opentelemetry.trace import Span, Status, StatusCode
 
 
 def _telemetry_destination_configured() -> bool:
@@ -101,9 +107,14 @@ _TRANSIENT_RETRY_OPTIONS = df.RetryOptions(
     first_retry_interval_in_milliseconds=2000,
     max_number_of_attempts=3,
 )
-_LLM_RETRY_OPTIONS = df.RetryOptions(
-    first_retry_interval_in_milliseconds=3000,
-    max_number_of_attempts=4,
+_VERIFICATION_SPAN_NAMES = frozenset(
+    {
+        "verification.start",
+        "verification.prepare",
+        "verification.execute",
+        "verification.grade",
+        "verification.finalize",
+    }
 )
 
 _engine: AsyncEngine | None = None
@@ -182,19 +193,25 @@ def _activity_payloads(value: object) -> list[dict[str, object]]:
     return [_activity_payload(item) for item in value]
 
 
+def _safe_llm_error_type(value: object) -> str:
+    """Return a whitelisted LLM error category."""
+    if isinstance(value, str) and value in LLM_ERROR_TYPES:
+        return value
+    return "llm.unknown"
+
+
 def _set_verification_span_attributes(
+    span: Span,
     *,
     attempt_id: str,
     user_id: int | None = None,
-    github_username: str | None = None,
     phase_id: int | None = None,
     requirement_slug: str | None = None,
     submission_type: str | None = None,
     status: str | None = None,
     grading_disposition: str | None = None,
 ) -> None:
-    """Add verification identity to the current span when telemetry is enabled."""
-    span = otel_trace.get_current_span()
+    """Add the approved verification attributes to one business span."""
     if not span.is_recording():
         return
 
@@ -210,39 +227,37 @@ def _set_verification_span_attributes(
     if grading_disposition:
         span.set_attribute("verification.grading_disposition", grading_disposition)
     if user_id is not None:
-        user_id_text = str(user_id)
-        span.set_attribute("enduser.id", user_id_text)
-        span.set_attribute("app.user_id", user_id_text)
-    if github_username:
-        span.set_attribute("enduser.name", github_username)
-        span.set_attribute("app.github_username", github_username)
+        span.set_attribute("enduser.id", str(user_id))
 
 
-def _set_attempt_span_attributes(attempt: PreparedVerificationAttempt) -> None:
-    _set_verification_span_attributes(
-        attempt_id=str(attempt.id),
-        user_id=attempt.user_id,
-        github_username=attempt.github_username,
-        requirement_slug=attempt.requirement.slug,
-        submission_type=attempt.requirement.submission_type.value,
-    )
-
-
-def _set_result_span_attributes(result: VerificationRunResult) -> None:
-    attempt = result.attempt
-    _set_verification_span_attributes(
-        attempt_id=str(attempt.id),
-        user_id=attempt.user_id,
-        github_username=attempt.github_username,
-        requirement_slug=attempt.requirement.slug,
-        submission_type=attempt.requirement.submission_type.value,
-        status=outcome_for_validation(result.validation_result),
-        grading_disposition=(
-            result.grading_disposition.value
-            if result.grading_disposition is not None
-            else None
-        ),
-    )
+@contextmanager
+def _verification_span(
+    name: str,
+    *,
+    attempt_id: str,
+    user_id: int | None = None,
+    result: VerificationRunResult | None = None,
+) -> Iterator[Span]:
+    """Create an explicit business span rather than enriching framework spans."""
+    if name not in _VERIFICATION_SPAN_NAMES:
+        raise ValueError(f"Unknown verification span name: {name}")
+    with otel_trace.get_tracer(__name__).start_as_current_span(name) as span:
+        _set_verification_span_attributes(
+            span,
+            attempt_id=attempt_id,
+            user_id=user_id,
+            requirement_slug=result.attempt.requirement.slug if result else None,
+            submission_type=(
+                result.attempt.requirement.submission_type.value if result else None
+            ),
+            status=outcome_for_validation(result.validation_result) if result else None,
+            grading_disposition=(
+                result.grading_disposition.value
+                if result and result.grading_disposition is not None
+                else None
+            ),
+        )
+        yield span
 
 
 def _attempt_custom_status(
@@ -322,45 +337,41 @@ def _llm_grading_step(
     )
     config_status = yield context.call_activity("ensure_grading_config", None)
     if not config_status.get("valid"):
-        missing = config_status.get("missing_vars") or []
         return (
             yield context.call_activity(
                 "llm_grading_failed",
-                {
-                    "run_result": run_result,
-                    "detail": f"missing grading config: {', '.join(missing)}",
-                    "error_type": "MissingGradingConfig",
-                },
+                {"run_result": run_result, "error_type": "llm.configuration"},
             )
         )
 
-    try:
-        decisions: list[dict[str, object]] = []
-        for request_payload in llm_requests:
-            decision_payload = yield context.call_activity_with_retry(
-                "run_llm_grading",
-                _LLM_RETRY_OPTIONS,
-                request_payload,
+    decisions: list[dict[str, object]] = []
+    for request_payload in llm_requests:
+        grading_result = yield context.call_activity(
+            "run_llm_grading",
+            {"attempt_id": outcome.attempt_id, "request": request_payload},
+        )
+        result_payload = _activity_payload(grading_result)
+        technical_outcome = result_payload.get("outcome")
+        if technical_outcome != LLM_OUTCOME_SUCCESS:
+            error_type = _safe_llm_error_type(result_payload.get("error_type"))
+            return (
+                yield context.call_activity(
+                    "llm_grading_failed",
+                    {
+                        "run_result": run_result,
+                        "error_type": error_type,
+                        "outcome": technical_outcome,
+                    },
+                )
             )
-            decisions.append(_activity_payload(decision_payload))
+        decisions.append(_activity_payload(result_payload["decision"]))
 
-        return (
-            yield context.call_activity(
-                "apply_llm_grading_results",
-                {"run_result": run_result, "decisions": decisions},
-            )
+    return (
+        yield context.call_activity(
+            "apply_llm_grading_results",
+            {"run_result": run_result, "decisions": decisions},
         )
-    except Exception as exc:
-        return (
-            yield context.call_activity(
-                "llm_grading_failed",
-                {
-                    "run_result": run_result,
-                    "detail": str(exc),
-                    "error_type": type(exc).__name__,
-                },
-            )
-        )
+    )
 
 
 @app.activity_trigger(input_name="job_payload")
@@ -373,20 +384,19 @@ async def execute_requirement_verification(
         prepared_attempt = PreparedVerificationAttempt.from_payload(
             _activity_payload(job_payload)
         )
-        _set_attempt_span_attributes(prepared_attempt)
-        run_result = await run_profile(prepared_attempt)
-        span = otel_trace.get_current_span()
-        if span.is_recording():
-            span.set_attribute(
-                "verification.is_valid", run_result.validation_result.is_valid
-            )
-            span.set_attribute(
-                "verification.completed",
-                run_result.validation_result.verification_completed,
-            )
-        result_payload = run_result.to_payload()
-        _set_result_span_attributes(run_result)
-        return result_payload
+        with _verification_span(
+            "verification.execute", attempt_id=str(prepared_attempt.id)
+        ) as span:
+            run_result = await run_profile(prepared_attempt)
+            if span.is_recording():
+                span.set_attribute(
+                    "verification.is_valid", run_result.validation_result.is_valid
+                )
+                span.set_attribute(
+                    "verification.completed",
+                    run_result.validation_result.verification_completed,
+                )
+            return run_result.to_payload()
 
 
 @app.activity_trigger(input_name="payload")
@@ -412,15 +422,38 @@ async def run_llm_grading(
 ) -> dict[str, object]:
     """Call Foundry for one LLM grading request and return durable-safe JSON."""
     with _attached_invocation_context(context):
-        request = LLMGradingRequest.model_validate(_activity_payload(request_payload))
-        span = otel_trace.get_current_span()
-        if span.is_recording():
-            span.set_attribute("verification.llm_thread_id", request.thread_id)
-        decision = await grade_evidence(request.message)
-        return LLMGradingDecisionPayload(
-            task=request.task,
-            decision=decision,
-        ).model_dump(mode="json")
+        data = _activity_payload(request_payload)
+        attempt_id = str(data["attempt_id"])
+        request = LLMGradingRequest.model_validate(_activity_payload(data["request"]))
+        with _verification_span("verification.grade", attempt_id=attempt_id) as span:
+            try:
+                decision = await grade_evidence(request.message)
+            except LLMGradingError as exc:
+                if span.is_recording():
+                    span.set_attribute("verification.llm.outcome", LLM_OUTCOME_ERROR)
+                    span.set_attribute("error.type", exc.error_type)
+                    if exc.http_status is not None:
+                        span.set_attribute("http.response.status_code", exc.http_status)
+                    span.set_status(Status(StatusCode.ERROR))
+                return {
+                    "outcome": LLM_OUTCOME_ERROR,
+                    "error_type": exc.error_type,
+                }
+            except ContentFilteredError:
+                if span.is_recording():
+                    span.set_attribute(
+                        "verification.llm.outcome", LLM_OUTCOME_CONTENT_FILTERED
+                    )
+                return {"outcome": LLM_OUTCOME_CONTENT_FILTERED}
+            if span.is_recording():
+                span.set_attribute("verification.llm.outcome", LLM_OUTCOME_SUCCESS)
+            return {
+                "outcome": LLM_OUTCOME_SUCCESS,
+                "decision": LLMGradingDecisionPayload(
+                    task=request.task,
+                    decision=decision,
+                ).model_dump(mode="json"),
+            }
 
 
 @app.activity_trigger(input_name="payload")
@@ -433,7 +466,6 @@ async def apply_llm_grading_results(
         data = _activity_payload(payload)
         run_payload = _activity_payload(data["run_result"])
         run_result_payload = VerificationRunResult.from_payload(run_payload)
-        _set_attempt_span_attributes(run_result_payload.attempt)
         decision_payloads = [
             LLMGradingDecisionPayload.model_validate(item)
             for item in _activity_payloads(data["decisions"])
@@ -442,21 +474,7 @@ async def apply_llm_grading_results(
             run_result_payload,
             decision_payloads,
         )
-        result_payload = run_result.to_payload()
-        _set_result_span_attributes(run_result)
-        return result_payload
-
-
-def _is_content_filter_failure(error_type: str, detail: str) -> bool:
-    """Classify a grading failure as an Azure content-safety block.
-
-    Durable Functions may deliver the activity error to the orchestrator as a
-    wrapped exception, so the original type can be lost while the message text
-    survives. Check both the type name and the detail for the stable marker.
-    """
-    return (
-        error_type == "ContentFilteredError" or CONTENT_FILTER_MARKER in detail.lower()
-    )
+        return run_result.to_payload()
 
 
 @app.activity_trigger(input_name="payload")
@@ -467,33 +485,23 @@ async def llm_grading_failed(
     """Convert LLM grader errors into a persisted server-error result."""
     with _attached_invocation_context(context):
         data = _activity_payload(payload)
-        detail = data.get("detail")
-        if not isinstance(detail, str) or not detail:
-            detail = "unknown_error"
-        error_type = data.get("error_type")
-        if not isinstance(error_type, str) or not error_type:
-            error_type = "unknown"
+        error_type = _safe_llm_error_type(data.get("error_type"))
+        technical_outcome = data.get("outcome")
         run_result_payload = VerificationRunResult.from_payload(
             _activity_payload(data["run_result"])
         )
-        _set_attempt_span_attributes(run_result_payload.attempt)
-        # Record the real cause in telemetry so operators can diagnose the
-        # failure. The user-facing result stays generic on purpose.
-        span = otel_trace.get_current_span()
-        if span.is_recording():
-            span.set_attribute("verification.llm_grading_error_type", error_type)
-            span.set_attribute("verification.llm_grading_error_detail", detail)
-        logger.error(
-            "verification.llm_grading.failed",
-            extra={"error_type": error_type, "detail": detail},
-        )
-        if _is_content_filter_failure(error_type, detail):
+        if technical_outcome == LLM_OUTCOME_CONTENT_FILTERED:
             run_result = llm_grading_content_filtered_result(run_result_payload)
         else:
-            run_result = llm_grading_unavailable_result(run_result_payload)
-        result_payload = run_result.to_payload()
-        _set_result_span_attributes(run_result)
-        return result_payload
+            logger.error(
+                "verification.llm_grading.failed",
+                extra={"error.type": error_type},
+            )
+            run_result = llm_grading_unavailable_result(
+                run_result_payload,
+                error_type=error_type,
+            )
+        return run_result.to_payload()
 
 
 @app.route(route="verification/attempts/{instance_id}/status", methods=["GET"])
@@ -514,7 +522,6 @@ async def get_verification_attempt_status(
         except ValueError:
             return _json_response({"error": "invalid_instance_id"}, status_code=400)
 
-        _set_verification_span_attributes(attempt_id=instance_id)
         status = await client.get_status(
             instance_id,
             show_history=False,
@@ -614,7 +621,6 @@ def _run_attempt_orchestration(context: df.DurableOrchestrationContext):
     orchestration tests can drive it directly.
     """
     attempt_id = _attempt_id_from_input(context)
-    _set_verification_span_attributes(attempt_id=attempt_id)
     context.set_custom_status({"step": "preparing", "attempt_id": attempt_id})
     failure_stage = "prepare"
     try:
@@ -627,7 +633,6 @@ def _run_attempt_orchestration(context: df.DurableOrchestrationContext):
         prepared_attempt = PreparedVerificationAttempt.from_payload(
             _activity_payload(prepared_attempt_payload)
         )
-        _set_attempt_span_attributes(prepared_attempt)
         outcome = _PreparedOutcome(
             attempt_id=attempt_id,
             prepared_payload=prepared_attempt_payload,
@@ -676,12 +681,17 @@ async def prepare_verification_attempt(
         if not isinstance(raw_attempt_id, str):
             raise TypeError("prepare_verification_attempt: missing attempt_id")
         attempt_id = UUID(raw_attempt_id)
-        _set_verification_span_attributes(attempt_id=str(attempt_id))
-        preparation = await prepare_attempt(
-            attempt_id,
-            session_maker=_get_session_maker(),
-        )
-        _set_attempt_span_attributes(preparation.attempt)
+        with _verification_span("verification.prepare", attempt_id=str(attempt_id)):
+            preparation = await prepare_attempt(
+                attempt_id,
+                session_maker=_get_session_maker(),
+            )
+        with _verification_span(
+            "verification.start",
+            attempt_id=str(attempt_id),
+            user_id=preparation.attempt.user_id,
+        ):
+            pass
         return preparation.to_payload()
 
 
@@ -693,11 +703,15 @@ async def finalize_verification_attempt(
     """Compare-and-set the attempt's real outcome."""
     with _attached_invocation_context(context):
         run_result = VerificationRunResult.from_payload(_activity_payload(run_payload))
-        _set_attempt_span_attributes(run_result.attempt)
-        result = await finalize_attempt(
-            run_result,
-            session_maker=_get_session_maker(),
-        )
+        with _verification_span(
+            "verification.finalize",
+            attempt_id=str(run_result.attempt.id),
+            result=run_result,
+        ):
+            result = await finalize_attempt(
+                run_result,
+                session_maker=_get_session_maker(),
+            )
         state = result.state
         return _terminal_state_payload(state)
 
@@ -922,8 +936,6 @@ async def start_verification_attempt(
             return _json_response({"error": "invalid_attempt_id"}, status_code=400)
 
         instance_id = str(attempt_uuid)
-        _set_verification_span_attributes(attempt_id=instance_id)
-
         outcome = await _start_attempt_orchestration(
             client,
             attempt_uuid,

--- a/apps/verification-functions/tests/test_attempt_orchestrations.py
+++ b/apps/verification-functions/tests/test_attempt_orchestrations.py
@@ -107,6 +107,50 @@ def _sequence(calls: list[_RecordedCall]) -> list[tuple[str, str]]:
     return [call.as_tuple() for call in calls]
 
 
+class _Span:
+    def __init__(self) -> None:
+        self.attributes: dict[str, object] = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+    def is_recording(self) -> bool:
+        return True
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+
+class _Tracer:
+    def __init__(self) -> None:
+        self.spans: list[tuple[str, _Span]] = []
+
+    def start_as_current_span(self, name: str) -> _Span:
+        span = _Span()
+        self.spans.append((name, span))
+        return span
+
+
+def test_business_span_uses_canonical_identity_only() -> None:
+    tracer = _Tracer()
+    with patch.object(function_app.otel_trace, "get_tracer", return_value=tracer):
+        with function_app._verification_span(
+            "verification.start",
+            attempt_id="attempt-1",
+            user_id=42,
+        ):
+            pass
+
+    assert tracer.spans[0][0] == "verification.start"
+    assert tracer.spans[0][1].attributes == {
+        "verification.attempt.id": "attempt-1",
+        "enduser.id": "42",
+    }
+
+
 def _make_responder(
     prepared_payload: dict[str, object],
     *,
@@ -126,7 +170,7 @@ def _make_responder(
         if name == "ensure_grading_config":
             return {"valid": True, "missing_vars": []}
         if name == "run_llm_grading":
-            return {"decision": "pass"}
+            return {"outcome": "success", "decision": {"decision": "pass"}}
         if name == "apply_llm_grading_results":
             return {"status": "graded"}
         if name == "finalize_verification_attempt":
@@ -166,11 +210,122 @@ class TestAttemptOrchestration:
             ("activity_with_retry", "prepare_verification_attempt"),
             ("activity_with_retry", "execute_requirement_verification"),
             ("activity", "ensure_grading_config"),
-            ("activity_with_retry", "run_llm_grading"),
+            ("activity", "run_llm_grading"),
             ("activity", "apply_llm_grading_results"),
             ("activity_with_retry", "finalize_verification_attempt"),
         ]
         assert result == {"attempt_id": "a-1", "outcome": "succeeded"}
+
+    def test_llm_error_uses_safe_durable_payload_without_outer_retry(self) -> None:
+        payload = _prepared_payload(
+            journal_api_verifier_requirement(slug="journal"),
+            "https://github.com/alice/journal",
+        )
+        prepared = PreparedVerificationAttempt.from_payload(payload)
+        outcome = function_app._PreparedOutcome(
+            attempt_id="a-1",
+            prepared_payload=payload,
+            prepared_attempt=prepared,
+        )
+        ctx = _FakeOrchestrationContext({"attempt_id": "a-1"})
+
+        def responder(call: _RecordedCall) -> object:
+            if call.name == "ensure_grading_config":
+                return {"valid": True, "missing_vars": []}
+            if call.name == "run_llm_grading":
+                return {"outcome": "error", "error_type": "llm.rate_limit"}
+            if call.name == "llm_grading_failed":
+                return {"status": "unavailable"}
+            raise AssertionError(call.name)
+
+        calls, _ = _drive(
+            function_app._llm_grading_step(
+                ctx,
+                outcome,
+                {"grading_requests": [{"task": "a"}]},
+            ),
+            responder,
+        )
+
+        assert _sequence(calls) == [
+            ("activity", "ensure_grading_config"),
+            ("activity", "run_llm_grading"),
+            ("activity", "llm_grading_failed"),
+        ]
+        assert calls[-1].payload == {
+            "run_result": {"grading_requests": [{"task": "a"}]},
+            "error_type": "llm.rate_limit",
+            "outcome": "error",
+        }
+
+    def test_content_filter_is_not_retried(self) -> None:
+        payload = _prepared_payload(
+            journal_api_verifier_requirement(slug="journal"),
+            "https://github.com/alice/journal",
+        )
+        prepared = PreparedVerificationAttempt.from_payload(payload)
+        outcome = function_app._PreparedOutcome(
+            attempt_id="a-1",
+            prepared_payload=payload,
+            prepared_attempt=prepared,
+        )
+        ctx = _FakeOrchestrationContext({"attempt_id": "a-1"})
+
+        def responder(call: _RecordedCall) -> object:
+            if call.name == "ensure_grading_config":
+                return {"valid": True, "missing_vars": []}
+            if call.name == "run_llm_grading":
+                return {"outcome": "content_filtered"}
+            if call.name == "llm_grading_failed":
+                return {"status": "filtered"}
+            raise AssertionError(call.name)
+
+        calls, _ = _drive(
+            function_app._llm_grading_step(
+                ctx,
+                outcome,
+                {"grading_requests": [{"task": "a"}]},
+            ),
+            responder,
+        )
+        assert _sequence(calls) == [
+            ("activity", "ensure_grading_config"),
+            ("activity", "run_llm_grading"),
+            ("activity", "llm_grading_failed"),
+        ]
+        assert calls[-1].payload["outcome"] == "content_filtered"
+
+    def test_unknown_durable_error_category_is_normalized(self) -> None:
+        payload = _prepared_payload(
+            journal_api_verifier_requirement(slug="journal"),
+            "https://github.com/alice/journal",
+        )
+        prepared = PreparedVerificationAttempt.from_payload(payload)
+        outcome = function_app._PreparedOutcome(
+            attempt_id="a-1",
+            prepared_payload=payload,
+            prepared_attempt=prepared,
+        )
+        ctx = _FakeOrchestrationContext({"attempt_id": "a-1"})
+
+        def responder(call: _RecordedCall) -> object:
+            if call.name == "ensure_grading_config":
+                return {"valid": True, "missing_vars": []}
+            if call.name == "run_llm_grading":
+                return {"outcome": "error", "error_type": "provider raw detail"}
+            if call.name == "llm_grading_failed":
+                return {"status": "unavailable"}
+            raise AssertionError(call.name)
+
+        calls, _ = _drive(
+            function_app._llm_grading_step(
+                ctx,
+                outcome,
+                {"grading_requests": [{"task": "a"}]},
+            ),
+            responder,
+        )
+        assert calls[-1].payload["error_type"] == "llm.unknown"
 
     def test_prepare_failure_terminalizes(self) -> None:
         payload = _prepared_payload(

--- a/apps/verification-functions/tests/test_verification_agents.py
+++ b/apps/verification-functions/tests/test_verification_agents.py
@@ -10,7 +10,9 @@ import pytest
 import verification_agents
 from verification_agents import (
     ContentFilteredError,
+    LLMGradingError,
     _find_content_filter_error,
+    classify_llm_error,
     grade_evidence,
 )
 
@@ -69,9 +71,35 @@ def test_grade_evidence_translates_content_filter(monkeypatch) -> None:
         asyncio.run(grade_evidence("grade this"))
 
 
-def test_grade_evidence_reraises_other_errors(monkeypatch) -> None:
+def test_grade_evidence_maps_unknown_errors_without_raw_detail(monkeypatch) -> None:
     agent = _FakeAgent(RuntimeError("network down"))
     monkeypatch.setattr(verification_agents, "get_verification_grader", lambda: agent)
 
-    with pytest.raises(RuntimeError, match="network down"):
+    with pytest.raises(LLMGradingError) as caught:
         asyncio.run(grade_evidence("grade this"))
+    assert caught.value.error_type == "llm.unknown"
+    assert str(caught.value) == "llm.unknown"
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (
+            openai.APITimeoutError(
+                request=httpx.Request("POST", "https://example.com")
+            ),
+            "llm.timeout",
+        ),
+        (
+            openai.APIConnectionError(
+                request=httpx.Request("POST", "https://example.com")
+            ),
+            "llm.network",
+        ),
+    ],
+)
+def test_classify_llm_error_uses_safe_categories(
+    exc: BaseException,
+    expected: str,
+) -> None:
+    assert classify_llm_error(exc).error_type == expected

--- a/apps/verification-functions/verification_agents.py
+++ b/apps/verification-functions/verification_agents.py
@@ -14,19 +14,43 @@ from agent_framework.foundry import FoundryChatClient
 from agent_framework_openai import OpenAIChatOptions
 from azure.identity import DefaultAzureCredential, ManagedIdentityCredential
 from learn_to_cloud_shared.verification.tasks import LLMGradingDecision
+from pydantic import ValidationError
 
 CONTENT_FILTER_MARKER = "content_filter"
+LLM_OUTCOME_SUCCESS = "success"
+LLM_OUTCOME_CONTENT_FILTERED = "content_filtered"
+LLM_OUTCOME_ERROR = "error"
+
+LLM_CONFIGURATION = "llm.configuration"
+LLM_AUTHENTICATION = "llm.authentication"
+LLM_AUTHORIZATION = "llm.authorization"
+LLM_RATE_LIMIT = "llm.rate_limit"
+LLM_PROVIDER_UNAVAILABLE = "llm.provider_unavailable"
+LLM_NETWORK = "llm.network"
+LLM_TIMEOUT = "llm.timeout"
+LLM_RESPONSE_VALIDATION = "llm.response_validation"
+LLM_UNKNOWN = "llm.unknown"
+
+_LLM_CONFIGURATION_CODES = frozenset(
+    {"deployment_not_found", "invalid_deployment", "model_not_found"}
+)
 
 
 class ContentFilteredError(RuntimeError):
     """Raised when Azure's content safety filter blocks a grading request.
 
-    Azure's Prompt Shield scans the learner's free-text evidence and can
-    block the request (HTTP 400, code ``content_filter``). The blocking is
-    non-deterministic, so the orchestrator retries; this typed error keeps
-    telemetry meaningful and lets callers render an actionable message when
-    every retry is blocked.
+    Azure's Prompt Shield scans the learner's free-text evidence and can block
+    the request (HTTP 400, code ``content_filter``).
     """
+
+
+class LLMGradingError(Exception):
+    """A bounded operational grading failure safe for application telemetry."""
+
+    def __init__(self, error_type: str, http_status: int | None = None) -> None:
+        super().__init__(error_type)
+        self.error_type = error_type
+        self.http_status = http_status
 
 
 def _find_content_filter_error(exc: BaseException) -> openai.APIStatusError | None:
@@ -49,6 +73,54 @@ def _find_content_filter_error(exc: BaseException) -> openai.APIStatusError | No
                 return current
         current = current.__cause__ or current.__context__
     return None
+
+
+def _http_status(exc: BaseException) -> int | None:
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    return status if isinstance(status, int) else None
+
+
+def _provider_code(exc: BaseException) -> str | None:
+    code = getattr(exc, "code", None)
+    if isinstance(code, str):
+        return code
+    body = getattr(exc, "body", None)
+    if isinstance(body, Mapping):
+        body_code = body.get("code")
+        if isinstance(body_code, str):
+            return body_code
+    return None
+
+
+def classify_llm_error(exc: BaseException) -> LLMGradingError:
+    """Map provider failures to the fixed safe operational vocabulary."""
+    if isinstance(exc, (ValidationError, ValueError)):
+        return LLMGradingError(LLM_RESPONSE_VALIDATION)
+    if isinstance(exc, openai.APITimeoutError):
+        return LLMGradingError(LLM_TIMEOUT)
+    if isinstance(exc, openai.APIConnectionError):
+        return LLMGradingError(LLM_NETWORK)
+    if isinstance(exc, openai.AuthenticationError):
+        return LLMGradingError(LLM_AUTHENTICATION, _http_status(exc))
+    if isinstance(exc, openai.PermissionDeniedError):
+        return LLMGradingError(LLM_AUTHORIZATION, _http_status(exc))
+    if isinstance(exc, openai.RateLimitError):
+        return LLMGradingError(LLM_RATE_LIMIT, _http_status(exc))
+
+    status = _http_status(exc)
+    code = _provider_code(exc)
+    if code in _LLM_CONFIGURATION_CODES:
+        return LLMGradingError(LLM_CONFIGURATION, status)
+    if status == 401:
+        return LLMGradingError(LLM_AUTHENTICATION, status)
+    if status == 403:
+        return LLMGradingError(LLM_AUTHORIZATION, status)
+    if status == 429:
+        return LLMGradingError(LLM_RATE_LIMIT, status)
+    if status in {502, 503, 504}:
+        return LLMGradingError(LLM_PROVIDER_UNAVAILABLE, status)
+    return LLMGradingError(LLM_UNKNOWN, status)
 
 
 VERIFICATION_GRADER_AGENT_NAME = "VerificationGrader"
@@ -156,17 +228,17 @@ async def grade_evidence(message: str) -> LLMGradingDecision:
     except Exception as exc:
         filtered = _find_content_filter_error(exc)
         if filtered is not None:
-            raise ContentFilteredError(
-                f"{CONTENT_FILTER_MARKER}: Azure content safety blocked the "
-                "grading request"
-            ) from exc
-        raise
-    value = response.value
-    if isinstance(value, LLMGradingDecision):
-        return value
-    if isinstance(value, Mapping):
-        return LLMGradingDecision.model_validate(value)
-    text = response.text.strip()
-    if not text:
-        raise ValueError("VerificationGrader returned an empty grading decision")
-    return LLMGradingDecision.model_validate_json(text)
+            raise ContentFilteredError(CONTENT_FILTER_MARKER) from exc
+        raise classify_llm_error(exc) from exc
+    try:
+        value = response.value
+        if isinstance(value, LLMGradingDecision):
+            return value
+        if isinstance(value, Mapping):
+            return LLMGradingDecision.model_validate(value)
+        text = response.text.strip()
+        if not text:
+            raise ValueError
+        return LLMGradingDecision.model_validate_json(text)
+    except (ValidationError, ValueError) as exc:
+        raise LLMGradingError(LLM_RESPONSE_VALIDATION) from exc

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -240,6 +240,62 @@ Fix the underlying dependency or code path before asking the learner to retry.
 Do not rewrite a final outcome. Use established replay/reset procedures only
 after confirming they are safe for that attempt.
 
+## Verification LLM grading failures
+
+### Meaning
+
+The grader produced a bounded operational category after its OpenAI-compatible
+SDK retry budget was exhausted. Notifications contain only the category, count,
+15-minute window when applicable, and the safe query link. They never contain
+learner data, attempt IDs, provider request IDs, prompts, completions, response
+bodies, or raw exception text.
+
+`llm.configuration`, `llm.authentication`, `llm.authorization`,
+`llm.response_validation`, and `llm.unknown` page immediately after controlled
+production smoke validation. `llm.rate_limit`, `llm.provider_unavailable`,
+`llm.network`, and `llm.timeout` page only after three exhausted failures of
+the same category in 15 minutes. Content filtering is a completed learner
+rewrite path, not an error or alert.
+
+### First checks
+
+1. Start with the alert category and count; do not add customer information to
+   the query.
+2. Confirm the Functions revision and model deployment configuration.
+3. For transient categories, check Foundry and Azure service health, quotas,
+   outbound connectivity, and whether the count continues after the alert
+   window.
+
+### Detailed Kusto
+
+```kusto
+traces
+| where timestamp > ago(2h)
+| where message == "verification.llm_grading.failed"
+| extend ErrorType = tostring(customDimensions["error.type"])
+| where ErrorType in (
+    "llm.configuration", "llm.authentication", "llm.authorization",
+    "llm.rate_limit", "llm.provider_unavailable", "llm.network",
+    "llm.timeout", "llm.response_validation", "llm.unknown"
+)
+| summarize FailureCount = count() by ErrorType, bin(timestamp, 15m)
+| order by timestamp desc
+```
+
+For authorized support investigation, resolve a learner to an internal attempt
+ID through the production database, then use that opaque ID and a narrow time
+window to inspect correlated Application Insights spans. Do not add usernames,
+provider IDs, or raw exception data to the alert, query annotations, or incident
+notes.
+
+### Safe recovery
+
+Correct configuration, credentials, or permissions before retrying a controlled
+production smoke validation. For a response-validation category, inspect the
+deployed structured response contract and model deployment, not learner
+evidence. Keep the SDK's 10-minute timeout until 100 successful calls have been
+observed over 30 days; do not introduce a shorter deadline from an alert alone.
+
 ## Verification active beyond limit
 
 ### Meaning

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -261,6 +261,97 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
   }
 }
 
+# LLM grading emits only a fixed safe category in the application log. The alert
+# query deliberately excludes attempt, learner, provider-request, and error-detail
+# fields so the common alert payload is safe to deliver to the action group.
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_llm_immediate_failure" {
+  name                = "alert-ltc-verification-llm-immediate-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Alert immediately for non-retryable LLM grading failures. Query: https://portal.azure.com/#view/Microsoft_Azure_Monitoring_Logs/LogsBlade. Response guide: https://github.com/learntocloud/learn-to-cloud-app/blob/main/docs/runbooks/alerts.md#verification-llm-grading-failures"
+  severity            = 1
+  enabled             = true
+  tags                = local.tags
+
+  scopes                = [azurerm_application_insights.main.id]
+  evaluation_frequency  = "PT5M"
+  window_duration       = "PT5M"
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query                   = <<-QUERY
+      traces
+      | where message == "verification.llm_grading.failed"
+      | extend ErrorType = tostring(customDimensions["error.type"])
+      | where ErrorType in ("llm.configuration", "llm.authentication", "llm.authorization", "llm.response_validation", "llm.unknown")
+      | summarize FailureCount = count() by ErrorType, bin(timestamp, 5m)
+    QUERY
+    time_aggregation_method = "Maximum"
+    metric_measure_column   = "FailureCount"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+
+    dimension {
+      name     = "ErrorType"
+      operator = "Include"
+      values   = ["llm.configuration", "llm.authentication", "llm.authorization", "llm.response_validation", "llm.unknown"]
+    }
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.critical.id]
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_llm_transient_failure" {
+  name                = "alert-ltc-verification-llm-transient-${var.environment}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  description         = "Alert after three exhausted same-category transient LLM grading failures in 15 minutes. Query: https://portal.azure.com/#view/Microsoft_Azure_Monitoring_Logs/LogsBlade. Response guide: https://github.com/learntocloud/learn-to-cloud-app/blob/main/docs/runbooks/alerts.md#verification-llm-grading-failures"
+  severity            = 2
+  enabled             = true
+  tags                = local.tags
+
+  scopes                = [azurerm_application_insights.main.id]
+  evaluation_frequency  = "PT5M"
+  window_duration       = "PT15M"
+  target_resource_types = ["microsoft.insights/components"]
+
+  criteria {
+    query                   = <<-QUERY
+      traces
+      | where message == "verification.llm_grading.failed"
+      | extend ErrorType = tostring(customDimensions["error.type"])
+      | where ErrorType in ("llm.rate_limit", "llm.provider_unavailable", "llm.network", "llm.timeout")
+      | summarize FailureCount = count() by ErrorType
+    QUERY
+    time_aggregation_method = "Maximum"
+    metric_measure_column   = "FailureCount"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 3
+
+    dimension {
+      name     = "ErrorType"
+      operator = "Include"
+      values   = ["llm.rate_limit", "llm.provider_unavailable", "llm.network", "llm.timeout"]
+    }
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [azurerm_monitor_action_group.critical.id]
+  }
+}
+
 # Keep the existing Terraform address and Azure resource name to avoid an alert
 # replacement gap; the operator-facing description uses the clearer wording.
 resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_stuck" {

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/llm_grading.py
@@ -9,6 +9,8 @@ content-filter results.
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from learn_to_cloud_shared.verification.grading_requests import (
     LLMGradingDecisionPayload,
     LLMGradingRequest,
@@ -69,6 +71,8 @@ def apply_llm_grading_decisions(
 
 def llm_grading_unavailable_result(
     run_result: VerificationRunResult,
+    *,
+    error_type: str,
 ) -> VerificationRunResult:
     """Return a server-error validation result for LLM grader failures.
 
@@ -80,16 +84,15 @@ def llm_grading_unavailable_result(
             "is_valid": False,
             "message": (
                 "Automated grading is temporarily unavailable. This is a "
-                "problem on our end, not yours. Please report it so we can "
-                "fix it."
+                "problem on our end, not yours. Please submit again later."
             ),
             "verification_completed": False,
         }
     )
-    return VerificationRunResult(
-        attempt=run_result.attempt,
+    return replace(
+        run_result,
         validation_result=validation_result,
-        grading_disposition=run_result.grading_disposition,
+        llm_error_type=error_type,
     )
 
 
@@ -114,7 +117,7 @@ def llm_grading_content_filtered_result(
                 "or instructions, and submit again. If it keeps happening, "
                 "report it so we can help."
             ),
-            "verification_completed": False,
+            "verification_completed": True,
         }
     )
     return VerificationRunResult(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
@@ -48,6 +48,7 @@ from learn_to_cloud_shared.verification_attempt_snapshot import (
     validate_snapshot_integrity,
 )
 from learn_to_cloud_shared.verification_workflow import (
+    LLM_ERROR_TYPES,
     PreparedVerificationAttempt,
     VerificationRunResult,
     code_for_outcome,
@@ -172,7 +173,11 @@ async def finalize_verification_attempt(
     attempt = run_result.attempt
     validation_result = run_result.validation_result
     outcome = outcome_for_validation(validation_result)
-    error_code = code_for_outcome(outcome)
+    error_code = (
+        run_result.llm_error_type
+        if run_result.llm_error_type in LLM_ERROR_TYPES
+        else code_for_outcome(outcome)
+    )
     validation_message = (
         persisted_validation_message(validation_result.message)
         if not validation_result.is_valid

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_workflow.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_workflow.py
@@ -25,6 +25,19 @@ VERIFICATION_SUCCEEDED_CODE = "verification_succeeded"
 OUTCOME_SUCCEEDED = "succeeded"
 OUTCOME_FAILED = "failed"
 OUTCOME_SERVER_ERROR = "server_error"
+LLM_ERROR_TYPES = frozenset(
+    {
+        "llm.configuration",
+        "llm.authentication",
+        "llm.authorization",
+        "llm.rate_limit",
+        "llm.provider_unavailable",
+        "llm.network",
+        "llm.timeout",
+        "llm.response_validation",
+        "llm.unknown",
+    }
+)
 
 
 class GradingDisposition(StrEnum):
@@ -86,6 +99,7 @@ class VerificationRunResult:
     evidence: list[EvidenceBundle] | None = None
     grading_requests: list[LLMGradingRequest] | None = None
     grading_disposition: GradingDisposition | None = None
+    llm_error_type: str | None = None
 
     def to_payload(self) -> dict[str, object]:
         return {
@@ -106,6 +120,7 @@ class VerificationRunResult:
                 if self.grading_disposition is not None
                 else None
             ),
+            "llm_error_type": self.llm_error_type,
         }
 
     @classmethod
@@ -138,6 +153,11 @@ class VerificationRunResult:
             evidence=evidence,
             grading_requests=grading_requests,
             grading_disposition=grading_disposition,
+            llm_error_type=(
+                _expect_str(payload["llm_error_type"], "llm_error_type")
+                if payload.get("llm_error_type") is not None
+                else None
+            ),
         )
 
     def without_transport_data(self) -> VerificationRunResult:

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
@@ -166,4 +166,31 @@ async def test_terminalize_records_cancelled_outcome(
 
     assert result.won is True
     assert result.state.outcome == "cancelled"
-    assert result.state.error_code == "cancelled"
+
+
+async def test_finalize_persists_only_safe_llm_error_category(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    attempt = await _create_attempt(session_maker)
+    preparation = await prepare_verification_attempt(
+        attempt.id, session_maker=session_maker
+    )
+    run_result = VerificationRunResult(
+        attempt=preparation.attempt,
+        validation_result=ValidationResult(
+            is_valid=False,
+            message=(
+                "Automated grading is temporarily unavailable. "
+                "Please submit again later."
+            ),
+            verification_completed=False,
+        ),
+        llm_error_type="llm.provider_unavailable",
+    )
+
+    result = await finalize_verification_attempt(
+        run_result, session_maker=session_maker
+    )
+
+    assert result.state.error_code == "llm.provider_unavailable"
+    assert "provider" not in (result.state.validation_message or "").lower()

--- a/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_llm_grading.py
@@ -203,22 +203,25 @@ def test_phase5_holistic_review_enforces_strict_threshold():
 
 @pytest.mark.unit
 def test_llm_grading_unavailable_result_marks_server_error():
-    updated = llm_grading_unavailable_result(_run_result())
+    updated = llm_grading_unavailable_result(
+        _run_result(),
+        error_type="llm.provider_unavailable",
+    )
 
     assert updated.validation_result.is_valid is False
     assert updated.validation_result.verification_completed is False
     assert updated.validation_result.message == (
         "Automated grading is temporarily unavailable. This is a "
-        "problem on our end, not yours. Please report it so we can "
-        "fix it."
+        "problem on our end, not yours. Please submit again later."
     )
+    assert updated.llm_error_type == "llm.provider_unavailable"
 
 
 def test_llm_grading_content_filtered_result_asks_learner_to_rephrase():
     updated = llm_grading_content_filtered_result(_run_result())
 
     assert updated.validation_result.is_valid is False
-    assert updated.validation_result.verification_completed is False
+    assert updated.validation_result.verification_completed is True
     assert "content safety filter" in updated.validation_result.message
     assert "rewrite your answers" in updated.validation_result.message
 


### PR DESCRIPTION
## What changes

Implements #776 with safe, canonical verification telemetry and LLM failure handling.

- Records explicit verification business spans with only approved learner identity attributes.
- Maps LLM failures to fixed safe categories, preserves content filtering as a completed rewrite path, and removes the outer Durable retry layer.
- Persists only safe failure categories and adds immediate and transient monitoring alerts with an operator runbook.
- Adds focused coverage for telemetry, retries, safe payloads, and persistence.

## Validation

- `uv run poe check`
- Focused Functions and shared verification tests
- `terraform -chdir=infra fmt -check`
- `terraform -chdir=infra validate -no-color`