### PR TITLE
Enable Python debugging for verification Functions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-azurefunctions",
+    "ms-python.python",
+    "ms-python.debugpy"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,7 @@
         "host": "localhost",
         "port": 9091
       },
-      "preLaunchTask": "Verification: start Functions host",
+      "preLaunchTask": "func: host start",
       "justMyCode": false
     }
   ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,15 +29,14 @@
     },
     {
       "name": "Verification: Durable Functions",
-      "type": "node-terminal",
-      "request": "launch",
-      "command": "test -f local.settings.json || cp local.settings.example.json local.settings.json; uv sync --all-packages --locked; uv run func start --port 7071",
-      "cwd": "${workspaceFolder}/apps/verification-functions",
-      "env": {
-        "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
-        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:4317",
-        "OTEL_SERVICE_NAME": "learn-to-cloud-verification-functions"
-      }
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 9091
+      },
+      "preLaunchTask": "Verification: start Functions host",
+      "justMyCode": false
     }
   ],
   "compounds": [
@@ -50,7 +49,8 @@
       "configurations": [
         "Verification: Durable Functions",
         "API: FastAPI (uvicorn)"
-      ]
+      ],
+      "stopAll": true
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,9 +11,7 @@
       "cwd": "${workspaceFolder}/api",
       "envFile": "${workspaceFolder}/api/.env",
       "env": {
-        "DYLD_FALLBACK_LIBRARY_PATH": "/opt/homebrew/lib",
         "VERIFICATION_FUNCTIONS__BASE_URL": "http://localhost:7071",
-        "VERIFICATION_FUNCTIONS__KEY": "local-dev",
         "OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:4317",
         "OTEL_SERVICE_NAME": "learn-to-cloud-api"
       },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+  "azureFunctions.projectSubpath": "apps/verification-functions",
+  "azureFunctions.projectLanguage": "Python",
+  "azureFunctions.projectRuntime": "~4",
+  "azureFunctions.pythonVenv": ".venv",
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.terminal.activateEnvironment": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "label": "Verification: start Functions host",
+      "label": "func: host start",
       "type": "func",
       "command": "host start",
       "problemMatcher": "$func-python-watch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,6 +28,7 @@
         "env": {
           "VIRTUAL_ENV": "${workspaceFolder}/.venv",
           "PATH": "${workspaceFolder}/.venv/bin:${env:PATH}",
+          "languageWorkers__python__defaultExecutablePath": "${workspaceFolder}/.venv/bin/python",
           "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
           "OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:4317",
           "OTEL_SERVICE_NAME": "learn-to-cloud-verification-functions"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,6 +6,33 @@
       "type": "shell",
       "command": "cd ${workspaceFolder}/api && uv run alembic upgrade head",
       "problemMatcher": []
+    },
+    {
+      "label": "Verification: prepare Functions host",
+      "type": "shell",
+      "command": "test -f local.settings.json || cp local.settings.example.json local.settings.json; uv sync --all-packages --locked",
+      "problemMatcher": [],
+      "options": {
+        "cwd": "${workspaceFolder}/apps/verification-functions"
+      }
+    },
+    {
+      "label": "Verification: start Functions host",
+      "type": "func",
+      "command": "host start",
+      "problemMatcher": "$func-python-watch",
+      "isBackground": true,
+      "dependsOn": "Verification: prepare Functions host",
+      "options": {
+        "cwd": "${workspaceFolder}/apps/verification-functions",
+        "env": {
+          "VIRTUAL_ENV": "${workspaceFolder}/.venv",
+          "PATH": "${workspaceFolder}/.venv/bin:${env:PATH}",
+          "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
+          "OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:4317",
+          "OTEL_SERVICE_NAME": "learn-to-cloud-verification-functions"
+        }
+      }
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ cd apps/verification-functions
 uv run func start --port 7071
 ```
 
-Or use VS Code's **"API + Verification"** compound launch configuration.
+Or install the workspace's recommended Azure Functions extension and use
+VS Code's **"API + Verification"** compound launch configuration. It starts
+Core Tools and attaches the Python debugger to the Functions worker.
 
 **Notes:**
 - The API does not start local dependencies for you. Run `docker compose up -d db azurite dts` first.


### PR DESCRIPTION
This changes the VS Code verification launcher so it attaches the Python debugger instead of only starting Core Tools in a terminal.\n\nThe new background task prepares the uv workspace, starts the Functions host, and lets debugpy connect to the Python worker on port 9091. The compound launcher still starts both the API and verification service, and stopping it now stops both sessions.\n\nThe workspace also recommends the Azure Functions extension required by the Functions task.