### PR TITLE
Remove local protobuf workaround

### DIFF
--- a/apps/verification-functions/local.settings.example.json
+++ b/apps/verification-functions/local.settings.example.json
@@ -1,6 +1,5 @@
 {
   "IsEncrypted": false,
-  "_comment_PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "Local dev only. Forces protobuf's pure-Python implementation to avoid an upstream Azure Functions bug where the Python 3.13 worker segfaults (exit code 139) loading protobuf's native extension on arm64 Linux. Not used in production (this file is never deployed). See Azure/azure-functions-python-worker#1797.",
   "Values": {
     "AzureWebJobsStorage": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;",
     "FUNCTIONS_WORKER_RUNTIME": "python",
@@ -12,7 +11,6 @@
     "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:4317",
     "OTEL_SERVICE_NAME": "learn-to-cloud-verification-functions",
-    "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python",
     "FOUNDRY_PROJECT_ENDPOINT": "",
     "FOUNDRY_MODEL_DEPLOYMENT_NAME": "",
     "AzureWebJobsSecretStorageType": "Files",


### PR DESCRIPTION
## What changes

Removes the local setting that forced protobuf to use its pure-Python implementation.

PR #804 added a project-local Python 3.13 Functions environment and the supported runtime isolation package, so Core Tools no longer mixes application dependencies with its bundled worker dependencies. The Functions host now starts and indexes all 12 functions without the workaround.

Closes #559.