### PR TITLE
Add a dedicated verification workspace

### DIFF
--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -15,12 +15,6 @@ from learn_to_cloud_shared.content_service import (
 )
 from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.models import User
-from learn_to_cloud_shared.repositories.verification_attempt_repository import (
-    VerificationAttemptRepository,
-)
-from learn_to_cloud_shared.requirements import (
-    is_phase_verification_locked,
-)
 
 from learn_to_cloud.core.auth import OptionalUserId, UserId
 from learn_to_cloud.core.templates import templates
@@ -30,18 +24,16 @@ from learn_to_cloud.rendering.context import (
     HELP_LINKS,
     build_phase_topics,
     build_progress_dict,
-    build_requirement_card_context,
     build_topic_nav,
-    feedback_tasks_and_passed,
 )
 from learn_to_cloud.services.community_service import get_community_page_data
 from learn_to_cloud.services.dashboard_service import get_dashboard_data
 from learn_to_cloud.services.progress_service import fetch_phase_progress
 from learn_to_cloud.services.steps_service import get_valid_completed_steps
-from learn_to_cloud.services.submissions_service import get_phase_submission_context
 from learn_to_cloud.services.users_service import get_user_by_id
-from learn_to_cloud.services.verification_status_tokens import (
-    create_verification_status_token,
+from learn_to_cloud.services.verification_page_service import (
+    get_phase_verification_workspace,
+    get_verifications_overview,
 )
 
 logger = logging.getLogger(__name__)
@@ -112,7 +104,7 @@ async def phase_page(
     db: DbSession,
     user_id: UserId,
 ) -> HTMLResponse:
-    """Single phase detail with topics and verification (requires auth)."""
+    """Single phase learning detail (requires auth)."""
     user = await _get_user_or_none(db, user_id)
     phase = get_phase_by_slug(f"phase{phase_id}")
     if phase is None:
@@ -125,66 +117,8 @@ async def phase_page(
 
     detail = await fetch_phase_progress(db, user_id, phase)
     topics = build_phase_topics(phase, detail)
-
-    requirements = []
-    hands_on = phase.hands_on_verification
-    if hands_on:
-        requirements = hands_on.requirements
-
-    sub_context = await get_phase_submission_context(db, user_id, phase)
-    submissions_by_req = sub_context.submissions_by_req
-    feedback_by_req = sub_context.feedback_by_req
-    requirements_by_uuid = {req.uuid: req for req in requirements}
-    active_attempts = await VerificationAttemptRepository(
-        db
-    ).get_active_for_requirements(
-        user_id,
-        requirements_by_uuid.keys(),
-    )
-    active_jobs_by_req = {
-        requirements_by_uuid[attempt.requirement_uuid].slug: attempt
-        for attempt in active_attempts
-        if attempt.requirement_uuid in requirements_by_uuid
-    }
-    # The Durable orchestration instance id is the attempt UUID, so the status
-    # token keys off that same id.
-    verification_status_tokens_by_req = {
-        requirements_by_uuid[attempt.requirement_uuid].slug: (
-            create_verification_status_token(
-                user_id=user_id,
-                job_id=attempt.id,
-                instance_id=str(attempt.id),
-                requirement_slug=requirements_by_uuid[attempt.requirement_uuid].slug,
-            )
-        )
-        for attempt in active_attempts
-        if attempt.requirement_uuid in requirements_by_uuid
-    }
-
-    # Pre-compute one verification-card context per requirement -- derived
-    # URL, card state, and banner text all in one place, so the template
-    # never re-derives a card's flags from raw submission fields (also the
-    # single source of truth the locked and unlocked branches both read).
-    github_username = user.github_username if user else None
-    card_contexts_by_req: dict[str, dict] = {}
-    for req in requirements:
-        feedback_tasks, feedback_passed = feedback_tasks_and_passed(
-            feedback_by_req.get(req.slug)
-        )
-        active_job = active_jobs_by_req.get(req.slug)
-        card_contexts_by_req[req.slug] = build_requirement_card_context(
-            requirement=req,
-            github_username=github_username,
-            submission=submissions_by_req.get(req.slug),
-            feedback_tasks=feedback_tasks,
-            feedback_passed=feedback_passed,
-            processing=active_job is not None,
-            verification_status_token=verification_status_tokens_by_req.get(req.slug),
-        )
-
-    # Sequential phase gating — check if prerequisite phase is complete
-    verification_locked, prerequisite_phase_id = await is_phase_verification_locked(
-        db, user_id, phase_id
+    has_verification = bool(
+        phase.hands_on_verification and phase.hands_on_verification.requirements
     )
 
     return templates.TemplateResponse(
@@ -195,11 +129,80 @@ async def phase_page(
             user=user,
             phase=phase,
             topics=topics,
-            requirements=requirements,
-            card_contexts_by_req=card_contexts_by_req,
             phase_progress=detail,
-            verification_locked=verification_locked,
-            prerequisite_phase_id=prerequisite_phase_id,
+            has_verification=has_verification,
+        ),
+    )
+
+
+@router.get(
+    "/verifications",
+    response_class=HTMLResponse,
+    summary="Verification workspace",
+)
+async def verifications_page(
+    request: Request,
+    db: DbSession,
+    user_id: UserId,
+) -> HTMLResponse:
+    """Verification progress and phase navigation (requires auth)."""
+    user = await _get_user_or_none(db, user_id)
+    if user is None:
+        return templates.TemplateResponse(
+            request,
+            "pages/404.html",
+            _template_context(request),
+            status_code=404,
+        )
+
+    overview = await get_verifications_overview(db, user_id)
+    return templates.TemplateResponse(
+        request,
+        "pages/verifications.html",
+        _template_context(request, user=user, overview=overview),
+    )
+
+
+@router.get(
+    "/verifications/phase/{phase_id:int}",
+    response_class=HTMLResponse,
+    summary="Phase verification",
+)
+async def phase_verification_page(
+    request: Request,
+    phase_id: int,
+    db: DbSession,
+    user_id: UserId,
+) -> HTMLResponse:
+    """One phase's verification requirements and feedback (requires auth)."""
+    user = await _get_user_or_none(db, user_id)
+    phase = get_phase_by_slug(f"phase{phase_id}")
+    if user is None or phase is None:
+        return templates.TemplateResponse(
+            request,
+            "pages/404.html",
+            _template_context(request, user=user),
+            status_code=404,
+        )
+
+    workspace = await get_phase_verification_workspace(
+        db,
+        user_id,
+        phase,
+        user.github_username,
+    )
+    return templates.TemplateResponse(
+        request,
+        "pages/verification_phase.html",
+        _template_context(
+            request,
+            user=user,
+            phase=workspace.phase,
+            phase_progress=workspace.phase_progress,
+            requirements=workspace.requirements,
+            card_contexts_by_req=workspace.card_contexts_by_req,
+            verification_locked=workspace.verification_locked,
+            prerequisite_phase_id=workspace.prerequisite_phase_id,
         ),
     )
 

--- a/api/src/learn_to_cloud/services/progress_service.py
+++ b/api/src/learn_to_cloud/services/progress_service.py
@@ -231,7 +231,7 @@ def find_first_incomplete_step(
 
     ``None`` means every step in ``phase`` is checked (including trivially,
     when the phase has no steps at all) -- the caller should point the
-    learner at verification instead.
+    learner at the phase verification workspace instead.
     """
     for topic in phase.topics:
         for step in topic.learning_steps:
@@ -248,8 +248,8 @@ async def resolve_continue_destination(
     """Where the dashboard's "Continue" action should send this learner.
 
     Points at the first unchecked step's topic, since that's where a
-    learner actually left off -- falls back to the phase's verification
-    section once every current step is checked.
+    learner actually left off -- falls back to the dedicated phase
+    verification workspace once every current step is checked.
     """
     all_step_uuids = [
         step.uuid for topic in phase.topics for step in topic.learning_steps
@@ -265,5 +265,5 @@ async def resolve_continue_destination(
         phase.hands_on_verification is not None
         and phase.hands_on_verification.requirements
     ):
-        return f"/phase/{phase.order}#verification-section"
+        return f"/verifications/phase/{phase.order}"
     return f"/phase/{phase.order}"

--- a/api/src/learn_to_cloud/services/verification_page_service.py
+++ b/api/src/learn_to_cloud/services/verification_page_service.py
@@ -1,0 +1,219 @@
+"""View data for the dedicated verification workspace."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from learn_to_cloud_shared.content_service import get_curriculum_overview
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    VerificationAttemptRepository,
+)
+from learn_to_cloud_shared.requirements import (
+    get_prerequisite_phase,
+    is_phase_verification_locked,
+)
+from learn_to_cloud_shared.schemas import (
+    HandsOnRequirement,
+    Phase,
+    PhaseOverview,
+    PhaseProgress,
+    VerificationProgress,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud.rendering.context import (
+    build_requirement_card_context,
+    feedback_tasks_and_passed,
+)
+from learn_to_cloud.services.progress_service import (
+    fetch_phase_progress,
+    fetch_user_progress,
+)
+from learn_to_cloud.services.submissions_service import get_phase_submission_context
+from learn_to_cloud.services.verification_status_tokens import (
+    create_verification_status_token,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationPhaseSummary:
+    """One phase row in the verification hub."""
+
+    phase: PhaseOverview
+    progress: VerificationProgress
+    is_locked: bool
+    prerequisite_phase_id: int | None
+
+    @property
+    def status(self) -> str:
+        if self.is_locked:
+            return "locked"
+        if self.progress.is_complete:
+            return "complete"
+        if self.progress.requirements_verified > 0:
+            return "in_progress"
+        return "not_started"
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationsOverview:
+    """Aggregate progress and phase rows for the verification hub."""
+
+    phases: list[VerificationPhaseSummary]
+    requirements_verified: int
+    requirements_required: int
+    next_phase: VerificationPhaseSummary | None
+
+    @property
+    def percentage(self) -> float:
+        if self.requirements_required == 0:
+            return 0.0
+        return round(
+            min(
+                100.0,
+                (self.requirements_verified / self.requirements_required) * 100,
+            ),
+            1,
+        )
+
+    @property
+    def is_complete(self) -> bool:
+        return (
+            self.requirements_required > 0
+            and self.requirements_verified >= self.requirements_required
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class PhaseVerificationWorkspace:
+    """All state needed to render one phase's verification workflow."""
+
+    phase: Phase
+    phase_progress: PhaseProgress
+    requirements: list[HandsOnRequirement]
+    card_contexts_by_req: dict[str, dict[str, Any]]
+    verification_locked: bool
+    prerequisite_phase_id: int | None
+
+
+async def get_verifications_overview(
+    db: AsyncSession,
+    user_id: int,
+) -> VerificationsOverview:
+    """Build verification progress without loading attempt details."""
+    phases = get_curriculum_overview()
+    user_progress = await fetch_user_progress(db, user_id, phase_overview=phases)
+
+    summaries: list[VerificationPhaseSummary] = []
+    for phase in phases:
+        phase_progress = user_progress.phases.get(phase.order)
+        if (
+            phase_progress is None
+            or phase_progress.verification.requirements_required == 0
+        ):
+            continue
+
+        prerequisite_phase_id = get_prerequisite_phase(phase.order)
+        prerequisite_progress = (
+            user_progress.phases.get(prerequisite_phase_id)
+            if prerequisite_phase_id is not None
+            else None
+        )
+        is_locked = (
+            prerequisite_progress is not None
+            and not prerequisite_progress.verification.is_complete
+        )
+        summaries.append(
+            VerificationPhaseSummary(
+                phase=phase,
+                progress=phase_progress.verification,
+                is_locked=is_locked,
+                prerequisite_phase_id=prerequisite_phase_id if is_locked else None,
+            )
+        )
+
+    next_phase = next(
+        (
+            summary
+            for summary in summaries
+            if not summary.is_locked and not summary.progress.is_complete
+        ),
+        None,
+    )
+    return VerificationsOverview(
+        phases=summaries,
+        requirements_verified=sum(
+            summary.progress.requirements_verified for summary in summaries
+        ),
+        requirements_required=sum(
+            summary.progress.requirements_required for summary in summaries
+        ),
+        next_phase=next_phase,
+    )
+
+
+async def get_phase_verification_workspace(
+    db: AsyncSession,
+    user_id: int,
+    phase: Phase,
+    github_username: str | None,
+) -> PhaseVerificationWorkspace:
+    """Build cards, polling state, progress, and gating for one phase."""
+    phase_progress = await fetch_phase_progress(db, user_id, phase)
+    requirements = (
+        list(phase.hands_on_verification.requirements)
+        if phase.hands_on_verification
+        else []
+    )
+
+    submission_context = await get_phase_submission_context(db, user_id, phase)
+    requirements_by_uuid = {
+        requirement.uuid: requirement for requirement in requirements
+    }
+    active_attempts = await VerificationAttemptRepository(
+        db
+    ).get_active_for_requirements(user_id, requirements_by_uuid)
+    active_attempts_by_slug = {
+        requirements_by_uuid[attempt.requirement_uuid].slug: attempt
+        for attempt in active_attempts
+        if attempt.requirement_uuid in requirements_by_uuid
+    }
+
+    card_contexts_by_req: dict[str, dict[str, Any]] = {}
+    for requirement in requirements:
+        feedback_tasks, feedback_passed = feedback_tasks_and_passed(
+            submission_context.feedback_by_req.get(requirement.slug)
+        )
+        active_attempt = active_attempts_by_slug.get(requirement.slug)
+        status_token = (
+            create_verification_status_token(
+                user_id=user_id,
+                job_id=active_attempt.id,
+                instance_id=str(active_attempt.id),
+                requirement_slug=requirement.slug,
+            )
+            if active_attempt is not None
+            else None
+        )
+        card_contexts_by_req[requirement.slug] = build_requirement_card_context(
+            requirement=requirement,
+            github_username=github_username,
+            submission=submission_context.submissions_by_req.get(requirement.slug),
+            feedback_tasks=feedback_tasks,
+            feedback_passed=feedback_passed,
+            processing=active_attempt is not None,
+            verification_status_token=status_token,
+        )
+
+    verification_locked, prerequisite_phase_id = await is_phase_verification_locked(
+        db, user_id, phase.order
+    )
+    return PhaseVerificationWorkspace(
+        phase=phase,
+        phase_progress=phase_progress,
+        requirements=requirements,
+        card_contexts_by_req=card_contexts_by_req,
+        verification_locked=verification_locked,
+        prerequisite_phase_id=prerequisite_phase_id,
+    )

--- a/api/src/learn_to_cloud/templates/pages/curriculum.html
+++ b/api/src/learn_to_cloud/templates/pages/curriculum.html
@@ -28,7 +28,7 @@
         </p>
         <p class="leading-6 text-blue-950 dark:text-blue-100">
             <strong class="font-bold">Prove the work.</strong>
-            Phase pages pair learning topics with hands-on verification.
+            A dedicated verification workspace keeps submissions and feedback separate from learning content.
         </p>
     </div>
 </header>

--- a/api/src/learn_to_cloud/templates/pages/dashboard.html
+++ b/api/src/learn_to_cloud/templates/pages/dashboard.html
@@ -14,7 +14,7 @@
 <section class="mb-10 rounded-lg border border-blue-200 bg-blue-50 p-5 dark:border-blue-800 dark:bg-blue-950/40" aria-labelledby="continue-heading">
     <div class="flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-center">
         <div class="min-w-0">
-            <h2 id="continue-heading" class="text-xl font-bold text-blue-950 dark:text-blue-100">Continue learning</h2>
+            <h2 id="continue-heading" class="text-xl font-bold text-blue-950 dark:text-blue-100">Continue your path</h2>
             <p class="mt-1 break-words text-sm leading-6 text-blue-800 dark:text-blue-200">{{ dashboard.continue_phase.label }}</p>
         </div>
         <a href="{{ dashboard.continue_phase.destination_url }}" class="inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">
@@ -46,13 +46,16 @@
 
 {% if dashboard.phases %}
 <section class="mb-12" aria-labelledby="progress-heading">
-    <div class="flex flex-col justify-between gap-2 sm:flex-row sm:items-end">
+    <div class="flex flex-col justify-between gap-3 sm:flex-row sm:items-end">
         <div>
             <h2 id="progress-heading" class="text-xl font-bold text-gray-950 dark:text-white">Your progress</h2>
             <p class="mt-1 text-sm leading-6 text-gray-600 dark:text-gray-400">
                 {{ dashboard.phases_completed }} of {{ dashboard.total_phases }} phases complete. Complete each phase's verification to progress.
             </p>
         </div>
+        <a href="/verifications" class="inline-flex min-h-11 items-center text-sm font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300">
+            Open verification workspace
+        </a>
     </div>
 
     <div class="mt-5 grid gap-6 border-y border-gray-200 py-6 dark:border-gray-700 sm:grid-cols-2 sm:gap-10">
@@ -100,7 +103,7 @@
     <div class="flex items-end justify-between gap-4">
         <div>
             <h2 id="phase-progress-heading" class="text-xl font-bold text-gray-950 dark:text-white">Phases</h2>
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Open a phase to continue learning or complete verification.</p>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Open a phase to continue learning. Use the verification workspace to submit hands-on work.</p>
         </div>
         <a href="/curriculum" class="hidden min-h-11 items-center text-sm font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300 sm:inline-flex">
             Full curriculum

--- a/api/src/learn_to_cloud/templates/pages/dashboard.html
+++ b/api/src/learn_to_cloud/templates/pages/dashboard.html
@@ -105,9 +105,6 @@
             <h2 id="phase-progress-heading" class="text-xl font-bold text-gray-950 dark:text-white">Phases</h2>
             <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Open a phase to continue learning. Use the verification workspace to submit hands-on work.</p>
         </div>
-        <a href="/curriculum" class="hidden min-h-11 items-center text-sm font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300 sm:inline-flex">
-            Full curriculum
-        </a>
     </div>
 
     <div class="mt-8">
@@ -180,9 +177,6 @@
         {% endfor %}
     </div>
 
-    <a href="/curriculum" class="mt-6 inline-flex min-h-11 items-center text-sm font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300 sm:hidden">
-        Full curriculum
-    </a>
 </section>
 {% else %}
 <section class="rounded-lg border border-gray-200 bg-gray-50 p-8 dark:border-gray-700 dark:bg-gray-800/50" aria-labelledby="dashboard-empty-heading">

--- a/api/src/learn_to_cloud/templates/pages/phase.html
+++ b/api/src/learn_to_cloud/templates/pages/phase.html
@@ -77,7 +77,7 @@
 <section class="pt-12 sm:pt-14" aria-labelledby="topics-heading">
     <div>
         <h2 id="topics-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Topics</h2>
-        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Work through the learning steps in order, then return here for verification.</p>
+        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Work through the learning steps in order, then open the verification workspace when you are ready.</p>
     </div>
 
     {% if topics %}
@@ -105,81 +105,24 @@
     {% endif %}
 </section>
 
-{% if requirements %}
+{% if has_verification %}
 <section id="verification-section" class="mt-14 border-t border-gray-200 pt-12 dark:border-gray-700 sm:mt-16 sm:pt-14" aria-labelledby="verification-heading">
-    <h2 id="verification-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Hands-on verification</h2>
-    <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">Submit proof of the work you completed in this phase. Requirements unlock in sequence.</p>
-
-    {% if verification_locked %}
-    <div class="mb-6 mt-6 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
-        <div class="flex items-start gap-3">
-            <svg class="mt-0.5 h-5 w-5 shrink-0 text-amber-700 dark:text-amber-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
-                <rect x="4.5" y="8.5" width="11" height="8" rx="1.5"/>
-                <path stroke-linecap="round" d="M7 8.5V6a3 3 0 0 1 6 0v2.5"/>
-            </svg>
-            <div>
-                <p class="text-sm font-bold text-amber-950 dark:text-amber-100">Phase {{ prerequisite_phase_id }} verification required</p>
-                <p class="mt-1 text-sm leading-6 text-amber-800 dark:text-amber-200">
-                    Complete every hands-on verification in
-                    <a href="/phase/{{ prerequisite_phase_id }}" class="font-bold underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-700">Phase {{ prerequisite_phase_id }}</a>
-                    before submitting here.
-                </p>
-            </div>
+    <div class="flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-center">
+        <div>
+            <h2 id="verification-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Hands-on verification</h2>
+            <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
+                Submit work, follow active checks, and review feedback in the dedicated workspace.
+            </p>
+            {% if phase_progress.verification.requirements_required > 0 %}
+            <p class="mt-2 text-sm font-bold {% if phase_progress.verification.is_complete %}text-green-700 dark:text-green-300{% else %}text-blue-700 dark:text-blue-300{% endif %}">
+                {{ phase_progress.verification.requirements_verified }}/{{ phase_progress.verification.requirements_required }} requirements verified
+            </p>
+            {% endif %}
         </div>
+        <a href="/verifications/phase/{{ phase.order }}" class="inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">
+            {% if phase_progress.verification.is_complete %}Review verification{% elif phase_progress.verification.requirements_verified > 0 %}Continue verification{% else %}Start verification{% endif %}
+        </a>
     </div>
-    <div class="space-y-3">
-        {% for req in requirements %}
-        {% set card = card_contexts_by_req[req.slug] %}
-        {% if card.card_state == 'passed' %}
-        {% include "partials/verified_requirement_row.html" %}
-        {% else %}
-        <div class="flex min-h-11 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
-            <svg class="h-5 w-5 shrink-0 text-gray-500 dark:text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
-                <rect x="4.5" y="8.5" width="11" height="8" rx="1.5"/>
-                <path stroke-linecap="round" d="M7 8.5V6a3 3 0 0 1 6 0v2.5"/>
-            </svg>
-            <span class="min-w-0 flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">{{ req.name }}</span>
-            <span class="text-xs font-bold text-gray-500 dark:text-gray-400">Locked</span>
-        </div>
-        {% endif %}
-        {% endfor %}
-    </div>
-    {% else %}
-    {% set ns = namespace(found_active=false) %}
-    <div class="mt-6 space-y-3">
-        {% for req in requirements %}
-        {% set card = card_contexts_by_req[req.slug] %}
-        {% if card.card_state == 'passed' %}
-        {% include "partials/verified_requirement_row.html" %}
-        {% elif not ns.found_active %}
-        {% set ns.found_active = true %}
-        {% with
-            requirement=card.requirement,
-            submission=card.submission,
-            feedback_tasks=card.feedback_tasks,
-            feedback_passed=card.feedback_passed,
-            card_state=card.card_state,
-            server_error=card.server_error,
-            server_error_message=card.server_error_message,
-            server_error_retryable=card.server_error_retryable,
-            error_banner=card.error_banner,
-            processing=card.processing,
-            verification_status_token=card.verification_status_token,
-            verification_status_delay_seconds=card.verification_status_delay_seconds,
-            derived_url=card.derived_url
-        %}
-        {% include "partials/requirement_card.html" %}
-        {% endwith %}
-        {% else %}
-        <div class="flex min-h-11 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
-            <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-gray-400 text-xs text-gray-500 dark:border-gray-500 dark:text-gray-400" aria-hidden="true">{{ loop.index }}</span>
-            <span class="min-w-0 flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">{{ req.name }}</span>
-            <span class="text-xs font-bold text-gray-500 dark:text-gray-400">Up next</span>
-        </div>
-        {% endif %}
-        {% endfor %}
-    </div>
-    {% endif %}
 </section>
 {% endif %}
 

--- a/api/src/learn_to_cloud/templates/pages/verification_phase.html
+++ b/api/src/learn_to_cloud/templates/pages/verification_phase.html
@@ -1,0 +1,136 @@
+{% extends "base.html" %}
+{% set footer_margin = "mt-8" %}
+{% from "macros/badges.html" import status_pill %}
+{% block title %}Phase {{ phase.order }} Verification - Learn to Cloud{% endblock %}
+
+{% block content %}
+<nav class="mb-6 flex min-h-11 flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400" aria-label="Breadcrumb">
+    <a href="/verifications" class="inline-flex min-h-11 items-center font-medium hover:text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:text-blue-300">Verifications</a>
+    <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m8 5 5 5-5 5"/>
+    </svg>
+    <span aria-current="page">Phase {{ phase.order }}</span>
+</nav>
+
+<header class="border-b border-gray-200 pb-10 dark:border-gray-700 sm:pb-12">
+    <div class="flex flex-wrap items-center gap-3">
+        <h1 class="text-balance text-3xl font-bold tracking-[-0.03em] text-gray-950 dark:text-white sm:text-4xl">
+            Phase {{ phase.order }} verification
+        </h1>
+        {% if verification_locked %}
+        {{ status_pill("Locked", "warning") }}
+        {% elif phase_progress.verification.is_complete %}
+        {{ status_pill("Verification complete", "success") }}
+        {% elif phase_progress.verification.requirements_verified > 0 %}
+        {{ status_pill("In progress", "info") }}
+        {% endif %}
+    </div>
+    <p class="mt-3 text-lg font-medium text-gray-700 dark:text-gray-200">{{ phase.name }}</p>
+    <p class="mt-3 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
+        Submit proof of your hands-on work. Requirements unlock in sequence, and the latest result and feedback stay with each requirement.
+    </p>
+    <div class="mt-5 flex flex-wrap gap-4">
+        <a href="/phase/{{ phase.order }}" class="inline-flex min-h-11 items-center font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300">
+            Review Phase {{ phase.order }} learning
+        </a>
+    </div>
+
+    {% if phase_progress.verification.requirements_required > 0 %}
+    <div class="mt-7 max-w-2xl">
+        {% with
+            value=phase_progress.verification.percentage,
+            label='Verification progress — ' ~ phase_progress.verification.requirements_verified ~ '/' ~ phase_progress.verification.requirements_required ~ ' requirements',
+            complete=phase_progress.verification.is_complete,
+            aria_label='Requirements verified: ' ~ phase_progress.verification.requirements_verified ~ ' of ' ~ phase_progress.verification.requirements_required
+        %}
+        {% include "partials/progress_bar.html" %}
+        {% endwith %}
+    </div>
+    {% endif %}
+</header>
+
+{% if requirements %}
+<section class="pt-12 sm:pt-14" aria-labelledby="requirements-heading">
+    <h2 id="requirements-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Requirements</h2>
+    <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">Complete the current requirement to unlock the next one.</p>
+
+    {% if verification_locked %}
+    <div class="mb-6 mt-6 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
+        <div class="flex items-start gap-3">
+            <svg class="mt-0.5 h-5 w-5 shrink-0 text-amber-700 dark:text-amber-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+                <rect x="4.5" y="8.5" width="11" height="8" rx="1.5"/>
+                <path stroke-linecap="round" d="M7 8.5V6a3 3 0 0 1 6 0v2.5"/>
+            </svg>
+            <div>
+                <p class="text-sm font-bold text-amber-950 dark:text-amber-100">Phase {{ prerequisite_phase_id }} verification required</p>
+                <p class="mt-1 text-sm leading-6 text-amber-800 dark:text-amber-200">
+                    Complete every hands-on verification in
+                    <a href="/verifications/phase/{{ prerequisite_phase_id }}" class="font-bold underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-700">Phase {{ prerequisite_phase_id }}</a>
+                    before submitting here.
+                </p>
+            </div>
+        </div>
+    </div>
+    <div class="space-y-3">
+        {% for req in requirements %}
+        {% set card = card_contexts_by_req[req.slug] %}
+        {% if card.card_state == 'passed' %}
+        {% include "partials/verified_requirement_row.html" %}
+        {% else %}
+        <div class="flex min-h-11 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+            <svg class="h-5 w-5 shrink-0 text-gray-500 dark:text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+                <rect x="4.5" y="8.5" width="11" height="8" rx="1.5"/>
+                <path stroke-linecap="round" d="M7 8.5V6a3 3 0 0 1 6 0v2.5"/>
+            </svg>
+            <span class="min-w-0 flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">{{ req.name }}</span>
+            <span class="text-xs font-bold text-gray-500 dark:text-gray-400">Locked</span>
+        </div>
+        {% endif %}
+        {% endfor %}
+    </div>
+    {% else %}
+    {% set ns = namespace(found_active=false) %}
+    <div class="mt-6 space-y-3">
+        {% for req in requirements %}
+        {% set card = card_contexts_by_req[req.slug] %}
+        {% if card.card_state == 'passed' %}
+        {% include "partials/verified_requirement_row.html" %}
+        {% elif not ns.found_active %}
+        {% set ns.found_active = true %}
+        {% with
+            requirement=card.requirement,
+            submission=card.submission,
+            feedback_tasks=card.feedback_tasks,
+            feedback_passed=card.feedback_passed,
+            card_state=card.card_state,
+            server_error=card.server_error,
+            server_error_message=card.server_error_message,
+            server_error_retryable=card.server_error_retryable,
+            error_banner=card.error_banner,
+            processing=card.processing,
+            verification_status_token=card.verification_status_token,
+            verification_status_delay_seconds=card.verification_status_delay_seconds,
+            derived_url=card.derived_url
+        %}
+        {% include "partials/requirement_card.html" %}
+        {% endwith %}
+        {% else %}
+        <div class="flex min-h-11 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+            <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-gray-400 text-xs text-gray-500 dark:border-gray-500 dark:text-gray-400" aria-hidden="true">{{ loop.index }}</span>
+            <span class="min-w-0 flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">{{ req.name }}</span>
+            <span class="text-xs font-bold text-gray-500 dark:text-gray-400">Up next</span>
+        </div>
+        {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+</section>
+{% else %}
+<section class="pt-12 sm:pt-14" aria-labelledby="requirements-empty-heading">
+    <div class="rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
+        <h2 id="requirements-empty-heading" class="text-xl font-bold text-gray-950 dark:text-white">No verification requirements are available.</h2>
+        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">Return to the phase curriculum while this workspace is prepared.</p>
+    </div>
+</section>
+{% endif %}
+{% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/verifications.html
+++ b/api/src/learn_to_cloud/templates/pages/verifications.html
@@ -75,7 +75,7 @@
     <div class="mt-6 border-y border-gray-200 dark:border-gray-700">
         {% for item in overview.phases %}
         <a href="/verifications/phase/{{ item.phase.order }}" class="group grid min-h-11 grid-cols-[2.75rem_1fr] gap-4 py-4 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 sm:grid-cols-[2.75rem_1fr_auto] sm:items-center {% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %}">
-            <span class="flex h-9 w-9 items-center justify-center rounded-full {% if item.status == 'complete' %}bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200{% elif item.status == 'locked' %}bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200{% else %}bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200{% endif %} text-xs font-bold">
+            <span class="flex h-9 w-9 items-center justify-center rounded-full {% if item.status == 'complete' %}bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200{% elif item.status == 'locked' %}bg-amber-100 text-amber-800 dark:bg-amber-950/30 dark:text-amber-200{% else %}bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200{% endif %} text-xs font-bold">
                 {{ item.phase.order }}
             </span>
             <span class="min-w-0">

--- a/api/src/learn_to_cloud/templates/pages/verifications.html
+++ b/api/src/learn_to_cloud/templates/pages/verifications.html
@@ -1,0 +1,110 @@
+{% extends "layouts/content_page.html" %}
+{% set footer_margin = "mt-8" %}
+{% from "macros/badges.html" import status_pill %}
+{% block title %}Verifications - Learn to Cloud{% endblock %}
+{% block description %}Track and complete hands-on Learn to Cloud verification requirements.{% endblock %}
+
+{% block page_header %}
+<div class="flex flex-col justify-between gap-5 sm:flex-row sm:items-end">
+    <div class="max-w-2xl">
+        <p class="text-sm font-bold uppercase tracking-[0.12em] text-blue-700 dark:text-blue-300">Hands-on work</p>
+        <h1 class="mt-2 text-3xl font-bold tracking-[-0.025em] text-gray-950 dark:text-white sm:text-4xl">Verification workspace</h1>
+        <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-300">
+            Submit your work, follow active checks, and review the latest feedback for every phase.
+        </p>
+    </div>
+    <a href="/curriculum" class="inline-flex min-h-11 items-center font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300">
+        Browse curriculum
+    </a>
+</div>
+{% endblock %}
+
+{% block page_body %}
+{% if overview.phases %}
+<section aria-labelledby="overall-verification-heading">
+    <div class="rounded-lg border border-gray-200 p-5 dark:border-gray-700">
+        <div class="flex items-baseline justify-between gap-4">
+            <div>
+                <h2 id="overall-verification-heading" class="text-lg font-bold text-gray-950 dark:text-white">Overall progress</h2>
+                <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                    {{ overview.requirements_verified }} of {{ overview.requirements_required }} current requirements verified
+                </p>
+            </div>
+            <span class="text-lg font-bold text-blue-700 dark:text-blue-300">{{ overview.percentage | round(0) | int }}%</span>
+        </div>
+        {% with
+            value=overview.percentage,
+            label='Verification progress — ' ~ overview.requirements_verified ~ '/' ~ overview.requirements_required ~ ' requirements',
+            complete=overview.is_complete,
+            aria_label='Requirements verified: ' ~ overview.requirements_verified ~ ' of ' ~ overview.requirements_required
+        %}
+        {% include "partials/progress_bar.html" %}
+        {% endwith %}
+    </div>
+</section>
+
+{% if overview.next_phase %}
+<section class="mt-8 rounded-lg border border-blue-200 bg-blue-50 p-5 dark:border-blue-800 dark:bg-blue-950/40" aria-labelledby="next-verification-heading">
+    <div class="flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-center">
+        <div>
+            <h2 id="next-verification-heading" class="text-lg font-bold text-blue-950 dark:text-blue-100">
+                {% if overview.next_phase.progress.requirements_verified > 0 %}Continue verification{% else %}Start verification{% endif %}
+            </h2>
+            <p class="mt-1 text-sm text-blue-800 dark:text-blue-200">
+                Phase {{ overview.next_phase.phase.order }}: {{ overview.next_phase.phase.name }}
+            </p>
+        </div>
+        <a href="/verifications/phase/{{ overview.next_phase.phase.order }}" class="inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">
+            Open workspace
+        </a>
+    </div>
+</section>
+{% elif overview.is_complete %}
+<section class="mt-8 rounded-lg border border-green-200 bg-green-50 p-5 dark:border-green-800 dark:bg-green-950/30" aria-labelledby="verification-complete-heading">
+    <h2 id="verification-complete-heading" class="text-lg font-bold text-green-950 dark:text-green-100">All current verifications complete</h2>
+    <p class="mt-1 text-sm text-green-800 dark:text-green-200">You can still open any phase to review the work and feedback that was recorded.</p>
+</section>
+{% endif %}
+
+<section class="mt-12" aria-labelledby="verification-phases-heading">
+    <div>
+        <h2 id="verification-phases-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Phases</h2>
+        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Each workspace keeps submissions, processing state, and latest feedback together.</p>
+    </div>
+
+    <div class="mt-6 border-y border-gray-200 dark:border-gray-700">
+        {% for item in overview.phases %}
+        <a href="/verifications/phase/{{ item.phase.order }}" class="group grid min-h-11 grid-cols-[2.75rem_1fr] gap-4 py-4 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 sm:grid-cols-[2.75rem_1fr_auto] sm:items-center {% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %}">
+            <span class="flex h-9 w-9 items-center justify-center rounded-full {% if item.status == 'complete' %}bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200{% elif item.status == 'locked' %}bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200{% else %}bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200{% endif %} text-xs font-bold">
+                {{ item.phase.order }}
+            </span>
+            <span class="min-w-0">
+                <span class="block text-sm font-bold text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ item.phase.name }}</span>
+                <span class="mt-1 block text-xs leading-5 text-gray-500 dark:text-gray-400">
+                    {{ item.progress.requirements_verified }}/{{ item.progress.requirements_required }} requirements verified
+                    {% if item.is_locked %} · Complete Phase {{ item.prerequisite_phase_id }} verification first{% endif %}
+                </span>
+            </span>
+            <span class="col-start-2 sm:col-start-auto">
+                {% if item.status == 'complete' %}
+                {{ status_pill("Verified", "success") }}
+                {% elif item.status == 'locked' %}
+                {{ status_pill("Locked", "warning") }}
+                {% elif item.status == 'in_progress' %}
+                {{ status_pill("In progress", "info") }}
+                {% else %}
+                {{ status_pill("Ready", "info") }}
+                {% endif %}
+            </span>
+        </a>
+        {% endfor %}
+    </div>
+</section>
+{% else %}
+<section class="rounded-lg border border-gray-200 bg-gray-50 p-8 dark:border-gray-700 dark:bg-gray-800/50" aria-labelledby="verification-empty-heading">
+    <h2 id="verification-empty-heading" class="text-xl font-bold text-gray-950 dark:text-white">No verification requirements are available.</h2>
+    <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">Open the curriculum to continue learning while new hands-on work is prepared.</p>
+    <a href="/curriculum" class="mt-5 inline-flex min-h-11 items-center font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">Browse curriculum</a>
+</section>
+{% endif %}
+{% endblock %}

--- a/api/src/learn_to_cloud/templates/partials/navbar.html
+++ b/api/src/learn_to_cloud/templates/partials/navbar.html
@@ -14,6 +14,9 @@
                     <a href="/dashboard" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
                         Dashboard
                     </a>
+                    <a href="/verifications" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
+                        Verifications
+                    </a>
                     {% endif %}
                     <a href="/community" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
                         Community
@@ -84,6 +87,7 @@
             <div class="grid gap-1">
                 {% if user %}
                 <a href="/dashboard" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">Dashboard</a>
+                <a href="/verifications" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">Verifications</a>
                 {% endif %}
                 <a href="/community" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">Community</a>
                 <a href="/faq" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">FAQ</a>

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -567,6 +567,7 @@ class TestDashboardPrimaryState:
 
         assert "Start the curriculum" in html
         assert "Resume" not in html
+        assert "Full curriculum" not in html
 
     def test_returning_learner_sees_resume_state(self):
         phase = SimpleNamespace(order=0, name="Prerequisites", progress=None)

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -183,7 +183,7 @@ def test_passing_feedback_panel_pluralizes_suggestions():
 
 @pytest.mark.unit
 class TestPhaseVerificationLocked:
-    """The gated (`verification_locked`) branch of pages/phase.html."""
+    """The gated branch of pages/verification_phase.html."""
 
     def _render_phase(
         self,
@@ -191,10 +191,16 @@ class TestPhaseVerificationLocked:
         submissions_by_req: dict[str, object],
     ) -> str:
         return _render(
-            "pages/phase.html",
+            "pages/verification_phase.html",
             phase=SimpleNamespace(name="Phase 6", description="", order=6),
-            topics=[],
-            phase_progress=None,
+            phase_progress=SimpleNamespace(
+                verification=SimpleNamespace(
+                    requirements_required=len(requirements),
+                    requirements_verified=len(submissions_by_req),
+                    percentage=0,
+                    is_complete=False,
+                )
+            ),
             requirements=requirements,
             card_contexts_by_req=_card_contexts(requirements, submissions_by_req),
             verification_locked=True,
@@ -238,7 +244,7 @@ class TestPhaseVerificationLocked:
 
 @pytest.mark.unit
 class TestPhaseVerificationCardStates:
-    """The unlocked branch's verification-card states in pages/phase.html."""
+    """The unlocked branch's cards in pages/verification_phase.html."""
 
     def _render_phase(
         self,
@@ -246,10 +252,16 @@ class TestPhaseVerificationCardStates:
         submissions_by_req: dict[str, object],
     ) -> str:
         return _render(
-            "pages/phase.html",
+            "pages/verification_phase.html",
             phase=SimpleNamespace(name="Phase 1", description="", order=1),
-            topics=[],
-            phase_progress=None,
+            phase_progress=SimpleNamespace(
+                verification=SimpleNamespace(
+                    requirements_required=len(requirements),
+                    requirements_verified=len(submissions_by_req),
+                    percentage=0,
+                    is_complete=False,
+                )
+            ),
             requirements=requirements,
             card_contexts_by_req=_card_contexts(requirements, submissions_by_req),
             verification_locked=False,
@@ -383,12 +395,43 @@ def test_phase_progress_uses_distinct_labels_without_explanatory_copy():
         phase=SimpleNamespace(name="Phase 1", description="", order=1),
         topics=[],
         phase_progress=phase_progress,
-        requirements=[],
+        has_verification=False,
     )
 
     assert "Verification progress — 1/2 requirements" in html
     assert "Learning progress — 2/5 steps" in html
     assert "Verification is what counts" not in html
+
+
+@pytest.mark.unit
+def test_phase_page_links_to_verification_workspace_without_rendering_form():
+    phase_progress = SimpleNamespace(
+        status="learning_complete",
+        verification=SimpleNamespace(
+            requirements_required=2,
+            requirements_verified=1,
+            percentage=50.0,
+            is_complete=False,
+        ),
+        learning=SimpleNamespace(
+            steps_required=5,
+            steps_completed=5,
+            percentage=100.0,
+            is_complete=True,
+        ),
+    )
+
+    html = _render(
+        "pages/phase.html",
+        phase=SimpleNamespace(name="Phase 4", description="", order=4),
+        topics=[],
+        phase_progress=phase_progress,
+        has_verification=True,
+    )
+
+    assert 'href="/verifications/phase/4"' in html
+    assert "Continue verification" in html
+    assert 'hx-post="/htmx/github/submit"' not in html
 
 
 @pytest.mark.unit
@@ -537,7 +580,7 @@ class TestDashboardPrimaryState:
             help_links=[],
         )
 
-        assert "Continue learning" in html
+        assert "Continue your path" in html
         assert 'href="/phase/0/linux"' in html
 
     def test_completed_learner_sees_completion_state(self):
@@ -574,7 +617,7 @@ def test_primary_links_are_in_navbar_and_footer_is_minimal():
     navbar = _render("partials/navbar.html")
     footer = _render("partials/footer.html")
 
-    for path in ("/community", "/faq"):
+    for path in ("/verifications", "/community", "/faq"):
         assert f'href="{path}"' in navbar
         assert f'href="{path}"' not in footer
 

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -3,7 +3,9 @@
 Tests cover:
 - GET / — home page (public)
 - GET /curriculum — curriculum page (public)
-- GET /phase/{id} — phase detail (requires auth)
+- GET /phase/{id} — phase learning detail (requires auth)
+- GET /verifications — verification workspace (requires auth)
+- GET /verifications/phase/{id} — phase verification (requires auth)
 - GET /phase/{id}/{topic} — topic detail (requires auth)
 - GET /dashboard — user dashboard (requires auth)
 - GET /account — account settings (requires auth)
@@ -32,10 +34,12 @@ from learn_to_cloud.routes.pages_routes import (
     faq_page,
     home_page,
     phase_page,
+    phase_verification_page,
     privacy_page,
     stats_page_redirect,
     terms_page,
     topic_page,
+    verifications_page,
 )
 
 
@@ -184,15 +188,11 @@ class TestPhasePage:
         assert call_kwargs.get("status_code") == 404
 
     async def test_phase_renders_with_progress_data(self, _patch_templates):
-        """Valid phase renders with topics, progress, and submissions."""
+        """Valid phase renders learning content without loading attempts."""
         request, template = _mock_request(_patch_templates)
         mock_db = AsyncMock()
         phase = _fake_phase()
         mock_user = MagicMock()
-
-        mock_sub_context = MagicMock()
-        mock_sub_context.submissions_by_req = {}
-        mock_sub_context.feedback_by_req = {}
 
         with (
             patch(
@@ -213,22 +213,6 @@ class TestPhasePage:
                 "learn_to_cloud.routes.pages_routes.build_phase_topics",
                 return_value=[],
             ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_phase_submission_context",
-                autospec=True,
-                return_value=mock_sub_context,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.VerificationAttemptRepository",
-                return_value=MagicMock(
-                    get_active_for_requirements=AsyncMock(return_value=[]),
-                ),
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.is_phase_verification_locked",
-                autospec=True,
-                return_value=(False, None),
-            ),
         ):
             await phase_page(request, phase_id=1, db=mock_db, user_id=42)
 
@@ -236,7 +220,115 @@ class TestPhasePage:
         ctx = template.call_args[0][2]
         assert ctx["phase"] is phase
         assert ctx["user"] is mock_user
-        assert ctx["verification_locked"] is False
+        assert ctx["has_verification"] is False
+
+
+@pytest.mark.unit
+class TestVerificationsPage:
+    """Tests for GET /verifications."""
+
+    async def test_verifications_renders_overview(self, _patch_templates):
+        request, template = _mock_request(_patch_templates)
+        mock_db = AsyncMock()
+        mock_user = MagicMock()
+        mock_overview = MagicMock()
+
+        with (
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                autospec=True,
+                return_value=mock_user,
+            ),
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_verifications_overview",
+                autospec=True,
+                return_value=mock_overview,
+            ),
+        ):
+            await verifications_page(request, mock_db, user_id=42)
+
+        assert template.call_args[0][1] == "pages/verifications.html"
+        ctx = template.call_args[0][2]
+        assert ctx["user"] is mock_user
+        assert ctx["overview"] is mock_overview
+
+    async def test_verifications_returns_404_when_user_missing(self, _patch_templates):
+        request, template = _mock_request(_patch_templates)
+
+        with patch(
+            "learn_to_cloud.routes.pages_routes.get_user_by_id",
+            autospec=True,
+            return_value=None,
+        ):
+            await verifications_page(request, AsyncMock(), user_id=999)
+
+        assert template.call_args[0][1] == "pages/404.html"
+
+
+@pytest.mark.unit
+class TestPhaseVerificationPage:
+    """Tests for GET /verifications/phase/{phase_id}."""
+
+    async def test_unknown_phase_returns_404(self, _patch_templates):
+        request, template = _mock_request(_patch_templates)
+
+        with (
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                autospec=True,
+                return_value=MagicMock(),
+            ),
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
+                return_value=None,
+            ),
+        ):
+            await phase_verification_page(
+                request, phase_id=999, db=AsyncMock(), user_id=42
+            )
+
+        assert template.call_args[0][1] == "pages/404.html"
+
+    async def test_phase_verification_renders_workspace(self, _patch_templates):
+        request, template = _mock_request(_patch_templates)
+        mock_db = AsyncMock()
+        mock_user = MagicMock(github_username="learner")
+        phase = _fake_phase(order=4)
+        workspace = MagicMock(
+            phase=phase,
+            phase_progress=MagicMock(),
+            requirements=[],
+            card_contexts_by_req={},
+            verification_locked=True,
+            prerequisite_phase_id=3,
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                autospec=True,
+                return_value=mock_user,
+            ),
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
+                return_value=phase,
+            ),
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_phase_verification_workspace",
+                autospec=True,
+                return_value=workspace,
+            ) as get_workspace,
+        ):
+            await phase_verification_page(request, phase_id=4, db=mock_db, user_id=42)
+
+        get_workspace.assert_awaited_once_with(
+            mock_db, 42, phase, mock_user.github_username
+        )
+        assert template.call_args[0][1] == "pages/verification_phase.html"
+        ctx = template.call_args[0][2]
+        assert ctx["phase"] is phase
+        assert ctx["verification_locked"] is True
+        assert ctx["prerequisite_phase_id"] == 3
 
 
 @pytest.mark.unit

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -20,6 +20,7 @@ Marked @pytest.mark.smoke so they can be run separately:
 """
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -293,10 +294,6 @@ class TestAuthPageSmoke:
             topic_progress={},
         )
 
-        mock_sub_context = MagicMock()
-        mock_sub_context.submissions_by_req = {}
-        mock_sub_context.feedback_by_req = {}
-
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_user_by_id",
@@ -306,25 +303,48 @@ class TestAuthPageSmoke:
                 "learn_to_cloud.routes.pages_routes.fetch_phase_progress",
                 return_value=detail,
             ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_phase_submission_context",
-                return_value=mock_sub_context,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.VerificationAttemptRepository",
-                return_value=MagicMock(
-                    get_active_for_requirements=AsyncMock(return_value=[])
-                ),
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.is_phase_verification_locked",
-                return_value=(False, None),
-            ),
         ):
             response = await auth_client.get("/phase/1")
         assert response.status_code == 200
 
-    async def test_phase_page_shows_feedback_on_verified_requirement(
+    async def test_verifications_page_renders(self, auth_client: AsyncClient):
+        """GET /verifications renders the workspace hub."""
+        phase = SimpleNamespace(
+            phase=SimpleNamespace(order=1, name="Phase 1"),
+            progress=VerificationProgress(
+                requirements_verified=0,
+                requirements_required=1,
+            ),
+            status="not_started",
+            is_locked=False,
+            prerequisite_phase_id=None,
+        )
+        overview = SimpleNamespace(
+            phases=[phase],
+            requirements_verified=0,
+            requirements_required=1,
+            percentage=0.0,
+            is_complete=False,
+            next_phase=phase,
+        )
+
+        with (
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                return_value=_fake_user(),
+            ),
+            patch(
+                "learn_to_cloud.routes.pages_routes.get_verifications_overview",
+                return_value=overview,
+            ),
+        ):
+            response = await auth_client.get("/verifications")
+
+        assert response.status_code == 200
+        assert "Verification workspace" in response.text
+        assert 'href="/verifications/phase/1"' in response.text
+
+    async def test_phase_verification_page_shows_feedback(
         self, auth_client: AsyncClient
     ):
         """A passed requirement still surfaces its rubric feedback (the why)."""
@@ -334,6 +354,8 @@ class TestAuthPageSmoke:
             get_all_phases_from_yaml,
         )
         from learn_to_cloud_shared.schemas import SubmissionData
+
+        from learn_to_cloud.rendering.context import build_requirement_card_context
 
         phase = next(
             (p for p in get_all_phases_from_yaml() if p.slug == "phase1"), None
@@ -350,21 +372,15 @@ class TestAuthPageSmoke:
             verification_completed=True,
             created_at=datetime(2024, 1, 2, tzinfo=UTC),
         )
-        mock_sub_context = MagicMock()
-        mock_sub_context.submissions_by_req = {req_slug: verified_submission}
-        mock_sub_context.feedback_by_req = {
-            req_slug: {
-                "tasks": [
-                    {
-                        "name": "Reflection depth",
-                        "passed": True,
-                        "message": "You clearly explained what you explored.",
-                        "next_steps": "",
-                    }
-                ],
-                "passed": 1,
+        requirement = phase.hands_on_verification.requirements[0]
+        feedback_tasks = [
+            {
+                "name": "Reflection depth",
+                "passed": True,
+                "message": "You clearly explained what you explored.",
+                "next_steps": "",
             }
-        }
+        ]
 
         detail = PhaseProgress(
             phase_id=1,
@@ -374,6 +390,22 @@ class TestAuthPageSmoke:
             ),
             topic_progress={},
         )
+        workspace = SimpleNamespace(
+            phase=phase,
+            phase_progress=detail,
+            requirements=[requirement],
+            card_contexts_by_req={
+                req_slug: build_requirement_card_context(
+                    requirement=requirement,
+                    github_username="testuser",
+                    submission=verified_submission,
+                    feedback_tasks=feedback_tasks,
+                    feedback_passed=1,
+                )
+            },
+            verification_locked=False,
+            prerequisite_phase_id=None,
+        )
 
         with (
             patch(
@@ -381,25 +413,11 @@ class TestAuthPageSmoke:
                 return_value=_fake_user(),
             ),
             patch(
-                "learn_to_cloud.routes.pages_routes.fetch_phase_progress",
-                return_value=detail,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_phase_submission_context",
-                return_value=mock_sub_context,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.VerificationAttemptRepository",
-                return_value=MagicMock(
-                    get_active_for_requirements=AsyncMock(return_value=[])
-                ),
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.is_phase_verification_locked",
-                return_value=(False, None),
+                "learn_to_cloud.routes.pages_routes.get_phase_verification_workspace",
+                return_value=workspace,
             ),
         ):
-            response = await auth_client.get("/phase/1")
+            response = await auth_client.get("/verifications/phase/1")
 
         assert response.status_code == 200
         assert "All checks passed" in response.text
@@ -442,8 +460,16 @@ class TestAuthPageSmoke:
 class TestRedirectSmoke:
     """Verify redirect routes work through the full ASGI stack."""
 
-    async def test_auth_required_redirects_to_login(self, anon_client: AsyncClient):
-        """GET /dashboard without auth redirects to /auth/login."""
-        response = await anon_client.get("/dashboard", follow_redirects=False)
+    @pytest.mark.parametrize(
+        "path",
+        ["/dashboard", "/verifications", "/verifications/phase/1"],
+    )
+    async def test_auth_required_redirects_to_login(
+        self,
+        anon_client: AsyncClient,
+        path: str,
+    ):
+        """Authenticated pages redirect anonymous visitors to login."""
+        response = await anon_client.get(path, follow_redirects=False)
         assert response.status_code == 307
         assert "/auth/login" in response.headers["location"]

--- a/api/tests/services/test_progress_service.py
+++ b/api/tests/services/test_progress_service.py
@@ -572,7 +572,7 @@ class TestResolveContinueDestination:
         assert destination == "/phase/3/topic1"
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_verification_section_when_all_steps_checked(self):
+    async def test_falls_back_to_verification_workspace_when_all_steps_checked(self):
         topic = _make_topic("t1", steps=["s1"])
         phase = _with_requirement(_make_phase(3, topics=[topic]))
         completed = {s.uuid for s in topic.learning_steps}
@@ -585,7 +585,7 @@ class TestResolveContinueDestination:
                 AsyncMock(), user_id=1, phase=phase
             )
 
-        assert destination == "/phase/3#verification-section"
+        assert destination == "/verifications/phase/3"
 
     @pytest.mark.asyncio
     async def test_hands_on_only_phase_links_straight_to_verification(self):
@@ -601,7 +601,7 @@ class TestResolveContinueDestination:
                 AsyncMock(), user_id=1, phase=phase
             )
 
-        assert destination == "/phase/3#verification-section"
+        assert destination == "/verifications/phase/3"
         mock_resolve.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/api/tests/services/test_verification_page_service.py
+++ b/api/tests/services/test_verification_page_service.py
@@ -1,0 +1,179 @@
+"""Tests for verification workspace view data."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from learn_to_cloud_shared.schemas import (
+    LearningProgress,
+    Phase,
+    PhaseHandsOnVerificationOverview,
+    PhaseOverview,
+    PhaseProgress,
+    PhaseSubmissionContext,
+    UserProgress,
+    VerificationProgress,
+)
+from learn_to_cloud_shared.testing.requirement_factories import (
+    repo_fork_requirement,
+)
+
+from learn_to_cloud.services.verification_page_service import (
+    get_phase_verification_workspace,
+    get_verifications_overview,
+)
+
+
+def _phase_overview(order: int) -> PhaseOverview:
+    return PhaseOverview(
+        uuid=uuid4(),
+        order=order,
+        name=f"Phase {order}",
+        slug=f"phase{order}",
+    )
+
+
+def _phase_progress(
+    order: int,
+    *,
+    verified: int,
+    required: int,
+) -> PhaseProgress:
+    return PhaseProgress(
+        phase_id=order,
+        learning=LearningProgress(steps_completed=0, steps_required=1),
+        verification=VerificationProgress(
+            requirements_verified=verified,
+            requirements_required=required,
+        ),
+    )
+
+
+@pytest.mark.unit
+async def test_overview_builds_progress_gating_and_next_phase():
+    phases = tuple(_phase_overview(order) for order in (2, 3, 4, 5))
+    user_progress = UserProgress(
+        user_id=42,
+        phases={
+            2: _phase_progress(2, verified=0, required=0),
+            3: _phase_progress(3, verified=1, required=1),
+            4: _phase_progress(4, verified=1, required=2),
+            5: _phase_progress(5, verified=0, required=1),
+        },
+        total_phases=4,
+    )
+
+    with (
+        patch(
+            "learn_to_cloud.services.verification_page_service.get_curriculum_overview",
+            return_value=phases,
+        ),
+        patch(
+            "learn_to_cloud.services.verification_page_service.fetch_user_progress",
+            new=AsyncMock(return_value=user_progress),
+        ),
+    ):
+        result = await get_verifications_overview(AsyncMock(), user_id=42)
+
+    assert [item.phase.order for item in result.phases] == [3, 4, 5]
+    assert result.requirements_verified == 2
+    assert result.requirements_required == 4
+    assert result.percentage == 50.0
+    assert result.next_phase is result.phases[1]
+    assert result.phases[1].status == "in_progress"
+    assert result.phases[2].is_locked is True
+    assert result.phases[2].prerequisite_phase_id == 4
+    assert result.phases[2].status == "locked"
+
+
+@pytest.mark.unit
+async def test_overview_has_no_next_phase_when_everything_is_verified():
+    phases = (_phase_overview(3),)
+    user_progress = UserProgress(
+        user_id=42,
+        phases={3: _phase_progress(3, verified=1, required=1)},
+        total_phases=1,
+    )
+
+    with (
+        patch(
+            "learn_to_cloud.services.verification_page_service.get_curriculum_overview",
+            return_value=phases,
+        ),
+        patch(
+            "learn_to_cloud.services.verification_page_service.fetch_user_progress",
+            new=AsyncMock(return_value=user_progress),
+        ),
+    ):
+        result = await get_verifications_overview(AsyncMock(), user_id=42)
+
+    assert result.next_phase is None
+    assert result.is_complete is True
+    assert result.percentage == 100.0
+
+
+@pytest.mark.unit
+async def test_phase_workspace_preserves_active_attempt_polling_state():
+    requirement = repo_fork_requirement(slug="verify-repository")
+    phase = Phase(
+        uuid=uuid4(),
+        order=4,
+        name="Deploy",
+        slug="phase4",
+        hands_on_verification=PhaseHandsOnVerificationOverview(
+            requirements=[requirement]
+        ),
+    )
+    progress = _phase_progress(4, verified=0, required=1)
+    active_attempt = SimpleNamespace(
+        id=uuid4(),
+        requirement_uuid=requirement.uuid,
+    )
+    repository = MagicMock(
+        get_active_for_requirements=AsyncMock(return_value=[active_attempt])
+    )
+
+    with (
+        patch(
+            "learn_to_cloud.services.verification_page_service.fetch_phase_progress",
+            new=AsyncMock(return_value=progress),
+        ),
+        patch(
+            "learn_to_cloud.services.verification_page_service.get_phase_submission_context",
+            new=AsyncMock(
+                return_value=PhaseSubmissionContext(
+                    submissions_by_req={},
+                    feedback_by_req={},
+                )
+            ),
+        ),
+        patch(
+            "learn_to_cloud.services.verification_page_service.VerificationAttemptRepository",
+            return_value=repository,
+        ),
+        patch(
+            "learn_to_cloud.services.verification_page_service.create_verification_status_token",
+            return_value="status-token",
+        ),
+        patch(
+            "learn_to_cloud.services.verification_page_service.is_phase_verification_locked",
+            new=AsyncMock(return_value=(True, 3)),
+        ),
+    ):
+        result = await get_phase_verification_workspace(
+            AsyncMock(),
+            user_id=42,
+            phase=phase,
+            github_username="learner",
+        )
+
+    card = result.card_contexts_by_req[requirement.slug]
+    assert result.phase_progress is progress
+    assert result.verification_locked is True
+    assert result.prerequisite_phase_id == 3
+    assert card["card_state"] == "checking"
+    assert card["verification_status_token"] == "status-token"
+    repository.get_active_for_requirements.assert_awaited_once_with(
+        42, {requirement.uuid: requirement}
+    )

