### PR TITLE
Fix missing verification activity spans

### DIFF
--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -230,13 +230,33 @@ def _set_verification_span_attributes(
         span.set_attribute("enduser.id", str(user_id))
 
 
+def _mark_verification_span_success(
+    span: Span,
+    result: VerificationRunResult,
+) -> None:
+    """Apply the completed verification result to its recording span."""
+    _set_verification_span_attributes(
+        span,
+        attempt_id=str(result.attempt.id),
+        requirement_slug=result.attempt.requirement.slug,
+        submission_type=result.attempt.requirement.submission_type.value,
+        status=outcome_for_validation(result.validation_result),
+        grading_disposition=(
+            result.grading_disposition.value
+            if result.grading_disposition is not None
+            else None
+        ),
+    )
+    if span.is_recording():
+        span.set_status(Status(StatusCode.OK))
+
+
 @contextmanager
 def _verification_span(
     name: str,
     *,
     attempt_id: str,
     user_id: int | None = None,
-    result: VerificationRunResult | None = None,
 ) -> Iterator[Span]:
     """Create an explicit business span rather than enriching framework spans."""
     if name not in _VERIFICATION_SPAN_NAMES:
@@ -246,16 +266,6 @@ def _verification_span(
             span,
             attempt_id=attempt_id,
             user_id=user_id,
-            requirement_slug=result.attempt.requirement.slug if result else None,
-            submission_type=(
-                result.attempt.requirement.submission_type.value if result else None
-            ),
-            status=outcome_for_validation(result.validation_result) if result else None,
-            grading_disposition=(
-                result.grading_disposition.value
-                if result and result.grading_disposition is not None
-                else None
-            ),
         )
         yield span
 
@@ -396,6 +406,7 @@ async def execute_requirement_verification(
                     "verification.completed",
                     run_result.validation_result.verification_completed,
                 )
+            _mark_verification_span_success(span, run_result)
             return run_result.to_payload()
 
 
@@ -706,12 +717,12 @@ async def finalize_verification_attempt(
         with _verification_span(
             "verification.finalize",
             attempt_id=str(run_result.attempt.id),
-            result=run_result,
-        ):
+        ) as span:
             result = await finalize_attempt(
                 run_result,
                 session_maker=_get_session_maker(),
             )
+            _mark_verification_span_success(span, run_result)
         state = result.state
         return _terminal_state_payload(state)
 

--- a/apps/verification-functions/pyproject.toml
+++ b/apps/verification-functions/pyproject.toml
@@ -25,6 +25,7 @@ learn-to-cloud-shared = { workspace = true }
 [dependency-groups]
 dev = [
     "pytest>=9.1.1",
+    "pytest-asyncio>=1.3.0",
     "ruff==0.15.12",
     "ty==0.0.34",
 ]

--- a/apps/verification-functions/tests/test_attempt_orchestrations.py
+++ b/apps/verification-functions/tests/test_attempt_orchestrations.py
@@ -8,8 +8,10 @@ Durable client and status are faked -- no live Azure calls.
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Generator
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -21,12 +23,17 @@ from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     AttemptStatusRow,
 )
 from learn_to_cloud_shared.submission_values import SubmittedValue
+from learn_to_cloud_shared.schemas import ValidationResult
 from learn_to_cloud_shared.testing.requirement_factories import (
     journal_api_verifier_requirement,
     repo_fork_requirement,
 )
 from learn_to_cloud_shared.verification_attempt_reconciler import stale_cutoff
-from learn_to_cloud_shared.verification_workflow import PreparedVerificationAttempt
+from learn_to_cloud_shared.verification_workflow import (
+    PreparedVerificationAttempt,
+    VerificationRunResult,
+)
+from opentelemetry.trace import Status, StatusCode
 
 
 # --------------------------------------------------------------------------- #
@@ -110,18 +117,26 @@ def _sequence(calls: list[_RecordedCall]) -> list[tuple[str, str]]:
 class _Span:
     def __init__(self) -> None:
         self.attributes: dict[str, object] = {}
+        self.status: Status | None = None
+        self.ended = False
+        self.exit_exception: BaseException | None = None
 
     def __enter__(self):
         return self
 
-    def __exit__(self, *_args) -> None:
-        return None
+    def __exit__(self, _exc_type, exc, _traceback) -> bool:
+        self.ended = True
+        self.exit_exception = exc
+        return False
 
     def is_recording(self) -> bool:
         return True
 
     def set_attribute(self, key: str, value: object) -> None:
         self.attributes[key] = value
+
+    def set_status(self, status: Status) -> None:
+        self.status = status
 
 
 class _Tracer:
