### PR TITLE
Simplify Durable verification telemetry

### DIFF
--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -39,7 +39,6 @@ from learn_to_cloud_shared.verification_attempt_snapshot import (
     build_requirement_snapshot,
     compute_snapshot_hash,
 )
-from opentelemetry.propagate import inject
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
@@ -147,13 +146,6 @@ class VerificationAttemptSubmission:
     created: bool
 
 
-def _current_traceparent() -> str | None:
-    """Return the active W3C trace parent when telemetry is available."""
-    carrier: dict[str, str] = {}
-    inject(carrier)
-    return carrier.get("traceparent")
-
-
 async def _check_submission_preconditions(
     session_maker: async_sessionmaker[AsyncSession],
     user_id: int,
@@ -244,7 +236,6 @@ async def create_verification_attempt(
     requirement_snapshot = build_requirement_snapshot(ctx.requirement)
     requirement_snapshot_hash = compute_snapshot_hash(requirement_snapshot)
     attempt_id = uuid4()
-    traceparent = _current_traceparent()
 
     async with session_maker() as write_session:
         attempt_repo = VerificationAttemptRepository(write_session)
@@ -262,7 +253,6 @@ async def create_verification_attempt(
                 github_username_snapshot=github_username,
                 submitted_value=typed_value,
                 cloud_provider=None,
-                traceparent=traceparent,
             )
         except AttemptAlreadyValidatedError as exc:
             raise AlreadyValidatedError(

--- a/api/tests/services/test_submissions_service.py
+++ b/api/tests/services/test_submissions_service.py
@@ -415,12 +415,6 @@ class TestCreateVerificationAttempt:
                 "VerificationAttemptRepository",
                 autospec=True,
             ) as mock_attempt_repo_class,
-            patch(
-                "learn_to_cloud.services.submissions_service._current_traceparent",
-                return_value=(
-                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
-                ),
-            ),
         ):
             mock_attempt_repo = MagicMock()
             mock_attempt_repo.create_or_get_active = AsyncMock(
@@ -440,10 +434,9 @@ class TestCreateVerificationAttempt:
         assert result.attempt_id == mock_attempt.id
         assert result.created is True
         mock_attempt_repo.create_or_get_active.assert_awaited_once()
-        expected_traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
         attempt_create_await_args = mock_attempt_repo.create_or_get_active.await_args
         assert attempt_create_await_args is not None
-        assert attempt_create_await_args.kwargs["traceparent"] == expected_traceparent
+        assert "traceparent" not in attempt_create_await_args.kwargs
 
     @pytest.mark.asyncio
     async def test_returns_verification_attempt_submission(self):

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -18,8 +18,15 @@ import azure.durable_functions as df
 import azure.functions as func
 from learn_to_cloud_shared.core.config import get_worker_settings
 from learn_to_cloud_shared.core.database import create_engine, create_session_maker
-from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE, configure_logging
-from learn_to_cloud_shared.core.observability import configure_observability
+from learn_to_cloud_shared.core.logger import (
+    APP_LOGGER_NAMESPACE,
+    configure_logging,
+    remove_app_stdout_handler,
+)
+from learn_to_cloud_shared.core.observability import (
+    configure_dependency_instrumentation,
+    configure_otlp_observability,
+)
 from learn_to_cloud_shared.models import utcnow
 from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     AttemptTerminalState,
@@ -52,10 +59,8 @@ from learn_to_cloud_shared.verification_workflow import (
     LLM_ERROR_TYPES,
     PreparedVerificationAttempt,
     VerificationRunResult,
-    outcome_for_validation,
 )
 from opentelemetry import context as otel_context
-from opentelemetry import trace as otel_trace
 from opentelemetry.propagate import extract
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from verification_agents import (
@@ -67,34 +72,31 @@ from verification_agents import (
     grade_evidence,
     missing_grading_config,
 )
-from opentelemetry.trace import Span, Status, StatusCode
 
 
-def _telemetry_destination_configured() -> bool:
-    return bool(
-        os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
-        or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+def _python_worker_telemetry_enabled() -> bool:
+    return (
+        os.getenv("PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY", "").strip().lower()
+        == "true"
     )
 
 
-def _configure_function_logging() -> None:
-    if _telemetry_destination_configured():
-        root = logging.getLogger()
-        for handler in list(root.handlers):
-            root.removeHandler(handler)
-    else:
-        configure_logging()
-
+def _configure_function_telemetry() -> None:
+    configure_logging()
     logging.getLogger(APP_LOGGER_NAMESPACE).setLevel(logging.INFO)
     for logger_name in ("azure.functions", "proxy_worker"):
         logging.getLogger(logger_name).setLevel(logging.WARNING)
 
+    if _python_worker_telemetry_enabled():
+        configure_dependency_instrumentation()
+        return
+    if configure_otlp_observability():
+        remove_app_stdout_handler()
 
-_configure_function_logging()
+
+_configure_function_telemetry()
 
 logger = logging.getLogger(f"{APP_LOGGER_NAMESPACE}.verification_functions")
-
-configure_observability()
 
 app = df.DFApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
@@ -107,16 +109,6 @@ _TRANSIENT_RETRY_OPTIONS = df.RetryOptions(
     first_retry_interval_in_milliseconds=2000,
     max_number_of_attempts=3,
 )
-_VERIFICATION_SPAN_NAMES = frozenset(
-    {
-        "verification.start",
-        "verification.prepare",
-        "verification.execute",
-        "verification.grade",
-        "verification.finalize",
-    }
-)
-
 _engine: AsyncEngine | None = None
 _session_maker: async_sessionmaker[AsyncSession] | None = None
 
@@ -198,76 +190,6 @@ def _safe_llm_error_type(value: object) -> str:
     if isinstance(value, str) and value in LLM_ERROR_TYPES:
         return value
     return "llm.unknown"
-
-
-def _set_verification_span_attributes(
-    span: Span,
-    *,
-    attempt_id: str,
-    user_id: int | None = None,
-    phase_id: int | None = None,
-    requirement_slug: str | None = None,
-    submission_type: str | None = None,
-    status: str | None = None,
-    grading_disposition: str | None = None,
-) -> None:
-    """Add the approved verification attributes to one business span."""
-    if not span.is_recording():
-        return
-
-    span.set_attribute("verification.attempt.id", attempt_id)
-    if phase_id is not None:
-        span.set_attribute("verification.phase_id", phase_id)
-    if requirement_slug:
-        span.set_attribute("verification.requirement_slug", requirement_slug)
-    if submission_type:
-        span.set_attribute("verification.submission_type", submission_type)
-    if status:
-        span.set_attribute("verification.status", status)
-    if grading_disposition:
-        span.set_attribute("verification.grading_disposition", grading_disposition)
-    if user_id is not None:
-        span.set_attribute("enduser.id", str(user_id))
-
-
-def _mark_verification_span_success(
-    span: Span,
-    result: VerificationRunResult,
-) -> None:
-    """Apply the completed verification result to its recording span."""
-    _set_verification_span_attributes(
-        span,
-        attempt_id=str(result.attempt.id),
-        requirement_slug=result.attempt.requirement.slug,
-        submission_type=result.attempt.requirement.submission_type.value,
-        status=outcome_for_validation(result.validation_result),
-        grading_disposition=(
-            result.grading_disposition.value
-            if result.grading_disposition is not None
-            else None
-        ),
-    )
-    if span.is_recording():
-        span.set_status(Status(StatusCode.OK))
-
-
-@contextmanager
-def _verification_span(
-    name: str,
-    *,
-    attempt_id: str,
-    user_id: int | None = None,
-) -> Iterator[Span]:
-    """Create an explicit business span rather than enriching framework spans."""
-    if name not in _VERIFICATION_SPAN_NAMES:
-        raise ValueError(f"Unknown verification span name: {name}")
-    with otel_trace.get_tracer(__name__).start_as_current_span(name) as span:
-        _set_verification_span_attributes(
-            span,
-            attempt_id=attempt_id,
-            user_id=user_id,
-        )
-        yield span
 
 
 def _attempt_custom_status(
@@ -358,7 +280,7 @@ def _llm_grading_step(
     for request_payload in llm_requests:
         grading_result = yield context.call_activity(
             "run_llm_grading",
-            {"attempt_id": outcome.attempt_id, "request": request_payload},
+            {"request": request_payload},
         )
         result_payload = _activity_payload(grading_result)
         technical_outcome = result_payload.get("outcome")
@@ -394,20 +316,8 @@ async def execute_requirement_verification(
         prepared_attempt = PreparedVerificationAttempt.from_payload(
             _activity_payload(job_payload)
         )
-        with _verification_span(
-            "verification.execute", attempt_id=str(prepared_attempt.id)
-        ) as span:
-            run_result = await run_profile(prepared_attempt)
-            if span.is_recording():
-                span.set_attribute(
-                    "verification.is_valid", run_result.validation_result.is_valid
-                )
-                span.set_attribute(
-                    "verification.completed",
-                    run_result.validation_result.verification_completed,
-                )
-            _mark_verification_span_success(span, run_result)
-            return run_result.to_payload()
+        run_result = await run_profile(prepared_attempt)
+        return run_result.to_payload()
 
 
 @app.activity_trigger(input_name="payload")
@@ -434,37 +344,23 @@ async def run_llm_grading(
     """Call Foundry for one LLM grading request and return durable-safe JSON."""
     with _attached_invocation_context(context):
         data = _activity_payload(request_payload)
-        attempt_id = str(data["attempt_id"])
         request = LLMGradingRequest.model_validate(_activity_payload(data["request"]))
-        with _verification_span("verification.grade", attempt_id=attempt_id) as span:
-            try:
-                decision = await grade_evidence(request.message)
-            except LLMGradingError as exc:
-                if span.is_recording():
-                    span.set_attribute("verification.llm.outcome", LLM_OUTCOME_ERROR)
-                    span.set_attribute("error.type", exc.error_type)
-                    if exc.http_status is not None:
-                        span.set_attribute("http.response.status_code", exc.http_status)
-                    span.set_status(Status(StatusCode.ERROR))
-                return {
-                    "outcome": LLM_OUTCOME_ERROR,
-                    "error_type": exc.error_type,
-                }
-            except ContentFilteredError:
-                if span.is_recording():
-                    span.set_attribute(
-                        "verification.llm.outcome", LLM_OUTCOME_CONTENT_FILTERED
-                    )
-                return {"outcome": LLM_OUTCOME_CONTENT_FILTERED}
-            if span.is_recording():
-                span.set_attribute("verification.llm.outcome", LLM_OUTCOME_SUCCESS)
+        try:
+            decision = await grade_evidence(request.message)
+        except LLMGradingError as exc:
             return {
-                "outcome": LLM_OUTCOME_SUCCESS,
-                "decision": LLMGradingDecisionPayload(
-                    task=request.task,
-                    decision=decision,
-                ).model_dump(mode="json"),
+                "outcome": LLM_OUTCOME_ERROR,
+                "error_type": exc.error_type,
             }
+        except ContentFilteredError:
+            return {"outcome": LLM_OUTCOME_CONTENT_FILTERED}
+        return {
+            "outcome": LLM_OUTCOME_SUCCESS,
+            "decision": LLMGradingDecisionPayload(
+                task=request.task,
+                decision=decision,
+            ).model_dump(mode="json"),
+        }
 
 
 @app.activity_trigger(input_name="payload")
@@ -656,9 +552,8 @@ def _run_attempt_orchestration(context: df.DurableOrchestrationContext):
         failure_stage = "finalization"
         return (yield from _finalize_attempt_step(context, outcome, run_result))
     except Exception:
-        return (
-            yield from _terminalize_attempt_step(context, attempt_id, failure_stage)
-        )
+        yield from _terminalize_attempt_step(context, attempt_id, failure_stage)
+        raise
 
 
 @app.orchestration_trigger(context_name="context")
@@ -692,17 +587,10 @@ async def prepare_verification_attempt(
         if not isinstance(raw_attempt_id, str):
             raise TypeError("prepare_verification_attempt: missing attempt_id")
         attempt_id = UUID(raw_attempt_id)
-        with _verification_span("verification.prepare", attempt_id=str(attempt_id)):
-            preparation = await prepare_attempt(
-                attempt_id,
-                session_maker=_get_session_maker(),
-            )
-        with _verification_span(
-            "verification.start",
-            attempt_id=str(attempt_id),
-            user_id=preparation.attempt.user_id,
-        ):
-            pass
+        preparation = await prepare_attempt(
+            attempt_id,
+            session_maker=_get_session_maker(),
+        )
         return preparation.to_payload()
 
 
@@ -714,15 +602,10 @@ async def finalize_verification_attempt(
     """Compare-and-set the attempt's real outcome."""
     with _attached_invocation_context(context):
         run_result = VerificationRunResult.from_payload(_activity_payload(run_payload))
-        with _verification_span(
-            "verification.finalize",
-            attempt_id=str(run_result.attempt.id),
-        ) as span:
-            result = await finalize_attempt(
-                run_result,
-                session_maker=_get_session_maker(),
-            )
-            _mark_verification_span_success(span, run_result)
+        result = await finalize_attempt(
+            run_result,
+            session_maker=_get_session_maker(),
+        )
         state = result.state
         return _terminal_state_payload(state)
 
@@ -906,7 +789,7 @@ async def _start_attempt_orchestration(
 
         logger.error(
             "verification.attempt.start.failed",
-            extra={"attempt_id": instance_id, "error": str(exc)},
+            extra={"attempt_id": instance_id, "error_type": type(exc).__name__},
         )
         await terminalize_attempt(
             attempt_uuid,

--- a/apps/verification-functions/host.json
+++ b/apps/verification-functions/host.json
@@ -5,7 +5,7 @@
     "logLevel": {
       "Host.Triggers.DurableTask": "Warning",
       "DurableTask.Core": "Warning",
-      "DurableTask.DurableTaskScheduler": "Warning"
+      "DurableTask.AzureManagedBackend": "Warning"
     }
   },
   "extensions": {

--- a/apps/verification-functions/pyproject.toml
+++ b/apps/verification-functions/pyproject.toml
@@ -11,7 +11,6 @@ version = "0.1.0"
 description = "Durable Functions host for Learn to Cloud verification jobs"
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    "azure-monitor-opentelemetry>=1.8.9",
     "azure-functions>=2.2.0",
     "azure-functions-durable>=1.7.0",
     "learn-to-cloud-shared",

--- a/apps/verification-functions/tests/test_attempt_orchestrations.py
+++ b/apps/verification-functions/tests/test_attempt_orchestrations.py
@@ -8,10 +8,8 @@ Durable client and status are faked -- no live Azure calls.
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable, Generator
 from datetime import UTC, datetime, timedelta
-from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -23,7 +21,6 @@ from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     AttemptStatusRow,
 )
 from learn_to_cloud_shared.submission_values import SubmittedValue
-from learn_to_cloud_shared.schemas import ValidationResult
 from learn_to_cloud_shared.testing.requirement_factories import (
     journal_api_verifier_requirement,
     repo_fork_requirement,
@@ -31,9 +28,7 @@ from learn_to_cloud_shared.testing.requirement_factories import (
 from learn_to_cloud_shared.verification_attempt_reconciler import stale_cutoff
 from learn_to_cloud_shared.verification_workflow import (
     PreparedVerificationAttempt,
-    VerificationRunResult,
 )
-from opentelemetry.trace import Status, StatusCode
 
 
 # --------------------------------------------------------------------------- #
@@ -80,9 +75,12 @@ Responder = Callable[[_RecordedCall], object]
 
 
 def _drive(
-    gen: Generator[_RecordedCall, object, object], responder: Responder
+    gen: Generator[_RecordedCall, object, object],
+    responder: Responder,
+    *,
+    calls: list[_RecordedCall] | None = None,
 ) -> tuple[list[_RecordedCall], object]:
-    calls: list[_RecordedCall] = []
+    calls = calls if calls is not None else []
     try:
         call = next(gen)
     except StopIteration as stop:
@@ -112,207 +110,6 @@ def _prepared_payload(requirement: Any, value: str) -> dict[str, object]:
 
 def _sequence(calls: list[_RecordedCall]) -> list[tuple[str, str]]:
     return [call.as_tuple() for call in calls]
-
-
-class _Span:
-    def __init__(self) -> None:
-        self.attributes: dict[str, object] = {}
-        self.status: Status | None = None
-        self.ended = False
-        self.exit_exception: BaseException | None = None
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, _exc_type, exc, _traceback) -> bool:
-        self.ended = True
-        self.exit_exception = exc
-        return False
-
-    def is_recording(self) -> bool:
-        return True
-
-    def set_attribute(self, key: str, value: object) -> None:
-        self.attributes[key] = value
-
-    def set_status(self, status: Status) -> None:
-        self.status = status
-
-
-class _Tracer:
-    def __init__(self) -> None:
-        self.spans: list[tuple[str, _Span]] = []
-
-    def start_as_current_span(self, name: str) -> _Span:
-        span = _Span()
-        self.spans.append((name, span))
-        return span
-
-
-def test_business_span_uses_canonical_identity_only() -> None:
-    tracer = _Tracer()
-    with patch.object(function_app.otel_trace, "get_tracer", return_value=tracer):
-        with function_app._verification_span(
-            "verification.start",
-            attempt_id="attempt-1",
-            user_id=42,
-        ):
-            pass
-
-    assert tracer.spans[0][0] == "verification.start"
-    assert tracer.spans[0][1].attributes == {
-        "verification.attempt.id": "attempt-1",
-        "enduser.id": "42",
-    }
-
-
-def _successful_run_result() -> VerificationRunResult:
-    requirement = repo_fork_requirement(
-        slug="fork",
-        required_repo="owner/repo",
-    )
-    attempt = PreparedVerificationAttempt(
-        id=uuid4(),
-        user_id=1,
-        github_username="alice",
-        requirement=requirement,
-        submitted_value=SubmittedValue.from_raw(
-            requirement,
-            "https://github.com/alice/repo",
-        ),
-    )
-    return VerificationRunResult(
-        attempt=attempt,
-        validation_result=ValidationResult(
-            is_valid=True,
-            message="Verified.",
-        ),
-    )
-
-
-@pytest.mark.parametrize(
-    ("handler_name", "dependency_name", "span_name"),
-    [
-        (
-            "execute_requirement_verification",
-            "run_profile",
-            "verification.execute",
-        ),
-        (
-            "finalize_verification_attempt",
-            "finalize_attempt",
-            "verification.finalize",
-        ),
-    ],
-)
-def test_verification_activity_records_success_span(
-    handler_name: str,
-    dependency_name: str,
-    span_name: str,
-) -> None:
-    run_result = _successful_run_result()
-    tracer = _Tracer()
-    handler = getattr(function_app, handler_name).build()._func
-    dependency = AsyncMock(
-        return_value=(
-            run_result
-            if dependency_name == "run_profile"
-            else SimpleNamespace(
-                state=SimpleNamespace(
-                    id=run_result.attempt.id,
-                    outcome="succeeded",
-                    error_code=None,
-                    validation_message=None,
-                    terminal_source="orchestrator",
-                    completed_at=None,
-                )
-            )
-        )
-    )
-    payload = (
-        run_result.attempt.to_payload()
-        if handler_name == "execute_requirement_verification"
-        else run_result.to_payload()
-    )
-
-    with (
-        patch.object(function_app.otel_trace, "get_tracer", return_value=tracer),
-        patch.object(function_app, dependency_name, new=dependency),
-        patch.object(function_app, "_get_session_maker", return_value=object()),
-    ):
-        asyncio.run(handler(payload, None))
-
-    name, span = tracer.spans[0]
-    assert name == span_name
-    assert span.ended is True
-    assert span.exit_exception is None
-    expected_attributes = {
-        "verification.attempt.id": str(run_result.attempt.id),
-        "verification.requirement_slug": "fork",
-        "verification.submission_type": "repo_fork",
-        "verification.status": "succeeded",
-    }
-    if handler_name == "execute_requirement_verification":
-        expected_attributes.update(
-            {
-                "verification.is_valid": True,
-                "verification.completed": True,
-            }
-        )
-    assert span.attributes == expected_attributes
-    assert "enduser.id" not in span.attributes
-    assert span.status is not None
-    assert span.status.status_code is StatusCode.OK
-
-
-@pytest.mark.parametrize(
-    ("handler_name", "dependency_name", "span_name"),
-    [
-        (
-            "execute_requirement_verification",
-            "run_profile",
-            "verification.execute",
-        ),
-        (
-            "finalize_verification_attempt",
-            "finalize_attempt",
-            "verification.finalize",
-        ),
-    ],
-)
-def test_verification_activity_closes_span_when_dependency_raises(
-    handler_name: str,
-    dependency_name: str,
-    span_name: str,
-) -> None:
-    run_result = _successful_run_result()
-    tracer = _Tracer()
-    handler = getattr(function_app, handler_name).build()._func
-    payload = (
-        run_result.attempt.to_payload()
-        if handler_name == "execute_requirement_verification"
-        else run_result.to_payload()
-    )
-
-    with (
-        patch.object(function_app.otel_trace, "get_tracer", return_value=tracer),
-        patch.object(
-            function_app,
-            dependency_name,
-            new=AsyncMock(side_effect=RuntimeError("dependency failed")),
-        ),
-        patch.object(function_app, "_get_session_maker", return_value=object()),
-        pytest.raises(RuntimeError, match="dependency failed"),
-    ):
-        asyncio.run(handler(payload, None))
-
-    name, span = tracer.spans[0]
-    assert name == span_name
-    assert span.ended is True
-    assert isinstance(span.exit_exception, RuntimeError)
-    assert span.attributes == {
-        "verification.attempt.id": str(run_result.attempt.id),
-    }
 
 
 def _make_responder(
@@ -378,6 +175,7 @@ class TestAttemptOrchestration:
             ("activity", "apply_llm_grading_results"),
             ("activity_with_retry", "finalize_verification_attempt"),
         ]
+        assert calls[3].payload == {"request": {"task": "a"}}
         assert result == {"attempt_id": "a-1", "outcome": "succeeded"}
 
     def test_llm_error_uses_safe_durable_payload_without_outer_retry(self) -> None:
@@ -500,7 +298,13 @@ class TestAttemptOrchestration:
         responder = _make_responder(
             payload, fail_activity="prepare_verification_attempt"
         )
-        calls, result = _drive(function_app._run_attempt_orchestration(ctx), responder)
+        calls: list[_RecordedCall] = []
+        with pytest.raises(RuntimeError, match="activity failed"):
+            _drive(
+                function_app._run_attempt_orchestration(ctx),
+                responder,
+                calls=calls,
+            )
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_attempt"),
             ("activity_with_retry", "terminalize_verification_attempt"),
@@ -508,7 +312,6 @@ class TestAttemptOrchestration:
         assert calls[-1].payload["terminal_source"] == (
             "orchestrator_prepare_exception"
         )
-        assert result == {"attempt_id": "a-1", "outcome": "server_error"}
 
     def test_verify_failure_terminalizes(self) -> None:
         payload = _prepared_payload(
@@ -519,7 +322,13 @@ class TestAttemptOrchestration:
         responder = _make_responder(
             payload, fail_activity="execute_requirement_verification"
         )
-        calls, _ = _drive(function_app._run_attempt_orchestration(ctx), responder)
+        calls: list[_RecordedCall] = []
+        with pytest.raises(RuntimeError, match="activity failed"):
+            _drive(
+                function_app._run_attempt_orchestration(ctx),
+                responder,
+                calls=calls,
+            )
         assert _sequence(calls) == [
             ("activity_with_retry", "prepare_verification_attempt"),
             ("activity_with_retry", "execute_requirement_verification"),

--- a/apps/verification-functions/tests/test_startup_telemetry.py
+++ b/apps/verification-functions/tests/test_startup_telemetry.py
@@ -1,0 +1,121 @@
+"""Tests for Functions worker telemetry startup and trace correlation."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import function_app
+import pytest
+from learn_to_cloud_shared.core.logger import _APP_HANDLER_NAME
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_logger():
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    original_level = root.level
+    yield
+    root.handlers = original_handlers
+    root.setLevel(original_level)
+
+
+def _app_handlers() -> list[logging.Handler]:
+    return [
+        handler
+        for handler in logging.getLogger().handlers
+        if handler.get_name() == _APP_HANDLER_NAME
+    ]
+
+
+def test_worker_telemetry_skips_manual_setup_and_keeps_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY", "true")
+    monkeypatch.setenv(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING",
+        "InstrumentationKey=test",
+    )
+
+    with (
+        patch.object(function_app, "configure_otlp_observability") as configure_otlp,
+        patch.object(
+            function_app,
+            "configure_dependency_instrumentation",
+        ) as configure_dependencies,
+    ):
+        function_app._configure_function_telemetry()
+
+    configure_otlp.assert_not_called()
+    configure_dependencies.assert_called_once_with()
+    assert len(_app_handlers()) == 1
+
+
+def test_local_otlp_removes_only_app_stdout_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(
+        "PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY",
+        raising=False,
+    )
+    external_handler = logging.NullHandler()
+    logging.getLogger().addHandler(external_handler)
+
+    with patch.object(
+        function_app,
+        "configure_otlp_observability",
+        return_value=True,
+    ):
+        function_app._configure_function_telemetry()
+
+    assert _app_handlers() == []
+    assert external_handler in logging.getLogger().handlers
+
+
+def test_failed_local_setup_keeps_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(
+        "PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY",
+        raising=False,
+    )
+
+    with patch.object(
+        function_app,
+        "configure_otlp_observability",
+        return_value=False,
+    ):
+        function_app._configure_function_telemetry()
+
+    assert len(_app_handlers()) == 1
+
+
+def test_invocation_context_attaches_function_trace_context() -> None:
+    context = SimpleNamespace(
+        trace_context=SimpleNamespace(
+            trace_parent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+            trace_state="vendor=value",
+        )
+    )
+    extracted_context = object()
+    token = object()
+
+    with (
+        patch.object(
+            function_app, "extract", return_value=extracted_context
+        ) as extract,
+        patch.object(function_app.otel_context, "attach", return_value=token) as attach,
+        patch.object(function_app.otel_context, "detach") as detach,
+        function_app._attached_invocation_context(context),
+    ):
+        pass
+
+    extract.assert_called_once_with(
+        {
+            "traceparent": context.trace_context.trace_parent,
+            "tracestate": context.trace_context.trace_state,
+        }
+    )
+    attach.assert_called_once_with(extracted_context)
+    detach.assert_called_once_with(token)

--- a/infra/functions.tf
+++ b/infra/functions.tf
@@ -120,26 +120,28 @@ locals {
   # app configuration. Secrets stay as Key Vault references, which the app
   # resolves with keyVaultReferenceIdentity.
   verification_functions_app_settings = {
-    APPLICATIONINSIGHTS_CONNECTION_STRING    = azurerm_application_insights.main.connection_string
-    AZURE_CLIENT_ID                          = azurerm_user_assigned_identity.verification_functions.client_id
-    AzureWebJobsStorage__accountName         = azurerm_storage_account.verification_functions.name
-    AzureWebJobsStorage__credential          = "managedidentity"
-    AzureWebJobsStorage__clientId            = azurerm_user_assigned_identity.verification_functions.client_id
-    DATABASE__URL                            = ""
-    DATABASE__HOST                           = azurerm_postgresql_flexible_server.main.fqdn
-    DATABASE__NAME                           = azurerm_postgresql_flexible_server_database.main.name
-    DATABASE__USER                           = local.verification_functions_postgres_role
-    DURABLE_TASK_SCHEDULER_CONNECTION_STRING = "Endpoint=${azapi_resource.verification_scheduler.output.properties.endpoint};Authentication=ManagedIdentity;ClientID=${azurerm_user_assigned_identity.verification_functions.client_id}"
-    ENABLE_INSTRUMENTATION                   = "true"
-    FOUNDRY_MODEL_DEPLOYMENT_NAME            = azapi_resource.foundry_model_deployment.name
-    FOUNDRY_PROJECT_ENDPOINT                 = local.foundry_project_endpoint
-    GITHUB__TOKEN                            = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-token)"
-    LABS__VERIFICATION_SECRET                = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=labs-verification-secret)"
-    OAUTH__CLIENT_ID                         = var.github_client_id
-    OAUTH__CLIENT_SECRET                     = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-client-secret)"
-    OTEL_SERVICE_NAME                        = "learn-to-cloud-verification-functions"
-    SESSION__SECRET_KEY                      = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=session-secret-key)"
-    TASKHUB_NAME                             = local.verification_functions_task_hub_name
+    APPLICATIONINSIGHTS_CONNECTION_STRING       = azurerm_application_insights.main.connection_string
+    AZURE_CLIENT_ID                             = azurerm_user_assigned_identity.verification_functions.client_id
+    AzureWebJobsStorage__accountName            = azurerm_storage_account.verification_functions.name
+    AzureWebJobsStorage__credential             = "managedidentity"
+    AzureWebJobsStorage__clientId               = azurerm_user_assigned_identity.verification_functions.client_id
+    DATABASE__URL                               = ""
+    DATABASE__HOST                              = azurerm_postgresql_flexible_server.main.fqdn
+    DATABASE__NAME                              = azurerm_postgresql_flexible_server_database.main.name
+    DATABASE__USER                              = local.verification_functions_postgres_role
+    DURABLE_TASK_SCHEDULER_CONNECTION_STRING    = "Endpoint=${azapi_resource.verification_scheduler.output.properties.endpoint};Authentication=ManagedIdentity;ClientID=${azurerm_user_assigned_identity.verification_functions.client_id}"
+    ENABLE_INSTRUMENTATION                      = "true"
+    ENABLE_SENSITIVE_DATA                       = "false"
+    FOUNDRY_MODEL_DEPLOYMENT_NAME               = azapi_resource.foundry_model_deployment.name
+    FOUNDRY_PROJECT_ENDPOINT                    = local.foundry_project_endpoint
+    GITHUB__TOKEN                               = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-token)"
+    LABS__VERIFICATION_SECRET                   = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=labs-verification-secret)"
+    OAUTH__CLIENT_ID                            = var.github_client_id
+    OAUTH__CLIENT_SECRET                        = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=github-client-secret)"
+    OTEL_SERVICE_NAME                           = "learn-to-cloud-verification-functions"
+    PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY = "true"
+    SESSION__SECRET_KEY                         = "@Microsoft.KeyVault(VaultName=${azurerm_key_vault.main.name};SecretName=session-secret-key)"
+    TASKHUB_NAME                                = local.verification_functions_task_hub_name
   }
 }
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/logger.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/logger.py
@@ -63,3 +63,11 @@ def configure_logging() -> None:
         "azure.monitor.opentelemetry",
     ):
         logging.getLogger(name).setLevel(logging.WARNING)
+
+
+def remove_app_stdout_handler() -> None:
+    """Remove only the JSON stdout handler owned by this application."""
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if handler.get_name() == _APP_HANDLER_NAME:
+            root.removeHandler(handler)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
@@ -22,6 +22,8 @@ from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE
 logger = logging.getLogger(__name__)
 
 _telemetry_enabled: bool = False
+_dependency_tracing_enabled: bool = False
+_httpx_instrumented: bool = False
 
 
 def _build_resource() -> Resource:
@@ -147,14 +149,18 @@ def _configure_otlp(resource: Resource) -> None:
         raise ValueError(f"Unsupported OTLP protocol: {protocol}")
 
 
-def configure_observability() -> None:
-    """Set up the OTel telemetry pipeline."""
+def _configure_observability(*, allow_azure_monitor: bool) -> bool:
+    """Set up one telemetry pipeline and report whether it is active."""
     global _telemetry_enabled
 
     if _telemetry_enabled:
-        return
+        return True
 
-    conn_str = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
+    conn_str = (
+        os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
+        if allow_azure_monitor
+        else None
+    )
     otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
     resource = _build_resource()
 
@@ -168,18 +174,53 @@ def configure_observability() -> None:
                 "telemetry.configure.failed",
                 extra={"reason": "telemetry_destination_missing"},
             )
-            return
-    except Exception:
-        logger.exception("telemetry.configure.failed")
-        return
+            return False
+    except Exception as exc:
+        logger.error(
+            "telemetry.configure.failed",
+            extra={"error.type": type(exc).__name__},
+        )
+        return False
 
     _telemetry_enabled = True
-    HTTPXClientInstrumentor().instrument()
+    configure_dependency_instrumentation()
+    return True
+
+
+def configure_dependency_instrumentation() -> bool:
+    """Instrument dependencies against the active global tracer provider."""
+    global _dependency_tracing_enabled, _httpx_instrumented
+
+    _dependency_tracing_enabled = True
+    if _httpx_instrumented:
+        return True
+
+    try:
+        HTTPXClientInstrumentor().instrument()
+    except Exception as exc:
+        logger.warning(
+            "telemetry.httpx.failed",
+            extra={"error.type": type(exc).__name__},
+        )
+        return False
+
+    _httpx_instrumented = True
+    return True
+
+
+def configure_observability() -> bool:
+    """Set up manual Azure Monitor or local OTLP telemetry."""
+    return _configure_observability(allow_azure_monitor=True)
+
+
+def configure_otlp_observability() -> bool:
+    """Set up local OTLP without enabling Azure Monitor manually."""
+    return _configure_observability(allow_azure_monitor=False)
 
 
 def instrument_database(engine: Any) -> None:
     """Instrument a SQLAlchemy engine for database dependency spans."""
-    if not _telemetry_enabled:
+    if not _dependency_tracing_enabled:
         return
 
     from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
@@ -190,5 +231,5 @@ def instrument_database(engine: Any) -> None:
     except Exception as exc:
         logger.warning(
             "telemetry.sqlalchemy.failed",
-            extra={"error": str(exc)},
+            extra={"error.type": type(exc).__name__},
         )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -197,7 +197,7 @@ class VerificationAttempt(TimestampMixin, Base):
     submission_value_kind: Mapped[str] = mapped_column(Text, nullable=False)
     submitted_value: Mapped[str] = mapped_column(Text, nullable=False)
     cloud_provider: Mapped[str | None] = mapped_column(Text, nullable=True)
-    traceparent: Mapped[str | None] = mapped_column(Text, nullable=True)
+    traceparent: Mapped[str | None] = mapped_column(Text, nullable=True, deferred=True)
 
     outcome: Mapped[str | None] = mapped_column(Text, nullable=True)
     started_at: Mapped[datetime | None] = mapped_column(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     DateTime,
+    FetchedValue,
     ForeignKey,
     Index,
     String,
@@ -114,6 +115,7 @@ class VerificationAttempt(TimestampMixin, Base):
     """One verification attempt, keyed by its Durable instance UUID."""
 
     __tablename__ = "verification_attempts"
+    __mapper_args__ = {"eager_defaults": False}
     __table_args__ = (
         CheckConstraint(
             "submission_value_kind IN ('github_url', 'token', 'deployed_url', 'text')",
@@ -197,7 +199,12 @@ class VerificationAttempt(TimestampMixin, Base):
     submission_value_kind: Mapped[str] = mapped_column(Text, nullable=False)
     submitted_value: Mapped[str] = mapped_column(Text, nullable=False)
     cloud_provider: Mapped[str | None] = mapped_column(Text, nullable=True)
-    traceparent: Mapped[str | None] = mapped_column(Text, nullable=True, deferred=True)
+    traceparent: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        deferred=True,
+        server_default=FetchedValue(),
+    )
 
     outcome: Mapped[str | None] = mapped_column(Text, nullable=True)
     started_at: Mapped[datetime | None] = mapped_column(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
@@ -46,7 +46,6 @@ class AttemptPrepareState:
     submitted_value: str
     github_username_snapshot: str | None
     cloud_provider: str | None
-    traceparent: str | None
     outcome: str | None
     started_at: datetime | None
 
@@ -158,7 +157,6 @@ class VerificationAttemptRepository:
         github_username_snapshot: str | None,
         submitted_value: SubmittedValue,
         cloud_provider: str | None,
-        traceparent: str | None,
     ) -> tuple[VerificationAttempt, bool]:
         """Create a new attempt, or return the active one, under an advisory lock.
 
@@ -216,7 +214,6 @@ class VerificationAttemptRepository:
             payload_version=payload_version,
             github_username_snapshot=github_username_snapshot,
             cloud_provider=cloud_provider,
-            traceparent=traceparent,
             submission_value_kind=submitted_value.kind.value,
             submitted_value=submitted_value.as_text,
         )
@@ -256,7 +253,6 @@ class VerificationAttemptRepository:
                 VerificationAttempt.submitted_value,
                 VerificationAttempt.github_username_snapshot,
                 VerificationAttempt.cloud_provider,
-                VerificationAttempt.traceparent,
                 VerificationAttempt.outcome,
                 VerificationAttempt.started_at,
             ).where(VerificationAttempt.id == attempt_id)
@@ -276,7 +272,6 @@ class VerificationAttemptRepository:
             submitted_value=row.submitted_value,
             github_username_snapshot=row.github_username_snapshot,
             cloud_provider=row.cloud_provider,
-            traceparent=row.traceparent,
             outcome=row.outcome,
             started_at=row.started_at,
         )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ci_status.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ci_status.py
@@ -36,8 +36,6 @@ from learn_to_cloud_shared.verification.workflow_runs import (
     default_workflow_runs,
 )
 
-tracer = trace.get_tracer(__name__)
-
 # The workflow filename in learntocloud/journal-starter.
 _CI_WORKFLOW_FILE = "ci.yml"
 
@@ -62,93 +60,74 @@ async def verify_ci_status(
         ``main`` has ``conclusion == "success"``.
     """
     runs = runs or default_workflow_runs()
-    with tracer.start_as_current_span(
-        "ci_status_verification",
-        attributes={
-            "github.owner": owner,
-            "github.repo": repo,
-        },
-    ) as span:
-        # ── Fetch latest CI workflow run on main ──────────────────────────
-        try:
-            latest_run = await runs.latest_run(owner, repo, _CI_WORKFLOW_FILE)
-        except (
-            httpx.HTTPStatusError,
-            *RETRIABLE_EXCEPTIONS,
-        ) as e:
-            if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
-                span.set_attribute("verification.passed", False)
-                span.set_attribute("verification.reason", "workflow_not_found")
-                return ValidationResult(
-                    is_valid=False,
-                    message=(
-                        f"CI workflow not found in {owner}/{repo}. "
-                        "Make sure you've synced your fork with the upstream "
-                        "repository to get the .github/workflows/ci.yml file, "
-                        "and that GitHub Actions is enabled on your fork."
-                    ),
-                )
-            span.record_exception(e)
-            return github_error_to_result(
-                e,
-                event="ci_status.api_error",
-                context={"owner": owner, "repo": repo},
-            )
-
-        if latest_run is None:
-            span.set_attribute("verification.passed", False)
-            span.set_attribute("verification.reason", "no_runs")
+    span = trace.get_current_span()
+    try:
+        latest_run = await runs.latest_run(owner, repo, _CI_WORKFLOW_FILE)
+    except (
+        httpx.HTTPStatusError,
+        *RETRIABLE_EXCEPTIONS,
+    ) as e:
+        if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
+            span.set_attribute("http.response.status_code", 404)
+            span.add_event("ci.workflow_not_found")
             return ValidationResult(
                 is_valid=False,
                 message=(
-                    "No CI runs found on the main branch. "
-                    "Push a commit to main or merge a PR to trigger "
-                    "the CI workflow, then try again."
+                    f"CI workflow not found in {owner}/{repo}. "
+                    "Make sure you've synced your fork with the upstream "
+                    "repository to get the .github/workflows/ci.yml file, "
+                    "and that GitHub Actions is enabled on your fork."
                 ),
             )
+        return github_error_to_result(
+            e,
+            event="ci_status.api_error",
+        )
 
-        conclusion = latest_run.get("conclusion")
-        status = latest_run.get("status")
-        run_url = latest_run.get("html_url", "")
-        run_number = latest_run.get("run_number", 0)
-
-        span.set_attribute("ci.status", status or "unknown")
-        span.set_attribute("ci.conclusion", conclusion or "unknown")
-        span.set_attribute("ci.run_number", run_number)
-
-        # ── Still running ─────────────────────────────────────────────────
-        if status != "completed":
-            span.set_attribute("verification.passed", False)
-            span.set_attribute("verification.reason", "still_running")
-            return ValidationResult(
-                is_valid=False,
-                message=(
-                    f"CI run #{run_number} is still {status}. "
-                    "Wait for it to finish, then try again."
-                ),
-            )
-
-        # ── Completed — check conclusion ──────────────────────────────────
-        if conclusion == "success":
-            span.set_attribute("verification.passed", True)
-            return ValidationResult(
-                is_valid=True,
-                message=(
-                    f"CI tests are passing on main (run #{run_number}). "
-                    "Your Journal API implementation is verified!"
-                ),
-            )
-
-        # CI ran but did not succeed
-        span.set_attribute("verification.passed", False)
-        span.set_attribute("verification.reason", f"conclusion:{conclusion}")
+    if latest_run is None:
+        span.add_event("ci.no_runs")
         return ValidationResult(
             is_valid=False,
             message=(
-                f"CI run #{run_number} finished with "
-                f"conclusion '{conclusion}'. "
-                f"Check the run details at {run_url} "
-                "to see which tests are failing, fix them, "
-                "and push to main."
+                "No CI runs found on the main branch. "
+                "Push a commit to main or merge a PR to trigger "
+                "the CI workflow, then try again."
             ),
         )
+
+    conclusion = latest_run.get("conclusion")
+    status = latest_run.get("status")
+    run_url = latest_run.get("html_url", "")
+    run_number = latest_run.get("run_number", 0)
+
+    if status != "completed":
+        span.add_event("ci.still_running")
+        return ValidationResult(
+            is_valid=False,
+            message=(
+                f"CI run #{run_number} is still {status}. "
+                "Wait for it to finish, then try again."
+            ),
+        )
+
+    if conclusion == "success":
+        span.add_event("ci.passed")
+        return ValidationResult(
+            is_valid=True,
+            message=(
+                f"CI tests are passing on main (run #{run_number}). "
+                "Your Journal API implementation is verified!"
+            ),
+        )
+
+    span.add_event("ci.failed")
+    return ValidationResult(
+        is_valid=False,
+        message=(
+            f"CI run #{run_number} finished with "
+            f"conclusion '{conclusion}'. "
+            f"Check the run details at {run_url} "
+            "to see which tests are failing, fix them, "
+            "and push to main."
+        ),
+    )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/codeql_status.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/codeql_status.py
@@ -45,8 +45,6 @@ from learn_to_cloud_shared.verification.workflow_runs import (
     default_workflow_runs,
 )
 
-tracer = trace.get_tracer(__name__)
-
 # The committed workflow filename CodeQL advanced setup creates.
 CODEQL_WORKFLOW_FILE = "codeql.yml"
 
@@ -75,132 +73,111 @@ async def verify_codeql_status(
     """
     runs = runs or default_workflow_runs()
     ref = ref or default_repo_ref()
-    with tracer.start_as_current_span(
-        "codeql_status_verification",
-        attributes={"github.owner": owner, "github.repo": repo},
-    ) as span:
-        # ── Latest CodeQL workflow run on main ────────────────────────────
-        try:
-            latest_run = await runs.latest_run(owner, repo, CODEQL_WORKFLOW_FILE)
-        except (httpx.HTTPStatusError, *RETRIABLE_EXCEPTIONS) as e:
-            if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
-                span.set_attribute("verification.passed", False)
-                span.set_attribute("verification.reason", "workflow_not_found")
-                return ValidationResult(
-                    is_valid=False,
-                    message=(
-                        f"No CodeQL workflow found in {owner}/{repo}. "
-                        "Enable CodeQL 'advanced setup' and commit the workflow "
-                        "as .github/workflows/codeql.yml, and make sure GitHub "
-                        "Actions is enabled on your fork."
-                    ),
-                )
-            span.record_exception(e)
-            return github_error_to_result(
-                e,
-                event="codeql_status.api_error",
-                context={"owner": owner, "repo": repo},
-            )
-
-        if latest_run is None:
-            span.set_attribute("verification.passed", False)
-            span.set_attribute("verification.reason", "no_runs")
+    span = trace.get_current_span()
+    try:
+        latest_run = await runs.latest_run(owner, repo, CODEQL_WORKFLOW_FILE)
+    except (httpx.HTTPStatusError, *RETRIABLE_EXCEPTIONS) as e:
+        if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
+            span.set_attribute("http.response.status_code", 404)
+            span.add_event("codeql.workflow_not_found")
             return ValidationResult(
                 is_valid=False,
                 message=(
-                    "No CodeQL runs found on the main branch. "
-                    "Push a commit to main (or run the workflow) to trigger "
-                    "CodeQL, then try again."
+                    f"No CodeQL workflow found in {owner}/{repo}. "
+                    "Enable CodeQL 'advanced setup' and commit the workflow "
+                    "as .github/workflows/codeql.yml, and make sure GitHub "
+                    "Actions is enabled on your fork."
                 ),
             )
+        return github_error_to_result(
+            e,
+            event="codeql_status.api_error",
+        )
 
-        status = latest_run.get("status")
-        conclusion = latest_run.get("conclusion")
-        run_head_sha = latest_run.get("head_sha")
-        run_url = latest_run.get("html_url", "")
-        run_number = latest_run.get("run_number", 0)
-
-        span.set_attribute("codeql.status", status or "unknown")
-        span.set_attribute("codeql.conclusion", conclusion or "unknown")
-        span.set_attribute("codeql.run_number", run_number)
-
-        # ── Still running ─────────────────────────────────────────────────
-        if status != "completed":
-            span.set_attribute("verification.passed", False)
-            span.set_attribute("verification.reason", "still_running")
-            return ValidationResult(
-                is_valid=False,
-                message=(
-                    f"CodeQL run #{run_number} is still {status}. "
-                    "Wait for it to finish, then try again."
-                ),
-            )
-
-        # ── Completed but not successful ──────────────────────────────────
-        if conclusion != "success":
-            span.set_attribute("verification.passed", False)
-            span.set_attribute("verification.reason", f"conclusion:{conclusion}")
-            return ValidationResult(
-                is_valid=False,
-                message=(
-                    f"CodeQL run #{run_number} finished with "
-                    f"conclusion '{conclusion}'. "
-                    f"Check the run details at {run_url} "
-                    "to see what went wrong, fix it, and push to main."
-                ),
-            )
-
-        # ── Anchor to the current main HEAD (strict_head) ─────────────────
-        try:
-            head_sha = await ref.head_sha(owner, repo)
-        except (httpx.HTTPStatusError, *RETRIABLE_EXCEPTIONS) as e:
-            if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
-                span.set_attribute("verification.passed", False)
-                span.set_attribute("verification.reason", "branch_not_found")
-                return ValidationResult(
-                    is_valid=False,
-                    message=(
-                        f"Could not find the main branch of {owner}/{repo}. "
-                        "Make sure the repository is public and has a main branch."
-                    ),
-                )
-            span.record_exception(e)
-            return github_error_to_result(
-                e,
-                event="codeql_status.api_error",
-                context={"owner": owner, "repo": repo},
-            )
-
-        if not head_sha:
-            span.set_attribute("verification.passed", False)
-            span.set_attribute("verification.reason", "no_head_sha")
-            return ValidationResult(
-                is_valid=False,
-                message=(
-                    "Could not determine the latest commit on your main branch. "
-                    "Make sure the repository is public and try again."
-                ),
-            )
-
-        if run_head_sha != head_sha:
-            span.set_attribute("verification.passed", False)
-            span.set_attribute("verification.reason", "head_not_scanned")
-            return ValidationResult(
-                is_valid=False,
-                message=(
-                    "CodeQL passed, but not on your latest commit. Your most "
-                    "recent commit on main has not finished scanning yet. "
-                    "CodeQL runs a few minutes after you push; wait for the run "
-                    "on your latest commit, then try again."
-                ),
-            )
-
-        # ── Green on current HEAD ─────────────────────────────────────────
-        span.set_attribute("verification.passed", True)
+    if latest_run is None:
+        span.add_event("codeql.no_runs")
         return ValidationResult(
-            is_valid=True,
+            is_valid=False,
             message=(
-                f"CodeQL is passing on main (run #{run_number}) for your latest "
-                "commit. Security scanning is verified!"
+                "No CodeQL runs found on the main branch. "
+                "Push a commit to main (or run the workflow) to trigger "
+                "CodeQL, then try again."
             ),
         )
+
+    status = latest_run.get("status")
+    conclusion = latest_run.get("conclusion")
+    run_head_sha = latest_run.get("head_sha")
+    run_url = latest_run.get("html_url", "")
+    run_number = latest_run.get("run_number", 0)
+
+    if status != "completed":
+        span.add_event("codeql.still_running")
+        return ValidationResult(
+            is_valid=False,
+            message=(
+                f"CodeQL run #{run_number} is still {status}. "
+                "Wait for it to finish, then try again."
+            ),
+        )
+
+    if conclusion != "success":
+        span.add_event("codeql.failed")
+        return ValidationResult(
+            is_valid=False,
+            message=(
+                f"CodeQL run #{run_number} finished with "
+                f"conclusion '{conclusion}'. "
+                f"Check the run details at {run_url} "
+                "to see what went wrong, fix it, and push to main."
+            ),
+        )
+
+    try:
+        head_sha = await ref.head_sha(owner, repo)
+    except (httpx.HTTPStatusError, *RETRIABLE_EXCEPTIONS) as e:
+        if isinstance(e, httpx.HTTPStatusError) and e.response.status_code == 404:
+            span.set_attribute("http.response.status_code", 404)
+            span.add_event("codeql.branch_not_found")
+            return ValidationResult(
+                is_valid=False,
+                message=(
+                    f"Could not find the main branch of {owner}/{repo}. "
+                    "Make sure the repository is public and has a main branch."
+                ),
+            )
+        return github_error_to_result(
+            e,
+            event="codeql_status.api_error",
+        )
+
+    if not head_sha:
+        span.add_event("codeql.no_head_sha")
+        return ValidationResult(
+            is_valid=False,
+            message=(
+                "Could not determine the latest commit on your main branch. "
+                "Make sure the repository is public and try again."
+            ),
+        )
+
+    if run_head_sha != head_sha:
+        span.add_event("codeql.head_not_scanned")
+        return ValidationResult(
+            is_valid=False,
+            message=(
+                "CodeQL passed, but not on your latest commit. Your most "
+                "recent commit on main has not finished scanning yet. "
+                "CodeQL runs a few minutes after you push; wait for the run "
+                "on your latest commit, then try again."
+            ),
+        )
+
+    span.add_event("codeql.passed")
+    return ValidationResult(
+        is_valid=True,
+        message=(
+            f"CodeQL is passing on main (run #{run_number}) for your latest "
+            "commit. Security scanning is verified!"
+        ),
+    )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
@@ -125,7 +125,7 @@ async def _validate_url_target(url: str) -> str | None:
             span = trace.get_current_span()
             span.add_event(
                 "ssrf_blocked",
-                {"url": url, "reason": "private_ip_literal"},
+                {"verification.reason": "private_ip_literal"},
             )
             return "URL must point to a publicly accessible server."
         return None
@@ -150,7 +150,7 @@ async def _validate_url_target(url: str) -> str | None:
             span = trace.get_current_span()
             span.add_event(
                 "ssrf_blocked",
-                {"url": url, "resolved_ip": addr, "reason": "private_ip_resolved"},
+                {"verification.reason": "private_ip_resolved"},
             )
             return "URL must point to a publicly accessible server."
 
@@ -178,7 +178,7 @@ def _check_response_ip(response: httpx.Response) -> None:
         span = trace.get_current_span()
         span.add_event(
             "ssrf_blocked",
-            {"resolved_ip": addr, "reason": "dns_rebinding"},
+            {"verification.reason": "dns_rebinding"},
         )
         raise _SsrfError(addr)
 
@@ -438,7 +438,7 @@ async def _cleanup_challenge_entry(
         span = trace.get_current_span()
         span.add_event(
             "ssrf_blocked",
-            {"entry_id": entry_id, "reason": "cleanup_dns_rebinding"},
+            {"verification.reason": "cleanup_dns_rebinding"},
         )
     except Exception:
         pass  # best-effort cleanup
@@ -474,7 +474,7 @@ async def _post_challenge(
         httpx.RequestError,
         DeployedApiServerError,
     ) as exc:
-        return deployed_api_error_to_result(exc, entries_url, step="POST /entries")
+        return deployed_api_error_to_result(exc, step="POST /entries")
 
     if response.status_code == 404:
         return ValidationResult(
@@ -538,7 +538,7 @@ async def _verify_challenge(
         httpx.RequestError,
         DeployedApiServerError,
     ) as exc:
-        return deployed_api_error_to_result(exc, entries_url, step="GET /entries"), None
+        return deployed_api_error_to_result(exc, step="GET /entries"), None
 
     if response.status_code != 200:
         return (
@@ -587,7 +587,7 @@ async def _verify_challenge(
 
     if not nonce_found:
         span = trace.get_current_span()
-        span.add_event("challenge_failed", {"url": base_url})
+        span.add_event("challenge_failed")
         return (
             ValidationResult(
                 is_valid=False,
@@ -617,7 +617,6 @@ async def _verify_challenge(
 
     span = trace.get_current_span()
     span.set_attribute("deployed_api.challenge_verified", True)
-    span.set_attribute("deployed_api.entries_count", len(real_entries))
 
     count = len(real_entries)
     entry_word = "entry" if count == 1 else "entries"
@@ -654,7 +653,6 @@ async def _verify_analysis(base_url: str, entry_id: str) -> ValidationResult:
     ) as exc:
         return deployed_api_error_to_result(
             exc,
-            analysis_url,
             step="POST /entries/{id}/analyze",
         )
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/devops_analysis.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/devops_analysis.py
@@ -16,7 +16,6 @@ from learn_to_cloud_shared.verification.tasks.phase5 import (
     PHASE5_REQUIRED_PATHS,
 )
 
-_tracer = trace.get_tracer(__name__)
 _FILES_TASK_NAME = "Required DevOps Files"
 
 
@@ -92,21 +91,15 @@ async def verify_required_devops_files(
 ) -> ValidationResult:
     """Fetch the repository tree and run the required-files gate."""
     repo_files = repo_files or default_repo_files()
-    with _tracer.start_as_current_span(
-        "devops_required_files",
-        attributes={"github.owner": owner, "github.repo": repo},
-    ) as span:
-        try:
-            all_files = await repo_files.tree(owner, repo)
-        except (httpx.HTTPStatusError, *RETRIABLE_EXCEPTIONS) as exc:
-            span.record_exception(exc)
-            return github_error_to_result(
-                exc,
-                event="devops_analysis.repo_tree_error",
-                context={"owner": owner, "repo": repo},
-            )
+    span = trace.get_current_span()
+    try:
+        all_files = await repo_files.tree(owner, repo)
+    except (httpx.HTTPStatusError, *RETRIABLE_EXCEPTIONS) as exc:
+        return github_error_to_result(
+            exc,
+            event="devops_analysis.repo_tree_error",
+        )
 
-        result = check_required_devops_files(all_files)
-        span.set_attribute("verification.passed", result.is_valid)
-        span.set_attribute("repo.total_files", len(all_files))
-        return result
+    result = check_required_devops_files(all_files)
+    span.add_event("devops.required_files_checked")
+    return result

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -24,6 +24,7 @@ from typing import ClassVar
 
 import httpx
 from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
 from pydantic import Field, model_validator
 
 from learn_to_cloud_shared.github_target import GitHubTarget
@@ -404,7 +405,6 @@ async def _check_llm_rubric_review(
             result = github_error_to_result(
                 exc,
                 event="llm_rubric_review.repo_tree_error",
-                context={"owner": target.owner, "repo": target.repo},
             )
             return StepResult(
                 passed=False,
@@ -1073,6 +1073,42 @@ def _grading_disposition_for(
     raise ValueError("Rubric profile completed without a grading request")
 
 
+def _step_result_state(result: StepResult) -> str:
+    if result.passed:
+        return "passed"
+    if (
+        result.validation_result is not None
+        and not result.validation_result.verification_completed
+    ):
+        return "unavailable"
+    return "failed"
+
+
+async def _run_step(step: Step, context: StepContext) -> StepResult:
+    with _tracer.start_as_current_span(
+        "verification.step",
+        attributes={
+            "verification.check.name": step.params.check_name,
+            "verification.task.id": step.task_id,
+        },
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        try:
+            result = await check_for(step.params)(context, step.params)
+        except Exception as exc:
+            span.set_attribute("verification.step.result", "error")
+            span.set_attribute("error.type", type(exc).__name__)
+            span.set_status(Status(StatusCode.ERROR))
+            raise
+
+        result_state = _step_result_state(result)
+        span.set_attribute("verification.step.result", result_state)
+        if result_state == "unavailable":
+            span.set_status(Status(StatusCode.ERROR))
+        return result
+
+
 async def run_profile(
     job: PreparedVerificationAttempt,
     *,
@@ -1128,7 +1164,7 @@ async def run_profile(
     step_results: list[StepResult] = []
     bundles: list[EvidenceBundle] = []
     for step in steps:
-        result = await check_for(step.params)(context, step.params)
+        result = await _run_step(step, context)
         step_results.append(result)
         if result.evidence:
             bundles.extend(result.evidence)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/errors.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/errors.py
@@ -11,15 +11,13 @@ import logging
 
 import httpx
 from opentelemetry import metrics, trace
-from opentelemetry.util.types import AttributeValue
 
 from learn_to_cloud_shared.schemas import ValidationResult
 
 logger = logging.getLogger(__name__)
 
 _meter = metrics.get_meter("learn_to_cloud")
-# Low-cardinality counter for alerting on upstream/auth failures. Owner/repo
-# stay out of the metric (high cardinality); they live on the log and span.
+# Low-cardinality counter for alerting on upstream/auth failures.
 _GITHUB_API_ERROR_COUNTER = _meter.create_counter(
     name="github.api_error",
     description="GitHub API calls that failed with an auth, client, or server error",
@@ -84,7 +82,6 @@ def github_error_to_result(
     e: Exception,
     *,
     event: str,
-    context: dict[str, AttributeValue],
 ) -> ValidationResult:
     """Map GitHub API exceptions to a user-facing ValidationResult.
 
@@ -99,7 +96,6 @@ def github_error_to_result(
     Args:
         e: The caught exception.
         event: Structured log event name (e.g. ``"pr_verification.api_error"``).
-        context: Extra fields for structured logging (owner, repo, pr, etc.).
     """
     if isinstance(e, httpx.HTTPStatusError):
         status = e.response.status_code
@@ -109,8 +105,9 @@ def github_error_to_result(
                 message="Resource not found on GitHub. Check the URL and try again.",
             )
         span = trace.get_current_span()
-        span.add_event(event, {**context, "status": status})
-        logger.warning(event, extra={**context, "status": status})
+        span.set_attribute("http.response.status_code", status)
+        span.add_event(event, {"http.response.status_code": status})
+        logger.warning(event, extra={"http.response.status_code": status})
         _GITHUB_API_ERROR_COUNTER.add(1, {"status": status})
         return ValidationResult(
             is_valid=False,
@@ -119,9 +116,11 @@ def github_error_to_result(
         )
 
     # RETRIABLE_EXCEPTIONS (RequestError, TimeoutException, etc.)
+    error_type = type(e).__name__
     span = trace.get_current_span()
-    span.add_event(event, {**context, "error": str(e)})
-    logger.warning(event, extra={**context, "error": str(e)})
+    span.set_attribute("error.type", error_type)
+    span.add_event(event, {"error.type": error_type})
+    logger.warning(event, extra={"error.type": error_type})
     _GITHUB_API_ERROR_COUNTER.add(1, {"status": "transient"})
     return ValidationResult(
         is_valid=False,
@@ -132,7 +131,6 @@ def github_error_to_result(
 
 def deployed_api_error_to_result(
     exc: Exception,
-    entries_url: str,
     *,
     step: str = "",
 ) -> ValidationResult:
@@ -142,10 +140,14 @@ def deployed_api_error_to_result(
     and server errors that can occur during any HTTP call in the flow.
     """
     step_prefix = f"{step}: " if step else ""
+    span = trace.get_current_span()
 
     if isinstance(exc, httpx.TimeoutException):
-        span = trace.get_current_span()
-        span.add_event("deployed_api_timeout", {"url": entries_url, "step": step})
+        span.set_attribute("error.type", "timeout")
+        span.add_event(
+            "deployed_api_timeout",
+            {"error.type": "timeout", "verification.operation": step or "request"},
+        )
         return ValidationResult(
             is_valid=False,
             message=(
@@ -155,10 +157,13 @@ def deployed_api_error_to_result(
         )
 
     if isinstance(exc, DeployedApiServerError):
-        span = trace.get_current_span()
+        span.set_attribute("error.type", "server_error")
         span.add_event(
             "deployed_api_server_error",
-            {"url": entries_url, "error": str(exc), "step": step},
+            {
+                "error.type": "server_error",
+                "verification.operation": step or "request",
+            },
         )
         return ValidationResult(
             is_valid=False,
@@ -169,10 +174,13 @@ def deployed_api_error_to_result(
         )
 
     if isinstance(exc, httpx.RequestError):
-        span = trace.get_current_span()
+        span.set_attribute("error.type", "request_error")
         span.add_event(
             "deployed_api_request_error",
-            {"url": entries_url, "error": str(exc), "step": step},
+            {
+                "error.type": "request_error",
+                "verification.operation": step or "request",
+            },
         )
         return ValidationResult(
             is_valid=False,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ghcr.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ghcr.py
@@ -29,7 +29,6 @@ _MANIFEST_ACCEPT = ", ".join(
     )
 )
 _TASK_NAME = "Public GHCR Image"
-_tracer = trace.get_tracer(__name__)
 
 
 class _GhcrServerError(Exception):
@@ -141,67 +140,69 @@ async def verify_public_ghcr_image(
     image_ref = f"ghcr.io/{normalized_owner}/{GHCR_IMAGE_NAME}:{GHCR_IMAGE_TAG}"
     client = client or await _get_client()
 
-    with _tracer.start_as_current_span(
-        "ghcr_manifest_check",
-        attributes={"github.owner": normalized_owner, "container.image": image_ref},
-    ) as span:
-        try:
-            status = await _get_manifest_status(normalized_owner, client)
-        except RETRIABLE_EXCEPTIONS as exc:
-            span.record_exception(exc)
-            return _result(
-                passed=False,
-                message="Could not reach GHCR to verify the container image.",
-                feedback="GHCR was temporarily unavailable.",
-                next_steps="Try submitting again later.",
-                verification_completed=False,
-            )
-        except (_GhcrProtocolError, httpx.HTTPStatusError) as exc:
-            span.record_exception(exc)
-            return _result(
-                passed=False,
-                message="GHCR returned an unexpected response.",
-                feedback="Automated verification could not read the GHCR response.",
-                next_steps="Try submitting again later.",
-                verification_completed=False,
-            )
-
-        span.set_attribute("http.response.status_code", status)
-        if status == 200:
-            span.set_attribute("verification.passed", True)
-            return _result(
-                passed=True,
-                message="The public GHCR image is pullable.",
-                feedback=f"Verified public image {image_ref}.",
-            )
-        if status in {401, 403}:
-            span.set_attribute("verification.passed", False)
-            return _result(
-                passed=False,
-                message="The GHCR package is not publicly pullable.",
-                feedback=f"Could not pull {image_ref} without authentication.",
-                next_steps=(
-                    "Open the journal-api package settings on GitHub, change "
-                    "visibility to public, and submit again."
-                ),
-            )
-        if status == 404:
-            span.set_attribute("verification.passed", False)
-            return _result(
-                passed=False,
-                message="The required GHCR image was not found.",
-                feedback=f"No public manifest exists for {image_ref}.",
-                next_steps=(
-                    "Build and push journal-api with the latest tag to GHCR, "
-                    "make the package public, and submit again."
-                ),
-            )
-
-        span.set_attribute("verification.passed", False)
+    span = trace.get_current_span()
+    try:
+        status = await _get_manifest_status(normalized_owner, client)
+    except RETRIABLE_EXCEPTIONS:
+        span.set_attribute("error.type", "ghcr_unavailable")
+        span.add_event("ghcr.request_failed", {"error.type": "ghcr_unavailable"})
         return _result(
             passed=False,
-            message="GHCR returned an unexpected response.",
-            feedback=f"Automated verification received HTTP {status} from GHCR.",
+            message="Could not reach GHCR to verify the container image.",
+            feedback="GHCR was temporarily unavailable.",
             next_steps="Try submitting again later.",
             verification_completed=False,
         )
+    except (_GhcrProtocolError, httpx.HTTPStatusError):
+        span.set_attribute("error.type", "ghcr_response_error")
+        span.add_event(
+            "ghcr.request_failed",
+            {"error.type": "ghcr_response_error"},
+        )
+        return _result(
+            passed=False,
+            message="GHCR returned an unexpected response.",
+            feedback="Automated verification could not read the GHCR response.",
+            next_steps="Try submitting again later.",
+            verification_completed=False,
+        )
+
+    span.set_attribute("http.response.status_code", status)
+    if status == 200:
+        span.add_event("ghcr.image_available")
+        return _result(
+            passed=True,
+            message="The public GHCR image is pullable.",
+            feedback=f"Verified public image {image_ref}.",
+        )
+    if status in {401, 403}:
+        span.add_event("ghcr.image_private")
+        return _result(
+            passed=False,
+            message="The GHCR package is not publicly pullable.",
+            feedback=f"Could not pull {image_ref} without authentication.",
+            next_steps=(
+                "Open the journal-api package settings on GitHub, change "
+                "visibility to public, and submit again."
+            ),
+        )
+    if status == 404:
+        span.add_event("ghcr.image_not_found")
+        return _result(
+            passed=False,
+            message="The required GHCR image was not found.",
+            feedback=f"No public manifest exists for {image_ref}.",
+            next_steps=(
+                "Build and push journal-api with the latest tag to GHCR, "
+                "make the package public, and submit again."
+            ),
+        )
+
+    span.add_event("ghcr.unexpected_status")
+    return _result(
+        passed=False,
+        message="GHCR returned an unexpected response.",
+        feedback=f"Automated verification received HTTP {status} from GHCR.",
+        next_steps="Try submitting again later.",
+        verification_completed=False,
+    )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
@@ -59,20 +59,23 @@ async def check_github_url_exists(
         )
     except RETRIABLE_EXCEPTIONS as e:
         span = trace.get_current_span()
-        span.record_exception(e)
-        span.add_event("url_check_failed", {"url": url})
+        span.set_attribute("error.type", type(e).__name__)
+        span.add_event("url_check_failed", {"error.type": type(e).__name__})
         return ValidationResult(
             is_valid=False,
-            message=f"Request error: {e!s}",
+            message="Could not reach GitHub. Please try again later.",
             verification_completed=False,
         )
-    except Exception as e:
+    except Exception:
         span = trace.get_current_span()
-        span.record_exception(e)
-        span.add_event("url_check_unexpected_error", {"url": url})
+        span.set_attribute("error.type", "unexpected_exception")
+        span.add_event(
+            "url_check_unexpected_error",
+            {"error.type": "unexpected_exception"},
+        )
         return ValidationResult(
             is_valid=False,
-            message=f"Unexpected error: {e!s}",
+            message="GitHub verification could not be completed.",
             verification_completed=False,
         )
 
@@ -119,31 +122,28 @@ async def check_repo_is_fork_of(
         )
     except RETRIABLE_EXCEPTIONS as e:
         span = trace.get_current_span()
-        span.record_exception(e)
-        span.add_event("fork_check_failed", {"username": username, "repo": repo_name})
+        span.set_attribute("error.type", type(e).__name__)
+        span.add_event("fork_check_failed", {"error.type": type(e).__name__})
         return ValidationResult(
             is_valid=False,
-            message=f"Request error: {e!s}",
+            message="Could not reach GitHub. Please try again later.",
             verification_completed=False,
         )
     except httpx.HTTPStatusError as e:
-        span = trace.get_current_span()
-        span.record_exception(e)
         return github_error_to_result(
             e,
             event="fork_check.api_error",
-            context={"username": username, "repo": repo_name},
         )
-    except Exception as e:
+    except Exception:
         span = trace.get_current_span()
-        span.record_exception(e)
+        span.set_attribute("error.type", "unexpected_exception")
         span.add_event(
             "fork_check_unexpected_error",
-            {"username": username, "repo": repo_name},
+            {"error.type": "unexpected_exception"},
         )
         return ValidationResult(
             is_valid=False,
-            message=f"Unexpected error: {e!s}",
+            message="GitHub verification could not be completed.",
             verification_completed=False,
         )
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_files.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_files.py
@@ -67,10 +67,7 @@ class GitHubRepoFiles:
             response.raise_for_status()
         except httpx.HTTPStatusError:
             span = trace.get_current_span()
-            span.add_event(
-                "repo_file_fetch_failed",
-                {"owner": owner, "repo": repo, "path": path},
-            )
+            span.add_event("repo_file_fetch_failed")
             return None
         return response.text
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/token_base.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/token_base.py
@@ -132,9 +132,7 @@ def verify_lab_token(
             return _fail("Invalid timestamp. The token appears to be from the future.")
 
         span = trace.get_current_span()
-        span.set_attribute("token.verified", True)
-        span.set_attribute("token.display_name", display_name)
-        span.set_attribute("token.challenges", challenges)
+        span.add_event("token_verification_succeeded")
 
         return ValidationResult(
             is_valid=True,
@@ -145,9 +143,13 @@ def verify_lab_token(
             cloud_provider=cloud_provider,
         )
 
-    except Exception as e:
+    except Exception:
         span = trace.get_current_span()
-        span.record_exception(e)
+        span.set_attribute("error.type", "unexpected_exception")
+        span.add_event(
+            "token_verification_failed",
+            {"error.type": "unexpected_exception"},
+        )
         return _fail(
             "Token verification failed. Please try again or contact support.",
             completed=False,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification_attempt_executor.py
@@ -25,7 +25,6 @@ import logging
 from dataclasses import dataclass
 from uuid import UUID
 
-from opentelemetry import trace
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE
@@ -55,7 +54,6 @@ from learn_to_cloud_shared.verification_workflow import (
     outcome_for_validation,
 )
 
-tracer = trace.get_tracer(__name__)
 logger = logging.getLogger(f"{APP_LOGGER_NAMESPACE}.verification_attempt_executor")
 
 _SNAPSHOT_SOURCE_SUBMITTED = "submitted"
@@ -100,67 +98,62 @@ async def prepare_verification_attempt(
     :class:`AttemptPreparationError` subclass so the orchestrator converts it
     into a terminal outcome instead of leaving the attempt hanging.
     """
-    with tracer.start_as_current_span(
-        "prepare_verification_attempt",
-        attributes={"verification.attempt.id": str(attempt_id)},
-    ):
-        async with session_maker() as db:
-            repo = VerificationAttemptRepository(db)
-            state = await repo.get_prepare_state(attempt_id)
-            if state is None:
-                raise AttemptNotFoundError(str(attempt_id))
-            if state.outcome is not None:
-                raise AttemptNotActiveError(
-                    f"attempt {attempt_id} is already terminal ({state.outcome})"
-                )
-            if state.started_at is None:
-                marked_started = await repo.mark_started(attempt_id)
-                if not marked_started:
-                    current = await repo.get_status(attempt_id)
-                    if current is None:
-                        raise AttemptNotFoundError(str(attempt_id))
-                    if current.outcome is not None:
-                        raise AttemptNotActiveError(
-                            f"attempt {attempt_id} is already terminal "
-                            f"({current.outcome})"
-                        )
-                await db.commit()
-        if state.snapshot_source != _SNAPSHOT_SOURCE_SUBMITTED:
-            raise AttemptNotRunnableError(
-                f"attempt {attempt_id} has non-runnable snapshot_source "
-                f"{state.snapshot_source!r}"
+    async with session_maker() as db:
+        repo = VerificationAttemptRepository(db)
+        state = await repo.get_prepare_state(attempt_id)
+        if state is None:
+            raise AttemptNotFoundError(str(attempt_id))
+        if state.outcome is not None:
+            raise AttemptNotActiveError(
+                f"attempt {attempt_id} is already terminal ({state.outcome})"
             )
-        if state.payload_version not in SUPPORTED_PAYLOAD_VERSIONS:
-            raise AttemptSnapshotError(
-                f"attempt {attempt_id} payload_version "
-                f"{state.payload_version!r} is not supported"
-            )
-
-        requirement = validate_snapshot_integrity(
-            snapshot=state.requirement_snapshot,
-            snapshot_hash=state.requirement_snapshot_hash,
+        if state.started_at is None:
+            marked_started = await repo.mark_started(attempt_id)
+            if not marked_started:
+                current = await repo.get_status(attempt_id)
+                if current is None:
+                    raise AttemptNotFoundError(str(attempt_id))
+                if current.outcome is not None:
+                    raise AttemptNotActiveError(
+                        f"attempt {attempt_id} is already terminal ({current.outcome})"
+                    )
+            await db.commit()
+    if state.snapshot_source != _SNAPSHOT_SOURCE_SUBMITTED:
+        raise AttemptNotRunnableError(
+            f"attempt {attempt_id} has non-runnable snapshot_source "
+            f"{state.snapshot_source!r}"
+        )
+    if state.payload_version not in SUPPORTED_PAYLOAD_VERSIONS:
+        raise AttemptSnapshotError(
+            f"attempt {attempt_id} payload_version "
+            f"{state.payload_version!r} is not supported"
         )
 
-        expected_kind = value_kind_for_submission_type(requirement.submission_type)
-        if state.submission_value_kind != expected_kind.value:
-            raise AttemptSnapshotError(
-                f"attempt {attempt_id} submission_value_kind "
-                f"{state.submission_value_kind!r} does not match requirement "
-                f"kind {expected_kind.value!r}"
-            )
+    requirement = validate_snapshot_integrity(
+        snapshot=state.requirement_snapshot,
+        snapshot_hash=state.requirement_snapshot_hash,
+    )
 
-        submitted_value = SubmittedValue.from_kind_and_value(
-            state.submission_value_kind,
-            state.submitted_value,
+    expected_kind = value_kind_for_submission_type(requirement.submission_type)
+    if state.submission_value_kind != expected_kind.value:
+        raise AttemptSnapshotError(
+            f"attempt {attempt_id} submission_value_kind "
+            f"{state.submission_value_kind!r} does not match requirement "
+            f"kind {expected_kind.value!r}"
         )
-        attempt = PreparedVerificationAttempt(
-            id=state.id,
-            user_id=state.user_id,
-            github_username=state.github_username_snapshot,
-            requirement=requirement,
-            submitted_value=submitted_value,
-        )
-        return AttemptPreparation(attempt=attempt)
+
+    submitted_value = SubmittedValue.from_kind_and_value(
+        state.submission_value_kind,
+        state.submitted_value,
+    )
+    attempt = PreparedVerificationAttempt(
+        id=state.id,
+        user_id=state.user_id,
+        github_username=state.github_username_snapshot,
+        requirement=requirement,
+        submitted_value=submitted_value,
+    )
+    return AttemptPreparation(attempt=attempt)
 
 
 async def finalize_verification_attempt(
@@ -239,27 +232,19 @@ async def terminalize_unstarted_verification_attempt(
     session_maker: async_sessionmaker[AsyncSession],
 ) -> FinalizeResult | None:
     """Terminalize a pre-start failure without racing a Functions claim."""
-    with tracer.start_as_current_span(
-        "terminalize_unstarted_verification_attempt",
-        attributes={"verification.attempt.id": str(attempt_id)},
-    ) as span:
-        async with session_maker() as db:
-            result = await VerificationAttemptRepository(db).finalize_unstarted(
-                attempt_id,
-                outcome=VerificationAttemptOutcome.SERVER_ERROR,
-                error_code=error_code,
-                validation_message=validation_message,
-                terminal_source=terminal_source,
-            )
-            if result is not None:
-                await db.commit()
-        span.set_attribute(
-            "verification.finalization.disposition",
-            "claimed" if result is None else ("written" if result.won else "existing"),
+    async with session_maker() as db:
+        result = await VerificationAttemptRepository(db).finalize_unstarted(
+            attempt_id,
+            outcome=VerificationAttemptOutcome.SERVER_ERROR,
+            error_code=error_code,
+            validation_message=validation_message,
+            terminal_source=terminal_source,
         )
         if result is not None:
-            _log_canonical_completion(result)
-        return result
+            await db.commit()
+    if result is not None:
+        _log_canonical_completion(result)
+    return result
 
 
 async def _finalize(
@@ -272,31 +257,19 @@ async def _finalize(
     terminal_source: str,
     feedback_json: list[dict] | None,
 ) -> FinalizeResult:
-    with tracer.start_as_current_span(
-        "finalize_verification_attempt",
-        attributes={
-            "verification.attempt.id": str(attempt_id),
-            "verification.outcome": outcome.value,
-        },
-    ) as span:
-        async with session_maker() as db:
-            repo = VerificationAttemptRepository(db)
-            result = await repo.finalize(
-                attempt_id,
-                outcome=outcome,
-                error_code=error_code,
-                validation_message=validation_message,
-                terminal_source=terminal_source,
-                feedback_json=feedback_json,
-            )
-            await db.commit()
-        span.set_attribute(
-            "verification.finalization.disposition",
-            "written" if result.won else "existing",
+    async with session_maker() as db:
+        repo = VerificationAttemptRepository(db)
+        result = await repo.finalize(
+            attempt_id,
+            outcome=outcome,
+            error_code=error_code,
+            validation_message=validation_message,
+            terminal_source=terminal_source,
+            feedback_json=feedback_json,
         )
-        _log_canonical_completion(result)
-
-        return result
+        await db.commit()
+    _log_canonical_completion(result)
+    return result
 
 
 def _failure_stage(state: AttemptTerminalState) -> str | None:

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import event, func, select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from learn_to_cloud_shared.models import (
@@ -308,6 +308,42 @@ async def test_create_or_get_active_creates_new_attempt(
     assert attempt.id == attempt_id
     assert attempt.snapshot_source == "submitted"
     assert attempt.submitted_value == "https://github.com/attemptrepo/repo"
+
+
+async def test_create_or_get_active_omits_traceparent_from_insert(
+    test_engine: AsyncEngine,
+    session_maker: async_sessionmaker[AsyncSession],
+    user: int,
+) -> None:
+    statements: list[str] = []
+
+    def capture_insert(
+        _connection,
+        _cursor,
+        statement: str,
+        _parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        if statement.lstrip().startswith("INSERT INTO verification_attempts"):
+            statements.append(statement)
+
+    event.listen(test_engine.sync_engine, "before_cursor_execute", capture_insert)
+    try:
+        async with session_maker() as db:
+            await VerificationAttemptRepository(db).create_or_get_active(
+                **_create_kwargs(
+                    id=uuid4(),
+                    requirement_uuid=uuid4(),
+                    submitted_value=_submitted_value(),
+                )
+            )
+            await db.commit()
+    finally:
+        event.remove(test_engine.sync_engine, "before_cursor_execute", capture_insert)
+
+    assert len(statements) == 1
+    assert "traceparent" not in statements[0]
 
 
 async def test_create_or_get_active_returns_existing_active_attempt(

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
@@ -285,7 +285,6 @@ def _create_kwargs(
         "github_username_snapshot": "attemptrepo",
         "submitted_value": submitted_value,
         "cloud_provider": None,
-        "traceparent": None,
     }
 
 

--- a/packages/learn-to-cloud-shared/tests/test_logger.py
+++ b/packages/learn-to-cloud-shared/tests/test_logger.py
@@ -18,6 +18,7 @@ from learn_to_cloud_shared.core.logger import (
     _APP_HANDLER_NAME,
     _json_formatter,
     configure_logging,
+    remove_app_stdout_handler,
 )
 
 
@@ -233,6 +234,17 @@ class TestConfigureLogging:
 
         configure_logging()
 
+        assert external_handler in root.handlers
+
+    def test_remove_app_stdout_handler_preserves_external_handlers(self):
+        root = logging.getLogger()
+        external_handler = logging.NullHandler()
+        root.addHandler(external_handler)
+        configure_logging()
+
+        remove_app_stdout_handler()
+
+        assert _app_handlers() == []
         assert external_handler in root.handlers
 
     def test_child_logger_output_does_not_auto_add_github_username(self):

--- a/packages/learn-to-cloud-shared/tests/test_observability.py
+++ b/packages/learn-to-cloud-shared/tests/test_observability.py
@@ -12,10 +12,16 @@ from learn_to_cloud_shared.core import observability
 @pytest.fixture(autouse=True)
 def _restore_telemetry_flag():
     """Restore module telemetry state after each test."""
-    original = observability._telemetry_enabled
+    original_telemetry = observability._telemetry_enabled
+    original_dependencies = observability._dependency_tracing_enabled
+    original_httpx = observability._httpx_instrumented
     observability._telemetry_enabled = False
+    observability._dependency_tracing_enabled = False
+    observability._httpx_instrumented = False
     yield
-    observability._telemetry_enabled = original
+    observability._telemetry_enabled = original_telemetry
+    observability._dependency_tracing_enabled = original_dependencies
+    observability._httpx_instrumented = original_httpx
 
 
 @pytest.mark.unit
@@ -33,12 +39,13 @@ def test_configure_observability_logs_missing_destination(
         ) as httpx_instrumentor,
         caplog.at_level("ERROR"),
     ):
-        observability.configure_observability()
+        configured = observability.configure_observability()
 
     azure_monitor.assert_not_called()
     otlp.assert_not_called()
     httpx_instrumentor.assert_not_called()
     assert observability._telemetry_enabled is False
+    assert configured is False
     records = [
         record
         for record in caplog.records
@@ -118,12 +125,13 @@ def test_configure_observability_uses_azure_monitor_when_connection_string_set()
             "learn_to_cloud_shared.core.observability.HTTPXClientInstrumentor"
         ) as httpx_instrumentor,
     ):
-        observability.configure_observability()
+        configured = observability.configure_observability()
 
     azure_monitor.assert_called_once_with(resource)
     otlp.assert_not_called()
     httpx_instrumentor.return_value.instrument.assert_called_once_with()
     assert observability._telemetry_enabled is True
+    assert configured is True
 
 
 @pytest.mark.unit
@@ -147,12 +155,45 @@ def test_configure_observability_uses_otlp_when_endpoint_set():
             "learn_to_cloud_shared.core.observability.HTTPXClientInstrumentor"
         ) as httpx_instrumentor,
     ):
-        observability.configure_observability()
+        configured = observability.configure_observability()
 
     azure_monitor.assert_not_called()
     otlp.assert_called_once_with(resource)
     httpx_instrumentor.return_value.instrument.assert_called_once_with()
     assert observability._telemetry_enabled is True
+    assert configured is True
+
+
+@pytest.mark.unit
+def test_configure_otlp_observability_never_uses_azure_monitor():
+    resource = MagicMock(spec=Resource)
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+            },
+            clear=True,
+        ),
+        patch(
+            "learn_to_cloud_shared.core.observability._build_resource",
+            return_value=resource,
+        ),
+        patch(
+            "learn_to_cloud_shared.core.observability._configure_azure_monitor"
+        ) as azure_monitor,
+        patch("learn_to_cloud_shared.core.observability._configure_otlp") as otlp,
+        patch(
+            "learn_to_cloud_shared.core.observability.HTTPXClientInstrumentor"
+        ) as httpx_instrumentor,
+    ):
+        configured = observability.configure_otlp_observability()
+
+    assert configured is True
+    azure_monitor.assert_not_called()
+    otlp.assert_called_once_with(resource)
+    httpx_instrumentor.return_value.instrument.assert_called_once_with()
 
 
 @pytest.mark.unit
@@ -174,18 +215,20 @@ def test_configure_observability_azure_failure_is_nonfatal_by_default(
         ) as httpx_instrumentor,
         caplog.at_level("ERROR"),
     ):
-        observability.configure_observability()
+        configured = observability.configure_observability()
 
     azure_monitor.assert_called_once()
     httpx_instrumentor.assert_not_called()
     assert observability._telemetry_enabled is False
+    assert configured is False
     records = [
         record
         for record in caplog.records
         if record.message == "telemetry.configure.failed"
     ]
     assert len(records) == 1
-    assert records[0].exc_info is not None
+    assert records[0].exc_info is None
+    assert records[0].__dict__["error.type"] == "RuntimeError"
 
 
 @pytest.mark.unit
@@ -207,17 +250,19 @@ def test_configure_observability_otlp_failure_is_nonfatal(
         ) as httpx_instrumentor,
         caplog.at_level("ERROR"),
     ):
-        observability.configure_observability()
+        configured = observability.configure_observability()
 
     httpx_instrumentor.assert_not_called()
     assert observability._telemetry_enabled is False
+    assert configured is False
     records = [
         record
         for record in caplog.records
         if record.message == "telemetry.configure.failed"
     ]
     assert len(records) == 1
-    assert records[0].exc_info is not None
+    assert records[0].exc_info is None
+    assert records[0].__dict__["error.type"] == "RuntimeError"
 
 
 @pytest.mark.unit
@@ -232,10 +277,11 @@ def test_configure_observability_noops_when_already_enabled():
             "learn_to_cloud_shared.core.observability.HTTPXClientInstrumentor"
         ) as httpx_instrumentor,
     ):
-        observability.configure_observability()
+        configured = observability.configure_observability()
 
     azure_monitor.assert_not_called()
     httpx_instrumentor.assert_not_called()
+    assert configured is True
 
 
 @pytest.mark.unit
@@ -394,7 +440,7 @@ def test_instrument_database_noops_when_telemetry_disabled():
     with patch(
         "opentelemetry.instrumentation.sqlalchemy.SQLAlchemyInstrumentor"
     ) as instrumentor_cls:
-        observability._telemetry_enabled = False
+        observability._dependency_tracing_enabled = False
 
         observability.instrument_database(engine)
 
@@ -409,7 +455,7 @@ def test_instrument_database_uses_sync_engine():
     with patch(
         "opentelemetry.instrumentation.sqlalchemy.SQLAlchemyInstrumentor"
     ) as instrumentor_cls:
-        observability._telemetry_enabled = True
+        observability._dependency_tracing_enabled = True
 
         observability.instrument_database(engine)
 

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -3,6 +3,7 @@
 from uuid import uuid4
 
 import pytest
+from opentelemetry.trace import Status, StatusCode
 
 from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
 from learn_to_cloud_shared.submission_values import SubmittedValue
@@ -63,6 +64,39 @@ class UnknownCheckParams(CheckParams):
     check_name = "does-not-exist"
 
 
+class ExplodingCheckParams(CheckParams):
+    check_name = "exploding"
+
+
+class _Span:
+    def __init__(self) -> None:
+        self.attributes: dict[str, object] = {}
+        self.status: Status | None = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc, _traceback) -> bool:
+        return False
+
+    def set_attribute(self, key: str, value: object) -> None:
+        self.attributes[key] = value
+
+    def set_status(self, status: Status) -> None:
+        self.status = status
+
+
+class _Tracer:
+    def __init__(self) -> None:
+        self.spans: list[tuple[str, _Span, dict[str, object]]] = []
+
+    def start_as_current_span(self, name: str, **kwargs) -> _Span:
+        span = _Span()
+        span.attributes.update(kwargs.get("attributes", {}))
+        self.spans.append((name, span, kwargs))
+        return span
+
+
 def _job(requirement=None) -> PreparedVerificationAttempt:
     requirement = requirement or repo_fork_requirement()
     return PreparedVerificationAttempt(
@@ -105,6 +139,8 @@ async def test_run_profile_uses_declared_steps(monkeypatch):
         "profile_for",
         lambda _t: _profile(_step(PassingCheckParams(), "gate")),
     )
+    tracer = _Tracer()
+    monkeypatch.setattr(engine_module, "_tracer", tracer)
 
     result = await run_profile(_job())
 
@@ -113,6 +149,44 @@ async def test_run_profile_uses_declared_steps(monkeypatch):
         TaskResult(task_name="Gate", passed=True, feedback="ok")
     ]
     assert result.evidence == [bundle]
+    assert len(tracer.spans) == 1
+    name, span, options = tracer.spans[0]
+    assert name == "verification.step"
+    assert span.attributes == {
+        "verification.check.name": "test_gate_pass",
+        "verification.task.id": "gate",
+        "verification.step.result": "passed",
+    }
+    assert options["record_exception"] is False
+    assert options["set_status_on_exception"] is False
+
+
+@pytest.mark.asyncio
+async def test_step_span_records_error_type_without_exception_details(monkeypatch):
+    @register_check(ExplodingCheckParams)
+    async def _explode(context: StepContext, params) -> StepResult:
+        raise RuntimeError("sensitive failure details")
+
+    monkeypatch.setattr(
+        engine_module,
+        "profile_for",
+        lambda _t: _profile(_step(ExplodingCheckParams(), "explode")),
+    )
+    tracer = _Tracer()
+    monkeypatch.setattr(engine_module, "_tracer", tracer)
+
+    with pytest.raises(RuntimeError, match="sensitive failure details"):
+        await run_profile(_job())
+
+    _, span, _ = tracer.spans[0]
+    assert span.attributes == {
+        "verification.check.name": "exploding",
+        "verification.task.id": "explode",
+        "verification.step.result": "error",
+        "error.type": "RuntimeError",
+    }
+    assert span.status is not None
+    assert span.status.status_code is StatusCode.ERROR
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1001,7 +1001,6 @@ dependencies = [
     { name = "azure-functions" },
     { name = "azure-functions-durable" },
     { name = "azure-identity" },
-    { name = "azure-monitor-opentelemetry" },
     { name = "learn-to-cloud-shared" },
 ]
 
@@ -1019,7 +1018,6 @@ requires-dist = [
     { name = "azure-functions", specifier = ">=2.2.0" },
     { name = "azure-functions-durable", specifier = ">=1.7.0" },
     { name = "azure-identity", specifier = ">=1.25.3" },
-    { name = "azure-monitor-opentelemetry", specifier = ">=1.8.9" },
     { name = "learn-to-cloud-shared", editable = "packages/learn-to-cloud-shared" },
 ]
 


### PR DESCRIPTION
## Summary

Azure Durable Task Scheduler now owns orchestration and activity lifecycle spans, while Agent Framework owns `invoke_agent` and `chat` spans. Application telemetry is limited to one bounded `verification.step` span per internal engine step, dependency spans, and the structured business logs used by alerts.

This removes duplicate activity and persistence spans, keeps HTTPX and SQLAlchemy dependency instrumentation without installing a second Functions exporter, uses the documented Python Functions Azure Monitor worker path, corrects the Durable backend log category, and keeps Agent Framework sensitive-data capture disabled. Unexpected orchestration failures still persist the authoritative database result, then rethrow so Durable records a failed orchestration.

New attempts no longer capture or write `traceparent`; real HTTP and Function invocation propagation remains intact. The legacy column stays as a deferred, server-generated compatibility mapping in this layer so the follow-up contract migration can run safely.

## Terraform plan

The Azure-backed plan contains 0 creates, 2 in-place updates, and 0 destroys or replacements. The Function App gains the worker telemetry and sensitive-data settings. The API Container App only refreshes its existing Function URL reference because the Function resource output becomes unknown during the in-place update; no identity, authentication, network, or data resource changes are planned.

## Rollout

Merge and deploy this PR first. After its production deployment succeeds, merge #781 to remove the compatibility mapping and database column.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.

This PR intentionally contains no schema drop; that deployment boundary is isolated in #781.