### PR TITLE
Modernize deployment image builds with Buildx caching

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -245,40 +245,44 @@ jobs:
       - name: Log in to ACR
         run: az acr login --name ${{ needs.deployment_context.outputs.container_registry_name }}
 
-      - name: Build and Push Container Images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v4.3.0
+
+      - name: Build API image for validation
+        uses: docker/build-push-action@37fe631027851001ddb9b187196cc803df7f5f0e # v7.3.0
+        with:
+          context: .
+          file: api/Dockerfile
+          target: api-runtime
+          load: true
+          push: false
+          tags: ${{ needs.deployment_context.outputs.container_registry_endpoint }}/api:${{ github.sha }}
+          labels: git-commit=${{ github.sha }}
+          cache-from: type=gha,scope=api-runtime
+          cache-to: type=gha,scope=api-runtime,mode=max
+          no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.force_rebuild == 'true' }}
+          pull: ${{ github.event_name == 'workflow_dispatch' && inputs.force_rebuild == 'true' }}
+
+      - name: Build migrations image for validation
+        uses: docker/build-push-action@37fe631027851001ddb9b187196cc803df7f5f0e # v7.3.0
+        with:
+          context: .
+          file: api/Dockerfile
+          target: migrations-runtime
+          load: true
+          push: false
+          tags: ${{ needs.deployment_context.outputs.container_registry_endpoint }}/migrations:${{ github.sha }}
+          labels: git-commit=${{ github.sha }}
+          cache-from: type=gha,scope=migrations-runtime
+          cache-to: type=gha,scope=migrations-runtime,mode=max
+          no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.force_rebuild == 'true' }}
+          pull: ${{ github.event_name == 'workflow_dispatch' && inputs.force_rebuild == 'true' }}
+
+      - name: Validate runtime images
         env:
           REGISTRY: ${{ needs.deployment_context.outputs.container_registry_endpoint }}
-          FORCE_REBUILD: ${{ inputs.force_rebuild || 'false' }}
         run: |
           set -euo pipefail
-          API_CACHE_FLAGS=""
-          MIGRATIONS_CACHE_FLAGS=""
-          if [[ "$FORCE_REBUILD" == "true" ]]; then
-            API_CACHE_FLAGS="--no-cache --pull"
-            MIGRATIONS_CACHE_FLAGS="--no-cache --pull"
-          else
-            docker pull "$REGISTRY/api:latest" || true
-            docker pull "$REGISTRY/migrations:latest" || true
-            API_CACHE_FLAGS="--cache-from=$REGISTRY/api:latest"
-            MIGRATIONS_CACHE_FLAGS="--cache-from=$REGISTRY/migrations:latest"
-          fi
-
-          docker build -f api/Dockerfile \
-            --target api-runtime \
-            $API_CACHE_FLAGS \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --label git-commit="$GITHUB_SHA" \
-            -t "$REGISTRY/api:$GITHUB_SHA" \
-            -t "$REGISTRY/api:latest" .
-
-          docker build -f api/Dockerfile \
-            --target migrations-runtime \
-            $MIGRATIONS_CACHE_FLAGS \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --label git-commit="$GITHUB_SHA" \
-            -t "$REGISTRY/migrations:$GITHUB_SHA" \
-            -t "$REGISTRY/migrations:latest" .
-
           docker run --rm "$REGISTRY/api:$GITHUB_SHA" \
             python -m learn_to_cloud_shared.runtime_package_check
 
@@ -291,10 +295,39 @@ jobs:
           main()
           PY
 
