### PR TITLE
Run application deployment when infrastructure is skipped

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -190,9 +190,12 @@ jobs:
   deploy_app:
     needs: [changes, deployment_context]
     if: >-
-      needs.changes.outputs.app == 'true' ||
-      needs.changes.outputs.infra == 'true' ||
-      github.event_name == 'workflow_dispatch'
+      always() &&
+      needs.changes.result == 'success' &&
+      needs.deployment_context.result == 'success' &&
+      (needs.changes.outputs.app == 'true' ||
+       needs.changes.outputs.infra == 'true' ||
+       github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
## What changes

The application deployment condition now evaluates even when the optional infrastructure job is skipped. It still requires change detection and deployment context setup to succeed before deploying.

## Why

The production run for #814 correctly detected `.github/workflows/app-deploy.yml` as an application change, but GitHub skipped `deploy_app` because the upstream infrastructure job did not run. As a result, the merged Buildx workflow was not exercised.

Adding `always()` with explicit success checks preserves failure blocking while allowing application-only deployments to proceed.

## Evidence

Run 33773976905 reported `app=true`, completed `deployment_context`, skipped `infrastructure`, and then incorrectly skipped `deploy_app`.