### PR TITLE
feat(telemetry): add pseudonymous request actor ID

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -18,6 +18,9 @@ WEB_SECURITY__REQUIRE_HTTPS=false
 # Session cookie signing key (generate: python -c "import secrets; print(secrets.token_hex(32))")
 # SESSION__SECRET_KEY=change-me-in-production
 
+# Pseudonymous request actor HMAC key (generate independently from the session key)
+# REQUEST_TELEMETRY__ACTOR_HMAC_KEY=change-me-in-production
+
 # GitHub API token (optional, for higher rate limits on verification)
 # GITHUB__TOKEN=ghp_xxx
 

--- a/api/src/learn_to_cloud/core/middleware.py
+++ b/api/src/learn_to_cloud/core/middleware.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 from typing import ClassVar
 
 from opentelemetry import trace
@@ -58,10 +60,36 @@ class SecurityHeadersMiddleware:
 
 
 class TelemetrySanitizationMiddleware:
-    """Replace request URL attributes with a bounded route template."""
+    """Sanitize request telemetry and add a pseudonymous actor dimension."""
 
-    def __init__(self, app: ASGIApp) -> None:
+    def __init__(self, app: ASGIApp, *, actor_hmac_key: str = "") -> None:
         self.app = app
+        self._actor_hmac_key = actor_hmac_key.encode()
+
+    def _actor_id(self, scope: Scope) -> str | None:
+        if not self._actor_hmac_key:
+            return None
+
+        session = scope.get("session")
+        if not isinstance(session, dict):
+            return None
+
+        raw_user_id = session.get("user_id")
+        if isinstance(raw_user_id, bool):
+            return None
+        try:
+            user_id = int(raw_user_id)
+        except (TypeError, ValueError):
+            return None
+        if user_id <= 0:
+            return None
+
+        digest = hmac.new(
+            self._actor_hmac_key,
+            f"request-actor:v1:{user_id}".encode(),
+            hashlib.sha256,
+        ).hexdigest()
+        return digest[:32]
 
     @staticmethod
     def _route_template(scope: Scope) -> str:
@@ -92,5 +120,7 @@ class TelemetrySanitizationMiddleware:
             span.set_attribute("url.full", route_path)
             span.set_attribute("url.path", route_path)
             span.set_attribute("url.query", "")
+            if actor_id := self._actor_id(scope):
+                span.set_attribute("request.actor.id", actor_id)
 
         await self.app(scope, receive, send)

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -174,7 +174,10 @@ async def global_exception_handler(_request: Request, exc: Exception) -> JSONRes
     )
 
 
