### PR TITLE
Add dedicated verification pages and attempt history

### DIFF
--- a/api/src/learn_to_cloud/rendering/context.py
+++ b/api/src/learn_to_cloud/rendering/context.py
@@ -7,6 +7,7 @@ avoids duplicated dict-building logic.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, cast
 
 from learn_to_cloud_shared.submission_derivation import (
@@ -361,7 +362,7 @@ def build_requirement_card_context(
     requirement: Any,
     github_username: str | None,
     submission: Any = None,
-    feedback_tasks: list[dict[str, Any]] | None = None,
+    feedback_tasks: Sequence[Mapping[str, object]] | None = None,
     feedback_passed: int = 0,
     server_error: bool = False,
     server_error_message: str | None = None,

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -75,11 +75,17 @@ from learn_to_cloud.services.users_service import (
     delete_user_account,
     get_user_by_id,
 )
+from learn_to_cloud.services.verification_history_cursors import (
+    VerificationHistoryCursorError,
+)
 from learn_to_cloud.services.verification_status_tokens import (
     VerificationStatusToken,
     VerificationStatusTokenError,
     create_verification_status_token,
     load_verification_status_token,
+)
+from learn_to_cloud.services.verifications_service import (
+    get_verification_history_page,
 )
 
 logger = logging.getLogger(__name__)
@@ -654,6 +660,47 @@ async def htmx_verification_attempt_status(
         "Verification is in an unexpected state. "
         "Refresh the page to check for results.",
         status_code=409,
+    )
+
+
+@router.get(
+    "/verifications/phase/{phase_id:int}/requirements/{requirement_slug}/history",
+    response_class=HTMLResponse,
+)
+async def htmx_verification_history(
+    request: Request,
+    phase_id: int,
+    requirement_slug: str,
+    cursor: Annotated[str, Query(max_length=4096)],
+    db: DbSession,
+    current_user: CurrentUser,
+) -> HTMLResponse:
+    """Append older terminal attempts for one current catalog requirement."""
+    try:
+        history = await get_verification_history_page(
+            db,
+            current_user.user_id,
+            phase_id,
+            requirement_slug,
+            cursor,
+        )
+    except VerificationHistoryCursorError:
+        return _status_error_response(
+            "Attempt history link is invalid.", status_code=400
+        )
+    requirement = get_requirement_by_slug(requirement_slug)
+    if history is None or requirement is None:
+        return _status_error_response(
+            "Verification requirement not found.", status_code=404
+        )
+    return templates.TemplateResponse(
+        request,
+        "partials/verification_history_page.html",
+        {
+            "history": history,
+            "phase_id": phase_id,
+            "requirement": requirement,
+        },
     )
 
 

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -15,12 +15,6 @@ from learn_to_cloud_shared.content_service import (
 )
 from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.models import User
-from learn_to_cloud_shared.repositories.verification_attempt_repository import (
-    VerificationAttemptRepository,
-)
-from learn_to_cloud_shared.requirements import (
-    is_phase_verification_locked,
-)
 
 from learn_to_cloud.core.auth import OptionalUserId, UserId
 from learn_to_cloud.core.templates import templates
@@ -30,18 +24,16 @@ from learn_to_cloud.rendering.context import (
     HELP_LINKS,
     build_phase_topics,
     build_progress_dict,
-    build_requirement_card_context,
     build_topic_nav,
-    feedback_tasks_and_passed,
 )
 from learn_to_cloud.services.community_service import get_community_page_data
 from learn_to_cloud.services.dashboard_service import get_dashboard_data
 from learn_to_cloud.services.progress_service import fetch_phase_progress
 from learn_to_cloud.services.steps_service import get_valid_completed_steps
-from learn_to_cloud.services.submissions_service import get_phase_submission_context
 from learn_to_cloud.services.users_service import get_user_by_id
-from learn_to_cloud.services.verification_status_tokens import (
-    create_verification_status_token,
+from learn_to_cloud.services.verifications_service import (
+    get_phase_verification_context,
+    get_verification_overview,
 )
 
 logger = logging.getLogger(__name__)
@@ -112,7 +104,7 @@ async def phase_page(
     db: DbSession,
     user_id: UserId,
 ) -> HTMLResponse:
-    """Single phase detail with topics and verification (requires auth)."""
+    """Single learning-only phase detail (requires auth)."""
     user = await _get_user_or_none(db, user_id)
     phase = get_phase_by_slug(f"phase{phase_id}")
     if phase is None:
@@ -126,67 +118,6 @@ async def phase_page(
     detail = await fetch_phase_progress(db, user_id, phase)
     topics = build_phase_topics(phase, detail)
 
-    requirements = []
-    hands_on = phase.hands_on_verification
-    if hands_on:
-        requirements = hands_on.requirements
-
-    sub_context = await get_phase_submission_context(db, user_id, phase)
-    submissions_by_req = sub_context.submissions_by_req
-    feedback_by_req = sub_context.feedback_by_req
-    requirements_by_uuid = {req.uuid: req for req in requirements}
-    active_attempts = await VerificationAttemptRepository(
-        db
-    ).get_active_for_requirements(
-        user_id,
-        requirements_by_uuid.keys(),
-    )
-    active_jobs_by_req = {
-        requirements_by_uuid[attempt.requirement_uuid].slug: attempt
-        for attempt in active_attempts
-        if attempt.requirement_uuid in requirements_by_uuid
-    }
-    # The Durable orchestration instance id is the attempt UUID, so the status
-    # token keys off that same id.
-    verification_status_tokens_by_req = {
-        requirements_by_uuid[attempt.requirement_uuid].slug: (
-            create_verification_status_token(
-                user_id=user_id,
-                job_id=attempt.id,
-                instance_id=str(attempt.id),
-                requirement_slug=requirements_by_uuid[attempt.requirement_uuid].slug,
-            )
-        )
-        for attempt in active_attempts
-        if attempt.requirement_uuid in requirements_by_uuid
-    }
-
-    # Pre-compute one verification-card context per requirement -- derived
-    # URL, card state, and banner text all in one place, so the template
-    # never re-derives a card's flags from raw submission fields (also the
-    # single source of truth the locked and unlocked branches both read).
-    github_username = user.github_username if user else None
-    card_contexts_by_req: dict[str, dict] = {}
-    for req in requirements:
-        feedback_tasks, feedback_passed = feedback_tasks_and_passed(
-            feedback_by_req.get(req.slug)
-        )
-        active_job = active_jobs_by_req.get(req.slug)
-        card_contexts_by_req[req.slug] = build_requirement_card_context(
-            requirement=req,
-            github_username=github_username,
-            submission=submissions_by_req.get(req.slug),
-            feedback_tasks=feedback_tasks,
-            feedback_passed=feedback_passed,
-            processing=active_job is not None,
-            verification_status_token=verification_status_tokens_by_req.get(req.slug),
-        )
-
-    # Sequential phase gating — check if prerequisite phase is complete
-    verification_locked, prerequisite_phase_id = await is_phase_verification_locked(
-        db, user_id, phase_id
-    )
-
     return templates.TemplateResponse(
         request,
         "pages/phase.html",
@@ -195,12 +126,64 @@ async def phase_page(
             user=user,
             phase=phase,
             topics=topics,
-            requirements=requirements,
-            card_contexts_by_req=card_contexts_by_req,
             phase_progress=detail,
-            verification_locked=verification_locked,
-            prerequisite_phase_id=prerequisite_phase_id,
+            has_verification=bool(
+                phase.hands_on_verification and phase.hands_on_verification.requirements
+            ),
         ),
+    )
+
+
+@router.get(
+    "/verifications",
+    response_class=HTMLResponse,
+    summary="Verification overview",
+)
+async def verifications_page(
+    request: Request,
+    db: DbSession,
+    user_id: UserId,
+) -> HTMLResponse:
+    """Authenticated verification progress across the curriculum."""
+    user = await _get_user_or_none(db, user_id)
+    overview = await get_verification_overview(db, user_id)
+    return templates.TemplateResponse(
+        request,
+        "pages/verifications.html",
+        _template_context(request, user=user, overview=overview),
+    )
+
+
+@router.get(
+    "/verifications/phase/{phase_id:int}",
+    response_class=HTMLResponse,
+    summary="Phase verification",
+)
+async def phase_verification_page(
+    request: Request,
+    phase_id: int,
+    db: DbSession,
+    user_id: UserId,
+) -> HTMLResponse:
+    """Authenticated submissions, live status, feedback, and history."""
+    user = await _get_user_or_none(db, user_id)
+    context = await get_phase_verification_context(
+        db,
+        user_id,
+        phase_id,
+        github_username=user.github_username if user else None,
+    )
+    if context is None:
+        return templates.TemplateResponse(
+            request,
+            "pages/404.html",
+            _template_context(request, user=user),
+            status_code=404,
+        )
+    return templates.TemplateResponse(
+        request,
+        "pages/phase_verification.html",
+        _template_context(request, user=user, verification=context),
     )
 
 

--- a/api/src/learn_to_cloud/services/progress_service.py
+++ b/api/src/learn_to_cloud/services/progress_service.py
@@ -249,7 +249,7 @@ async def resolve_continue_destination(
 
     Points at the first unchecked step's topic, since that's where a
     learner actually left off -- falls back to the phase's verification
-    section once every current step is checked.
+    page once every current step is checked.
     """
     all_step_uuids = [
         step.uuid for topic in phase.topics for step in topic.learning_steps
@@ -265,5 +265,5 @@ async def resolve_continue_destination(
         phase.hands_on_verification is not None
         and phase.hands_on_verification.requirements
     ):
-        return f"/phase/{phase.order}#verification-section"
+        return f"/verifications/phase/{phase.order}"
     return f"/phase/{phase.order}"

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -41,6 +41,8 @@ from learn_to_cloud_shared.verification_attempt_snapshot import (
 )
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from learn_to_cloud.services.verification_feedback import convert_feedback
+
 
 async def get_phase_submission_context(
     db: AsyncSession,
@@ -71,26 +73,6 @@ async def get_phase_submission_context(
     submissions_by_req: dict[str, SubmissionData] = {}
     feedback_by_req: dict[str, dict[str, object]] = {}
 
-    def _record_feedback(
-        requirement_slug: str, feedback_json: list[dict] | None
-    ) -> None:
-        # Surface rubric feedback for both passing and failing submissions
-        # (#425). Stored as JSONB (#459) so the rows arrive as a list of
-        # TaskResult dicts and we don't need json.loads / try / except.
-        if not feedback_json:
-            return
-        tasks = [
-            {
-                "name": t.get("task_name", ""),
-                "passed": t.get("passed", False),
-                "message": t.get("feedback", ""),
-                "next_steps": t.get("next_steps", ""),
-            }
-            for t in feedback_json
-        ]
-        passed = sum(1 for t in tasks if t["passed"])
-        feedback_by_req[requirement_slug] = {"tasks": tasks, "passed": passed}
-
     for attempt in latest_attempts:
         requirement = requirements_by_uuid.get(attempt.requirement_uuid)
         if requirement is None:
@@ -99,7 +81,12 @@ async def get_phase_submission_context(
             # slips one past us we skip silently rather than crash the page.
             continue
         submissions_by_req[requirement.slug] = attempt_to_submission_data(attempt)
-        _record_feedback(requirement.slug, attempt.feedback_json)
+        feedback = convert_feedback(attempt.feedback_json)
+        if feedback is not None:
+            feedback_by_req[requirement.slug] = {
+                "tasks": feedback.tasks,
+                "passed": feedback.passed,
+            }
 
     return PhaseSubmissionContext(
         submissions_by_req=submissions_by_req,

--- a/api/src/learn_to_cloud/services/verification_feedback.py
+++ b/api/src/learn_to_cloud/services/verification_feedback.py
@@ -1,0 +1,38 @@
+"""Typed conversion of stored rubric feedback for templates."""
+
+from dataclasses import dataclass
+from typing import TypedDict
+
+
+class FeedbackTaskContext(TypedDict):
+    name: str
+    passed: bool
+    message: str
+    next_steps: str
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationFeedbackContext:
+    tasks: list[FeedbackTaskContext]
+    passed: int
+
+
+def convert_feedback(
+    feedback_json: list[dict] | None,
+) -> VerificationFeedbackContext | None:
+    """Convert persisted task results to the shared feedback view shape."""
+    if not feedback_json:
+        return None
+    tasks: list[FeedbackTaskContext] = [
+        {
+            "name": str(task.get("task_name") or ""),
+            "passed": bool(task.get("passed", False)),
+            "message": str(task.get("feedback") or ""),
+            "next_steps": str(task.get("next_steps") or ""),
+        }
+        for task in feedback_json
+    ]
+    return VerificationFeedbackContext(
+        tasks=tasks,
+        passed=sum(1 for task in tasks if task["passed"]),
+    )

--- a/api/src/learn_to_cloud/services/verification_history_cursors.py
+++ b/api/src/learn_to_cloud/services/verification_history_cursors.py
@@ -1,0 +1,100 @@
+"""Opaque cursors for verification-attempt history."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from itsdangerous import BadData, URLSafeSerializer
+from learn_to_cloud_shared.core.config import get_web_settings
+
+_CURSOR_SALT = "verification-history-v1"
+
+
+class VerificationHistoryCursorError(Exception):
+    """Raised when a history cursor is invalid or belongs to another scope."""
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationHistoryCursor:
+    created_at: datetime
+    attempt_id: UUID
+
+
+def _serializer() -> URLSafeSerializer:
+    return URLSafeSerializer(
+        get_web_settings().session.secret_key,
+        salt=_CURSOR_SALT,
+    )
+
+
+def create_history_cursor(
+    *,
+    user_id: int,
+    requirement_uuid: UUID,
+    created_at: datetime,
+    attempt_id: UUID,
+) -> str:
+    return _serializer().dumps(
+        {
+            "user_id": user_id,
+            "requirement_uuid": str(requirement_uuid),
+            "created_at": created_at.isoformat(),
+            "attempt_id": str(attempt_id),
+        }
+    )
+
+
+def load_history_cursor(
+    token: str,
+    *,
+    expected_user_id: int,
+    expected_requirement_uuid: UUID,
+) -> VerificationHistoryCursor:
+    try:
+        payload = _serializer().loads(token)
+    except BadData as exc:
+        raise VerificationHistoryCursorError("Invalid history cursor.") from exc
+    if not isinstance(payload, dict):
+        raise VerificationHistoryCursorError("Invalid history cursor.")
+
+    user_id = _expect_int(payload, "user_id")
+    requirement_uuid = _expect_uuid(payload, "requirement_uuid")
+    if user_id != expected_user_id or requirement_uuid != expected_requirement_uuid:
+        raise VerificationHistoryCursorError("History cursor scope mismatch.")
+
+    created_at_raw = _expect_str(payload, "created_at")
+    try:
+        created_at = datetime.fromisoformat(created_at_raw)
+    except ValueError as exc:
+        raise VerificationHistoryCursorError("Invalid history cursor date.") from exc
+    if created_at.tzinfo is None:
+        raise VerificationHistoryCursorError("Invalid history cursor date.")
+
+    return VerificationHistoryCursor(
+        created_at=created_at,
+        attempt_id=_expect_uuid(payload, "attempt_id"),
+    )
+
+
+def _expect_str(payload: dict[Any, Any], field_name: str) -> str:
+    value = payload.get(field_name)
+    if not isinstance(value, str) or not value:
+        raise VerificationHistoryCursorError(f"History cursor is missing {field_name}.")
+    return value
+
+
+def _expect_int(payload: dict[Any, Any], field_name: str) -> int:
+    value = payload.get(field_name)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise VerificationHistoryCursorError(f"History cursor is missing {field_name}.")
+    return value
+
+
+def _expect_uuid(payload: dict[Any, Any], field_name: str) -> UUID:
+    try:
+        return UUID(_expect_str(payload, field_name))
+    except ValueError as exc:
+        raise VerificationHistoryCursorError(
+            f"History cursor has invalid {field_name}."
+        ) from exc

--- a/api/src/learn_to_cloud/services/verifications_service.py
+++ b/api/src/learn_to_cloud/services/verifications_service.py
@@ -1,0 +1,333 @@
+"""Page contexts for the dedicated verification experience."""
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+from urllib.parse import urlsplit
+from uuid import UUID
+
+from learn_to_cloud_shared.content_service import (
+    get_curriculum_overview,
+    get_phase_by_slug,
+)
+from learn_to_cloud_shared.models import SubmissionValueKind
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    AttemptHistoryProjection,
+    VerificationAttemptRepository,
+)
+from learn_to_cloud_shared.requirements import is_phase_verification_locked
+from learn_to_cloud_shared.schemas import (
+    HandsOnRequirement,
+    Phase,
+    PhaseOverview,
+    PhaseProgress,
+)
+from learn_to_cloud_shared.verification.execution import attempt_to_submission_data
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud.rendering.context import build_requirement_card_context
+from learn_to_cloud.services.progress_service import (
+    fetch_phase_progress,
+    fetch_user_progress,
+)
+from learn_to_cloud.services.verification_feedback import (
+    FeedbackTaskContext,
+    convert_feedback,
+)
+from learn_to_cloud.services.verification_history_cursors import (
+    create_history_cursor,
+    load_history_cursor,
+)
+from learn_to_cloud.services.verification_status_tokens import (
+    create_verification_status_token,
+)
+
+HISTORY_PAGE_SIZE = 10
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationOverviewPhase:
+    phase: PhaseOverview
+    progress: PhaseProgress
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationOverviewContext:
+    phases: tuple[VerificationOverviewPhase, ...]
+    requirements_verified: int
+    requirements_required: int
+    percentage: float
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationHistoryItem:
+    id: UUID
+    occurred_at: datetime
+    outcome: str
+    validation_message: str | None
+    artifact_url: str | None
+    feedback_tasks: list[FeedbackTaskContext]
+    feedback_passed: int
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationHistoryPage:
+    items: tuple[VerificationHistoryItem, ...]
+    next_cursor: str | None
+
+
+RequirementPageState = Literal["passed", "current", "up_next", "locked"]
+
+
+@dataclass(frozen=True, slots=True)
+class RequirementVerificationContext:
+    requirement: HandsOnRequirement
+    card: dict[str, Any]
+    page_state: RequirementPageState
+    history: VerificationHistoryPage
+
+
+@dataclass(frozen=True, slots=True)
+class PhaseVerificationContext:
+    phase: Phase
+    progress: PhaseProgress
+    requirements: tuple[RequirementVerificationContext, ...]
+    verification_locked: bool
+    prerequisite_phase_id: int | None
+
+
+async def get_verification_overview(
+    db: AsyncSession,
+    user_id: int,
+) -> VerificationOverviewContext:
+    """Build verification progress across every current curriculum phase."""
+    phase_overview = get_curriculum_overview()
+    progress = await fetch_user_progress(
+        db,
+        user_id,
+        phase_overview=phase_overview,
+    )
+    phases = tuple(
+        VerificationOverviewPhase(phase=phase, progress=progress.phases[phase.order])
+        for phase in phase_overview
+    )
+    required = sum(
+        phase.progress.verification.requirements_required for phase in phases
+    )
+    verified = sum(
+        phase.progress.verification.requirements_verified for phase in phases
+    )
+    percentage = 100.0 if required == 0 else round(verified / required * 100, 1)
+    return VerificationOverviewContext(
+        phases=phases,
+        requirements_verified=verified,
+        requirements_required=required,
+        percentage=percentage,
+    )
+
+
+async def get_phase_verification_context(
+    db: AsyncSession,
+    user_id: int,
+    phase_id: int,
+    *,
+    github_username: str | None,
+) -> PhaseVerificationContext | None:
+    """Assemble one dedicated phase verification page."""
+    phase = get_phase_by_slug(f"phase{phase_id}")
+    if phase is None:
+        return None
+
+    catalog_requirements = tuple(
+        phase.hands_on_verification.requirements
+        if phase.hands_on_verification is not None
+        else ()
+    )
+    requirement_by_uuid = {
+        requirement.uuid: requirement for requirement in catalog_requirements
+    }
+    requirement_uuids = tuple(requirement_by_uuid)
+
+    progress = await fetch_phase_progress(db, user_id, phase)
+    verification_locked, prerequisite_phase_id = await is_phase_verification_locked(
+        db, user_id, phase_id
+    )
+    repository = VerificationAttemptRepository(db)
+    latest_attempts = await repository.get_latest_terminal_for_requirements(
+        user_id, requirement_uuids
+    )
+    active_attempts = await repository.get_active_for_requirements(
+        user_id, requirement_uuids
+    )
+    history_rows = await repository.get_terminal_history_for_requirements(
+        user_id,
+        requirement_uuids,
+        per_requirement_limit=HISTORY_PAGE_SIZE + 1,
+    )
+
+    latest_by_uuid = {attempt.requirement_uuid: attempt for attempt in latest_attempts}
+    active_by_uuid = {attempt.requirement_uuid: attempt for attempt in active_attempts}
+    active_requirement_uuid = next(
+        (
+            requirement.uuid
+            for requirement in catalog_requirements
+            if requirement.uuid in active_by_uuid
+        ),
+        None,
+    )
+    history_by_uuid: dict[UUID, list[AttemptHistoryProjection]] = defaultdict(list)
+    for row in history_rows:
+        if row.requirement_uuid in requirement_by_uuid:
+            history_by_uuid[row.requirement_uuid].append(row)
+
+    contexts: list[RequirementVerificationContext] = []
+    found_current = False
+    for requirement in catalog_requirements:
+        latest = latest_by_uuid.get(requirement.uuid)
+        active = active_by_uuid.get(requirement.uuid)
+        submission = attempt_to_submission_data(latest) if latest is not None else None
+        feedback = (
+            convert_feedback(latest.feedback_json) if latest is not None else None
+        )
+        card = build_requirement_card_context(
+            requirement=requirement,
+            github_username=github_username,
+            submission=submission,
+            feedback_tasks=feedback.tasks if feedback else [],
+            feedback_passed=feedback.passed if feedback else 0,
+            processing=active is not None,
+            verification_status_token=(
+                create_verification_status_token(
+                    user_id=user_id,
+                    job_id=active.id,
+                    instance_id=str(active.id),
+                    requirement_slug=requirement.slug,
+                )
+                if active is not None
+                else None
+            ),
+        )
+        if card["card_state"] == "passed":
+            page_state: RequirementPageState = "passed"
+        elif requirement.uuid == active_requirement_uuid:
+            page_state = "current"
+            found_current = True
+        elif verification_locked:
+            page_state = "locked"
+        elif not found_current and active_requirement_uuid is None:
+            page_state = "current"
+            found_current = True
+        else:
+            page_state = "up_next"
+
+        rows = history_by_uuid[requirement.uuid]
+        contexts.append(
+            RequirementVerificationContext(
+                requirement=requirement,
+                card=card,
+                page_state=page_state,
+                history=_history_page(
+                    rows,
+                    user_id=user_id,
+                    requirement_uuid=requirement.uuid,
+                ),
+            )
+        )
+
+    return PhaseVerificationContext(
+        phase=phase,
+        progress=progress,
+        requirements=tuple(contexts),
+        verification_locked=verification_locked,
+        prerequisite_phase_id=prerequisite_phase_id,
+    )
+
+
+async def get_verification_history_page(
+    db: AsyncSession,
+    user_id: int,
+    phase_id: int,
+    requirement_slug: str,
+    cursor: str,
+) -> VerificationHistoryPage | None:
+    """Load ten older terminal attempts for one current requirement."""
+    phase = get_phase_by_slug(f"phase{phase_id}")
+    requirements = (
+        phase.hands_on_verification.requirements
+        if phase is not None and phase.hands_on_verification is not None
+        else ()
+    )
+    requirement = next(
+        (item for item in requirements if item.slug == requirement_slug),
+        None,
+    )
+    if requirement is None:
+        return None
+
+    decoded = load_history_cursor(
+        cursor,
+        expected_user_id=user_id,
+        expected_requirement_uuid=requirement.uuid,
+    )
+    rows = await VerificationAttemptRepository(db).get_terminal_history(
+        user_id,
+        requirement.uuid,
+        limit=HISTORY_PAGE_SIZE + 1,
+        before=(decoded.created_at, decoded.attempt_id),
+    )
+    return _history_page(
+        rows,
+        user_id=user_id,
+        requirement_uuid=requirement.uuid,
+    )
+
+
+def _history_page(
+    rows: list[AttemptHistoryProjection],
+    *,
+    user_id: int,
+    requirement_uuid: UUID,
+) -> VerificationHistoryPage:
+    visible = rows[:HISTORY_PAGE_SIZE]
+    next_cursor = None
+    if len(rows) > HISTORY_PAGE_SIZE:
+        last = visible[-1]
+        next_cursor = create_history_cursor(
+            user_id=user_id,
+            requirement_uuid=requirement_uuid,
+            created_at=last.created_at,
+            attempt_id=last.id,
+        )
+    return VerificationHistoryPage(
+        items=tuple(_history_item(row) for row in visible),
+        next_cursor=next_cursor,
+    )
+
+
+def _history_item(row: AttemptHistoryProjection) -> VerificationHistoryItem:
+    feedback = convert_feedback(row.feedback_json)
+    return VerificationHistoryItem(
+        id=row.id,
+        occurred_at=row.completed_at or row.created_at,
+        outcome=row.outcome,
+        validation_message=row.validation_message,
+        artifact_url=_safe_artifact_url(
+            row.submission_value_kind,
+            row.submitted_value,
+        ),
+        feedback_tasks=feedback.tasks if feedback else [],
+        feedback_passed=feedback.passed if feedback else 0,
+    )
+
+
+def _safe_artifact_url(value_kind: str, value: str) -> str | None:
+    if value_kind not in {
+        SubmissionValueKind.GITHUB_URL.value,
+        SubmissionValueKind.DEPLOYED_URL.value,
+    }:
+        return None
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    return value

--- a/api/src/learn_to_cloud/templates/pages/phase.html
+++ b/api/src/learn_to_cloud/templates/pages/phase.html
@@ -77,7 +77,7 @@
 <section class="pt-12 sm:pt-14" aria-labelledby="topics-heading">
     <div>
         <h2 id="topics-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Topics</h2>
-        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Work through the learning steps in order, then return here for verification.</p>
+        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Work through the learning steps in order, then use the dedicated verification page.</p>
     </div>
 
     {% if topics %}
@@ -105,81 +105,17 @@
     {% endif %}
 </section>
 
-{% if requirements %}
-<section id="verification-section" class="mt-14 border-t border-gray-200 pt-12 dark:border-gray-700 sm:mt-16 sm:pt-14" aria-labelledby="verification-heading">
-    <h2 id="verification-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Hands-on verification</h2>
-    <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">Submit proof of the work you completed in this phase. Requirements unlock in sequence.</p>
-
-    {% if verification_locked %}
-    <div class="mb-6 mt-6 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
-        <div class="flex items-start gap-3">
-            <svg class="mt-0.5 h-5 w-5 shrink-0 text-amber-700 dark:text-amber-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
-                <rect x="4.5" y="8.5" width="11" height="8" rx="1.5"/>
-                <path stroke-linecap="round" d="M7 8.5V6a3 3 0 0 1 6 0v2.5"/>
-            </svg>
-            <div>
-                <p class="text-sm font-bold text-amber-950 dark:text-amber-100">Phase {{ prerequisite_phase_id }} verification required</p>
-                <p class="mt-1 text-sm leading-6 text-amber-800 dark:text-amber-200">
-                    Complete every hands-on verification in
-                    <a href="/phase/{{ prerequisite_phase_id }}" class="font-bold underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-700">Phase {{ prerequisite_phase_id }}</a>
-                    before submitting here.
-                </p>
-            </div>
+{% if has_verification %}
+<section class="mt-14 border-t border-gray-200 pt-12 dark:border-gray-700 sm:mt-16 sm:pt-14" aria-labelledby="verification-heading">
+    <div class="rounded-xl border border-blue-200 bg-blue-50 p-6 dark:border-blue-800 dark:bg-blue-950/40 sm:flex sm:items-center sm:justify-between sm:gap-8">
+        <div>
+            <h2 id="verification-heading" class="text-xl font-bold text-blue-950 dark:text-blue-100">Ready to verify your work?</h2>
+            <p class="mt-2 max-w-2xl text-sm leading-6 text-blue-800 dark:text-blue-200">Submissions, live results, feedback, and your attempt history are on the dedicated Phase {{ phase.order }} verification page.</p>
         </div>
+        <a href="/verifications/phase/{{ phase.order }}" class="mt-5 inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-5 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300 sm:mt-0">
+            Open verification
+        </a>
     </div>
-    <div class="space-y-3">
-        {% for req in requirements %}
-        {% set card = card_contexts_by_req[req.slug] %}
-        {% if card.card_state == 'passed' %}
-        {% include "partials/verified_requirement_row.html" %}
-        {% else %}
-        <div class="flex min-h-11 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
-            <svg class="h-5 w-5 shrink-0 text-gray-500 dark:text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
-                <rect x="4.5" y="8.5" width="11" height="8" rx="1.5"/>
-                <path stroke-linecap="round" d="M7 8.5V6a3 3 0 0 1 6 0v2.5"/>
-            </svg>
-            <span class="min-w-0 flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">{{ req.name }}</span>
-            <span class="text-xs font-bold text-gray-500 dark:text-gray-400">Locked</span>
-        </div>
-        {% endif %}
-        {% endfor %}
-    </div>
-    {% else %}
-    {% set ns = namespace(found_active=false) %}
-    <div class="mt-6 space-y-3">
-        {% for req in requirements %}
-        {% set card = card_contexts_by_req[req.slug] %}
-        {% if card.card_state == 'passed' %}
-        {% include "partials/verified_requirement_row.html" %}
-        {% elif not ns.found_active %}
-        {% set ns.found_active = true %}
-        {% with
-            requirement=card.requirement,
-            submission=card.submission,
-            feedback_tasks=card.feedback_tasks,
-            feedback_passed=card.feedback_passed,
-            card_state=card.card_state,
-            server_error=card.server_error,
-            server_error_message=card.server_error_message,
-            server_error_retryable=card.server_error_retryable,
-            error_banner=card.error_banner,
-            processing=card.processing,
-            verification_status_token=card.verification_status_token,
-            verification_status_delay_seconds=card.verification_status_delay_seconds,
-            derived_url=card.derived_url
-        %}
-        {% include "partials/requirement_card.html" %}
-        {% endwith %}
-        {% else %}
-        <div class="flex min-h-11 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
-            <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-gray-400 text-xs text-gray-500 dark:border-gray-500 dark:text-gray-400" aria-hidden="true">{{ loop.index }}</span>
-            <span class="min-w-0 flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">{{ req.name }}</span>
-            <span class="text-xs font-bold text-gray-500 dark:text-gray-400">Up next</span>
-        </div>
-        {% endif %}
-        {% endfor %}
-    </div>
-    {% endif %}
 </section>
 {% endif %}
 

--- a/api/src/learn_to_cloud/templates/pages/phase_verification.html
+++ b/api/src/learn_to_cloud/templates/pages/phase_verification.html
@@ -1,0 +1,94 @@
+{% extends "base.html" %}
+{% from "macros/badges.html" import status_pill %}
+{% block title %}Phase {{ verification.phase.order }} Verification - Learn to Cloud{% endblock %}
+
+{% block content %}
+<nav class="mb-6 flex min-h-11 flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400" aria-label="Breadcrumb">
+    <a href="/verifications" class="inline-flex min-h-11 items-center font-medium hover:text-blue-700 dark:hover:text-blue-300">Verifications</a>
+    <span aria-hidden="true">/</span>
+    <span aria-current="page">Phase {{ verification.phase.order }}</span>
+</nav>
+
+<header class="border-b border-gray-200 pb-10 dark:border-gray-700">
+    <div class="flex flex-wrap items-center gap-3">
+        <h1 class="text-3xl font-bold tracking-[-0.03em] text-gray-950 dark:text-white sm:text-4xl">Phase {{ verification.phase.order }} verification</h1>
+        {% if verification.progress.verification.is_complete %}
+        {{ status_pill("Complete", "success") }}
+        {% endif %}
+    </div>
+    <p class="mt-3 text-lg font-medium text-gray-700 dark:text-gray-200">{{ verification.phase.name }}</p>
+    <p class="mt-3 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">Requirements unlock in order. Results update here while verification runs.</p>
+    <div class="mt-6 flex flex-wrap gap-3">
+        <a href="/phase/{{ verification.phase.order }}" class="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-300 px-4 py-2 text-sm font-bold text-gray-800 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800">Back to learning</a>
+    </div>
+</header>
+
+{% if verification.verification_locked %}
+<div class="mt-8 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
+    <p class="text-sm font-bold text-amber-950 dark:text-amber-100">Phase {{ verification.prerequisite_phase_id }} verification required</p>
+    <p class="mt-1 text-sm text-amber-800 dark:text-amber-200">Complete every requirement in <a href="/verifications/phase/{{ verification.prerequisite_phase_id }}" class="font-bold underline">Phase {{ verification.prerequisite_phase_id }}</a> before submitting here.</p>
+</div>
+{% endif %}
+
+<section class="mt-10" aria-labelledby="requirements-heading">
+    <h2 id="requirements-heading" class="text-2xl font-bold text-gray-950 dark:text-white">Requirements</h2>
+    {% if verification.requirements %}
+    <div class="mt-6 space-y-8">
+        {% for item in verification.requirements %}
+        <article aria-labelledby="requirement-heading-{{ item.requirement.slug }}">
+            <h3 id="requirement-heading-{{ item.requirement.slug }}" class="sr-only">{{ item.requirement.name }}</h3>
+            {% set card = item.card %}
+            {% if item.page_state == 'passed' %}
+                {% include "partials/verified_requirement_row.html" %}
+            {% elif item.page_state == 'current' %}
+                {% with
+                    requirement=card.requirement,
+                    submission=card.submission,
+                    feedback_tasks=card.feedback_tasks,
+                    feedback_passed=card.feedback_passed,
+                    card_state=card.card_state,
+                    server_error=card.server_error,
+                    server_error_message=card.server_error_message,
+                    server_error_retryable=card.server_error_retryable,
+                    error_banner=card.error_banner,
+                    processing=card.processing,
+                    verification_status_token=card.verification_status_token,
+                    verification_status_delay_seconds=card.verification_status_delay_seconds,
+                    derived_url=card.derived_url,
+                    graded_url=card.graded_url
+                %}
+                {% include "partials/requirement_card.html" %}
+                {% endwith %}
+            {% else %}
+            <div class="flex min-h-11 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+                <svg class="h-5 w-5 text-gray-500" viewBox="0 0 20 20" fill="none" stroke="currentColor" aria-hidden="true"><rect x="4.5" y="8.5" width="11" height="8" rx="1.5"/><path d="M7 8.5V6a3 3 0 0 1 6 0v2.5"/></svg>
+                <span class="flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">{{ item.requirement.name }}</span>
+                <span class="text-xs font-bold text-gray-500">{{ "Locked" if item.page_state == "locked" else "Up next" }}</span>
+            </div>
+            {% endif %}
+
+            <details class="mt-3 rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900">
+                <summary class="flex min-h-11 cursor-pointer items-center justify-between px-4 py-3 text-sm font-bold text-gray-700 dark:text-gray-200">
+                    Attempt history
+                    <span class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ item.history.items | length }} shown</span>
+                </summary>
+                <div class="border-t border-gray-200 px-4 py-4 dark:border-gray-700">
+                    {% if item.history.items %}
+                    <div class="space-y-3">
+                        {% with history=item.history, phase_id=verification.phase.order, requirement=item.requirement %}
+                        {% include "partials/verification_history_page.html" %}
+                        {% endwith %}
+                    </div>
+                    {% else %}
+                    <p class="text-sm text-gray-500 dark:text-gray-400">No completed attempts yet.</p>
+                    {% endif %}
+                </div>
+            </details>
+        </article>
+        {% endfor %}
+    </div>
+    {% else %}
+    <p class="mt-6 text-sm text-gray-600 dark:text-gray-400">This phase has no verification requirements.</p>
+    {% endif %}
+</section>
+{% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/verifications.html
+++ b/api/src/learn_to_cloud/templates/pages/verifications.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% from "macros/badges.html" import status_pill %}
+{% block title %}Verifications - Learn to Cloud{% endblock %}
+
+{% block content %}
+<header class="border-b border-gray-200 pb-10 dark:border-gray-700">
+    <p class="text-sm font-bold uppercase tracking-wider text-blue-700 dark:text-blue-300">Hands-on work</p>
+    <h1 class="mt-2 text-3xl font-bold tracking-[-0.03em] text-gray-950 dark:text-white sm:text-4xl">Verifications</h1>
+    <p class="mt-4 max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-300">Submit your phase projects, follow checks as they run, and review feedback from earlier attempts.</p>
+    <div class="mt-6">
+        {% with
+            value=overview.percentage,
+            label='Overall verification progress — ' ~ overview.requirements_verified ~ '/' ~ overview.requirements_required ~ ' requirements',
+            complete=overview.requirements_verified >= overview.requirements_required,
+            aria_label='Requirements verified: ' ~ overview.requirements_verified ~ ' of ' ~ overview.requirements_required
+        %}
+        {% include "partials/progress_bar.html" %}
+        {% endwith %}
+    </div>
+</header>
+
+<section class="pt-10" aria-labelledby="phase-verifications-heading">
+    <h2 id="phase-verifications-heading" class="text-2xl font-bold text-gray-950 dark:text-white">By phase</h2>
+    <div class="mt-6 grid gap-4">
+        {% for item in overview.phases %}
+        <a href="/verifications/phase/{{ item.phase.order }}" class="group rounded-lg border border-gray-200 p-5 hover:border-blue-300 hover:bg-blue-50/50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-700 dark:hover:border-blue-700 dark:hover:bg-blue-950/20">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                    <p class="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">Phase {{ item.phase.order }}</p>
+                    <h3 class="mt-1 text-lg font-bold text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ item.phase.name }}</h3>
+                </div>
+                {% if item.progress.verification.is_complete %}
+                {{ status_pill("Verified", "success") }}
+                {% elif item.progress.verification.requirements_required == 0 %}
+                {{ status_pill("No requirements", "info") }}
+                {% else %}
+                <span class="text-sm font-bold text-gray-600 dark:text-gray-300">{{ item.progress.verification.requirements_verified }}/{{ item.progress.verification.requirements_required }}</span>
+                {% endif %}
+            </div>
+            {% if item.progress.verification.requirements_required > 0 %}
+            <div class="mt-4">
+                {% with
+                    value=item.progress.verification.percentage,
+                    label='Verification progress',
+                    complete=item.progress.verification.is_complete,
+                    aria_label='Phase ' ~ item.phase.order ~ ' requirements verified: ' ~ item.progress.verification.requirements_verified ~ ' of ' ~ item.progress.verification.requirements_required
+                %}
+                {% include "partials/progress_bar.html" %}
+                {% endwith %}
+            </div>
+            {% endif %}
+        </a>
+        {% endfor %}
+    </div>
+</section>
+{% endblock %}

--- a/api/src/learn_to_cloud/templates/partials/navbar.html
+++ b/api/src/learn_to_cloud/templates/partials/navbar.html
@@ -14,6 +14,9 @@
                     <a href="/dashboard" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
                         Dashboard
                     </a>
+                    <a href="/verifications" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
+                        Verifications
+                    </a>
                     {% endif %}
                     <a href="/community" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
                         Community
@@ -84,6 +87,7 @@
             <div class="grid gap-1">
                 {% if user %}
                 <a href="/dashboard" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">Dashboard</a>
+                <a href="/verifications" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">Verifications</a>
                 {% endif %}
                 <a href="/community" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">Community</a>
                 <a href="/faq" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">FAQ</a>

--- a/api/src/learn_to_cloud/templates/partials/verification_history_page.html
+++ b/api/src/learn_to_cloud/templates/partials/verification_history_page.html
@@ -1,0 +1,30 @@
+{% for attempt in history.items %}
+<article class="border-l-2 {% if attempt.outcome == 'succeeded' %}border-green-500{% elif attempt.outcome == 'failed' %}border-red-500{% else %}border-amber-500{% endif %} pl-4">
+    <div class="flex flex-wrap items-center gap-2">
+        <time datetime="{{ attempt.occurred_at.isoformat() }}" class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ attempt.occurred_at.strftime('%b %d, %Y at %H:%M UTC') }}</time>
+        <span class="rounded-full px-2 py-0.5 text-xs font-bold {% if attempt.outcome == 'succeeded' %}bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200{% elif attempt.outcome == 'failed' %}bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200{% else %}bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200{% endif %}">{{ attempt.outcome | replace('_', ' ') | title }}</span>
+    </div>
+    {% if attempt.validation_message %}
+    <p class="mt-2 break-words text-sm text-gray-700 dark:text-gray-300">{{ attempt.validation_message }}</p>
+    {% endif %}
+    {% if attempt.artifact_url %}
+    <p class="mt-2 break-all text-xs text-gray-600 dark:text-gray-400">Artifact: <a href="{{ attempt.artifact_url }}" target="_blank" rel="noopener noreferrer" class="font-medium underline">{{ attempt.artifact_url }}</a></p>
+    {% endif %}
+    {% if attempt.feedback_tasks %}
+        {% with feedback_tasks=attempt.feedback_tasks, feedback_passed=attempt.feedback_passed, requirement_slug=requirement.slug ~ '-history-' ~ attempt.id %}
+        {% include "partials/verification_feedback.html" %}
+        {% endwith %}
+    {% endif %}
+</article>
+{% endfor %}
+{% if history.next_cursor %}
+<div>
+    <button
+        type="button"
+        hx-get="/htmx/verifications/phase/{{ phase_id }}/requirements/{{ requirement.slug }}/history?cursor={{ history.next_cursor | urlencode }}"
+        hx-target="closest div"
+        hx-swap="outerHTML"
+        class="inline-flex min-h-11 items-center text-sm font-bold text-blue-700 underline underline-offset-4 dark:text-blue-300"
+    >Load 10 older attempts</button>
+</div>
+{% endif %}

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -78,6 +78,45 @@ def _card_contexts(
     }
 
 