@@ -148,6 +163,155 @@ def test_business_span_uses_canonical_identity_only() -> None:
     assert tracer.spans[0][1].attributes == {
         "verification.attempt.id": "attempt-1",
         "enduser.id": "42",
+    }
+
+
+def _successful_run_result() -> VerificationRunResult:
+    requirement = repo_fork_requirement(
+        slug="fork",
+        required_repo="owner/repo",
+    )
+    attempt = PreparedVerificationAttempt(
+        id=uuid4(),
+        user_id=1,
+        github_username="alice",
+        requirement=requirement,
+        submitted_value=SubmittedValue.from_raw(
+            requirement,
+            "https://github.com/alice/repo",
+        ),
+    )
+    return VerificationRunResult(
+        attempt=attempt,
+        validation_result=ValidationResult(
+            is_valid=True,
+            message="Verified.",
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("handler_name", "dependency_name", "span_name"),
+    [
+        (
+            "execute_requirement_verification",
+            "run_profile",
+            "verification.execute",
+        ),
+        (
+            "finalize_verification_attempt",
+            "finalize_attempt",
+            "verification.finalize",
+        ),
+    ],
+)
+def test_verification_activity_records_success_span(
+    handler_name: str,
+    dependency_name: str,
+    span_name: str,
+) -> None:
+    run_result = _successful_run_result()
+    tracer = _Tracer()
+    handler = getattr(function_app, handler_name).build()._func
+    dependency = AsyncMock(
+        return_value=(
+            run_result
+            if dependency_name == "run_profile"
+            else SimpleNamespace(
+                state=SimpleNamespace(
+                    id=run_result.attempt.id,
+                    outcome="succeeded",
+                    error_code=None,
+                    validation_message=None,
+                    terminal_source="orchestrator",
+                    completed_at=None,
+                )
+            )
+        )
+    )
+    payload = (
+        run_result.attempt.to_payload()
+        if handler_name == "execute_requirement_verification"
+        else run_result.to_payload()
+    )
+
+    with (
+        patch.object(function_app.otel_trace, "get_tracer", return_value=tracer),
+        patch.object(function_app, dependency_name, new=dependency),
+        patch.object(function_app, "_get_session_maker", return_value=object()),
+    ):
+        asyncio.run(handler(payload, None))
+
+    name, span = tracer.spans[0]
+    assert name == span_name
+    assert span.ended is True
+    assert span.exit_exception is None
+    expected_attributes = {
+        "verification.attempt.id": str(run_result.attempt.id),
+        "verification.requirement_slug": "fork",
+        "verification.submission_type": "repo_fork",
+        "verification.status": "succeeded",
+    }
+    if handler_name == "execute_requirement_verification":
+        expected_attributes.update(
+            {
+                "verification.is_valid": True,
+                "verification.completed": True,
+            }
+        )
+    assert span.attributes == expected_attributes
+    assert "enduser.id" not in span.attributes
+    assert span.status is not None
+    assert span.status.status_code is StatusCode.OK
+
+
+@pytest.mark.parametrize(
+    ("handler_name", "dependency_name", "span_name"),
+    [
+        (
+            "execute_requirement_verification",
+            "run_profile",
+            "verification.execute",
+        ),
+        (
+            "finalize_verification_attempt",
+            "finalize_attempt",
+            "verification.finalize",
+        ),
+    ],
+)
+def test_verification_activity_closes_span_when_dependency_raises(
+    handler_name: str,
+    dependency_name: str,
+    span_name: str,
+) -> None:
+    run_result = _successful_run_result()
+    tracer = _Tracer()
+    handler = getattr(function_app, handler_name).build()._func
+    payload = (
+        run_result.attempt.to_payload()
+        if handler_name == "execute_requirement_verification"
+        else run_result.to_payload()
+    )
+
+    with (
+        patch.object(function_app.otel_trace, "get_tracer", return_value=tracer),
+        patch.object(
+            function_app,
+            dependency_name,
+            new=AsyncMock(side_effect=RuntimeError("dependency failed")),
+        ),
+        patch.object(function_app, "_get_session_maker", return_value=object()),
+        pytest.raises(RuntimeError, match="dependency failed"),
+    ):
+        asyncio.run(handler(payload, None))
+
+    name, span = tracer.spans[0]
+    assert name == span_name
+    assert span.ended is True
+    assert isinstance(span.exit_exception, RuntimeError)
+    assert span.attributes == {
+        "verification.attempt.id": str(run_result.attempt.id),
     }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1008,6 +1008,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -1025,6 +1026,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = "==0.15.12" },
     { name = "ty", specifier = "==0.0.34" },
 ]


### PR DESCRIPTION
## What changes

Records completed success attributes and explicit OK status on `verification.execute` and `verification.finalize` spans after their activity work finishes. The focused regression coverage invokes the registered Azure Functions handlers for both success and exception lifecycles.

Adds `pytest-asyncio` to the Functions development dependencies so the existing async activity tests run in the repository quality gate.

## Validation

- `uv run poe check`
- `uv run --project apps/verification-functions pytest apps/verification-functions/tests/test_attempt_orchestrations.py -q`