### PR TITLE
Add safe verification attempt history

### DIFF
--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -6,8 +6,9 @@ JSON API routes but render HTML templates instead of returning JSON.
 
 import logging
 from datetime import UTC, datetime
+from typing import Annotated
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from learn_to_cloud_shared.content_service import (
     get_curriculum_overview,
@@ -173,6 +174,7 @@ async def phase_verification_page(
     phase_id: int,
     db: DbSession,
     user_id: UserId,
+    history_page: Annotated[int, Query(ge=1)] = 1,
 ) -> HTMLResponse:
     """One phase's verification requirements and feedback (requires auth)."""
     user = await _get_user_or_none(db, user_id)
@@ -190,6 +192,7 @@ async def phase_verification_page(
         user_id,
         phase,
         user.github_username,
+        history_page=history_page,
     )
     return templates.TemplateResponse(
         request,
@@ -203,6 +206,7 @@ async def phase_verification_page(
             card_contexts_by_req=workspace.card_contexts_by_req,
             verification_locked=workspace.verification_locked,
             prerequisite_phase_id=workspace.prerequisite_phase_id,
+            history=workspace.history,
         ),
     )
 

--- a/api/src/learn_to_cloud/services/submissions_service.py
+++ b/api/src/learn_to_cloud/services/submissions_service.py
@@ -71,26 +71,6 @@ async def get_phase_submission_context(
     submissions_by_req: dict[str, SubmissionData] = {}
     feedback_by_req: dict[str, dict[str, object]] = {}
 
-    def _record_feedback(
-        requirement_slug: str, feedback_json: list[dict] | None
-    ) -> None:
-        # Surface rubric feedback for both passing and failing submissions
-        # (#425). Stored as JSONB (#459) so the rows arrive as a list of
-        # TaskResult dicts and we don't need json.loads / try / except.
-        if not feedback_json:
-            return
-        tasks = [
-            {
-                "name": t.get("task_name", ""),
-                "passed": t.get("passed", False),
-                "message": t.get("feedback", ""),
-                "next_steps": t.get("next_steps", ""),
-            }
-            for t in feedback_json
-        ]
-        passed = sum(1 for t in tasks if t["passed"])
-        feedback_by_req[requirement_slug] = {"tasks": tasks, "passed": passed}
-
     for attempt in latest_attempts:
         requirement = requirements_by_uuid.get(attempt.requirement_uuid)
         if requirement is None:
@@ -99,12 +79,36 @@ async def get_phase_submission_context(
             # slips one past us we skip silently rather than crash the page.
             continue
         submissions_by_req[requirement.slug] = attempt_to_submission_data(attempt)
-        _record_feedback(requirement.slug, attempt.feedback_json)
+        feedback = feedback_context_from_json(attempt.feedback_json)
+        if feedback is not None:
+            feedback_by_req[requirement.slug] = feedback
 
     return PhaseSubmissionContext(
         submissions_by_req=submissions_by_req,
         feedback_by_req=feedback_by_req,
     )
+
+
+def feedback_context_from_json(
+    feedback_json: list[dict] | None,
+) -> dict[str, object] | None:
+    """Convert persisted rubric results into learner-facing feedback context."""
+    if not feedback_json:
+        return None
+
+    tasks = [
+        {
+            "name": task.get("task_name", ""),
+            "passed": task.get("passed", False),
+            "message": task.get("feedback", ""),
+            "next_steps": task.get("next_steps", ""),
+        }
+        for task in feedback_json
+    ]
+    return {
+        "tasks": tasks,
+        "passed": sum(1 for task in tasks if task["passed"]),
+    }
 
 
 class RequirementNotFoundError(Exception):

--- a/api/src/learn_to_cloud/services/verification_page_service.py
+++ b/api/src/learn_to_cloud/services/verification_page_service.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
+from uuid import UUID
 
 from learn_to_cloud_shared.content_service import get_curriculum_overview
+from learn_to_cloud_shared.models import SubmissionType
 from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     VerificationAttemptRepository,
 )
@@ -30,10 +33,22 @@ from learn_to_cloud.services.progress_service import (
     fetch_phase_progress,
     fetch_user_progress,
 )
-from learn_to_cloud.services.submissions_service import get_phase_submission_context
+from learn_to_cloud.services.submissions_service import (
+    feedback_context_from_json,
+    get_phase_submission_context,
+)
 from learn_to_cloud.services.verification_status_tokens import (
     create_verification_status_token,
 )
+
+VERIFICATION_HISTORY_PAGE_SIZE = 10
+
+_HISTORY_STATUS = {
+    "succeeded": ("Verified", "success"),
+    "failed": ("Needs work", "error"),
+    "server_error": ("Service unavailable", "warning"),
+    "cancelled": ("Cancelled", "warning"),
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -86,6 +101,37 @@ class VerificationsOverview:
 
 
 @dataclass(frozen=True, slots=True)
+class VerificationAttemptHistoryItem:
+    """One terminal attempt rendered without its submitted value."""
+
+    id: UUID
+    requirement: HandsOnRequirement
+    outcome: str
+    validation_message: str | None
+    feedback_tasks: list[dict[str, Any]]
+    feedback_passed: int
+    completed_at: datetime | None
+
+    @property
+    def status_label(self) -> str:
+        return _HISTORY_STATUS.get(self.outcome, ("Completed", "info"))[0]
+
+    @property
+    def status_variant(self) -> str:
+        return _HISTORY_STATUS.get(self.outcome, ("Completed", "info"))[1]
+
+
+@dataclass(frozen=True, slots=True)
+class VerificationHistoryPage:
+    """A bounded page of terminal attempts."""
+
+    items: list[VerificationAttemptHistoryItem]
+    page: int
+    has_previous: bool
+    has_next: bool
+
+
+@dataclass(frozen=True, slots=True)
 class PhaseVerificationWorkspace:
     """All state needed to render one phase's verification workflow."""
 
@@ -95,6 +141,7 @@ class PhaseVerificationWorkspace:
     card_contexts_by_req: dict[str, dict[str, Any]]
     verification_locked: bool
     prerequisite_phase_id: int | None
+    history: VerificationHistoryPage
 
 
 async def get_verifications_overview(
@@ -158,8 +205,13 @@ async def get_phase_verification_workspace(
     user_id: int,
     phase: Phase,
     github_username: str | None,
+    *,
+    history_page: int = 1,
 ) -> PhaseVerificationWorkspace:
     """Build cards, polling state, progress, and gating for one phase."""
+    if history_page < 1:
+        raise ValueError("history_page must be at least 1")
+
     phase_progress = await fetch_phase_progress(db, user_id, phase)
     requirements = (
         list(phase.hands_on_verification.requirements)
@@ -171,9 +223,10 @@ async def get_phase_verification_workspace(
     requirements_by_uuid = {
         requirement.uuid: requirement for requirement in requirements
     }
-    active_attempts = await VerificationAttemptRepository(
-        db
-    ).get_active_for_requirements(user_id, requirements_by_uuid)
+    attempt_repository = VerificationAttemptRepository(db)
+    active_attempts = await attempt_repository.get_active_for_requirements(
+        user_id, requirements_by_uuid
+    )
     active_attempts_by_slug = {
         requirements_by_uuid[attempt.requirement_uuid].slug: attempt
         for attempt in active_attempts
@@ -206,6 +259,37 @@ async def get_phase_verification_workspace(
             verification_status_token=status_token,
         )
 
+    history_rows = await attempt_repository.list_terminal_history_for_requirements(
+        user_id,
+        requirements_by_uuid,
+        limit=VERIFICATION_HISTORY_PAGE_SIZE + 1,
+        offset=(history_page - 1) * VERIFICATION_HISTORY_PAGE_SIZE,
+    )
+    history_items: list[VerificationAttemptHistoryItem] = []
+    for attempt in history_rows[:VERIFICATION_HISTORY_PAGE_SIZE]:
+        requirement = requirements_by_uuid.get(attempt.requirement_uuid)
+        if requirement is None:
+            continue
+
+        feedback_tasks: list[dict[str, Any]] = []
+        feedback_passed = 0
+        if requirement.submission_type != SubmissionType.CAREER_REFLECTION:
+            feedback_context = feedback_context_from_json(attempt.feedback_json)
+            feedback_tasks, feedback_passed = feedback_tasks_and_passed(
+                feedback_context
+            )
+        history_items.append(
+            VerificationAttemptHistoryItem(
+                id=attempt.id,
+                requirement=requirement,
+                outcome=attempt.outcome,
+                validation_message=attempt.validation_message,
+                feedback_tasks=feedback_tasks,
+                feedback_passed=feedback_passed,
+                completed_at=attempt.completed_at,
+            )
+        )
+
     verification_locked, prerequisite_phase_id = await is_phase_verification_locked(
         db, user_id, phase.order
     )
@@ -216,4 +300,10 @@ async def get_phase_verification_workspace(
         card_contexts_by_req=card_contexts_by_req,
         verification_locked=verification_locked,
         prerequisite_phase_id=prerequisite_phase_id,
+        history=VerificationHistoryPage(
+            items=history_items,
+            page=history_page,
+            has_previous=history_page > 1,
+            has_next=len(history_rows) > VERIFICATION_HISTORY_PAGE_SIZE,
+        ),
     )

--- a/api/src/learn_to_cloud/templates/pages/verification_phase.html
+++ b/api/src/learn_to_cloud/templates/pages/verification_phase.html
@@ -27,7 +27,7 @@
     </div>
     <p class="mt-3 text-lg font-medium text-gray-700 dark:text-gray-200">{{ phase.name }}</p>
     <p class="mt-3 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
-        Submit proof of your hands-on work. Requirements unlock in sequence, and the latest result and feedback stay with each requirement.
+        Submit proof of your hands-on work. Requirements unlock in sequence, and completed attempts remain available below.
     </p>
     <div class="mt-5 flex flex-wrap gap-4">
         <a href="/phase/{{ phase.order }}" class="inline-flex min-h-11 items-center font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300">
@@ -133,4 +133,67 @@
     </div>
 </section>
 {% endif %}
+
+<section class="mt-14 border-t border-gray-200 pt-12 dark:border-gray-700 sm:mt-16 sm:pt-14" aria-labelledby="attempt-history-heading">
+    <div>
+        <h2 id="attempt-history-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Attempt history</h2>
+        <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
+            Completed attempts are kept as a private record. Sensitive submitted values and internal grading metadata are not shown.
+        </p>
+    </div>
+
+    {% if history.items %}
+    <div class="mt-6 space-y-3">
+        {% for item in history.items %}
+        <article class="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+            <div class="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                    <h3 class="text-sm font-bold text-gray-950 dark:text-white">{{ item.requirement.name }}</h3>
+                    {% if item.completed_at %}
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ item.completed_at.strftime('%b %d, %Y at %H:%M %Z') }}</p>
+                    {% endif %}
+                </div>
+                {{ status_pill(item.status_label, item.status_variant) }}
+            </div>
+
+            {% if item.validation_message %}
+            <p class="mt-3 text-sm leading-6 {% if item.outcome == 'failed' %}text-red-700 dark:text-red-300{% else %}text-gray-600 dark:text-gray-300{% endif %}">
+                {{ item.validation_message }}
+            </p>
+            {% endif %}
+
+            {% if item.feedback_tasks %}
+            {% with
+                feedback_tasks=item.feedback_tasks,
+                feedback_passed=item.feedback_passed,
+                requirement_slug='history-' ~ item.id
+            %}
+            {% include "partials/verification_feedback.html" %}
+            {% endwith %}
+            {% endif %}
+        </article>
+        {% endfor %}
+    </div>
+
+    {% if history.has_previous or history.has_next %}
+    <nav class="mt-6 flex items-center justify-between gap-4" aria-label="Attempt history pages">
+        {% if history.has_previous %}
+        <a href="/verifications/phase/{{ phase.order }}?history_page={{ history.page - 1 }}" class="inline-flex min-h-11 items-center font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">Newer attempts</a>
+        {% else %}
+        <span></span>
+        {% endif %}
+        {% if history.has_next %}
+        <a href="/verifications/phase/{{ phase.order }}?history_page={{ history.page + 1 }}" class="inline-flex min-h-11 items-center font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">Older attempts</a>
+        {% endif %}
+    </nav>
+    {% endif %}
+    {% else %}
+    <div class="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-5 dark:border-gray-700 dark:bg-gray-800/50">
+        <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">No completed attempts yet. Your results and allowed feedback will appear here after verification finishes.</p>
+        {% if history.has_previous %}
+        <a href="/verifications/phase/{{ phase.order }}?history_page={{ history.page - 1 }}" class="mt-3 inline-flex min-h-11 items-center font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">View newer attempts</a>
+        {% endif %}
+    </div>
+    {% endif %}
+</section>
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/verifications.html
+++ b/api/src/learn_to_cloud/templates/pages/verifications.html
@@ -10,7 +10,7 @@
         <p class="text-sm font-bold uppercase tracking-[0.12em] text-blue-700 dark:text-blue-300">Hands-on work</p>
         <h1 class="mt-2 text-3xl font-bold tracking-[-0.025em] text-gray-950 dark:text-white sm:text-4xl">Verification workspace</h1>
         <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-300">
-            Submit your work, follow active checks, and review the latest feedback for every phase.
+            Submit your work, follow active checks, and review feedback history for every phase.
         </p>
     </div>
     <a href="/curriculum" class="inline-flex min-h-11 items-center font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300">
@@ -69,7 +69,7 @@
 <section class="mt-12" aria-labelledby="verification-phases-heading">
     <div>
         <h2 id="verification-phases-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Phases</h2>
-        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Each workspace keeps submissions, processing state, and latest feedback together.</p>
+        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Each workspace keeps submissions, processing state, and private feedback history together.</p>
     </div>
 
     <div class="mt-6 border-y border-gray-200 dark:border-gray-700">

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -205,6 +205,12 @@ class TestPhaseVerificationLocked:
             card_contexts_by_req=_card_contexts(requirements, submissions_by_req),
             verification_locked=True,
             prerequisite_phase_id=5,
+            history=SimpleNamespace(
+                items=[],
+                page=1,
+                has_previous=False,
+                has_next=False,
+            ),
         )
 
     def test_validated_requirement_renders_as_complete_when_locked(self):
@@ -266,6 +272,12 @@ class TestPhaseVerificationCardStates:
             card_contexts_by_req=_card_contexts(requirements, submissions_by_req),
             verification_locked=False,
             prerequisite_phase_id=None,
+            history=SimpleNamespace(
+                items=[],
+                page=1,
+                has_previous=False,
+                has_next=False,
+            ),
         )
 
     def test_not_started_shows_form_no_pill(self):
@@ -432,6 +444,61 @@ def test_phase_page_links_to_verification_workspace_without_rendering_form():
     assert 'href="/verifications/phase/4"' in html
     assert "Continue verification" in html
     assert 'hx-post="/htmx/github/submit"' not in html
+
+
+@pytest.mark.unit
+def test_phase_verification_renders_paginated_safe_attempt_history():
+    requirement = _requirement("journal-api", "Journal API")
+    history_item = SimpleNamespace(
+        id="history-id",
+        requirement=requirement,
+        outcome="failed",
+        status_label="Needs work",
+        status_variant="error",
+        validation_message="The required endpoint is missing.",
+        feedback_tasks=[
+            {
+                "name": "API shape",
+                "passed": False,
+                "message": "No health endpoint was found.",
+                "next_steps": "Add GET /health.",
+            }
+        ],
+        feedback_passed=0,
+        completed_at=datetime(2026, 8, 28, 18, 0),
+    )
+    phase_progress = SimpleNamespace(
+        verification=SimpleNamespace(
+            requirements_required=1,
+            requirements_verified=0,
+            percentage=0,
+            is_complete=False,
+        )
+    )
+
+    html = _render(
+        "pages/verification_phase.html",
+        phase=SimpleNamespace(name="Phase 3", description="", order=3),
+        phase_progress=phase_progress,
+        requirements=[],
+        card_contexts_by_req={},
+        verification_locked=False,
+        prerequisite_phase_id=None,
+        history=SimpleNamespace(
+            items=[history_item],
+            page=2,
+            has_previous=True,
+            has_next=True,
+        ),
+    )
+
+    assert "Attempt history" in html
+    assert "The required endpoint is missing." in html
+    assert "No health endpoint was found." in html
+    assert "Add GET /health." in html
+    assert "submitted-token-value" not in html
+    assert 'href="/verifications/phase/3?history_page=1"' in html
+    assert 'href="/verifications/phase/3?history_page=3"' in html
 
 
 @pytest.mark.unit

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -301,6 +301,7 @@ class TestPhaseVerificationPage:
             card_contexts_by_req={},
             verification_locked=True,
             prerequisite_phase_id=3,
+            history=MagicMock(),
         )
 
         with (
@@ -322,13 +323,18 @@ class TestPhaseVerificationPage:
             await phase_verification_page(request, phase_id=4, db=mock_db, user_id=42)
 
         get_workspace.assert_awaited_once_with(
-            mock_db, 42, phase, mock_user.github_username
+            mock_db,
+            42,
+            phase,
+            mock_user.github_username,
+            history_page=1,
         )
         assert template.call_args[0][1] == "pages/verification_phase.html"
         ctx = template.call_args[0][2]
         assert ctx["phase"] is phase
         assert ctx["verification_locked"] is True
         assert ctx["prerequisite_phase_id"] == 3
+        assert ctx["history"] is workspace.history
 
 
 @pytest.mark.unit

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -405,6 +405,12 @@ class TestAuthPageSmoke:
             },
             verification_locked=False,
             prerequisite_phase_id=None,
+            history=SimpleNamespace(
+                items=[],
+                page=1,
+                has_previous=False,
+                has_next=False,
+            ),
         )
 
         with (

--- a/api/tests/services/test_verification_page_service.py
+++ b/api/tests/services/test_verification_page_service.py
@@ -1,10 +1,14 @@
 """Tests for verification workspace view data."""
 
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    AttemptHistoryProjection,
+)
 from learn_to_cloud_shared.schemas import (
     LearningProgress,
     Phase,
@@ -16,6 +20,7 @@ from learn_to_cloud_shared.schemas import (
     VerificationProgress,
 )
 from learn_to_cloud_shared.testing.requirement_factories import (
+    career_reflection_requirement,
     repo_fork_requirement,
 )
 
@@ -131,7 +136,8 @@ async def test_phase_workspace_preserves_active_attempt_polling_state():
         requirement_uuid=requirement.uuid,
     )
     repository = MagicMock(
-        get_active_for_requirements=AsyncMock(return_value=[active_attempt])
+        get_active_for_requirements=AsyncMock(return_value=[active_attempt]),
+        list_terminal_history_for_requirements=AsyncMock(return_value=[]),
     )
 
     with (
@@ -176,4 +182,116 @@ async def test_phase_workspace_preserves_active_attempt_polling_state():
     assert card["verification_status_token"] == "status-token"
     repository.get_active_for_requirements.assert_awaited_once_with(
         42, {requirement.uuid: requirement}
+    )
+    repository.list_terminal_history_for_requirements.assert_awaited_once_with(
+        42,
+        {requirement.uuid: requirement},
+        limit=11,
+        offset=0,
+    )
+
+
+@pytest.mark.unit
+async def test_phase_workspace_maps_safe_history_and_suppresses_reflection_feedback():
+    repository_requirement = repo_fork_requirement(slug="verify-repository")
+    reflection_requirement = career_reflection_requirement(slug="career-reflection")
+    phase = Phase(
+        uuid=uuid4(),
+        order=7,
+        name="Career",
+        slug="phase7",
+        hands_on_verification=PhaseHandsOnVerificationOverview(
+            requirements=[repository_requirement, reflection_requirement]
+        ),
+    )
+    progress = _phase_progress(7, verified=0, required=2)
+    completed_at = datetime.now(UTC)
+    repository_attempt = AttemptHistoryProjection(
+        id=uuid4(),
+        requirement_uuid=repository_requirement.uuid,
+        outcome="failed",
+        feedback_json=[
+            {
+                "task_name": "Repository",
+                "passed": False,
+                "feedback": "Add the required file.",
+                "next_steps": "Commit the file and retry.",
+            }
+        ],
+        validation_message="Repository evidence is incomplete.",
+        completed_at=completed_at,
+    )
+    reflection_attempt = AttemptHistoryProjection(
+        id=uuid4(),
+        requirement_uuid=reflection_requirement.uuid,
+        outcome="succeeded",
+        feedback_json=[
+            {
+                "task_name": "Private reflection",
+                "passed": True,
+                "feedback": "Sensitive retained coaching.",
+                "next_steps": "",
+            }
+        ],
+        validation_message=None,
+        completed_at=completed_at,
+    )
+    history_rows = [repository_attempt, reflection_attempt]
+    history_rows.extend([repository_attempt] * 9)
+    repository = MagicMock(
+        get_active_for_requirements=AsyncMock(return_value=[]),
+        list_terminal_history_for_requirements=AsyncMock(return_value=history_rows),
+    )
+
+    with (
+        patch(
+            "learn_to_cloud.services.verification_page_service.fetch_phase_progress",
+            new=AsyncMock(return_value=progress),
+        ),
+        patch(
+            "learn_to_cloud.services.verification_page_service.get_phase_submission_context",
+            new=AsyncMock(
+                return_value=PhaseSubmissionContext(
+                    submissions_by_req={},
+                    feedback_by_req={},
+                )
+            ),
+        ),
+        patch(
+            "learn_to_cloud.services.verification_page_service.VerificationAttemptRepository",
+            return_value=repository,
+        ),
+        patch(
+            "learn_to_cloud.services.verification_page_service.is_phase_verification_locked",
+            new=AsyncMock(return_value=(False, None)),
+        ),
+    ):
+        result = await get_phase_verification_workspace(
+            AsyncMock(),
+            user_id=42,
+            phase=phase,
+            github_username="learner",
+            history_page=2,
+        )
+
+    assert result.history.page == 2
+    assert result.history.has_previous is True
+    assert result.history.has_next is True
+    assert len(result.history.items) == 10
+    first = result.history.items[0]
+    assert first.status_label == "Needs work"
+    assert first.status_variant == "error"
+    assert first.feedback_tasks[0]["message"] == "Add the required file."
+    assert first.completed_at == completed_at
+    reflection = result.history.items[1]
+    assert reflection.feedback_tasks == []
+    assert reflection.feedback_passed == 0
+    repository.list_terminal_history_for_requirements.assert_awaited_once_with(
+        42,
+        {
+            repository_requirement.uuid: repository_requirement,
+            reflection_requirement.uuid: reflection_requirement,
+        },
+        limit=11,
+        offset=10,
     )

--- a/docs/progression-system.md
+++ b/docs/progression-system.md
@@ -19,8 +19,8 @@ Learning and verification use separate page spaces:
 
 - `/phase/{phase}` contains curriculum topics and learning progress.
 - `/verifications` summarizes hands-on progress across phases.
-- `/verifications/phase/{phase}` contains submissions, active checks, and the
-  latest retained feedback for that phase.
+- `/verifications/phase/{phase}` contains submissions, active checks, and
+  paginated learner-safe attempt and feedback history for that phase.
 
 ## Progress Calculation
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/verification_attempt_repository.py
@@ -101,6 +101,18 @@ class AttemptCardProjection:
 
 
 @dataclass(frozen=True, slots=True)
+class AttemptHistoryProjection:
+    """Learner-safe terminal attempt fields for history views."""
+
+    id: UUID
+    requirement_uuid: UUID
+    outcome: str
+    feedback_json: list[dict] | None
+    validation_message: str | None
+    completed_at: datetime | None
+
+
+@dataclass(frozen=True, slots=True)
 class FinalizeResult:
     """Outcome of a compare-and-set finalize.
 
@@ -663,6 +675,57 @@ class VerificationAttemptRepository:
                 completed_at=row.completed_at,
                 created_at=row.created_at,
                 updated_at=row.updated_at,
+            )
+            for row in result.all()
+        ]
+
+    async def list_terminal_history_for_requirements(
+        self,
+        user_id: int,
+        requirement_uuids: Iterable[UUID],
+        *,
+        limit: int,
+        offset: int = 0,
+    ) -> list[AttemptHistoryProjection]:
+        """List terminal attempts without submitted values or internal metadata."""
+        if limit < 1:
+            raise ValueError("limit must be at least 1")
+        if offset < 0:
+            raise ValueError("offset must not be negative")
+
+        uuids = list(requirement_uuids)
+        if not uuids:
+            return []
+
+        result = await self.db.execute(
+            select(
+                VerificationAttempt.id,
+                VerificationAttempt.requirement_uuid,
+                VerificationAttempt.outcome,
+                VerificationAttempt.feedback_json,
+                VerificationAttempt.validation_message,
+                VerificationAttempt.completed_at,
+            )
+            .where(
+                VerificationAttempt.user_id == user_id,
+                VerificationAttempt.requirement_uuid.in_(uuids),
+                VerificationAttempt.outcome.is_not(None),
+            )
+            .order_by(
+                VerificationAttempt.created_at.desc(),
+                VerificationAttempt.id.desc(),
+            )
+            .limit(limit)
+            .offset(offset)
+        )
+        return [
+            AttemptHistoryProjection(
+                id=row.id,
+                requirement_uuid=row.requirement_uuid,
+                outcome=row.outcome,
+                feedback_json=row.feedback_json,
+                validation_message=row.validation_message,
+                completed_at=row.completed_at,
             )
             for row in result.all()
         ]

--- a/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_verification_attempt_repository.py
@@ -55,12 +55,15 @@ async def _insert_attempt(
     completed_at=None,
     started_at=None,
     outcome: str | None = None,
+    user_id: int = USER_ID,
+    feedback_json: list[dict] | None = None,
+    validation_message: str | None = None,
 ) -> UUID:
     attempt_id = attempt_id or uuid4()
     async with session_maker() as db:
         attempt = VerificationAttempt(
             id=attempt_id,
-            user_id=USER_ID,
+            user_id=user_id,
             requirement_uuid=requirement_uuid or uuid4(),
             snapshot_source="reconstructed",
             submission_value_kind="github_url",
@@ -68,6 +71,8 @@ async def _insert_attempt(
             started_at=started_at,
             outcome=outcome,
             completed_at=completed_at or (utcnow() if outcome is not None else None),
+            feedback_json=feedback_json,
+            validation_message=validation_message,
         )
         if created_at is not None:
             attempt.created_at = created_at
@@ -703,6 +708,103 @@ async def test_get_latest_terminal_for_requirements_empty_input(
             db
         ).get_latest_terminal_for_requirements(USER_ID, [])
     assert rows == []
+
+
+async def test_list_terminal_history_is_scoped_ordered_paginated_and_safe(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    req = uuid4()
+    other_req = uuid4()
+    other_user_id = USER_ID + 1
+    now = utcnow()
+
+    async with session_maker() as db:
+        await UserRepository(db).upsert(
+            other_user_id,
+            github_username="otherattemptrepo",
+        )
+        await db.commit()
+
+    oldest_id = await _insert_attempt(
+        session_maker,
+        requirement_uuid=req,
+        created_at=now - timedelta(hours=3),
+        outcome="failed",
+        feedback_json=[{"task_name": "old"}],
+        validation_message="Needs work.",
+    )
+    middle_id = await _insert_attempt(
+        session_maker,
+        requirement_uuid=req,
+        created_at=now - timedelta(hours=2),
+        outcome="server_error",
+    )
+    newest_id = await _insert_attempt(
+        session_maker,
+        requirement_uuid=req,
+        created_at=now - timedelta(hours=1),
+        outcome="succeeded",
+    )
+    await _insert_attempt(
+        session_maker,
+        requirement_uuid=req,
+        created_at=now,
+    )
+    await _insert_attempt(
+        session_maker,
+        requirement_uuid=other_req,
+        outcome="succeeded",
+    )
+    await _insert_attempt(
+        session_maker,
+        requirement_uuid=req,
+        outcome="succeeded",
+        user_id=other_user_id,
+    )
+
+    async with session_maker() as db:
+        first_page = await VerificationAttemptRepository(
+            db
+        ).list_terminal_history_for_requirements(
+            USER_ID,
+            [req],
+            limit=2,
+        )
+        second_page = await VerificationAttemptRepository(
+            db
+        ).list_terminal_history_for_requirements(
+            USER_ID,
+            [req],
+            limit=2,
+            offset=2,
+        )
+
+    assert [row.id for row in first_page] == [newest_id, middle_id]
+    assert [row.id for row in second_page] == [oldest_id]
+    assert second_page[0].feedback_json == [{"task_name": "old"}]
+    assert second_page[0].validation_message == "Needs work."
+    assert not hasattr(second_page[0], "submitted_value")
+    assert not hasattr(second_page[0], "error_code")
+
+
+async def test_list_terminal_history_validates_pagination(
+    session_maker: async_sessionmaker[AsyncSession], user: int
+) -> None:
+    async with session_maker() as db:
+        repository = VerificationAttemptRepository(db)
+        with pytest.raises(ValueError, match="limit"):
+            await repository.list_terminal_history_for_requirements(
+                USER_ID,
+                [],
+                limit=0,
+            )
+        with pytest.raises(ValueError, match="offset"):
+            await repository.list_terminal_history_for_requirements(
+                USER_ID,
+                [],
+                limit=1,
+                offset=-1,
+            )
 
 
 class TestListPhaseCompletions:


### PR DESCRIPTION
## What changes

Adds paginated attempt history to each phase verification workspace introduced by the previous PR in this stack. Learners can review completed outcomes, timestamps, validation messages, and allowed criterion-level feedback.

The new repository read selects only learner-safe fields. It does not load or expose submitted values, raw tokens, reflection text, internal scores, confidence values, or execution metadata. Retained career-reflection coaching is also suppressed from history.

## Why

The dedicated workspace should preserve more than the latest result. This gives learners a private record of prior attempts and actionable feedback without broadening access to sensitive verification data.

## Checks

- `uv run poe check`
- Fresh API startup with successful health, readiness, and OpenAPI responses