### PR TITLE
Correct and validate pinned GitHub Action SHAs

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -249,10 +249,10 @@ jobs:
         run: az acr login --name ${{ needs.deployment_context.outputs.container_registry_name }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v4.3.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build API image for validation
-        uses: docker/build-push-action@37fe631027851001ddb9b187196cc803df7f5f0e # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: api/Dockerfile
@@ -268,7 +268,7 @@ jobs:
           pull: ${{ github.event_name == 'workflow_dispatch' && inputs.force_rebuild == 'true' }}
 
       - name: Build migrations image for validation
-        uses: docker/build-push-action@37fe631027851001ddb9b187196cc803df7f5f0e # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: api/Dockerfile
@@ -301,7 +301,7 @@ jobs:
           PY
 
       - name: Publish API image
-        uses: docker/build-push-action@37fe631027851001ddb9b187196cc803df7f5f0e # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: api/Dockerfile
@@ -320,7 +320,7 @@ jobs:
           pull: false
 
       - name: Publish migrations image
-        uses: docker/build-push-action@37fe631027851001ddb9b187196cc803df7f5f0e # v7.3.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: api/Dockerfile


### PR DESCRIPTION
## What changes

- Corrects the swapped release SHAs for `docker/setup-buildx-action` and `docker/build-push-action`.
- Adds a lightweight CI job for workflow changes.
- Validates that every external action uses a full commit SHA with a version comment.
- Resolves each public version tag with Git and confirms it points to the pinned commit.

## Why

Production run 33774741813 failed during job setup because valid SHAs were assigned to the wrong Docker action repositories. Existing YAML, CodeQL, and dependency checks did not detect that relationship.

Dependabot remains responsible for proposing future GitHub Action upgrades. This validation complements Dependabot by rejecting incorrect or mismatched pins immediately on pull requests and reusable production CI runs.

No Azure login, image build, push, migration, or deployment occurred in the failed run.