-          docker push "$REGISTRY/api:$GITHUB_SHA"
-          docker push "$REGISTRY/api:latest"
-          docker push "$REGISTRY/migrations:$GITHUB_SHA"
-          docker push "$REGISTRY/migrations:latest"
+      - name: Publish API image
+        uses: docker/build-push-action@37fe631027851001ddb9b187196cc803df7f5f0e # v7.3.0
+        with:
+          context: .
+          file: api/Dockerfile
+          target: api-runtime
+          push: true
+          tags: |
+            ${{ needs.deployment_context.outputs.container_registry_endpoint }}/api:${{ github.sha }}
+            ${{ needs.deployment_context.outputs.container_registry_endpoint }}/api:latest
+          labels: git-commit=${{ github.sha }}
+          cache-from: type=gha,scope=api-runtime
+          # Reuse the smoke-tested build result instead of resolving new base images.
+          no-cache: false
+          pull: false
+          provenance: false
+
+      - name: Publish migrations image
+        uses: docker/build-push-action@37fe631027851001ddb9b187196cc803df7f5f0e # v7.3.0
+        with:
+          context: .
+          file: api/Dockerfile
+          target: migrations-runtime
+          push: true
+          tags: |
+            ${{ needs.deployment_context.outputs.container_registry_endpoint }}/migrations:${{ github.sha }}
+            ${{ needs.deployment_context.outputs.container_registry_endpoint }}/migrations:latest
+          labels: git-commit=${{ github.sha }}
+          cache-from: type=gha,scope=migrations-runtime
+          # Reuse the smoke-tested build result instead of resolving new base images.
+          no-cache: false
+          pull: false
+          provenance: false
 
       - name: Run database migrations
         env:

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -254,6 +254,7 @@ jobs:
           context: .
           file: api/Dockerfile
           target: api-runtime
+          platforms: linux/amd64
           load: true
           push: false
           tags: ${{ needs.deployment_context.outputs.container_registry_endpoint }}/api:${{ github.sha }}
@@ -269,6 +270,7 @@ jobs:
           context: .
           file: api/Dockerfile
           target: migrations-runtime
+          platforms: linux/amd64
           load: true
           push: false
           tags: ${{ needs.deployment_context.outputs.container_registry_endpoint }}/migrations:${{ github.sha }}
@@ -301,16 +303,18 @@ jobs:
           context: .
           file: api/Dockerfile
           target: api-runtime
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ needs.deployment_context.outputs.container_registry_endpoint }}/api:${{ github.sha }}
             ${{ needs.deployment_context.outputs.container_registry_endpoint }}/api:latest
           labels: git-commit=${{ github.sha }}
           cache-from: type=gha,scope=api-runtime
+          # Keep the deployable manifest compatible with Azure Container Apps.
+          provenance: false
           # Reuse the smoke-tested build result instead of resolving new base images.
           no-cache: false
           pull: false
-          provenance: false
 
       - name: Publish migrations image
         uses: docker/build-push-action@37fe631027851001ddb9b187196cc803df7f5f0e # v7.3.0
@@ -318,16 +322,18 @@ jobs:
           context: .
           file: api/Dockerfile
           target: migrations-runtime
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ needs.deployment_context.outputs.container_registry_endpoint }}/migrations:${{ github.sha }}
             ${{ needs.deployment_context.outputs.container_registry_endpoint }}/migrations:latest
           labels: git-commit=${{ github.sha }}
           cache-from: type=gha,scope=migrations-runtime
+          # Keep the deployable manifest compatible with Azure Container Apps.
+          provenance: false
           # Reuse the smoke-tested build result instead of resolving new base images.
           no-cache: false
           pull: false
-          provenance: false
 
       - name: Run database migrations
         env:


### PR DESCRIPTION
## What changes

The production workflow now builds the API and migration images with Docker Buildx instead of manually pulling, building, tagging, and pushing images.

Each image has its own GitHub Actions cache. The workflow still builds both images locally and runs both runtime package checks before either final image tag is published. After those checks pass, Buildx publishes the commit tag and the existing `latest` tag.

## Why

The old cache depended on best-effort pulls of the previous `latest` images. Buildx provides a maintained cache backend and build summaries that make cache hits visible without changing migration or application deployment ordering.

A manual `force_rebuild=true` deployment still performs a clean validation build and refreshes base images. The publication pass then reuses that checked build result without pulling a different base image.

## Build comparison

The existing warm-cache implementation completed its combined image build, smoke checks, and pushes in 25 seconds in workflow run 33761036341. After merge, the first Buildx run will seed the new caches; a following normal run will provide the meaningful warm-cache comparison for both image targets.

Closes #811

## Azure compatibility

All validation and publication builds explicitly target `linux/amd64`, the platform required by Azure Container Apps. Buildx provenance is disabled on the published images because its attestation manifest uses an `unknown/unknown` platform entry that Container Apps may reject. Supply-chain metadata can be attached later as separate ACR OCI referrers without changing the deployable image manifest.
