### PR TITLE
chore: simplify local API startup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "request": "launch",
       "python": "${workspaceFolder}/.venv/bin/python",
       "module": "uvicorn",
-      "args": ["learn_to_cloud.main:app", "--reload", "--reload-include", "*.py", "--reload-include", "*.html", "--reload-exclude", ".venv", "--host", "0.0.0.0", "--port", "8000"],
+      "args": ["learn_to_cloud.main:app", "--reload", "--reload-include", "*.py", "--reload-include", "*.html", "--reload-exclude", ".venv", "--port", "8000"],
       "cwd": "${workspaceFolder}/api",
       "envFile": "${workspaceFolder}/api/.env",
       "env": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,23 +48,6 @@ services:
     environment:
       ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS: "true"
 
-  # Test service to reproduce multi-worker migration race condition
-  # Usage: docker compose up db api-multiworker --build
-  api-multiworker:
-    build:
-      context: .
-      dockerfile: api/Dockerfile
-    ports:
-      - "127.0.0.1:8000:8000"
-    environment:
-      - DATABASE__URL=postgresql+asyncpg://postgres:postgres@db:5432/learn_to_cloud
-      - GITHUB__TOKEN=test_token
-      - APPLICATIONINSIGHTS_CONNECTION_STRING=
-    depends_on:
-      db:
-        condition: service_healthy
-    # Uses default CMD from Dockerfile (single uvicorn worker)
-
 volumes:
   postgres_data:
   azurite_data:

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -136,23 +136,22 @@ cd api && uv run alembic current
 cd api && uv run alembic history --verbose
 ```
 
-## Using docker compose
+## Using the Compose database
 
-When running the full stack with `docker compose up`, you need to run migrations manually since they no longer auto-run on startup:
+Compose runs the local PostgreSQL dependency. Run migrations and the API
+directly from the Python workspace:
 
 ```bash
 # Start the database
 docker compose up db -d
 
-# Run migrations against the compose database
-docker compose run --rm api-multiworker python -m alembic upgrade head
+# Run migrations against the Compose database
+cd api
+uv run alembic upgrade head
 
-# Then start the API
-docker compose up api-multiworker
+# Start the API
+uv run python -m uvicorn learn_to_cloud.main:app --reload --port 8000
 ```
-
-`api-multiworker` is a diagnostic Compose service rather than the normal local
-development path. For day-to-day work, run Alembic directly from `api/`.
 
 ## Tips
 


### PR DESCRIPTION
## What changes

- Run the VS Code API debugger on Uvicorn's local-only default address instead of exposing it on every network interface.
- Remove the obsolete `api-multiworker` diagnostic service from Docker Compose.
- Update the migration guide to start PostgreSQL with Compose and run migrations and the API from the Python workspace.

## Why

Local development uses `http://localhost:8000`, including the GitHub OAuth callback. The old debugger binding and diagnostic Compose service made the intended startup path unclear.