+def _phase_verification_context(
+    requirements: list[SimpleNamespace],
+    submissions_by_req: dict[str, object],
+    *,
+    locked: bool,
+) -> SimpleNamespace:
+    cards = _card_contexts(requirements, submissions_by_req)
+    found_current = False
+    items = []
+    for requirement in requirements:
+        card = cards[requirement.slug]
+        if card["card_state"] == "passed":
+            page_state = "passed"
+        elif locked:
+            page_state = "locked"
+        elif not found_current:
+            page_state = "current"
+            found_current = True
+        else:
+            page_state = "up_next"
+        items.append(
+            SimpleNamespace(
+                requirement=requirement,
+                card=card,
+                page_state=page_state,
+                history=SimpleNamespace(items=[], next_cursor=None),
+            )
+        )
+    return SimpleNamespace(
+        phase=SimpleNamespace(name="Phase", order=6 if locked else 1),
+        progress=SimpleNamespace(
+            verification=SimpleNamespace(is_complete=False),
+        ),
+        requirements=items,
+        verification_locked=locked,
+        prerequisite_phase_id=5 if locked else None,
+    )
+
+
 @pytest.mark.unit
 def test_phase5_holistic_feedback_renders_in_shared_panel():
     html = _render(
@@ -183,7 +222,7 @@ def test_passing_feedback_panel_pluralizes_suggestions():
 
 @pytest.mark.unit
 class TestPhaseVerificationLocked:
-    """The gated (`verification_locked`) branch of pages/phase.html."""
+    """The gated branch of the dedicated verification page."""
 
     def _render_phase(
         self,
@@ -191,14 +230,10 @@ class TestPhaseVerificationLocked:
         submissions_by_req: dict[str, object],
     ) -> str:
         return _render(
-            "pages/phase.html",
-            phase=SimpleNamespace(name="Phase 6", description="", order=6),
-            topics=[],
-            phase_progress=None,
-            requirements=requirements,
-            card_contexts_by_req=_card_contexts(requirements, submissions_by_req),
-            verification_locked=True,
-            prerequisite_phase_id=5,
+            "pages/phase_verification.html",
+            verification=_phase_verification_context(
+                requirements, submissions_by_req, locked=True
+            ),
         )
 
     def test_validated_requirement_renders_as_complete_when_locked(self):
@@ -238,7 +273,7 @@ class TestPhaseVerificationLocked:
 
 @pytest.mark.unit
 class TestPhaseVerificationCardStates:
-    """The unlocked branch's verification-card states in pages/phase.html."""
+    """The dedicated page's unlocked verification-card states."""
 
     def _render_phase(
         self,
@@ -246,14 +281,10 @@ class TestPhaseVerificationCardStates:
         submissions_by_req: dict[str, object],
     ) -> str:
         return _render(
-            "pages/phase.html",
-            phase=SimpleNamespace(name="Phase 1", description="", order=1),
-            topics=[],
-            phase_progress=None,
-            requirements=requirements,
-            card_contexts_by_req=_card_contexts(requirements, submissions_by_req),
-            verification_locked=False,
-            prerequisite_phase_id=None,
+            "pages/phase_verification.html",
+            verification=_phase_verification_context(
+                requirements, submissions_by_req, locked=False
+            ),
         )
 
     def test_not_started_shows_form_no_pill(self):
@@ -383,12 +414,14 @@ def test_phase_progress_uses_distinct_labels_without_explanatory_copy():
         phase=SimpleNamespace(name="Phase 1", description="", order=1),
         topics=[],
         phase_progress=phase_progress,
-        requirements=[],
+        has_verification=True,
     )
 
     assert "Verification progress — 1/2 requirements" in html
     assert "Learning progress — 2/5 steps" in html
     assert "Verification is what counts" not in html
