### PR TITLE
Enforce the canonical telemetry schema

### DIFF
--- a/api/src/learn_to_cloud/core/auth.py
+++ b/api/src/learn_to_cloud/core/auth.py
@@ -41,7 +41,7 @@ def init_oauth(settings: OAuthConfig) -> None:
     if not settings.client_id:
         logger.warning(
             "auth.github_oauth_disabled",
-            extra={"reason": "github_client_id_not_configured"},
+            extra={"auth.configuration.reason": "github_client_id_not_configured"},
         )
         return
 

--- a/api/src/learn_to_cloud/core/templates.py
+++ b/api/src/learn_to_cloud/core/templates.py
@@ -58,10 +58,16 @@ def _frontend_telemetry_context(request: Request) -> dict[str, object]:
     if not conn_str:
         return {"frontend_telemetry": None}
 
+    route = request.scope.get("route")
+    route_path = getattr(route, "path", None)
+    if not isinstance(route_path, str):
+        route_path = "/unmatched"
+
     return {
         "frontend_telemetry": {
             "connection_string": conn_str,
             "sampling_percentage": settings.frontend_telemetry.sampling_percentage,
+            "route_path": route_path,
         }
     }
 

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -69,11 +69,13 @@ async def lifespan(app: fastapi.FastAPI):
     logger.info(
         "init.curriculum_loaded",
         extra={
-            "curriculum_version": app.state.curriculum_catalog.curriculum_version,
-            "artifact_schema_version": (
+            "content.curriculum.version": (
+                app.state.curriculum_catalog.curriculum_version
+            ),
+            "content.artifact_schema.version": (
                 app.state.curriculum_catalog.artifact_schema_version
             ),
-            "content_hash": app.state.curriculum_catalog.content_hash,
+            "content.artifact.hash": app.state.curriculum_catalog.content_hash,
         },
     )
 
@@ -92,10 +94,7 @@ async def lifespan(app: fastapi.FastAPI):
     except TimeoutError:
         logger.exception(
             "init.timeout",
-            extra={
-                "init_done": app.state.init_done,
-                "hint": "Startup hung — check DB connectivity and migration state",
-            },
+            extra={"startup.initialized": app.state.init_done},
         )
         raise RuntimeError("Application startup timed out") from None
     except Exception as e:

--- a/api/src/learn_to_cloud/routes/auth_routes.py
+++ b/api/src/learn_to_cloud/routes/auth_routes.py
@@ -96,7 +96,7 @@ async def callback(request: Request) -> RedirectResponse:
     if github_id is None:
         logger.error(
             "auth.callback.missing_github_id",
-            extra={"status_code": getattr(resp, "status_code", None)},
+            extra={"http.response.status_code": getattr(resp, "status_code", None)},
         )
         return RedirectResponse(url="/", status_code=302)
 
@@ -104,7 +104,7 @@ async def callback(request: Request) -> RedirectResponse:
     if not github_username:
         logger.error(
             "auth.callback.missing_github_login",
-            extra={"status_code": getattr(resp, "status_code", None)},
+            extra={"http.response.status_code": getattr(resp, "status_code", None)},
         )
         return RedirectResponse(url="/", status_code=302)
 

--- a/api/src/learn_to_cloud/routes/health_routes.py
+++ b/api/src/learn_to_cloud/routes/health_routes.py
@@ -33,8 +33,11 @@ def get_code_alembic_head() -> str | None:
     try:
         script = ScriptDirectory.from_config(Config(str(_ALEMBIC_INI)))
         return script.get_current_head()
-    except Exception:
-        logger.exception("health.alembic_head.resolve_failed")
+    except Exception as exc:
+        logger.error(
+            "health.alembic_head.resolve_failed",
+            extra={"error.type": type(exc).__name__},
+        )
         return None
 
 
@@ -129,7 +132,10 @@ async def ready(request: Request) -> HealthResponse:
             if db_head != code_head:
                 logger.warning(
                     "health.ready.schema_drift",
-                    extra={"db_head": db_head, "code_head": code_head},
+                    extra={
+                        "database.schema.current_revision": db_head,
+                        "database.schema.expected_revision": code_head,
+                    },
                 )
 
     catalog = get_curriculum_catalog()

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -192,11 +192,11 @@ async def _submit_canonical_verification(
     except _USER_FACING_ERRORS as exc:
         return render_input_error(request, current_user, requirement, str(exc))
     except Exception as exc:
-        logger.exception(
+        logger.error(
             "htmx.submit.unexpected_error",
             extra={
-                "requirement_slug": requirement_slug,
-                "error_type": type(exc).__name__,
+                "verification.requirement.slug": requirement_slug,
+                "error.type": type(exc).__name__,
             },
         )
         return render_unavailable(
@@ -409,10 +409,10 @@ async def htmx_verification_attempt_status(
         logger.warning(
             "verification.status.durable_read_failed",
             extra={
-                "attempt_id": token_data.job_id,
-                "error_type": type(exc).__name__,
-                "failure_kind": exc.failure_kind.value,
-                "status_code": exc.status_code,
+                "verification.attempt.id": token_data.job_id,
+                "error.type": type(exc).__name__,
+                "verification.failure.kind": exc.failure_kind.value,
+                "http.response.status_code": exc.status_code,
             },
         )
         return status_error_response(

--- a/api/src/learn_to_cloud/routes/internal_routes.py
+++ b/api/src/learn_to_cloud/routes/internal_routes.py
@@ -116,7 +116,10 @@ async def smoke_verification(
     try:
         result = await run_submit_smoke_check(request.app.state.session_maker)
     except Exception as exc:
-        logger.exception("internal.smoke.verification.failed")
+        logger.error(
+            "internal.smoke.verification.failed",
+            extra={"error.type": type(exc).__name__},
+        )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Verification smoke check failed.",
@@ -124,6 +127,6 @@ async def smoke_verification(
 
     logger.info(
         "internal.smoke.verification.ok",
-        extra={"requirement_slug": result["requirement_slug"]},
+        extra={"verification.requirement.slug": result["requirement_slug"]},
     )
     return {"status": "ok", **result}

--- a/api/src/learn_to_cloud/services/verification_attempt_service.py
+++ b/api/src/learn_to_cloud/services/verification_attempt_service.py
@@ -91,10 +91,9 @@ async def submit_verification_attempt(
     logger.info(
         "verification.attempt.created",
         extra={
-            "user_id": user_id,
-            "requirement_slug": requirement_slug,
-            "attempt_id": str(attempt_submission.attempt_id),
-            "attempt_created": attempt_submission.created,
+            "verification.requirement.slug": requirement_slug,
+            "verification.attempt.id": str(attempt_submission.attempt_id),
+            "verification.attempt.created": attempt_submission.created,
         },
     )
     return await _start_verification_attempt(
@@ -131,14 +130,14 @@ async def _start_verification_attempt(
         DurableVerificationAuthError,
         DurableVerificationStartError,
     ) as exc:
-        logger.exception(
+        logger.error(
             "verification.attempt.durable_start_failed",
             extra={
-                "requirement_slug": requirement_slug,
-                "attempt_id": str(attempt_submission.attempt_id),
-                "error_type": type(exc).__name__,
-                "failure_kind": exc.failure_kind.value,
-                "status_code": exc.status_code,
+                "verification.requirement.slug": requirement_slug,
+                "verification.attempt.id": str(attempt_submission.attempt_id),
+                "error.type": type(exc).__name__,
+                "verification.failure.kind": exc.failure_kind.value,
+                "http.response.status_code": exc.status_code,
             },
         )
         await terminalize_unstarted_verification_attempt(
@@ -184,7 +183,7 @@ async def poll_verification_attempt(
         )
 
     if status in _TERMINAL_DURABLE_STATUSES:
-        await _log_attempt_completion(session_maker, token_data, user_id, status)
+        await _log_attempt_completion(session_maker, token_data, status)
         return VerificationPollResult(
             VerificationPollKind.RELOAD,
             token_data,
@@ -194,8 +193,8 @@ async def poll_verification_attempt(
     logger.warning(
         "verification.status.unexpected_durable_status",
         extra={
-            "attempt_id": token_data.job_id,
-            "runtime_status": durable_status.runtime_status,
+            "verification.attempt.id": token_data.job_id,
+            "verification.durable.status": durable_status.runtime_status,
         },
     )
     return VerificationPollResult(
@@ -232,9 +231,9 @@ async def _terminalize_failed_attempt(
         logger.info(
             "verification.poller.finalize_skipped",
             extra={
-                "attempt_id": str(attempt_id),
-                "runtime_status": status,
-                "outcome": result.state.outcome,
+                "verification.attempt.id": str(attempt_id),
+                "verification.durable.status": status,
+                "verification.outcome": result.state.outcome,
             },
         )
         return
@@ -242,10 +241,10 @@ async def _terminalize_failed_attempt(
     logger.info(
         "verification.poller.attempt_terminalized",
         extra={
-            "attempt_id": str(attempt_id),
-            "runtime_status": status,
-            "outcome": result.state.outcome,
-            "cas_won": result.won,
+            "verification.attempt.id": str(attempt_id),
+            "verification.durable.status": status,
+            "verification.outcome": result.state.outcome,
+            "verification.terminal.write_won": result.won,
         },
     )
 
@@ -253,7 +252,6 @@ async def _terminalize_failed_attempt(
 async def _log_attempt_completion(
     session_maker: async_sessionmaker[AsyncSession],
     token_data: VerificationStatusToken,
-    user_id: int,
     status: str,
 ) -> None:
     attempt_id = UUID(token_data.job_id)
@@ -266,22 +264,20 @@ async def _log_attempt_completion(
         logger.warning(
             "verification.attempt.completed_read_failed",
             extra={
-                "user_id": user_id,
-                "requirement_slug": token_data.requirement_slug,
-                "attempt_id": str(attempt_id),
-                "error_type": type(exc).__name__,
+                "verification.requirement.slug": token_data.requirement_slug,
+                "verification.attempt.id": str(attempt_id),
+                "error.type": type(exc).__name__,
             },
         )
         return
 
     extra = {
-        "user_id": user_id,
-        "requirement_slug": token_data.requirement_slug,
-        "attempt_id": str(attempt_id),
-        "runtime_status": status,
-        "outcome": state.outcome if state else None,
-        "error_code": state.error_code if state else None,
-        "terminal_source": state.terminal_source if state else None,
+        "verification.requirement.slug": token_data.requirement_slug,
+        "verification.attempt.id": str(attempt_id),
+        "verification.durable.status": status,
+        "verification.outcome": state.outcome if state else None,
+        "verification.error.code": state.error_code if state else None,
+        "verification.terminal.source": state.terminal_source if state else None,
     }
     if state is None or state.outcome == "server_error":
         logger.warning("verification.attempt.observed", extra=extra)

--- a/api/src/learn_to_cloud/static/js/frontend-telemetry.js
+++ b/api/src/learn_to_cloud/static/js/frontend-telemetry.js
@@ -2,10 +2,10 @@
     'use strict';
 
     function pageUri() {
-        return window.location.origin + window.location.pathname;
+        var marker = document.querySelector('[data-telemetry-route]');
+        var route = marker ? marker.getAttribute('data-telemetry-route') : '/unmatched';
+        return window.location.origin + route;
     }
-
-    var lastTrackedUrl = pageUri();
 
     function appInsights() {
         if (window.appInsights && typeof window.appInsights.trackEvent === 'function') {
@@ -14,19 +14,31 @@
         return null;
     }
 
-    function trackHtmxPageView() {
+    function removeUrlProperties(envelope) {
+        var baseData = envelope && envelope.baseData;
+        if (!baseData) {
+            return true;
+        }
+
+        delete baseData.refUri;
+        if (envelope.baseType === 'PageviewData') {
+            baseData.uri = pageUri();
+        }
+        return true;
+    }
+
+    function trackPageView(navigationKind) {
         var telemetry = appInsights();
         var currentUrl = pageUri();
-        if (!telemetry || currentUrl === lastTrackedUrl) {
+        if (!telemetry) {
             return;
         }
 
-        lastTrackedUrl = currentUrl;
         telemetry.trackPageView({
             name: document.title,
             uri: currentUrl,
             properties: {
-                navigationType: 'htmx'
+                'navigation.type': navigationKind
             }
         });
     }
@@ -41,16 +53,26 @@
         telemetry.trackEvent({
             name: 'htmx.transport_error',
             properties: {
-                method: requestConfig.verb || '',
-                boosted: String(Boolean(event.detail.boosted))
+                'http.request.method': requestConfig.verb || '',
+                'htmx.boosted': Boolean(event.detail.boosted)
             }
         });
     }
 
+    var telemetry = appInsights();
+    if (telemetry) {
+        telemetry.addTelemetryInitializer(removeUrlProperties);
+        trackPageView('initial');
+    }
+
     document.addEventListener('htmx:afterSettle', function (event) {
         if (event.detail && event.detail.boosted) {
-            trackHtmxPageView();
+            trackPageView('htmx');
         }
+    });
+
+    document.addEventListener('htmx:historyRestore', function () {
+        trackPageView('history');
     });
 
     document.addEventListener('htmx:sendError', function (event) {

--- a/api/src/learn_to_cloud/templates/base.html
+++ b/api/src/learn_to_cloud/templates/base.html
@@ -25,15 +25,12 @@
                     enableAutoRouteTracking: false,
                     disableAjaxTracking: true,
                     disableFetchTracking: true,
+                    disableExceptionTracking: true,
                     samplingPercentage: {{ frontend_telemetry.sampling_percentage | tojson }},
-                    enableUnhandledPromiseRejectionTracking: true
+                    enableUnhandledPromiseRejectionTracking: false
                 }
             });
             window.appInsights.loadAppInsights();
-            window.appInsights.trackPageView({
-                name: document.title,
-                uri: window.location.origin + window.location.pathname
-            });
         }
     </script>
     <script defer src="{{ static_url('js/frontend-telemetry.js') }}"></script>
@@ -157,7 +154,10 @@
 <body class="h-full flex flex-col bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 text-lg" hx-boost="true">
     {% include "partials/navbar.html" %}
 
-    <main class="flex-1 w-full mx-auto max-w-content px-4 sm:px-6 lg:px-8 py-8">
+    <main
+        class="flex-1 w-full mx-auto max-w-content px-4 sm:px-6 lg:px-8 py-8"
+        {% if frontend_telemetry %}data-telemetry-route="{{ frontend_telemetry.route_path }}"{% endif %}
+    >
         {% block content %}{% endblock %}
     </main>
 

--- a/api/tests/core/test_templates.py
+++ b/api/tests/core/test_templates.py
@@ -1,5 +1,6 @@
 """Unit tests for template context processors."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,7 +23,7 @@ def test_frontend_telemetry_context_disabled_by_default(monkeypatch):
         raising=False,
     )
 
-    context = _frontend_telemetry_context(MagicMock())
+    context = _frontend_telemetry_context(MagicMock(scope={}))
 
     assert context == {"frontend_telemetry": None}
 
@@ -35,12 +36,15 @@ def test_frontend_telemetry_context_includes_connection_string(monkeypatch):
         conn_str,
     )
 
-    context = _frontend_telemetry_context(MagicMock())
+    context = _frontend_telemetry_context(
+        MagicMock(scope={"route": SimpleNamespace(path="/phases/{phase_slug}")})
+    )
 
     assert context == {
         "frontend_telemetry": {
             "connection_string": conn_str,
             "sampling_percentage": 100.0,
+            "route_path": "/phases/{phase_slug}",
         }
     }
 
@@ -54,11 +58,12 @@ def test_frontend_telemetry_context_includes_sampling_percentage(monkeypatch):
     )
     monkeypatch.setenv("FRONTEND_TELEMETRY__SAMPLING_PERCENTAGE", "10")
 
-    context = _frontend_telemetry_context(MagicMock())
+    context = _frontend_telemetry_context(MagicMock(scope={}))
 
     assert context == {
         "frontend_telemetry": {
             "connection_string": conn_str,
             "sampling_percentage": 10.0,
+            "route_path": "/unmatched",
         }
     }

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -509,10 +509,12 @@ class TestHtmxSubmitVerification:
         record = next(
             r for r in caplog.records if r.message == "verification.attempt.created"
         )
-        assert record.attempt_id == str(attempt_submission.attempt_id)
-        assert record.attempt_created is True
-        assert record.requirement_slug == "req-1"
-        assert record.user_id == 1
+        assert record.__dict__["verification.attempt.id"] == str(
+            attempt_submission.attempt_id
+        )
+        assert record.__dict__["verification.attempt.created"] is True
+        assert record.__dict__["verification.requirement.slug"] == "req-1"
+        assert "user_id" not in record.__dict__
 
     async def test_submit_unexpected_error_renders_server_error(self):
         """Unexpected exceptions render a server error card."""
@@ -970,10 +972,14 @@ class TestHtmxVerificationAttemptStatus:
         # A server_error is the case an operator most needs to find, so it must
         # not be buried at INFO.
         assert record.levelno == logging.WARNING
-        assert record.outcome == "server_error"
-        assert record.error_code == "verification_incomplete"
-        assert record.attempt_id == str(job_id)
-        assert record.requirement_slug == "journal-api-implementation"
+        assert record.__dict__["verification.outcome"] == "server_error"
+        assert record.__dict__["verification.error.code"] == "verification_incomplete"
+        assert record.__dict__["verification.attempt.id"] == str(job_id)
+        assert (
+            record.__dict__["verification.requirement.slug"]
+            == "journal-api-implementation"
+        )
+        assert "user_id" not in record.__dict__
 
     async def test_completed_status_survives_log_read_failure(self):
         """A logging read failure must not break the learner's page reload."""

--- a/api/tests/test_telemetry_contracts.py
+++ b/api/tests/test_telemetry_contracts.py
@@ -1,6 +1,9 @@
 """Static contracts for production telemetry and Azure Monitor alerts."""
 
+import ast
+import json
 import re
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -8,6 +11,91 @@ import pytest
 pytestmark = pytest.mark.unit
 
 _ROOT = Path(__file__).parents[2]
+_PYTHON_TELEMETRY_ROOTS = (
+    _ROOT / "api" / "src",
+    _ROOT / "apps" / "verification-functions",
+    _ROOT / "packages" / "learn-to-cloud-shared" / "src" / "learn_to_cloud_shared",
+)
+
+_ALLOWED_APPLICATION_ATTRIBUTES = {
+    "auth.configuration.reason",
+    "content.artifact.hash",
+    "content.artifact_schema.version",
+    "content.curriculum.version",
+    "content.phase.slug",
+    "content.requirement.slug",
+    "content.topic.slug",
+    "database.schema.current_revision",
+    "database.schema.expected_revision",
+    "error.type",
+    "github.repository",
+    "http.response.status_code",
+    "http.target",
+    "http.url",
+    "startup.initialized",
+    "telemetry.configuration.reason",
+    "url.full",
+    "url.path",
+    "url.query",
+    "verification.attempt.age_seconds",
+    "verification.attempt.created",
+    "verification.attempt.id",
+    "verification.check.name",
+    "verification.deployed_api.ai_verified",
+    "verification.deployed_api.challenge_verified",
+    "verification.deployed_api.verified",
+    "verification.durable.status",
+    "verification.error.code",
+    "verification.failure.kind",
+    "verification.failure.stage",
+    "verification.operation",
+    "verification.outcome",
+    "verification.reason",
+    "verification.reconciler.candidate_count",
+    "verification.reconciler.stuck_count",
+    "verification.reconciler.terminalized_count",
+    "verification.requirement.slug",
+    "verification.step.result",
+    "verification.stuck.reason",
+    "verification.task.id",
+    "verification.terminal.source",
+    "verification.terminal.write_won",
+}
+
+_PROHIBITED_APPLICATION_ATTRIBUTES = {
+    "attempt_age_seconds",
+    "attempt_created",
+    "attempt_id",
+    "candidate_count",
+    "cas_won",
+    "code_head",
+    "content_hash",
+    "cutoff",
+    "db_head",
+    "durable_status",
+    "error",
+    "error_code",
+    "error_type",
+    "failure_kind",
+    "github_username",
+    "hint",
+    "orchestrator_name",
+    "outcome",
+    "path",
+    "phase_slug",
+    "reason",
+    "repo",
+    "requirement_slug",
+    "runtime_status",
+    "status",
+    "status_code",
+    "stuck_count",
+    "stuck_reason",
+    "terminal_source",
+    "terminalized_count",
+    "topic_slug",
+    "user_id",
+}
 
 
 def _resource_block(source: str, resource_name: str) -> str:
@@ -16,6 +104,148 @@ def _resource_block(source: str, resource_name: str) -> str:
     )
     next_resource = source.find("\nresource ", start + 1)
     return source[start:] if next_resource == -1 else source[start:next_resource]
+
+
+def _dict_keys(
+    node: ast.AST | None,
+    bindings: dict[str, set[str]],
+) -> set[str] | None:
+    if not isinstance(node, ast.Dict):
+        if isinstance(node, ast.Name):
+            return bindings.get(node.id)
+        return None
+    keys = {
+        key.value
+        for key in node.keys
+        if isinstance(key, ast.Constant) and isinstance(key.value, str)
+    }
+    return keys if len(keys) == len(node.keys) else None
+
+
+def _application_attribute_names() -> tuple[set[str], list[str]]:
+    attributes: set[str] = set()
+    unresolved: list[str] = []
+    log_methods = {"critical", "debug", "error", "exception", "info", "warning"}
+
+    for root in _PYTHON_TELEMETRY_ROOTS:
+        for path in root.rglob("*.py"):
+            if ".venv" in path.parts:
+                continue
+            tree = ast.parse(path.read_text())
+            bindings: dict[str, set[str]] = {}
+            log_aliases: set[str] = set()
+            for node in ast.walk(tree):
+                if isinstance(node, ast.AnnAssign):
+                    if isinstance(node.target, ast.Name):
+                        keys = _dict_keys(node.value, bindings)
+                        if keys is not None:
+                            bindings.setdefault(node.target.id, set()).update(keys)
+                    continue
+                if not isinstance(node, ast.Assign):
+                    continue
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        candidates = (
+                            (node.value.body, node.value.orelse)
+                            if isinstance(node.value, ast.IfExp)
+                            else (node.value,)
+                        )
+                        if any(
+                            isinstance(candidate, ast.Attribute)
+                            and candidate.attr in log_methods
+                            for candidate in candidates
+                        ):
+                            log_aliases.add(target.id)
+                        keys = _dict_keys(node.value, bindings)
+                        if keys is not None:
+                            bindings.setdefault(target.id, set()).update(keys)
+                    elif (
+                        isinstance(target, ast.Subscript)
+                        and isinstance(target.value, ast.Name)
+                        and isinstance(target.slice, ast.Constant)
+                        and isinstance(target.slice.value, str)
+                    ):
+                        bindings.setdefault(target.value.id, set()).add(
+                            target.slice.value
+                        )
+
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+
+                name = (
+                    node.func.attr
+                    if isinstance(node.func, ast.Attribute)
+                    else node.func.id
+                    if isinstance(node.func, ast.Name)
+                    else ""
+                )
+                extra_keywords = [
+                    keyword for keyword in node.keywords if keyword.arg == "extra"
+                ]
+                if name in log_methods or name in log_aliases:
+                    for keyword in extra_keywords:
+                        keys = _dict_keys(keyword.value, bindings)
+                        if keys is None:
+                            unresolved.append(f"{path}:{node.lineno}:log extra")
+                        else:
+                            attributes.update(keys)
+                elif name == "set_attribute" and node.args:
+                    attribute = node.args[0]
+                    if isinstance(attribute, ast.Constant) and isinstance(
+                        attribute.value, str
+                    ):
+                        attributes.add(attribute.value)
+                elif name == "set_attributes" and node.args:
+                    keys = _dict_keys(node.args[0], bindings)
+                    if keys is None:
+                        unresolved.append(f"{path}:{node.lineno}:span attributes")
+                    else:
+                        attributes.update(keys)
+                elif name == "add_event" and len(node.args) > 1:
+                    keys = _dict_keys(node.args[1], bindings)
+                    if keys is None:
+                        unresolved.append(f"{path}:{node.lineno}:span event")
+                    else:
+                        attributes.update(keys)
+                elif name in {"start_as_current_span", "start_span"}:
+                    for keyword in node.keywords:
+                        if keyword.arg == "attributes":
+                            keys = _dict_keys(keyword.value, bindings)
+                            if keys is None:
+                                unresolved.append(
+                                    f"{path}:{node.lineno}:span attributes"
+                                )
+                            else:
+                                attributes.update(keys)
+                elif name in {"add", "record"} and len(node.args) > 1:
+                    keys = _dict_keys(node.args[1], bindings)
+                    if keys is None:
+                        unresolved.append(f"{path}:{node.lineno}:metric attributes")
+                    else:
+                        attributes.update(keys)
+
+    return attributes, unresolved
+
+
+def _exception_log_events() -> set[str]:
+    events: set[str] = set()
+    for root in _PYTHON_TELEMETRY_ROOTS:
+        for path in root.rglob("*.py"):
+            if ".venv" in path.parts:
+                continue
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "exception"
+                    and node.args
+                    and isinstance(node.args[0], ast.Constant)
+                    and isinstance(node.args[0].value, str)
+                ):
+                    events.add(node.args[0].value)
+    return events
 
 
 def test_every_alert_has_a_documented_signal_contract():
@@ -71,7 +301,41 @@ def test_api_trace_sampling_policy_is_explicit_and_alert_logs_are_unsampled():
     assert "enable_trace_based_sampling_for_logs=False" in observability
 
 
-def test_frontend_telemetry_does_not_capture_query_strings_or_request_paths():
+def test_application_owned_attributes_match_the_canonical_schema():
+    emitted, unresolved = _application_attribute_names()
+
+    assert unresolved == []
+    assert emitted == _ALLOWED_APPLICATION_ATTRIBUTES
+    assert emitted.isdisjoint(_PROHIBITED_APPLICATION_ATTRIBUTES)
+
+
+def test_raw_exception_details_are_limited_to_application_boundaries():
+    assert _exception_log_events() == {
+        "init.failed",
+        "init.timeout",
+        "unhandled.exception",
+    }
+
+
+def test_application_code_does_not_explicitly_record_raw_span_exceptions():
+    calls: list[str] = []
+    for root in _PYTHON_TELEMETRY_ROOTS:
+        for path in root.rglob("*.py"):
+            if ".venv" in path.parts:
+                continue
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "record_exception"
+                ):
+                    calls.append(f"{path}:{node.lineno}")
+
+    assert calls == []
+
+
+def test_frontend_telemetry_uses_only_bounded_properties():
     script = (
         _ROOT
         / "api"
@@ -86,7 +350,99 @@ def test_frontend_telemetry_does_not_capture_query_strings_or_request_paths():
     ).read_text()
 
     assert "window.location.href" not in script
+    assert "window.location.pathname" not in script
     assert "requestConfig.path" not in script
-    assert "uri: window.location.origin + window.location.pathname" in template
+    assert "data-telemetry-route" in template
+    assert "disableExceptionTracking: true" in template
+    assert "enableUnhandledPromiseRejectionTracking: false" in template
+    assert "delete baseData.refUri" in script
+    assert "'navigation.type'" in script
+    assert "'http.request.method'" in script
+    assert "'htmx.boosted'" in script
+    assert "navigationType" not in script
+    assert "statusCode" not in script
     assert "htmx:responseError" not in script
     assert "htmx:sendError" in script
+
+
+def test_frontend_initializer_removes_urls_and_tracks_same_route_navigation():
+    script = (
+        _ROOT
+        / "api"
+        / "src"
+        / "learn_to_cloud"
+        / "static"
+        / "js"
+        / "frontend-telemetry.js"
+    )
+    test_script = f"""
+const fs = require('fs');
+const tracked = [];
+const listeners = {{}};
+let initializer = null;
+let marker = {{
+  getAttribute: () => '/phase/{{phase_slug}}'
+}};
+global.window = {{
+  location: {{ origin: 'https://learntocloud.guide' }},
+  appInsights: {{
+    addTelemetryInitializer: (value) => {{ initializer = value; }},
+    trackEvent: (value) => tracked.push(value),
+    trackPageView: (value) => tracked.push(value)
+  }}
+}};
+global.document = {{
+  title: 'Phase',
+  querySelector: () => marker,
+  addEventListener: (name, callback) => {{ listeners[name] = callback; }}
+}};
+eval(fs.readFileSync({str(script)!r}, 'utf8'));
+const item = {{
+  baseType: 'PageviewData',
+  baseData: {{
+    uri: 'https://learntocloud.guide/phase/1?token=secret',
+    refUri: 'https://example.com/private?token=secret'
+  }}
+}};
+initializer(item);
+listeners['htmx:afterSettle']({{ detail: {{ boosted: true }} }});
+listeners['htmx:afterSettle']({{ detail: {{ boosted: false }} }});
+marker = null;
+listeners['htmx:historyRestore']();
+console.log(JSON.stringify({{ item, tracked }}));
+"""
+    result = subprocess.run(
+        ["node", "-e", test_script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    assert "refUri" not in payload["item"]["baseData"]
+    assert (
+        payload["item"]["baseData"]["uri"]
+        == "https://learntocloud.guide/phase/{phase_slug}"
+    )
+    assert [item["properties"]["navigation.type"] for item in payload["tracked"]] == [
+        "initial",
+        "htmx",
+        "history",
+    ]
+    assert payload["tracked"][2]["uri"] == "https://learntocloud.guide/unmatched"
+
+
+def test_stuck_alert_accepts_canonical_and_historical_attributes():
+    monitoring = (_ROOT / "infra" / "monitoring.tf").read_text()
+    runbook = (_ROOT / "docs" / "runbooks" / "alerts.md").read_text()
+    block = _resource_block(monitoring, "verification_attempt_stuck")
+
+    for canonical, historical in (
+        ("verification.durable.status", "durable_status"),
+        ("verification.attempt.age_seconds", "attempt_age_seconds"),
+        ("verification.stuck.reason", "stuck_reason"),
+    ):
+        assert f'customDimensions["{canonical}"]' in block
+        assert f'customDimensions["{historical}"]' in block
+        assert f'customDimensions["{canonical}"]' in runbook
+        assert f'customDimensions["{historical}"]' in runbook

--- a/apps/verification-functions/function_app.py
+++ b/apps/verification-functions/function_app.py
@@ -703,11 +703,14 @@ async def _resolve_ambiguous_start(
             await asyncio.sleep(delay_seconds)
         try:
             status = await _get_instance_status(client, instance_id)
-        except Exception:
+        except Exception as exc:
             all_queries_succeeded = False
-            logger.exception(
+            logger.warning(
                 "verification.attempt.start.status_query_failed",
-                extra={"attempt_id": instance_id},
+                extra={
+                    "verification.attempt.id": instance_id,
+                    "error.type": type(exc).__name__,
+                },
             )
             continue
         if _durable_instance_exists(status):
@@ -767,14 +770,14 @@ async def _start_attempt_orchestration(
         if not _durable_instance_exists(existing):
             logger.info(
                 "verification.attempt.start.claimed_pending",
-                extra={"attempt_id": instance_id},
+                extra={"verification.attempt.id": instance_id},
             )
             return _StartOutcome.ALREADY_CLAIMED
         logger.info(
             "verification.attempt.start.already_exists",
             extra={
-                "attempt_id": instance_id,
-                "runtime_status": _runtime_status_name(existing),
+                "verification.attempt.id": instance_id,
+                "verification.durable.status": _runtime_status_name(existing),
             },
         )
         return _StartOutcome.ALREADY_EXISTS
@@ -794,15 +797,18 @@ async def _start_attempt_orchestration(
             logger.warning(
                 "verification.attempt.start.ambiguous_but_started",
                 extra={
-                    "attempt_id": instance_id,
-                    "runtime_status": _runtime_status_name(status),
+                    "verification.attempt.id": instance_id,
+                    "verification.durable.status": _runtime_status_name(status),
                 },
             )
             return _StartOutcome.AMBIGUOUS_STARTED
 
         logger.error(
             "verification.attempt.start.failed",
-            extra={"attempt_id": instance_id, "error_type": type(exc).__name__},
+            extra={
+                "verification.attempt.id": instance_id,
+                "error.type": type(exc).__name__,
+            },
         )
         await terminalize_attempt(
             attempt_uuid,
@@ -817,8 +823,7 @@ async def _start_attempt_orchestration(
     logger.info(
         "verification.attempt.orchestration.started",
         extra={
-            "attempt_id": instance_id,
-            "orchestrator_name": _ATTEMPT_ORCHESTRATOR_NAME,
+            "verification.attempt.id": instance_id,
         },
     )
     return _StartOutcome.STARTED
@@ -885,12 +890,13 @@ async def _emit_stuck_if_active(
     logger.warning(
         "verification.attempt.stuck",
         extra={
-            "attempt_id": str(attempt_id),
             "verification.attempt.id": str(attempt_id),
             "verification.failure.stage": "reconciliation",
-            "durable_status": durable_status,
-            "stuck_reason": reason,
-            "attempt_age_seconds": int((reference - age_anchor).total_seconds()),
+            "verification.durable.status": durable_status,
+            "verification.stuck.reason": reason,
+            "verification.attempt.age_seconds": int(
+                (reference - age_anchor).total_seconds()
+            ),
         },
     )
     return True
@@ -920,7 +926,7 @@ async def _reconcile_stale_attempts(
         )
     logger.info(
         "verification.reconciler.scan",
-        extra={"candidate_count": len(stale), "cutoff": cutoff.isoformat()},
+        extra={"verification.reconciler.candidate_count": len(stale)},
     )
 
     terminalized = 0
@@ -929,10 +935,13 @@ async def _reconcile_stale_attempts(
         instance_id = str(attempt.id)
         try:
             status = await _get_instance_status(client, instance_id)
-        except Exception:
-            logger.exception(
+        except Exception as exc:
+            logger.warning(
                 "verification.reconciler.status_query_failed",
-                extra={"attempt_id": instance_id},
+                extra={
+                    "verification.attempt.id": instance_id,
+                    "error.type": type(exc).__name__,
+                },
             )
             stuck += await _emit_stuck_if_active(
                 attempt.id,
@@ -958,10 +967,13 @@ async def _reconcile_stale_attempts(
         if status_name is None:
             try:
                 confirmed_status = await _get_instance_status(client, instance_id)
-            except Exception:
-                logger.exception(
+            except Exception as exc:
+                logger.warning(
                     "verification.reconciler.status_recheck_failed",
-                    extra={"attempt_id": instance_id},
+                    extra={
+                        "verification.attempt.id": instance_id,
+                        "error.type": type(exc).__name__,
+                    },
                 )
                 stuck += await _emit_stuck_if_active(
                     attempt.id,
@@ -999,18 +1011,18 @@ async def _reconcile_stale_attempts(
         logger.info(
             "verification.reconciler.terminalized",
             extra={
-                "attempt_id": str(attempt.id),
-                "durable_status": status_name,
-                "outcome": decision.outcome.value,
+                "verification.attempt.id": str(attempt.id),
+                "verification.durable.status": status_name,
+                "verification.outcome": decision.outcome.value,
             },
         )
 
     logger.info(
         "verification.reconciler.completed",
         extra={
-            "candidate_count": len(stale),
-            "terminalized_count": terminalized,
-            "stuck_count": stuck,
+            "verification.reconciler.candidate_count": len(stale),
+            "verification.reconciler.terminalized_count": terminalized,
+            "verification.reconciler.stuck_count": stuck,
         },
     )
     return _ReconcileSummary(

--- a/apps/verification-functions/tests/test_attempt_orchestrations.py
+++ b/apps/verification-functions/tests/test_attempt_orchestrations.py
@@ -659,7 +659,10 @@ class TestReconciler:
             if record.message == "verification.attempt.stuck"
         )
         assert stuck_record.__dict__["verification.attempt.id"] == str(running)
-        assert stuck_record.durable_status == "Running"
+        assert stuck_record.__dict__["verification.durable.status"] == "Running"
+        assert (
+            stuck_record.__dict__["verification.stuck.reason"] == "active_beyond_limit"
+        )
 
     async def test_rechecks_missing_status_before_terminalizing(self) -> None:
         attempt_id = uuid4()

--- a/docs/observability/telemetry-schema.md
+++ b/docs/observability/telemetry-schema.md
@@ -170,7 +170,7 @@ user IDs, OAuth tokens, claims, or session identifiers.
 
 | Metric | Attribute | Purpose | Cardinality | Class | Decision |
 | --- | --- | --- | --- | --- | --- |
-| `github.api_error` | `error.type` | Count transient, authentication, authorization, rate-limit, and provider failures | Fixed category set | Operational | Keep metric; replace mixed numeric/string `status` with bounded categories |
+| `github.api_error` | `error.type` | Count network, authentication, authorization, rate-limit, client, and provider failures | Fixed category set | Operational | Keep metric; replace mixed numeric/string `status` with bounded categories |
 
 Metrics must use low-cardinality dimensions. Attempt IDs, routes with concrete
 identifiers, repository names outside the approved curriculum set, exception
@@ -221,6 +221,8 @@ The following event families are retained:
 - `init.*` and `telemetry.*`: startup and instrumentation state.
 - `verification.*`, `ci.*`, `codeql.*`, `ghcr.*`, and `deployed_api.*`:
   bounded verification operations and outcomes.
+- `github.*` and `token.*`: bounded GitHub and signed-token verification
+  outcomes.
 - `community.*`: fixed curriculum repository integration failures.
 - `unhandled.exception`: the final API exception boundary.
 - `user.account_deleted`: aggregate account-deletion completion without user

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -315,6 +315,8 @@ or it could not reliably query/recheck Durable status. The detector reads the
 ### Detailed Kusto
 
 ```kusto
+// Remove historical field fallbacks after all producer revisions have emitted
+// canonical fields for one full workspace-retention window.
 traces
 | where timestamp > ago(4h)
 | where cloud_RoleName in (
@@ -326,9 +328,18 @@ traces
 | where message == "verification.attempt.stuck"
 | extend
     AttemptId = tostring(customDimensions["verification.attempt.id"]),
-    DurableStatus = tostring(customDimensions["durable_status"]),
-    AttemptAgeSeconds = toint(customDimensions["attempt_age_seconds"]),
-    StuckReason = tostring(customDimensions["stuck_reason"])
+    DurableStatus = tostring(coalesce(
+        customDimensions["verification.durable.status"],
+        customDimensions["durable_status"]
+    )),
+    AttemptAgeSeconds = toint(coalesce(
+        customDimensions["verification.attempt.age_seconds"],
+        customDimensions["attempt_age_seconds"]
+    )),
+    StuckReason = tostring(coalesce(
+        customDimensions["verification.stuck.reason"],
+        customDimensions["stuck_reason"]
+    ))
 | where StuckReason in (
     "active_beyond_limit",
     "status_query_failed",

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -361,6 +361,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
 
   criteria {
     query                   = <<-QUERY
+      // Remove historical field fallbacks after all producer revisions have
+      // emitted canonical fields for one full workspace-retention window.
       traces
       | where cloud_RoleName in (
           "learn-to-cloud-verification-functions",
@@ -371,9 +373,18 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
       | where message == "verification.attempt.stuck"
       | extend
           AttemptId = tostring(customDimensions["verification.attempt.id"]),
-          DurableStatus = tostring(customDimensions["durable_status"]),
-          AttemptAgeSeconds = toint(customDimensions["attempt_age_seconds"]),
-          StuckReason = tostring(customDimensions["stuck_reason"])
+          DurableStatus = tostring(coalesce(
+            customDimensions["verification.durable.status"],
+            customDimensions["durable_status"]
+          )),
+          AttemptAgeSeconds = toint(coalesce(
+            customDimensions["verification.attempt.age_seconds"],
+            customDimensions["attempt_age_seconds"]
+          )),
+          StuckReason = tostring(coalesce(
+            customDimensions["verification.stuck.reason"],
+            customDimensions["stuck_reason"]
+          ))
       | where isnotempty(AttemptId)
       | where StuckReason in (
           "active_beyond_limit",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_yaml_loader.py
@@ -124,12 +124,12 @@ def _load_topic(
 
     try:
         return _build_topic(topic_file, order=order)
-    except (yaml.YAMLError, ContentValidationError, ValueError, KeyError):
-        logger.exception(
+    except (yaml.YAMLError, ContentValidationError, ValueError, KeyError) as exc:
+        logger.error(
             "content.topic.load_failed",
             extra={
-                "topic_slug": topic_slug,
-                "path": str(topic_file),
+                "content.topic.slug": topic_slug,
+                "error.type": type(exc).__name__,
             },
         )
         return None
@@ -180,12 +180,12 @@ def _load_requirement(
         ValidationError,
         ValueError,
         KeyError,
-    ):
-        logger.exception(
+    ) as exc:
+        logger.error(
             "content.requirement.load_failed",
             extra={
-                "requirement_slug": requirement_slug,
-                "path": str(req_file),
+                "content.requirement.slug": requirement_slug,
+                "error.type": type(exc).__name__,
             },
         )
         return None
@@ -252,12 +252,12 @@ def _load_phase(phase_slug: str, *, strict: bool = False) -> Phase | None:
 
     try:
         return _build_phase(phase_slug, phase_dir, meta_file, strict=strict)
-    except (yaml.YAMLError, ContentValidationError, ValueError, KeyError):
-        logger.exception(
+    except (yaml.YAMLError, ContentValidationError, ValueError, KeyError) as exc:
+        logger.error(
             "content.phase.load_failed",
             extra={
-                "phase_slug": phase_slug,
-                "path": str(meta_file),
+                "content.phase.slug": phase_slug,
+                "error.type": type(exc).__name__,
             },
         )
         return None

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/database.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/database.py
@@ -63,8 +63,11 @@ async def _azure_asyncpg_creator(settings: DatabaseConfig):
                 "statement_timeout": str(settings.statement_timeout_ms),
             },
         )
-    except asyncpg.PostgresConnectionError:
-        logger.exception("db.connection.failed")
+    except asyncpg.PostgresConnectionError as exc:
+        logger.error(
+            "db.connection.failed",
+            extra={"error.type": type(exc).__name__},
+        )
         raise
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
@@ -215,7 +215,9 @@ def _configure_observability(*, allow_azure_monitor: bool) -> bool:
         else:
             logger.error(
                 "telemetry.configure.failed",
-                extra={"reason": "telemetry_destination_missing"},
+                extra={
+                    "telemetry.configuration.reason": "telemetry_destination_missing"
+                },
             )
             return False
     except Exception as exc:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/github_updates.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/github_updates.py
@@ -84,7 +84,10 @@ async def _fetch_latest_commit(owner: str, repo: str) -> RepoUpdate:
     except (httpx.HTTPError, ValueError, KeyError, IndexError) as exc:
         logger.warning(
             "community.github_commit_failed",
-            extra={"repo": f"{owner}/{repo}", "error": str(exc)},
+            extra={
+                "github.repository": f"{owner}/{repo}",
+                "error.type": type(exc).__name__,
+            },
         )
         return _unavailable(owner, repo)
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
@@ -124,7 +124,7 @@ async def _validate_url_target(url: str) -> str | None:
         if _is_private_ip(str(ip)):
             span = trace.get_current_span()
             span.add_event(
-                "ssrf_blocked",
+                "deployed_api.ssrf_blocked",
                 {"verification.reason": "private_ip_literal"},
             )
             return "URL must point to a publicly accessible server."
@@ -149,7 +149,7 @@ async def _validate_url_target(url: str) -> str | None:
         if not isinstance(addr, str) or _is_private_ip(addr):
             span = trace.get_current_span()
             span.add_event(
-                "ssrf_blocked",
+                "deployed_api.ssrf_blocked",
                 {"verification.reason": "private_ip_resolved"},
             )
             return "URL must point to a publicly accessible server."
@@ -177,7 +177,7 @@ def _check_response_ip(response: httpx.Response) -> None:
     if _is_private_ip(addr):
         span = trace.get_current_span()
         span.add_event(
-            "ssrf_blocked",
+            "deployed_api.ssrf_blocked",
             {"verification.reason": "dns_rebinding"},
         )
         raise _SsrfError(addr)
@@ -437,7 +437,7 @@ async def _cleanup_challenge_entry(
     except _SsrfError:
         span = trace.get_current_span()
         span.add_event(
-            "ssrf_blocked",
+            "deployed_api.ssrf_blocked",
             {"verification.reason": "cleanup_dns_rebinding"},
         )
     except Exception:
@@ -587,7 +587,7 @@ async def _verify_challenge(
 
     if not nonce_found:
         span = trace.get_current_span()
-        span.add_event("challenge_failed")
+        span.add_event("deployed_api.challenge_failed")
         return (
             ValidationResult(
                 is_valid=False,
@@ -616,7 +616,7 @@ async def _verify_challenge(
             return validation, discovered_id
 
     span = trace.get_current_span()
-    span.set_attribute("deployed_api.challenge_verified", True)
+    span.set_attribute("verification.deployed_api.challenge_verified", True)
 
     count = len(real_entries)
     entry_word = "entry" if count == 1 else "entries"
@@ -759,8 +759,8 @@ async def validate_deployed_api(base_url: str) -> ValidationResult:
             return analysis_result
 
         span = trace.get_current_span()
-        span.set_attribute("deployed_api.verified", True)
-        span.set_attribute("deployed_api.ai_verified", True)
+        span.set_attribute("verification.deployed_api.verified", True)
+        span.set_attribute("verification.deployed_api.ai_verified", True)
         return ValidationResult(
             is_valid=True,
             message=f"{verify_result.message} Live AI analysis verified.",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/errors.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/errors.py
@@ -24,6 +24,37 @@ _GITHUB_API_ERROR_COUNTER = _meter.create_counter(
     unit="{error}",
 )
 
+
+def _github_error_type(response: httpx.Response) -> str:
+    status = response.status_code
+    if status == 429 or (
+        status == 403
+        and (
+            response.headers.get("x-ratelimit-remaining") == "0"
+            or "retry-after" in response.headers
+        )
+    ):
+        return "rate_limit"
+    if status == 403:
+        try:
+            body = response.json()
+        except ValueError:
+            body = None
+        if isinstance(body, dict):
+            message = body.get("message")
+            if isinstance(message, str) and (
+                "rate limit" in message.lower() or "abuse detection" in message.lower()
+            ):
+                return "rate_limit"
+    if status == 401:
+        return "authentication"
+    if status == 403:
+        return "authorization"
+    if status >= 500:
+        return "provider_unavailable"
+    return "client_error"
+
+
 # ---------------------------------------------------------------------------
 # Base retriable exceptions (httpx network / timeout errors)
 # ---------------------------------------------------------------------------
@@ -108,7 +139,8 @@ def github_error_to_result(
         span.set_attribute("http.response.status_code", status)
         span.add_event(event, {"http.response.status_code": status})
         logger.warning(event, extra={"http.response.status_code": status})
-        _GITHUB_API_ERROR_COUNTER.add(1, {"status": status})
+        error_type = _github_error_type(e.response)
+        _GITHUB_API_ERROR_COUNTER.add(1, {"error.type": error_type})
         return ValidationResult(
             is_valid=False,
             message=f"GitHub API error ({status}). Try again later.",
@@ -121,7 +153,7 @@ def github_error_to_result(
     span.set_attribute("error.type", error_type)
     span.add_event(event, {"error.type": error_type})
     logger.warning(event, extra={"error.type": error_type})
-    _GITHUB_API_ERROR_COUNTER.add(1, {"status": "transient"})
+    _GITHUB_API_ERROR_COUNTER.add(1, {"error.type": "network"})
     return ValidationResult(
         is_valid=False,
         message="Could not reach GitHub. Please try again later.",
@@ -145,7 +177,7 @@ def deployed_api_error_to_result(
     if isinstance(exc, httpx.TimeoutException):
         span.set_attribute("error.type", "timeout")
         span.add_event(
-            "deployed_api_timeout",
+            "deployed_api.timeout",
             {"error.type": "timeout", "verification.operation": step or "request"},
         )
         return ValidationResult(
@@ -159,7 +191,7 @@ def deployed_api_error_to_result(
     if isinstance(exc, DeployedApiServerError):
         span.set_attribute("error.type", "server_error")
         span.add_event(
-            "deployed_api_server_error",
+            "deployed_api.server_error",
             {
                 "error.type": "server_error",
                 "verification.operation": step or "request",
@@ -176,7 +208,7 @@ def deployed_api_error_to_result(
     if isinstance(exc, httpx.RequestError):
         span.set_attribute("error.type", "request_error")
         span.add_event(
-            "deployed_api_request_error",
+            "deployed_api.request_error",
             {
                 "error.type": "request_error",
                 "verification.operation": step or "request",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
@@ -60,7 +60,7 @@ async def check_github_url_exists(
     except RETRIABLE_EXCEPTIONS as e:
         span = trace.get_current_span()
         span.set_attribute("error.type", type(e).__name__)
-        span.add_event("url_check_failed", {"error.type": type(e).__name__})
+        span.add_event("github.url_check.failed", {"error.type": type(e).__name__})
         return ValidationResult(
             is_valid=False,
             message="Could not reach GitHub. Please try again later.",
@@ -70,7 +70,7 @@ async def check_github_url_exists(
         span = trace.get_current_span()
         span.set_attribute("error.type", "unexpected_exception")
         span.add_event(
-            "url_check_unexpected_error",
+            "github.url_check.unexpected_error",
             {"error.type": "unexpected_exception"},
         )
         return ValidationResult(
@@ -123,7 +123,7 @@ async def check_repo_is_fork_of(
     except RETRIABLE_EXCEPTIONS as e:
         span = trace.get_current_span()
         span.set_attribute("error.type", type(e).__name__)
-        span.add_event("fork_check_failed", {"error.type": type(e).__name__})
+        span.add_event("github.fork_check.failed", {"error.type": type(e).__name__})
         return ValidationResult(
             is_valid=False,
             message="Could not reach GitHub. Please try again later.",
@@ -138,7 +138,7 @@ async def check_repo_is_fork_of(
         span = trace.get_current_span()
         span.set_attribute("error.type", "unexpected_exception")
         span.add_event(
-            "fork_check_unexpected_error",
+            "github.fork_check.unexpected_error",
             {"error.type": "unexpected_exception"},
         )
         return ValidationResult(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_files.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_files.py
@@ -67,7 +67,7 @@ class GitHubRepoFiles:
             response.raise_for_status()
         except httpx.HTTPStatusError:
             span = trace.get_current_span()
-            span.add_event("repo_file_fetch_failed")
+            span.add_event("github.repo_file.fetch_failed")
             return None
         return response.text
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/token_base.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/token_base.py
@@ -110,7 +110,7 @@ def verify_lab_token(
                 )
         except RuntimeError:
             span = trace.get_current_span()
-            span.add_event("token_verification_misconfigured")
+            span.add_event("token.verification.misconfigured")
             return _fail(
                 f"{display_name} verification is not available right now.",
                 completed=False,
@@ -132,7 +132,7 @@ def verify_lab_token(
             return _fail("Invalid timestamp. The token appears to be from the future.")
 
         span = trace.get_current_span()
-        span.add_event("token_verification_succeeded")
+        span.add_event("token.verification.succeeded")
 
         return ValidationResult(
             is_valid=True,
@@ -147,7 +147,7 @@ def verify_lab_token(
         span = trace.get_current_span()
         span.set_attribute("error.type", "unexpected_exception")
         span.add_event(
-            "token_verification_failed",
+            "token.verification.failed",
             {"error.type": "unexpected_exception"},
         )
         return _fail(

--- a/packages/learn-to-cloud-shared/tests/test_observability.py
+++ b/packages/learn-to-cloud-shared/tests/test_observability.py
@@ -55,7 +55,10 @@ def test_configure_observability_logs_missing_destination(
         if record.message == "telemetry.configure.failed"
     ]
     assert len(records) == 1
-    assert records[0].__dict__["reason"] == "telemetry_destination_missing"
+    assert (
+        records[0].__dict__["telemetry.configuration.reason"]
+        == "telemetry_destination_missing"
+    )
     assert records[0].exc_info is None
 
 

--- a/packages/learn-to-cloud-shared/tests/verification/test_errors.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_errors.py
@@ -1,0 +1,79 @@
+"""Tests for bounded verification error telemetry."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from learn_to_cloud_shared.verification.errors import github_error_to_result
+
+
+def _status_error(
+    status: int,
+    *,
+    headers: dict[str, str] | None = None,
+) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://api.github.com/resource")
+    response = httpx.Response(status, headers=headers, request=request)
+    return httpx.HTTPStatusError("failed", request=request, response=response)
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (_status_error(401), "authentication"),
+        (_status_error(403), "authorization"),
+        (_status_error(403, headers={"X-RateLimit-Remaining": "0"}), "rate_limit"),
+        (_status_error(403, headers={"Retry-After": "60"}), "rate_limit"),
+        (_status_error(429), "rate_limit"),
+        (_status_error(503), "provider_unavailable"),
+        (_status_error(422), "client_error"),
+    ],
+)
+def test_github_http_error_metric_uses_bounded_category(error, expected):
+    counter = MagicMock()
+    with patch(
+        "learn_to_cloud_shared.verification.errors._GITHUB_API_ERROR_COUNTER",
+        counter,
+    ):
+        github_error_to_result(error, event="github.request.failed")
+
+    counter.add.assert_called_once_with(1, {"error.type": expected})
+
+
+def test_github_network_error_metric_uses_bounded_category():
+    counter = MagicMock()
+    request = httpx.Request("GET", "https://api.github.com/resource")
+    error = httpx.ConnectError("sensitive network detail", request=request)
+    with patch(
+        "learn_to_cloud_shared.verification.errors._GITHUB_API_ERROR_COUNTER",
+        counter,
+    ):
+        github_error_to_result(error, event="github.request.failed")
+
+    counter.add.assert_called_once_with(1, {"error.type": "network"})
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "You have exceeded a secondary rate limit.",
+        "You have triggered an abuse detection mechanism.",
+    ],
+)
+def test_github_403_body_can_identify_rate_limit(message):
+    request = httpx.Request("GET", "https://api.github.com/resource")
+    response = httpx.Response(
+        403,
+        json={"message": message},
+        request=request,
+    )
+    error = httpx.HTTPStatusError("failed", request=request, response=response)
+    counter = MagicMock()
+    with patch(
+        "learn_to_cloud_shared.verification.errors._GITHUB_API_ERROR_COUNTER",
+        counter,
+    ):
+        github_error_to_result(error, event="github.request.failed")
+
+    counter.add.assert_called_once_with(1, {"error.type": "rate_limit"})


### PR DESCRIPTION
## What changes

This applies the telemetry rulebook from #818 to the running application.

- Replaces duplicate field names with one canonical name across the API, verification Functions, and shared verification code.
- Stops recording raw database user IDs and removes raw details from handled exceptions.
- Keeps one opaque verification attempt ID only where operators need to connect an API event, Function event, and database attempt.
- Sends browser page views with route templates instead of concrete learner paths, removes referrer URLs, and disables automatic browser exception details.
- Changes the GitHub failure metric to fixed categories such as authentication, rate limit, network, and provider unavailable.
- Adds tests that enumerate every allowed application field and reject unapproved aliases, identity fields, raw URLs, and explicit exception recording.

## Safe rollout

The stuck-attempt alert and its runbook query temporarily understand both the new names and historical names. The old fallbacks can be removed after all running revisions use the new schema for one full telemetry-retention window.

## Stack

This PR depends on #818, which documents and explains the schema decisions. It should be squash-merged after #818.

Part of #776.