### PR TITLE
Drop unused verification attempt traceparent

### DIFF
--- a/api/alembic/versions/0057_drop_verification_attempt_traceparent.py
+++ b/api/alembic/versions/0057_drop_verification_attempt_traceparent.py
@@ -1,0 +1,128 @@
+"""drop unused verification attempt traceparent
+
+Why this change: runtime trace correlation flows through HTTP and Durable
+OpenTelemetry context. The copied ``traceparent`` value on
+``verification_attempts`` is never read for propagation or business behavior.
+
+Schema effect:
+- Removes ``verification_attempts.traceparent``.
+- Reapplies the Functions role's column grants without the removed column.
+
+Downgrade recreates the nullable column and restores its prior SELECT grant.
+Previously stored values cannot be recovered.
+
+Revision ID: 0057_drop_verification_attempt_traceparent
+Revises: 0056_add_community_activity_indexes
+Create Date: 2026-08-25
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0057_drop_verification_attempt_traceparent"
+down_revision: str | None = "0056_add_community_activity_indexes"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SELECT_COLUMNS: tuple[str, ...] = (
+    "id",
+    "user_id",
+    "requirement_uuid",
+    "snapshot_source",
+    "payload_version",
+    "requirement_snapshot",
+    "requirement_snapshot_hash",
+    "submission_value_kind",
+    "submitted_value",
+    "github_username_snapshot",
+    "cloud_provider",
+    "outcome",
+    "started_at",
+    "created_at",
+    "completed_at",
+    "error_code",
+    "validation_message",
+    "terminal_source",
+    "feedback_json",
+)
+
+_SELECT_COLUMNS_WITH_TRACEPARENT: tuple[str, ...] = (
+    *_SELECT_COLUMNS[:11],
+    "traceparent",
+    *_SELECT_COLUMNS[11:],
+)
+
+_UPDATE_COLUMNS: tuple[str, ...] = (
+    "outcome",
+    "error_code",
+    "validation_message",
+    "terminal_source",
+    "feedback_json",
+    "started_at",
+    "completed_at",
+    "updated_at",
+)
+
+
+def _verification_functions_role() -> str | None:
+    """Return the validated Functions database role name."""
+    role = os.environ.get("POSTGRES_VERIFICATION_FUNCTIONS_ROLE")
+    if not role:
+        return None
+    if not (role[0].isalpha() or role[0] == "_") or not all(
+        char.isalnum() or char == "_" for char in role
+    ):
+        raise RuntimeError(
+            f"POSTGRES_VERIFICATION_FUNCTIONS_ROLE is not a valid identifier: {role!r}"
+        )
+    return role
+
+
+def _apply_functions_grants(role: str, select_columns: tuple[str, ...]) -> None:
+    select_list = ", ".join(select_columns)
+    update_list = ", ".join(_UPDATE_COLUMNS)
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                REVOKE ALL ON verification_attempts FROM "{role}";
+                GRANT SELECT ({select_list})
+                    ON verification_attempts TO "{role}";
+                GRANT UPDATE ({update_list})
+                    ON verification_attempts TO "{role}";
+            END IF;
+        END $$;
+        """
+    )
+
+
+def upgrade() -> None:
+    """Drop the unused trace context copy and keep grants least-privileged."""
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    role = _verification_functions_role()
+    if role:
+        _apply_functions_grants(role, _SELECT_COLUMNS)
+    op.drop_column("verification_attempts", "traceparent")
+
+
+def downgrade() -> None:
+    """Restore an empty traceparent column and its prior SELECT grant."""
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    op.add_column(
+        "verification_attempts",
+        sa.Column("traceparent", sa.Text(), nullable=True),
+    )
+    role = _verification_functions_role()
+    if role:
+        _apply_functions_grants(role, _SELECT_COLUMNS_WITH_TRACEPARENT)