-app.add_middleware(TelemetrySanitizationMiddleware)
+app.add_middleware(
+    TelemetrySanitizationMiddleware,
+    actor_hmac_key=(_settings.request_telemetry.actor_hmac_key.get_secret_value()),
+)
 app.add_middleware(
     SessionMiddleware,
     secret_key=_settings.session.secret_key,

--- a/api/tests/core/test_middleware.py
+++ b/api/tests/core/test_middleware.py
@@ -33,6 +33,15 @@ async def _make_app_that_sends_response(scope, receive, send):
     await send({"type": "http.response.body", "body": b"OK"})
 
 
+def _span_attribute_value(span: MagicMock, name: str) -> str:
+    for args, _kwargs in span.set_attribute.call_args_list:
+        if args[0] == name:
+            value = args[1]
+            assert isinstance(value, str)
+            return value
+    raise AssertionError(f"Span attribute {name!r} was not set")
+
+
 @pytest.mark.unit
 class TestSecurityHeadersMiddleware:
     """Test SecurityHeadersMiddleware adds expected headers."""
@@ -197,3 +206,95 @@ class TestTelemetrySanitizationMiddleware:
         await middleware(scope, _noop_receive, _noop_send)
 
         span.set_attribute.assert_any_call("url.full", "/unmatched")
+
+    @patch("learn_to_cloud.core.middleware.trace", autospec=True)
+    async def test_adds_stable_pseudonymous_actor_for_authenticated_session(
+        self, mock_trace
+    ):
+        span = MagicMock()
+        span.is_recording.return_value = True
+        mock_trace.get_current_span.return_value = span
+        scope = {
+            "type": "http",
+            "path": "/dashboard",
+            "session": {"user_id": 42, "github_username": "sensitive-login"},
+        }
+
+        middleware = TelemetrySanitizationMiddleware(
+            _make_app_that_sends_response,
+            actor_hmac_key="first-key-that-is-at-least-32-bytes",
+        )
+        await middleware(scope, _noop_receive, _noop_send)
+        first_actor_id = _span_attribute_value(span, "request.actor.id")
+
+        span.reset_mock()
+        await middleware(scope, _noop_receive, _noop_send)
+        second_actor_id = _span_attribute_value(span, "request.actor.id")
+
+        assert first_actor_id == second_actor_id
+        assert len(first_actor_id) == 32
+        assert first_actor_id != "42"
+        assert "sensitive-login" not in first_actor_id
+
+    @patch("learn_to_cloud.core.middleware.trace", autospec=True)
+    async def test_actor_id_changes_after_key_rotation(self, mock_trace):
+        span = MagicMock()
+        span.is_recording.return_value = True
+        mock_trace.get_current_span.return_value = span
+        scope = {"type": "http", "path": "/dashboard", "session": {"user_id": 42}}
+
+        first_middleware = TelemetrySanitizationMiddleware(
+            _make_app_that_sends_response,
+            actor_hmac_key="first-key-that-is-at-least-32-bytes",
+        )
+        await first_middleware(scope, _noop_receive, _noop_send)
+        first_actor_id = _span_attribute_value(span, "request.actor.id")
+
+        span.reset_mock()
+        rotated_middleware = TelemetrySanitizationMiddleware(
+            _make_app_that_sends_response,
+            actor_hmac_key="rotated-key-that-is-at-least-32-bytes",
+        )
+        await rotated_middleware(scope, _noop_receive, _noop_send)
+        rotated_actor_id = _span_attribute_value(span, "request.actor.id")
+
+        assert first_actor_id != rotated_actor_id
+
+    @pytest.mark.parametrize(
+        "session",
+        [None, {}, {"user_id": None}, {"user_id": True}, {"user_id": 0}],
+    )
+    @patch("learn_to_cloud.core.middleware.trace", autospec=True)
+    async def test_omits_actor_for_anonymous_or_invalid_session(
+        self, mock_trace, session
+    ):
+        span = MagicMock()
+        span.is_recording.return_value = True
+        mock_trace.get_current_span.return_value = span
+        scope = {"type": "http", "path": "/", "session": session}
+        middleware = TelemetrySanitizationMiddleware(
+            _make_app_that_sends_response,
+            actor_hmac_key="first-key-that-is-at-least-32-bytes",
+        )
+
+        await middleware(scope, _noop_receive, _noop_send)
+
+        attribute_names = [
+            args[0] for args, _kwargs in span.set_attribute.call_args_list
+        ]
+        assert "request.actor.id" not in attribute_names
+
+    @patch("learn_to_cloud.core.middleware.trace", autospec=True)
+    async def test_omits_actor_when_hmac_key_is_not_configured(self, mock_trace):
+        span = MagicMock()
+        span.is_recording.return_value = True
+        mock_trace.get_current_span.return_value = span
+        scope = {"type": "http", "path": "/", "session": {"user_id": 42}}
+
+        middleware = TelemetrySanitizationMiddleware(_make_app_that_sends_response)
+        await middleware(scope, _noop_receive, _noop_send)
+
+        attribute_names = [
+            args[0] for args, _kwargs in span.set_attribute.call_args_list
+        ]
+        assert "request.actor.id" not in attribute_names

--- a/api/tests/test_telemetry_contracts.py
+++ b/api/tests/test_telemetry_contracts.py
@@ -32,6 +32,7 @@ _ALLOWED_APPLICATION_ATTRIBUTES = {
     "http.response.status_code",
     "http.target",
     "http.url",
+    "request.actor.id",
     "startup.initialized",
     "telemetry.configuration.reason",
     "url.full",

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -17,6 +17,61 @@ Analytics workspace. Replace `dev` if the alert came from another environment.
 | `verification_attempt_stuck` | `verification.attempt.stuck` structured business log | Unchanged; #780 owns the reconciler contract. |
 | `schema_drift` | `health.ready.schema_drift*` structured health logs | Unchanged; the query uses event names, not exception text or spans. |
 
+## Pseudonymous request actor telemetry
+
+Authenticated API requests carry `request.actor.id` in the Application Insights
+request `Properties`. It is the first 128 bits of an HMAC-SHA-256 digest over the
+internal user ID with a purpose-specific prefix. Anonymous requests omit the
+attribute. The raw internal user ID, GitHub username, and HMAC key must never be
+logged or exported as telemetry.
+
+Use this production `AppRequests` query to group traffic by actor:
+
+```kusto
+AppRequests
+| where TimeGenerated > ago(2h)
+| where AppRoleName == "learn-to-cloud-api"
+    or AppRoleName has "ca-ltc-api"
+| extend ActorId = tostring(Properties["request.actor.id"])
+| where isnotempty(ActorId)
+| summarize
+    RequestCount = sum(ItemCount),
+    OperationCount = dcount(OperationId),
+    FirstSeen = min(TimeGenerated),
+    LastSeen = max(TimeGenerated)
+    by ActorId
+| order by RequestCount desc
+```
+
+Always use `sum(ItemCount)` for request totals because Application Insights
+request sampling can make one stored record represent multiple requests. Treat
+the actor ID as an incident-correlation value only; it is not an authorization
+identity and must not be copied into learner-facing systems.
+
+### Key rotation
+
+Rotate the `telemetry-actor-hmac-key` Key Vault secret every 30 days and
+immediately after suspected disclosure. Generate it independently from all
+other application secrets and use at least 32 random bytes:
+
+```bash
+terraform -chdir=infra output -raw key_vault_name
+ACTOR_HMAC_KEY="$(openssl rand -hex 32)"
+az keyvault secret set \
+  --vault-name "<key-vault-name-from-output>" \
+  --name "telemetry-actor-hmac-key" \
+  --value "$ACTOR_HMAC_KEY" \
+  --output none
+unset ACTOR_HMAC_KEY
+```
+
+The Container App uses a versionless Key Vault reference. Azure checks for a
+new secret version within 30 minutes and restarts active revisions that consume
+it as an environment variable. Confirm the new revision is healthy, then run
+the grouping query above. Rotation intentionally changes every actor ID, so
+correlation does not cross a rotation boundary; investigations spanning that
+boundary must analyze the two windows separately.
+
 ## Unhandled API exception
 
 ### Meaning

--- a/infra/container-apps.tf
+++ b/infra/container-apps.tf
@@ -78,6 +78,12 @@ resource "azurerm_container_app" "api_v5" {
   }
 
   secret {
+    name                = "telemetry-actor-hmac-key"
+    identity            = azurerm_user_assigned_identity.api.id
+    key_vault_secret_id = "${azurerm_key_vault.main.vault_uri}secrets/telemetry-actor-hmac-key"
+  }
+
+  secret {
     name                = "ctf-master-secret"
     identity            = azurerm_user_assigned_identity.api.id
     key_vault_secret_id = "${azurerm_key_vault.main.vault_uri}secrets/labs-verification-secret"
@@ -146,6 +152,11 @@ resource "azurerm_container_app" "api_v5" {
       env {
         name        = "SESSION__SECRET_KEY"
         secret_name = "session-secret-key"
+      }
+
+      env {
+        name        = "REQUEST_TELEMETRY__ACTOR_HMAC_KEY"
+        secret_name = "telemetry-actor-hmac-key"
       }
 
       env {

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -47,6 +47,7 @@ github_client_id = "Ov23xxx"
 # - github-token
 # - session-secret-key
 # - labs-verification-secret
+# - telemetry-actor-hmac-key (rotate every 30 days; see docs/runbooks/alerts.md)
 
 # Optional - Override defaults
 # location    = "centralus"

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
@@ -8,7 +8,7 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -190,6 +190,12 @@ class FrontendTelemetryConfig(FrozenConfig):
     sampling_percentage: float = Field(default=100.0, ge=0.0, le=100.0)
 
 
+class RequestTelemetryConfig(FrozenConfig):
+    """Privacy-preserving server request telemetry config."""
+
+    actor_hmac_key: SecretStr = SecretStr("")
+
+
 class VerificationFunctionsConfig(FrozenConfig):
     """Durable verification Functions starter config."""
 
@@ -242,6 +248,7 @@ class WebSettings(BaseSettings):
     smoke_test: SmokeTestConfig = SmokeTestConfig()
     cors: CorsConfig = CorsConfig()
     frontend_telemetry: FrontendTelemetryConfig = FrontendTelemetryConfig()
+    request_telemetry: RequestTelemetryConfig = RequestTelemetryConfig()
     verification_functions: VerificationFunctionsConfig = VerificationFunctionsConfig()
     web_security: WebSecurityConfig = WebSecurityConfig()
     startup_timeout: int = 60
@@ -272,6 +279,14 @@ class WebSettings(BaseSettings):
                 raise ValueError(
                     "VERIFICATION_FUNCTIONS__TOKEN_SCOPE must be set "
                     "when ENVIRONMENT=production."
+                )
+            actor_hmac_key = (
+                self.request_telemetry.actor_hmac_key.get_secret_value().encode()
+            )
+            if len(actor_hmac_key) < 32:
+                raise ValueError(
+                    "REQUEST_TELEMETRY__ACTOR_HMAC_KEY must be set to at least "
+                    "32 bytes when ENVIRONMENT=production."
                 )
         return self
 

--- a/packages/learn-to-cloud-shared/tests/core/test_config.py
+++ b/packages/learn-to-cloud-shared/tests/core/test_config.py
@@ -12,6 +12,7 @@ from learn_to_cloud_shared.core.config import (
     GitHubConfig,
     LabsConfig,
     OAuthConfig,
+    RequestTelemetryConfig,
     SessionConfig,
     VerificationFunctionsConfig,
     WebSecurityConfig,
@@ -104,6 +105,7 @@ class TestWebSettingsValidation:
             environment="production",
             oauth=OAuthConfig(client_id="id", client_secret="secret"),
             session=SessionConfig(secret_key="a-real-secret-not-the-default"),
+            request_telemetry=RequestTelemetryConfig(actor_hmac_key="a" * 32),
             verification_functions=VerificationFunctionsConfig(
                 base_url="https://functions.example.test",
                 token_scope="api://verification/.default",
@@ -111,6 +113,20 @@ class TestWebSettingsValidation:
         )
         assert s.environment is Environment.PRODUCTION
         assert s.is_development is False
+
+    def test_production_requires_request_actor_hmac_key(self):
+        with pytest.raises(ValidationError, match="REQUEST_TELEMETRY__ACTOR_HMAC_KEY"):
+            WebSettings(
+                database=DatabaseConfig(url="postgresql+asyncpg://localhost/test"),
+                environment="production",
+                oauth=OAuthConfig(client_id="id", client_secret="secret"),
+                session=SessionConfig(secret_key="a-real-secret-not-the-default"),
+                verification_functions=VerificationFunctionsConfig(
+                    base_url="https://functions.example.test",
+                    token_scope="api://verification/.default",
+                ),
+                request_telemetry=RequestTelemetryConfig(actor_hmac_key="too-short"),
+            )
 
     def test_production_requires_verification_functions_base_url(self):
         with pytest.raises(ValidationError, match="VERIFICATION_FUNCTIONS__BASE_URL"):
@@ -169,6 +185,17 @@ class TestFrontendTelemetryConfig:
 
 
 @pytest.mark.unit
+class TestRequestTelemetryConfig:
+    def test_hmac_key_is_redacted_from_repr(self):
+        secret = "actor-hmac-key-that-must-not-be-rendered"
+
+        config = RequestTelemetryConfig(actor_hmac_key=secret)
+
+        assert secret not in repr(config)
+        assert "**********" in repr(config)
+
+
+@pytest.mark.unit
 class TestAllowedOrigins:
     def test_development_includes_localhost(self):
         s = WebSettings(
@@ -184,6 +211,7 @@ class TestAllowedOrigins:
             environment="production",
             oauth=OAuthConfig(client_id="id", client_secret="secret"),
             session=SessionConfig(secret_key="prod-secret"),
+            request_telemetry=RequestTelemetryConfig(actor_hmac_key="a" * 32),
             verification_functions=VerificationFunctionsConfig(
                 base_url="https://functions.example.test",
                 token_scope="api://verification/.default",


### PR DESCRIPTION
## Summary

- add an authenticated-only `request.actor.id` derived from the internal user ID with HMAC-SHA-256 and truncated to 128 bits
- keep the HMAC key redacted in application configuration and source it from an Azure Key Vault-backed Container App secret
- preserve the telemetry prohibition on raw `user_id` and `github_username`
- document the 30-day rotation cadence and a sampling-aware production `AppRequests` grouping query

## Validation completed

- `uv run poe check`
- `terraform -chdir=infra fmt -check`
- `terraform -chdir=infra validate` with Terraform 1.16.1
- regression tests for stable pseudonyms, key rotation, anonymous omission, and secret redaction

Refs #822

The issue should remain open through post-deployment production telemetry validation.