--- a/docs/progression-system.md
+++ b/docs/progression-system.md
@@ -15,6 +15,13 @@ curriculum in any order. Hands-on verification is sequential from Phase 4
 through Phase 7: each phase's requirements must be verified before submissions
 for the next phase unlock.
 
+Learning and verification use separate page spaces:
+
+- `/phase/{phase}` contains curriculum topics and learning progress.
+- `/verifications` summarizes hands-on progress across phases.
+- `/verifications/phase/{phase}` contains submissions, active checks, and the
+  latest retained feedback for that phase.
+
 ## Progress Calculation
 
 **Topic:** `Steps Completed / Total Steps`
@@ -34,6 +41,7 @@ requirements is complete by definition.
 | Progress | `api/src/learn_to_cloud/services/progress_service.py` |
 | Hands-on | `packages/learn-to-cloud-shared/src/learn_to_cloud_shared/requirements.py` |
 | Catalog reads | `packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py` |
+| Verification pages | `api/src/learn_to_cloud/services/verification_page_service.py` |
 
 ## Important
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -670,8 +670,8 @@ class ContinuePhaseData(FrozenModel):
     """Where the dashboard's "Continue" action should take the learner.
 
     ``destination_url`` already resolves to the specific place that matters
-    -- the first unchecked learning step's topic, or the phase's
-    verification section once every step is checked -- so templates never
+    -- the first unchecked learning step's topic, or the dedicated phase
+    verification workspace once every step is checked -- so templates never
     need to re-derive a phase link from separate id/order/slug fields.
     """
 


### PR DESCRIPTION
## What changes

Adds an authenticated `/verifications` workspace with an overall progress view and phase-specific pages at `/verifications/phase/{phase}`. Phase pages now focus on learning and link learners to the verification workspace for submissions, active checks, and the latest feedback.

The existing submission and status-polling behavior is unchanged. Navigation, dashboard continuation, curriculum copy, and progression documentation now point to the new page structure.

## Why

Learning content and hands-on assessment currently compete for space on the same phase page. Separating them gives verification enough room to grow while keeping phase context and prerequisite rules intact.

## Checks

- `uv run poe check`
- Fresh API startup with successful health, readiness, and OpenAPI responses