+    assert 'href="/verifications/phase/1"' in html
+    assert 'hx-post="/htmx/github/submit"' not in html
 
 
 @pytest.mark.unit

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -29,6 +29,7 @@ from learn_to_cloud.routes.htmx_routes import (
     htmx_submit_verification,
     htmx_uncomplete_step,
     htmx_verification_attempt_status,
+    htmx_verification_history,
 )
 from learn_to_cloud.services.durable_verification_client import (
     DurableStatusResult,
@@ -40,6 +41,9 @@ from learn_to_cloud.services.submissions_service import (
     VerificationAttemptSubmission,
 )
 from learn_to_cloud.services.users_service import UserNotFoundError
+from learn_to_cloud.services.verification_history_cursors import (
+    VerificationHistoryCursorError,
+)
 from learn_to_cloud.services.verification_status_tokens import VerificationStatusToken
 
 
@@ -54,6 +58,54 @@ def _mock_request(*, session: dict | None = None) -> MagicMock:
     request.app.state.session_maker = MagicMock()
 
     return request
+
+
+@pytest.mark.unit
+class TestHtmxVerificationHistory:
+    async def test_history_page_is_authenticated_and_rendered(self, _patch_templates):
+        history = MagicMock()
+        requirement = MagicMock()
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_verification_history_page",
+                return_value=history,
+            ) as service,
+            patch(
+                "learn_to_cloud.routes.htmx_routes.get_requirement_by_slug",
+                return_value=requirement,
+            ),
+        ):
+            response = await htmx_verification_history(
+                _mock_request(),
+                phase_id=3,
+                requirement_slug="project",
+                cursor="opaque",
+                db=AsyncMock(),
+                current_user=AuthenticatedUser(user_id=7, github_username="learner"),
+            )
+
+        assert response.status_code == 200
+        service.assert_awaited_once()
+        assert (
+            _patch_templates.TemplateResponse.call_args[0][1]
+            == "partials/verification_history_page.html"
+        )
+
+    async def test_invalid_history_cursor_returns_400(self):
+        with patch(
+            "learn_to_cloud.routes.htmx_routes.get_verification_history_page",
+            side_effect=VerificationHistoryCursorError,
+        ):
+            response = await htmx_verification_history(
+                _mock_request(),
+                phase_id=3,
+                requirement_slug="project",
+                cursor="bad",
+                db=AsyncMock(),
+                current_user=AuthenticatedUser(user_id=7, github_username="learner"),
+            )
+
+        assert response.status_code == 400
 
 
 @pytest.fixture(autouse=True)

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -32,10 +32,12 @@ from learn_to_cloud.routes.pages_routes import (
     faq_page,
     home_page,
     phase_page,
+    phase_verification_page,
     privacy_page,
     stats_page_redirect,
     terms_page,
     topic_page,
+    verifications_page,
 )
 
 