--- a/api/tests/test_migration_chain.py
+++ b/api/tests/test_migration_chain.py
@@ -163,3 +163,25 @@ def test_contract_removes_legacy_database_objects(
     assert "legacy_job_id" not in attempt_columns
     assert "legacy_submission_id" not in attempt_columns
     assert temporary_functions == set()
+
+
+def test_head_removes_unused_attempt_traceparent(
+    alembic_runner, alembic_engine
+) -> None:
+    alembic_runner.migrate_up_to("0057_drop_verification_attempt_traceparent")
+
+    with alembic_engine.connect() as conn:
+        attempt_columns = set(
+            conn.execute(
+                text(
+                    """
+                    SELECT column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'verification_attempts'
+                    """
+                )
+            ).scalars()
+        )
+
+    assert "traceparent" not in attempt_columns

--- a/api/tests/test_verification_attempt_grants_migration.py
+++ b/api/tests/test_verification_attempt_grants_migration.py
@@ -1,9 +1,11 @@
-"""Grants test for the column-level Functions role migration (0051).
+"""Grants tests for the column-level Functions role migrations.
 
 Creates the Functions role, runs the migration chain through the column-grant
 narrowing, and asserts the role can SELECT the prepare/reconcile columns and
 UPDATE only the result/lifecycle columns -- never the immutable
 user/requirement/snapshot/submitted-value identity, and never INSERT/DELETE.
+The head assertion also verifies the removed traceparent column and grant stay
+absent.
 """
 
 from __future__ import annotations
@@ -17,7 +19,8 @@ from sqlalchemy import create_engine, text
 
 MIGRATION_DB = "test_verification_attempt_grants"
 _BEFORE = "0048_validate_deployment_architecture_type"
-_HEAD = "0051_narrow_functions_role_attempt_grants"
+_NARROWED = "0051_narrow_functions_role_attempt_grants"
+_HEAD = "0057_drop_verification_attempt_traceparent"
 
 _EXPECTED_UPDATE_COLUMNS = {
     "outcome",
@@ -43,6 +46,28 @@ _IMMUTABLE_COLUMNS = (
     "github_username_snapshot",
     "legacy_job_id",
 )
+
+_EXPECTED_HEAD_SELECT_COLUMNS = {
+    "id",
+    "user_id",
+    "requirement_uuid",
+    "snapshot_source",
+    "payload_version",
+    "requirement_snapshot",
+    "requirement_snapshot_hash",
+    "submission_value_kind",
+    "submitted_value",
+    "github_username_snapshot",
+    "cloud_provider",
+    "outcome",
+    "started_at",
+    "created_at",
+    "completed_at",
+    "error_code",
+    "validation_message",
+    "terminal_source",
+    "feedback_json",
+}
 
 
 def _sync_url() -> str:
@@ -112,7 +137,7 @@ def test_functions_role_column_grants(alembic_runner, alembic_engine, monkeypatc
             conn.execute(text(f'CREATE ROLE "{role}"'))
         admin.dispose()
 
-        alembic_runner.migrate_up_to(_HEAD)
+        alembic_runner.migrate_up_to(_NARROWED)
 
         with alembic_engine.connect() as conn:
             update_columns = set(
@@ -169,6 +194,38 @@ def test_functions_role_column_grants(alembic_runner, alembic_engine, monkeypatc
         assert "DELETE" not in table_grants
         assert select_ok is True
         assert not any(immutable_update.values()), immutable_update
+
+        alembic_runner.migrate_up_to(_HEAD)
+        with alembic_engine.connect() as conn:
+            attempt_columns = set(
+                conn.execute(
+                    text(
+                        """
+                        SELECT column_name
+                        FROM information_schema.columns
+                        WHERE table_schema = 'public'
+                          AND table_name = 'verification_attempts'
+                        """
+                    )
+                ).scalars()
+            )
+            select_columns = set(
+                conn.execute(
+                    text(
+                        """
+                        SELECT column_name
+                        FROM information_schema.column_privileges
+                        WHERE grantee = :role
+                          AND table_name = 'verification_attempts'
+                          AND privilege_type = 'SELECT'
+                        """
+                    ),
+                    {"role": role},
+                ).scalars()
+            )
+
+        assert "traceparent" not in attempt_columns
+        assert select_columns == _EXPECTED_HEAD_SELECT_COLUMNS
     finally:
         admin = create_engine(_admin_url(), isolation_level="AUTOCOMMIT")
         with admin.connect() as conn:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -9,7 +9,6 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     DateTime,
-    FetchedValue,
     ForeignKey,
     Index,
     String,
@@ -115,7 +114,6 @@ class VerificationAttempt(TimestampMixin, Base):
     """One verification attempt, keyed by its Durable instance UUID."""
 
     __tablename__ = "verification_attempts"
-    __mapper_args__ = {"eager_defaults": False}
     __table_args__ = (
         CheckConstraint(
             "submission_value_kind IN ('github_url', 'token', 'deployed_url', 'text')",
@@ -199,12 +197,6 @@ class VerificationAttempt(TimestampMixin, Base):
     submission_value_kind: Mapped[str] = mapped_column(Text, nullable=False)
     submitted_value: Mapped[str] = mapped_column(Text, nullable=False)
     cloud_provider: Mapped[str | None] = mapped_column(Text, nullable=True)
-    traceparent: Mapped[str | None] = mapped_column(
-        Text,
-        nullable=True,
-        deferred=True,
-        server_default=FetchedValue(),
-    )
 
     outcome: Mapped[str | None] = mapped_column(Text, nullable=True)
     started_at: Mapped[datetime | None] = mapped_column(


### PR DESCRIPTION
## Summary

Drops the unused `verification_attempts.traceparent` column and removes the temporary ORM compatibility mapping. Runtime correlation continues through HTTP and Durable OpenTelemetry context; no stored trace header is used for behavior.

The migration uses local lock and statement timeouts, reapplies the Functions role's least-privilege column grants without `traceparent`, and provides a downgrade that recreates the nullable column and prior SELECT grant. Migration-chain and grant tests cover the final schema.

## Deployment boundary

Do not merge this PR until #780 has merged and its production deployment has succeeded. The deployment pipeline runs migrations before application rollout, so #780 first deploys a compatibility mapping that neither selects nor inserts `traceparent`; an integration test checks the emitted INSERT SQL. This makes the later column drop safe for the still-running revision.

## Checklist

- [x] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.

The runtime dependency was split into #780. This contract layer only removes the temporary mapping together with the column it represents.