### PR TITLE
Validate pinned GitHub Action versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       infra: ${{ steps.filter.outputs.infra }}
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -47,6 +48,9 @@ jobs:
             infra:
               - 'infra/**'
               - '.github/workflows/infra-deploy.yml'
+            workflows:
+              - '.github/workflows/**'
+              - 'scripts/check-action-pins.sh'
 
   dependency-review:
     if: github.event_name == 'pull_request'
@@ -56,6 +60,16 @@ jobs:
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
+
+  workflow-ci:
+    needs: [changes]
+    if: inputs.force_all || needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate GitHub Actions pins
+        run: bash scripts/check-action-pins.sh
 
   terraform-ci:
     needs: [changes]
@@ -201,7 +215,7 @@ jobs:
 
   ci-status:
     if: always()
-    needs: [changes, code-ci, terraform-ci]
+    needs: [changes, code-ci, terraform-ci, workflow-ci]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI results
@@ -209,15 +223,16 @@ jobs:
           CODE_RESULT: ${{ needs.code-ci.result }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           TERRAFORM_RESULT: ${{ needs.terraform-ci.result }}
+          WORKFLOW_RESULT: ${{ needs.workflow-ci.result }}
         run: |
           set -euo pipefail
           if [[ "$CHANGES_RESULT" != "success" ]]; then
             echo "Change detection failed: $CHANGES_RESULT"
             exit 1
           fi
-          for result in "$CODE_RESULT" "$TERRAFORM_RESULT"; do
+          for result in "$CODE_RESULT" "$TERRAFORM_RESULT" "$WORKFLOW_RESULT"; do
             if [[ ! "$result" =~ ^(success|skipped)$ ]]; then
-              echo "CI failed: code=$CODE_RESULT terraform=$TERRAFORM_RESULT"
+              echo "CI failed: code=$CODE_RESULT terraform=$TERRAFORM_RESULT workflows=$WORKFLOW_RESULT"
               exit 1
             fi
           done

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+declare -A checked
+failed=false
+
+while IFS=: read -r file line content; do
+  reference=$(sed -E 's/^[[:space:]-]*uses:[[:space:]]*([^[:space:]#]+).*/\1/' <<< "$content")
+  if [[ "$reference" == ./* || "$reference" == docker://* ]]; then
+    continue
+  fi
+
+  action=${reference%@*}
+  revision=${reference##*@}
+  repository=$(cut -d/ -f1,2 <<< "$action")
+  version=$(sed -nE 's/.*#[[:space:]]*(v[^[:space:]]+).*/\1/p' <<< "$content")
+
+  if [[ ! "$revision" =~ ^[0-9a-f]{40}$ || -z "$version" ]]; then
+    echo "::error file=$file,line=$line::External actions must use a full commit SHA and a version comment."
+    failed=true
+    continue
+  fi
+
+  key="$repository@$revision#$version"
+  if [[ -n "${checked[$key]:-}" ]]; then
+    continue
+  fi
+  checked[$key]=1
+
+  if ! tag_refs=$(
+    git ls-remote \
+      "https://github.com/$repository.git" \
+      "refs/tags/$version" \
+      "refs/tags/$version^{}"
+  ); then
+    echo "::error file=$file,line=$line::Unable to resolve $repository tag $version."
+    failed=true
+    continue
+  fi
+  tag_revision=$(awk '$2 ~ /\^\{\}$/ {print $1}' <<< "$tag_refs")
+  if [[ -z "$tag_revision" ]]; then
+    tag_revision=$(awk 'NR == 1 {print $1}' <<< "$tag_refs")
+  fi
+
+  if [[ -z "$tag_revision" ]]; then
+    echo "::error file=$file,line=$line::$repository does not have tag $version."
+    failed=true
+  elif [[ "$revision" != "$tag_revision" ]]; then
+    echo "::error file=$file,line=$line::$repository $version resolves to $tag_revision, not $revision."
+    failed=true
+  fi
+done < <(
+  grep -RnE '^[[:space:]]*(-[[:space:]]*)?uses:' \
+    --include='*.yml' \
+    --include='*.yaml' \
+    .github/workflows
+)
+
+if [[ "$failed" == "true" ]]; then
+  exit 1
+fi
+
+echo "All external GitHub Actions pins match their version tags."


### PR DESCRIPTION
## What changes

Adds a lightweight CI job that runs whenever workflow files change. It checks every external GitHub Action for:

- a full 40-character commit SHA;
- a human-readable version comment;
- a version tag that resolves to that exact SHA in the referenced repository.

## Why

The Buildx deployment initially failed because two valid SHAs were assigned to the wrong Docker action repositories. YAML validation and CodeQL could not detect that relationship.

Dependabot remains responsible for proposing future GitHub Action upgrades. This check complements Dependabot by rejecting incorrect initial pins and mismatched version comments before merge.