@@ -190,10 +192,6 @@ class TestPhasePage:
         phase = _fake_phase()
         mock_user = MagicMock()
 
-        mock_sub_context = MagicMock()
-        mock_sub_context.submissions_by_req = {}
-        mock_sub_context.feedback_by_req = {}
-
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
@@ -213,22 +211,6 @@ class TestPhasePage:
                 "learn_to_cloud.routes.pages_routes.build_phase_topics",
                 return_value=[],
             ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_phase_submission_context",
-                autospec=True,
-                return_value=mock_sub_context,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.VerificationAttemptRepository",
-                return_value=MagicMock(
-                    get_active_for_requirements=AsyncMock(return_value=[]),
-                ),
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.is_phase_verification_locked",
-                autospec=True,
-                return_value=(False, None),
-            ),
         ):
             await phase_page(request, phase_id=1, db=mock_db, user_id=42)
 
@@ -236,7 +218,70 @@ class TestPhasePage:
         ctx = template.call_args[0][2]
         assert ctx["phase"] is phase
         assert ctx["user"] is mock_user
-        assert ctx["verification_locked"] is False
+        assert ctx["has_verification"] is False
+
+
+@pytest.mark.unit
+class TestVerificationPages:
+    async def test_overview_renders_typed_context(self, _patch_templates):
+        request, template = _mock_request(_patch_templates)
+        overview = MagicMock()
+        user = MagicMock()
+        with (
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                return_value=user,
+            ),
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_verification_overview",
+                return_value=overview,
+            ),
+        ):
+            await verifications_page(request, AsyncMock(), user_id=42)
+
+        assert template.call_args[0][1] == "pages/verifications.html"
+        assert template.call_args[0][2]["overview"] is overview
+
+    async def test_phase_verification_renders_dedicated_page(self, _patch_templates):
+        request, template = _mock_request(_patch_templates)
+        context = MagicMock()
+        user = MagicMock(github_username="learner")
+        with (
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                return_value=user,
+            ),
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_phase_verification_context",
+                return_value=context,
+            ) as service,
+        ):
+            await phase_verification_page(
+                request, phase_id=2, db=AsyncMock(), user_id=42
+            )
+
+        service.assert_awaited_once()
+        assert template.call_args[0][1] == "pages/phase_verification.html"
+        assert template.call_args[0][2]["verification"] is context
+
+    async def test_phase_verification_returns_404(self, _patch_templates):
+        request, template = _mock_request(_patch_templates)
+        with (
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_phase_verification_context",
+                return_value=None,
+            ),
+        ):
+            await phase_verification_page(
+                request, phase_id=999, db=AsyncMock(), user_id=42
+            )
+
+        assert template.call_args[0][1] == "pages/404.html"
+        assert template.call_args.kwargs["status_code"] == 404
 
 
 @pytest.mark.unit

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -20,6 +20,7 @@ Marked @pytest.mark.smoke so they can be run separately:
 """
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -273,6 +274,28 @@ class TestAuthPageSmoke:
             response = await auth_client.get("/account")
         assert response.status_code == 200
 
+    async def test_verifications_overview_renders(self, auth_client: AsyncClient):
+        overview = SimpleNamespace(
+            phases=(),
+            requirements_verified=0,
+            requirements_required=0,
+            percentage=100.0,
+        )
+        with (
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                return_value=_fake_user(),
+            ),
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_verification_overview",
+                return_value=overview,
+            ),
+        ):
+            response = await auth_client.get("/verifications")
+
+        assert response.status_code == 200
+        assert "Verifications" in response.text
+
     async def test_phase_page_renders(self, auth_client: AsyncClient):
         """GET /phase/1 renders the phase detail template."""
         from learn_to_cloud_shared.content_yaml_loader import (
@@ -293,10 +316,6 @@ class TestAuthPageSmoke:
             topic_progress={},
         )
 
-        mock_sub_context = MagicMock()
-        mock_sub_context.submissions_by_req = {}
-        mock_sub_context.feedback_by_req = {}
-
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_user_by_id",
@@ -306,25 +325,11 @@ class TestAuthPageSmoke:
                 "learn_to_cloud.routes.pages_routes.fetch_phase_progress",
                 return_value=detail,
             ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_phase_submission_context",
-                return_value=mock_sub_context,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.VerificationAttemptRepository",
-                return_value=MagicMock(
-                    get_active_for_requirements=AsyncMock(return_value=[])
-                ),
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.is_phase_verification_locked",
-                return_value=(False, None),
-            ),
         ):
             response = await auth_client.get("/phase/1")
         assert response.status_code == 200
 
-    async def test_phase_page_shows_feedback_on_verified_requirement(
+    async def test_verification_page_shows_feedback_on_verified_requirement(
         self, auth_client: AsyncClient
     ):
         """A passed requirement still surfaces its rubric feedback (the why)."""
@@ -340,8 +345,6 @@ class TestAuthPageSmoke:
         )
         if not phase or not phase.hands_on_verification:
             pytest.skip("No hands-on requirements in phase1")
-        req_slug = phase.hands_on_verification.requirements[0].slug
-
         verified_submission = SubmissionData(
             id=uuid4(),
             submitted_value="https://github.com/testuser/repo",
@@ -350,22 +353,6 @@ class TestAuthPageSmoke:
             verification_completed=True,
             created_at=datetime(2024, 1, 2, tzinfo=UTC),
         )
-        mock_sub_context = MagicMock()
-        mock_sub_context.submissions_by_req = {req_slug: verified_submission}
-        mock_sub_context.feedback_by_req = {
-            req_slug: {
-                "tasks": [
-                    {
-                        "name": "Reflection depth",
-                        "passed": True,
-                        "message": "You clearly explained what you explored.",
-                        "next_steps": "",
-                    }
-                ],
-                "passed": 1,
-            }
-        }
-
         detail = PhaseProgress(
             phase_id=1,
             learning=LearningProgress(steps_completed=0, steps_required=0),
@@ -374,6 +361,42 @@ class TestAuthPageSmoke:
             ),
             topic_progress={},
         )
+        from learn_to_cloud.rendering.context import build_requirement_card_context
+        from learn_to_cloud.services.verifications_service import (
+            PhaseVerificationContext,
+            RequirementVerificationContext,
+            VerificationHistoryPage,
+        )
+
+        requirement = phase.hands_on_verification.requirements[0]
+        card = build_requirement_card_context(
+            requirement=requirement,
+            github_username="testuser",
+            submission=verified_submission,
+            feedback_tasks=[
+                {
+                    "name": "Reflection depth",
+                    "passed": True,
+                    "message": "You clearly explained what you explored.",
+                    "next_steps": "",
+                }
+            ],
+            feedback_passed=1,
+        )
+        verification = PhaseVerificationContext(
+            phase=phase,
+            progress=detail,
+            requirements=(
+                RequirementVerificationContext(
+                    requirement=requirement,
+                    card=card,
+                    page_state="passed",
+                    history=VerificationHistoryPage(items=(), next_cursor=None),
+                ),
+            ),
+            verification_locked=False,
+            prerequisite_phase_id=None,
+        )
 
         with (
             patch(
@@ -381,25 +404,11 @@ class TestAuthPageSmoke:
                 return_value=_fake_user(),
             ),
             patch(
-                "learn_to_cloud.routes.pages_routes.fetch_phase_progress",
-                return_value=detail,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_phase_submission_context",
-                return_value=mock_sub_context,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.VerificationAttemptRepository",
-                return_value=MagicMock(
-                    get_active_for_requirements=AsyncMock(return_value=[])
-                ),
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.is_phase_verification_locked",
-                return_value=(False, None),
+                "learn_to_cloud.routes.pages_routes.get_phase_verification_context",
+                return_value=verification,
             ),
         ):
-            response = await auth_client.get("/phase/1")
+            response = await auth_client.get("/verifications/phase/1")
 
         assert response.status_code == 200
         assert "All checks passed" in response.text

--- a/api/tests/services/test_progress_service.py
+++ b/api/tests/services/test_progress_service.py
@@ -585,7 +585,7 @@ class TestResolveContinueDestination:
                 AsyncMock(), user_id=1, phase=phase
             )
 
-        assert destination == "/phase/3#verification-section"
+        assert destination == "/verifications/phase/3"
 
     @pytest.mark.asyncio
     async def test_hands_on_only_phase_links_straight_to_verification(self):
@@ -601,7 +601,7 @@ class TestResolveContinueDestination:
                 AsyncMock(), user_id=1, phase=phase
             )
 
-        assert destination == "/phase/3#verification-section"
+        assert destination == "/verifications/phase/3"
         mock_resolve.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/api/tests/services/test_verification_history_cursors.py
+++ b/api/tests/services/test_verification_history_cursors.py
@@ -1,0 +1,64 @@
+"""Tests for scoped opaque verification-history cursors."""
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from itsdangerous import URLSafeSerializer
+
+from learn_to_cloud.services.verification_history_cursors import (
+    VerificationHistoryCursorError,
+    create_history_cursor,
+    load_history_cursor,
+)
+
+
+@pytest.fixture
+def cursor_serializer():
+    with patch(
+        "learn_to_cloud.services.verification_history_cursors._serializer",
+        return_value=URLSafeSerializer("test-secret", salt="history"),
+    ):
+        yield
+
+
+@pytest.mark.unit
+def test_cursor_round_trip_preserves_equal_timestamp_tiebreaker(cursor_serializer):
+    requirement_uuid = uuid4()
+    attempt_id = uuid4()
+    created_at = datetime(2026, 8, 1, 12, 30, tzinfo=UTC)
+    token = create_history_cursor(
+        user_id=7,
+        requirement_uuid=requirement_uuid,
+        created_at=created_at,
+        attempt_id=attempt_id,
+    )
+
+    cursor = load_history_cursor(
+        token,
+        expected_user_id=7,
+        expected_requirement_uuid=requirement_uuid,
+    )
+
+    assert cursor.created_at == created_at
+    assert cursor.attempt_id == attempt_id
+    assert str(attempt_id) not in token
+
+
+@pytest.mark.unit
+def test_cursor_cannot_cross_users(cursor_serializer):
+    requirement_uuid = uuid4()
+    token = create_history_cursor(
+        user_id=7,
+        requirement_uuid=requirement_uuid,
+        created_at=datetime(2026, 8, 1, tzinfo=UTC),
+        attempt_id=uuid4(),
+    )
+
+    with pytest.raises(VerificationHistoryCursorError):
+        load_history_cursor(
+            token,
+            expected_user_id=8,
+            expected_requirement_uuid=requirement_uuid,
+        )

--- a/api/tests/services/test_verifications_service.py
+++ b/api/tests/services/test_verifications_service.py
@@ -1,0 +1,134 @@
+"""Focused tests for dedicated verification page contexts."""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    AttemptCardProjection,
+    AttemptHistoryProjection,
+)
+
+from learn_to_cloud.services.verifications_service import (
+    _history_item,
+    _safe_artifact_url,
+    get_phase_verification_context,
+)
+
+
+def _terminal(requirement_uuid: UUID, *, outcome: str) -> AttemptCardProjection:
+    now = datetime(2026, 8, 1, tzinfo=UTC)
+    return AttemptCardProjection(
+        id=uuid4(),
+        requirement_uuid=requirement_uuid,
+        submission_value_kind="github_url",
+        submitted_value="https://github.com/learner/project",
+        github_username_snapshot="learner",
+        cloud_provider=None,
+        outcome=outcome,
+        feedback_json=None,
+        validation_message="Needs work" if outcome == "failed" else None,
+        completed_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.unit
+async def test_phase_context_keeps_only_first_incomplete_requirement_actionable():
+    passed = SimpleNamespace(
+        uuid=uuid4(),
+        slug="passed",
+        name="Passed",
+        description="",
+        submission_type="ctf_token",
+        type_config=SimpleNamespace(placeholder=None),
+    )
+    current = SimpleNamespace(
+        uuid=uuid4(),
+        slug="current",
+        name="Current",
+        description="",
+        submission_type="ctf_token",
+        type_config=SimpleNamespace(placeholder=None),
+    )
+    upcoming = SimpleNamespace(
+        uuid=uuid4(),
+        slug="upcoming",
+        name="Upcoming",
+        description="",
+        submission_type="ctf_token",
+        type_config=SimpleNamespace(placeholder=None),
+    )
+    phase = SimpleNamespace(
+        order=2,
+        hands_on_verification=SimpleNamespace(requirements=[passed, current, upcoming]),
+    )
+    repository = MagicMock()
+    repository.get_latest_terminal_for_requirements = AsyncMock(
+        return_value=[_terminal(passed.uuid, outcome="succeeded")]
+    )
+    repository.get_active_for_requirements = AsyncMock(return_value=[])
+    repository.get_terminal_history_for_requirements = AsyncMock(return_value=[])
+
+    with (
+        patch(
+            "learn_to_cloud.services.verifications_service.get_phase_by_slug",
+            return_value=phase,
+        ),
+        patch(
+            "learn_to_cloud.services.verifications_service.fetch_phase_progress",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "learn_to_cloud.services.verifications_service."
+            "is_phase_verification_locked",
+            return_value=(False, None),
+        ),
+        patch(
+            "learn_to_cloud.services.verifications_service."
+            "VerificationAttemptRepository",
+            return_value=repository,
+        ),
+    ):
+        context = await get_phase_verification_context(
+            AsyncMock(), 7, 2, github_username="learner"
+        )
+
+    assert context is not None
+    assert [item.page_state for item in context.requirements] == [
+        "passed",
+        "current",
+        "up_next",
+    ]
+
+
+@pytest.mark.unit
+def test_history_artifact_only_exposes_valid_url_value_kinds():
+    assert (
+        _safe_artifact_url("github_url", "https://github.com/learner/project")
+        == "https://github.com/learner/project"
+    )
+    assert _safe_artifact_url("token", "secret-token") is None
+    assert _safe_artifact_url("text", "https://example.com/reflection") is None
+    assert _safe_artifact_url("deployed_url", "javascript:alert(1)") is None
+
+
+@pytest.mark.unit
+def test_history_context_never_contains_token_or_reflection_values():
+    row = AttemptHistoryProjection(
+        id=uuid4(),
+        requirement_uuid=uuid4(),
+        submission_value_kind="token",
+        submitted_value="secret-token",
+        outcome="failed",
+        feedback_json=None,
+        validation_message="Invalid token",
+        completed_at=None,
+        created_at=datetime(2026, 8, 1, tzinfo=UTC),
+    )
+    item = _history_item(row)
+    assert item.artifact_url is None
+    assert not hasattr(item, "submitted_value")

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import (
@@ -14,12 +15,14 @@ from sqlalchemy import (
     column,
     func,
     literal,
+    or_,
     select,
     text,
     union_all,
     update,
     values,
 )
+from sqlalchemy.engine import Row
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from learn_to_cloud_shared.models import (
@@ -98,6 +101,35 @@ class AttemptCardProjection:
     completed_at: datetime | None
     created_at: datetime
     updated_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptHistoryProjection:
+    """Terminal attempt fields safe for learner history rendering."""
+
+    id: UUID
+    requirement_uuid: UUID
+    submission_value_kind: str
+    submitted_value: str
+    outcome: str
+    feedback_json: list[dict] | None
+    validation_message: str | None
+    completed_at: datetime | None
+    created_at: datetime
+
+
+def _to_history_projection(row: Row[Any]) -> AttemptHistoryProjection:
+    return AttemptHistoryProjection(
+        id=row.id,
+        requirement_uuid=row.requirement_uuid,
+        submission_value_kind=row.submission_value_kind,
+        submitted_value=row.submitted_value,
+        outcome=row.outcome,
+        feedback_json=row.feedback_json,
+        validation_message=row.validation_message,
+        completed_at=row.completed_at,
+        created_at=row.created_at,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -611,20 +643,7 @@ class VerificationAttemptRepository:
         if not uuids:
             return []
 
-        latest_sq = (
-            select(
-                VerificationAttempt.requirement_uuid,
-                func.max(VerificationAttempt.created_at).label("max_created_at"),
-            )
-            .where(
-                VerificationAttempt.user_id == user_id,
-                VerificationAttempt.requirement_uuid.in_(uuids),
-                VerificationAttempt.outcome.is_not(None),
-            )
-            .group_by(VerificationAttempt.requirement_uuid)
-            .subquery()
-        )
-        result = await self.db.execute(
+        ranked_sq = (
             select(
                 VerificationAttempt.id,
                 VerificationAttempt.requirement_uuid,
@@ -638,16 +657,38 @@ class VerificationAttemptRepository:
                 VerificationAttempt.completed_at,
                 VerificationAttempt.created_at,
                 VerificationAttempt.updated_at,
+                func.row_number()
+                .over(
+                    partition_by=VerificationAttempt.requirement_uuid,
+                    order_by=(
+                        VerificationAttempt.created_at.desc(),
+                        VerificationAttempt.id.desc(),
+                    ),
+                )
+                .label("row_number"),
             )
-            .join(
-                latest_sq,
-                and_(
-                    VerificationAttempt.requirement_uuid
-                    == latest_sq.c.requirement_uuid,
-                    VerificationAttempt.created_at == latest_sq.c.max_created_at,
-                ),
+            .where(
+                VerificationAttempt.user_id == user_id,
+                VerificationAttempt.requirement_uuid.in_(uuids),
+                VerificationAttempt.outcome.is_not(None),
             )
-            .where(VerificationAttempt.user_id == user_id)
+            .subquery()
+        )
+        result = await self.db.execute(
+            select(
+                ranked_sq.c.id,
+                ranked_sq.c.requirement_uuid,
+                ranked_sq.c.submission_value_kind,
+                ranked_sq.c.submitted_value,
+                ranked_sq.c.github_username_snapshot,
+                ranked_sq.c.cloud_provider,
+                ranked_sq.c.outcome,
+                ranked_sq.c.feedback_json,
+                ranked_sq.c.validation_message,
+                ranked_sq.c.completed_at,
+                ranked_sq.c.created_at,
+                ranked_sq.c.updated_at,
+            ).where(ranked_sq.c.row_number == 1)
         )
         return [
             AttemptCardProjection(
@@ -666,6 +707,114 @@ class VerificationAttemptRepository:
             )
             for row in result.all()
         ]
+
+    async def get_terminal_history_for_requirements(
+        self,
+        user_id: int,
+        requirement_uuids: Iterable[UUID],
+        *,
+        per_requirement_limit: int,
+    ) -> list[AttemptHistoryProjection]:
+        """Return each requirement's newest terminal attempts in one query."""
+        uuids = list(requirement_uuids)
+        if not uuids or per_requirement_limit <= 0:
+            return []
+
+        ranked_sq = (
+            select(
+                VerificationAttempt.id,
+                VerificationAttempt.requirement_uuid,
+                VerificationAttempt.submission_value_kind,
+                VerificationAttempt.submitted_value,
+                VerificationAttempt.outcome,
+                VerificationAttempt.feedback_json,
+                VerificationAttempt.validation_message,
+                VerificationAttempt.completed_at,
+                VerificationAttempt.created_at,
+                func.row_number()
+                .over(
+                    partition_by=VerificationAttempt.requirement_uuid,
+                    order_by=(
+                        VerificationAttempt.created_at.desc(),
+                        VerificationAttempt.id.desc(),
+                    ),
+                )
+                .label("row_number"),
+            )
+            .where(
+                VerificationAttempt.user_id == user_id,
+                VerificationAttempt.requirement_uuid.in_(uuids),
+                VerificationAttempt.outcome.is_not(None),
+            )
+            .subquery()
+        )
+        result = await self.db.execute(
+            select(
+                ranked_sq.c.id,
+                ranked_sq.c.requirement_uuid,
+                ranked_sq.c.submission_value_kind,
+                ranked_sq.c.submitted_value,
+                ranked_sq.c.outcome,
+                ranked_sq.c.feedback_json,
+                ranked_sq.c.validation_message,
+                ranked_sq.c.completed_at,
+                ranked_sq.c.created_at,
+            )
+            .where(ranked_sq.c.row_number <= per_requirement_limit)
+            .order_by(
+                ranked_sq.c.requirement_uuid,
+                ranked_sq.c.created_at.desc(),
+                ranked_sq.c.id.desc(),
+            )
+        )
+        return [_to_history_projection(row) for row in result.all()]
+
+    async def get_terminal_history(
+        self,
+        user_id: int,
+        requirement_uuid: UUID,
+        *,
+        limit: int,
+        before: tuple[datetime, UUID] | None = None,
+    ) -> list[AttemptHistoryProjection]:
+        """Return one cursor page of terminal attempts, newest first."""
+        if limit <= 0:
+            return []
+
+        query = select(
+            VerificationAttempt.id,
+            VerificationAttempt.requirement_uuid,
+            VerificationAttempt.submission_value_kind,
+            VerificationAttempt.submitted_value,
+            VerificationAttempt.outcome,
+            VerificationAttempt.feedback_json,
+            VerificationAttempt.validation_message,
+            VerificationAttempt.completed_at,
+            VerificationAttempt.created_at,
+        ).where(
+            VerificationAttempt.user_id == user_id,
+            VerificationAttempt.requirement_uuid == requirement_uuid,
+            VerificationAttempt.outcome.is_not(None),
+        )
+        if before is not None:
+            created_at, attempt_id = before
+            query = query.where(
+                or_(
+                    VerificationAttempt.created_at < created_at,
+                    and_(
+                        VerificationAttempt.created_at == created_at,
+                        VerificationAttempt.id < attempt_id,
+                    ),
+                )
+            )
+
+        result = await self.db.execute(
+            query.order_by(
+                VerificationAttempt.created_at.desc(),
+                VerificationAttempt.id.desc(),
+            ).limit(limit)
+        )
+        return [_to_history_projection(row) for row in result.all()]
 
     async def list_phase_completions(
         self,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -671,8 +671,8 @@ class ContinuePhaseData(FrozenModel):
 
     ``destination_url`` already resolves to the specific place that matters
     -- the first unchecked learning step's topic, or the phase's
-    verification section once every step is checked -- so templates never
-    need to re-derive a phase link from separate id/order/slug fields.
+    dedicated verification page once every step is checked -- so templates
+    never need to re-derive a phase link from separate id/order/slug fields.
     """
 
     destination_url: str

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
@@ -201,6 +201,37 @@ async def test_get_prepare_state_and_status(
     assert status.outcome is None
 
 
+async def test_terminal_history_cursor_is_equal_timestamp_safe(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    requirement_uuid = uuid4()
+    created_at = utcnow()
+    ids = sorted([uuid4(), uuid4(), uuid4()], reverse=True)
+    for attempt_id in ids:
+        await _insert_attempt(
+            session_maker,
+            attempt_id=attempt_id,
+            requirement_uuid=requirement_uuid,
+            created_at=created_at,
+            outcome="failed",
+        )
+
+    async with session_maker() as db:
+        repository = VerificationAttemptRepository(db)
+        first = await repository.get_terminal_history(
+            USER_ID, requirement_uuid, limit=2
+        )
+        second = await repository.get_terminal_history(
+            USER_ID,
+            requirement_uuid,
+            limit=2,
+            before=(first[-1].created_at, first[-1].id),
+        )
+
+    assert [row.id for row in first] == ids[:2]
+    assert [row.id for row in second] == ids[2:]
+
+
 async def test_mark_started_is_idempotent(
     session_maker: async_sessionmaker[AsyncSession], user: int
 ) -> None:


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? -->

Moves hands-on verification out of curriculum phase pages so learning and project submission each have a focused experience.

Adds an authenticated verification overview and dedicated phase verification pages with the existing submission and live polling flow. Each requirement now includes terminal attempt history, safe artifact links, shared rubric feedback, and signed cursor pagination that loads 10 older attempts at a time without skipping equal timestamps.

Phase pages keep learning progress and link to verification without reading attempts. Authenticated navigation and dashboard continuation now point learners to the dedicated verification experience. No database migration is needed because history uses the existing verification-attempt index and current requirement UUIDs.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.