### PR TITLE
Remove legacy telemetry query fields

### DIFF
--- a/api/tests/test_telemetry_contracts.py
+++ b/api/tests/test_telemetry_contracts.py
@@ -432,17 +432,19 @@ console.log(JSON.stringify({{ item, tracked }}));
     assert payload["tracked"][2]["uri"] == "https://learntocloud.guide/unmatched"
 
 
-def test_stuck_alert_accepts_canonical_and_historical_attributes():
+def test_stuck_alert_uses_only_canonical_attributes():
     monitoring = (_ROOT / "infra" / "monitoring.tf").read_text()
     runbook = (_ROOT / "docs" / "runbooks" / "alerts.md").read_text()
     block = _resource_block(monitoring, "verification_attempt_stuck")
 
-    for canonical, historical in (
-        ("verification.durable.status", "durable_status"),
-        ("verification.attempt.age_seconds", "attempt_age_seconds"),
-        ("verification.stuck.reason", "stuck_reason"),
+    for canonical in (
+        "verification.durable.status",
+        "verification.attempt.age_seconds",
+        "verification.stuck.reason",
     ):
         assert f'customDimensions["{canonical}"]' in block
-        assert f'customDimensions["{historical}"]' in block
         assert f'customDimensions["{canonical}"]' in runbook
-        assert f'customDimensions["{historical}"]' in runbook
+
+    for historical in ("durable_status", "attempt_age_seconds", "stuck_reason"):
+        assert f'customDimensions["{historical}"]' not in block
+        assert f'customDimensions["{historical}"]' not in runbook

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -315,8 +315,6 @@ or it could not reliably query/recheck Durable status. The detector reads the
 ### Detailed Kusto
 
 ```kusto
-// Remove historical field fallbacks after all producer revisions have emitted
-// canonical fields for one full workspace-retention window.
 traces
 | where timestamp > ago(4h)
 | where cloud_RoleName in (
@@ -328,18 +326,9 @@ traces
 | where message == "verification.attempt.stuck"
 | extend
     AttemptId = tostring(customDimensions["verification.attempt.id"]),
-    DurableStatus = tostring(coalesce(
-        customDimensions["verification.durable.status"],
-        customDimensions["durable_status"]
-    )),
-    AttemptAgeSeconds = toint(coalesce(
-        customDimensions["verification.attempt.age_seconds"],
-        customDimensions["attempt_age_seconds"]
-    )),
-    StuckReason = tostring(coalesce(
-        customDimensions["verification.stuck.reason"],
-        customDimensions["stuck_reason"]
-    ))
+    DurableStatus = tostring(customDimensions["verification.durable.status"]),
+    AttemptAgeSeconds = toint(customDimensions["verification.attempt.age_seconds"]),
+    StuckReason = tostring(customDimensions["verification.stuck.reason"])
 | where StuckReason in (
     "active_beyond_limit",
     "status_query_failed",

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -361,8 +361,6 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
 
   criteria {
     query                   = <<-QUERY
-      // Remove historical field fallbacks after all producer revisions have
-      // emitted canonical fields for one full workspace-retention window.
       traces
       | where cloud_RoleName in (
           "learn-to-cloud-verification-functions",
@@ -373,18 +371,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "verification_attempt_
       | where message == "verification.attempt.stuck"
       | extend
           AttemptId = tostring(customDimensions["verification.attempt.id"]),
-          DurableStatus = tostring(coalesce(
-            customDimensions["verification.durable.status"],
-            customDimensions["durable_status"]
-          )),
-          AttemptAgeSeconds = toint(coalesce(
-            customDimensions["verification.attempt.age_seconds"],
-            customDimensions["attempt_age_seconds"]
-          )),
-          StuckReason = tostring(coalesce(
-            customDimensions["verification.stuck.reason"],
-            customDimensions["stuck_reason"]
-          ))
+          DurableStatus = tostring(customDimensions["verification.durable.status"]),
+          AttemptAgeSeconds = toint(customDimensions["verification.attempt.age_seconds"]),
+          StuckReason = tostring(customDimensions["verification.stuck.reason"])
       | where isnotempty(AttemptId)
       | where StuckReason in (
           "active_beyond_limit",


### PR DESCRIPTION
## What changes

The stuck-verification alert and its operator query now use only the canonical telemetry names deployed by #819.

This removes temporary support for durable_status, attempt_age_seconds, and stuck_reason. Searches over older records will no longer populate those three calculated columns, but current telemetry and alerts use the approved schema only.

The contract test now prevents these legacy query fields from returning.

Completes #776.