### PR TITLE
Simplify the Learn to Cloud experience around deep learning

### DIFF
--- a/api/src/learn_to_cloud/static/css/input.css
+++ b/api/src/learn_to_cloud/static/css/input.css
@@ -2,10 +2,81 @@
 
 @theme {
     --container-content: 56rem;
+    --color-blue-50: #f0f8ff;
+    --color-blue-100: #dfedfb;
+    --color-blue-200: #b7d8f9;
+    --color-blue-300: #83dcff;
+    --color-blue-400: #52b7fa;
+    --color-blue-500: #0076f7;
+    --color-blue-600: #1264c0;
+    --color-blue-700: #124d99;
+    --color-blue-800: #103f7d;
+    --color-blue-900: #102f56;
+    --color-blue-950: #0b1f38;
 }
 
 /* Dark mode via class strategy (matches Alpine.js toggle on <html>) */
 @custom-variant dark (&:where(.dark, .dark *));
+
+@layer components {
+    .page-title {
+        @apply text-balance text-3xl font-medium leading-tight tracking-[-0.03em] text-gray-950 dark:text-white sm:text-4xl;
+    }
+
+    .section-title {
+        @apply text-xl font-medium tracking-tight text-gray-950 dark:text-white;
+    }
+
+    .button-primary,
+    .button-secondary {
+        @apply inline-flex min-h-11 items-center justify-center gap-2 rounded-md px-5 py-2.5 text-sm font-semibold transition-colors focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:focus-visible:outline-blue-300 disabled:cursor-not-allowed disabled:opacity-50;
+    }
+
+    .button-primary {
+        @apply bg-blue-700 text-white hover:bg-blue-800 dark:bg-blue-300 dark:text-blue-950 dark:hover:bg-blue-200;
+    }
+
+    .button-secondary {
+        @apply border border-gray-300 text-gray-700 hover:border-blue-700 hover:text-blue-700 dark:border-gray-600 dark:text-gray-200 dark:hover:border-blue-300 dark:hover:text-blue-300;
+    }
+
+    .text-link {
+        @apply inline-flex min-h-11 items-center gap-2 text-sm font-medium text-blue-700 underline decoration-blue-200 underline-offset-4 transition-colors hover:decoration-blue-700 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300 dark:focus-visible:outline-blue-300;
+    }
+
+    .policy-content {
+        @apply max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-400;
+    }
+
+    .policy-content section {
+        @apply border-t border-gray-200 py-8 dark:border-gray-700;
+    }
+
+    .policy-content h2 {
+        @apply mb-4 text-xl font-medium tracking-tight text-gray-950 dark:text-white;
+    }
+
+    .policy-content p + p,
+    .policy-content ul + p {
+        @apply mt-4;
+    }
+
+    .policy-content ul {
+        @apply mt-4 list-disc space-y-2 pl-5;
+    }
+
+    .policy-content strong {
+        @apply font-medium text-gray-950 dark:text-gray-200;
+    }
+
+    .policy-content a {
+        @apply wrap-anywhere text-blue-700 underline decoration-blue-200 underline-offset-4 transition-colors hover:decoration-blue-700 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300 dark:focus-visible:outline-blue-300;
+    }
+
+    .policy-content code {
+        @apply rounded bg-gray-100 px-1 py-0.5 text-sm text-gray-900 dark:bg-gray-800 dark:text-gray-200;
+    }
+}
 
 /* HTMX indicator styles */
 .htmx-indicator {

--- a/api/src/learn_to_cloud/static/css/styles.css
+++ b/api/src/learn_to_cloud/static/css/styles.css
@@ -13,11 +13,11 @@
     --color-red-200: oklch(88.5% 0.062 18.334);
     --color-red-300: oklch(80.8% 0.114 19.571);
     --color-red-400: oklch(70.4% 0.191 22.216);
-    --color-red-500: oklch(63.7% 0.237 25.331);
     --color-red-600: oklch(57.7% 0.245 27.325);
     --color-red-700: oklch(50.5% 0.213 27.518);
     --color-red-800: oklch(44.4% 0.177 26.899);
     --color-red-900: oklch(39.6% 0.141 25.723);
+    --color-red-950: oklch(25.8% 0.092 26.042);
     --color-orange-400: oklch(75% 0.183 55.934);
     --color-orange-500: oklch(70.5% 0.213 47.604);
     --color-amber-50: oklch(98.7% 0.022 95.277);
@@ -25,11 +25,11 @@
     --color-amber-200: oklch(92.4% 0.12 95.746);
     --color-amber-300: oklch(87.9% 0.169 91.605);
     --color-amber-400: oklch(82.8% 0.189 84.429);
+    --color-amber-500: oklch(76.9% 0.188 70.08);
     --color-amber-600: oklch(66.6% 0.179 58.318);
     --color-amber-700: oklch(55.5% 0.163 48.998);
     --color-amber-800: oklch(47.3% 0.137 46.201);
     --color-amber-900: oklch(41.4% 0.112 45.904);
-    --color-amber-950: oklch(27.9% 0.077 45.635);
     --color-green-50: oklch(98.2% 0.018 155.826);
     --color-green-100: oklch(96.2% 0.044 156.743);
     --color-green-200: oklch(92.5% 0.084 155.995);
@@ -38,18 +38,16 @@
     --color-green-700: oklch(52.7% 0.154 150.069);
     --color-green-800: oklch(44.8% 0.119 151.328);
     --color-green-900: oklch(39.3% 0.095 152.535);
-    --color-green-950: oklch(26.6% 0.065 152.934);
-    --color-blue-50: oklch(97% 0.014 254.604);
-    --color-blue-100: oklch(93.2% 0.032 255.585);
-    --color-blue-200: oklch(88.2% 0.059 254.128);
-    --color-blue-300: oklch(80.9% 0.105 251.813);
-    --color-blue-400: oklch(70.7% 0.165 254.624);
-    --color-blue-500: oklch(62.3% 0.214 259.815);
-    --color-blue-600: oklch(54.6% 0.245 262.881);
-    --color-blue-700: oklch(48.8% 0.243 264.376);
-    --color-blue-800: oklch(42.4% 0.199 265.638);
-    --color-blue-900: oklch(37.9% 0.146 265.522);
-    --color-blue-950: oklch(28.2% 0.091 267.935);
+    --color-blue-100: #dfedfb;
+    --color-blue-200: #b7d8f9;
+    --color-blue-300: #83dcff;
+    --color-blue-400: #52b7fa;
+    --color-blue-500: #0076f7;
+    --color-blue-600: #1264c0;
+    --color-blue-700: #124d99;
+    --color-blue-800: #103f7d;
+    --color-blue-900: #102f56;
+    --color-blue-950: #0b1f38;
     --color-indigo-400: oklch(67.3% 0.182 276.935);
     --color-indigo-500: oklch(58.5% 0.233 277.117);
     --color-gray-50: oklch(98.5% 0.002 247.839);
@@ -63,10 +61,6 @@
     --color-gray-800: oklch(27.8% 0.033 256.848);
     --color-gray-900: oklch(21% 0.034 264.665);
     --color-gray-950: oklch(13% 0.028 261.692);
-    --color-zinc-100: oklch(96.7% 0.001 286.375);
-    --color-zinc-300: oklch(87.1% 0.006 286.286);
-    --color-zinc-700: oklch(37% 0.013 285.805);
-    --color-zinc-800: oklch(27.4% 0.006 286.033);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
@@ -93,17 +87,15 @@
     --text-3xl--line-height: calc(2.25 / 1.875);
     --text-4xl: 2.25rem;
     --text-4xl--line-height: calc(2.5 / 2.25);
-    --text-5xl: 3rem;
-    --text-5xl--line-height: 1;
     --text-6xl: 3.75rem;
     --text-6xl--line-height: 1;
-    --text-7xl: 4.5rem;
-    --text-7xl--line-height: 1;
+    --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
     --tracking-tight: -0.025em;
     --tracking-wide: 0.025em;
+    --leading-tight: 1.25;
     --radius-sm: 0.25rem;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
@@ -413,14 +405,8 @@
   .mb-10 {
     margin-bottom: calc(var(--spacing) * 10);
   }
-  .mb-12 {
-    margin-bottom: calc(var(--spacing) * 12);
-  }
   .ml-1 {
     margin-left: var(--spacing);
-  }
-  .ml-2 {
-    margin-left: calc(var(--spacing) * 2);
   }
   .block {
     display: block;
@@ -437,9 +423,6 @@
   .inline {
     display: inline;
   }
-  .inline-block {
-    display: inline-block;
-  }
   .inline-flex {
     display: inline-flex;
   }
@@ -448,9 +431,6 @@
   }
   .h-2 {
     height: calc(var(--spacing) * 2);
-  }
-  .h-2\.5 {
-    height: calc(var(--spacing) * 2.5);
   }
   .h-4 {
     height: calc(var(--spacing) * 4);
@@ -470,9 +450,6 @@
   .h-9 {
     height: calc(var(--spacing) * 9);
   }
-  .h-10 {
-    height: calc(var(--spacing) * 10);
-  }
   .h-11 {
     height: calc(var(--spacing) * 11);
   }
@@ -481,12 +458,6 @@
   }
   .h-full {
     height: 100%;
-  }
-  .h-px {
-    height: 1px;
-  }
-  .min-h-9 {
-    min-height: calc(var(--spacing) * 9);
   }
   .min-h-11 {
     min-height: calc(var(--spacing) * 11);
@@ -512,9 +483,6 @@
   .w-9 {
     width: calc(var(--spacing) * 9);
   }
-  .w-10 {
-    width: calc(var(--spacing) * 10);
-  }
   .w-11 {
     width: calc(var(--spacing) * 11);
   }
@@ -529,6 +497,9 @@
   }
   .max-w-3xl {
     max-width: var(--container-3xl);
+  }
+  .max-w-32 {
+    max-width: calc(var(--spacing) * 32);
   }
   .max-w-content {
     max-width: var(--container-content);
@@ -581,20 +552,17 @@
   .resize {
     resize: both;
   }
-  .list-inside {
-    list-style-position: inside;
+  .grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
-  .list-disc {
-    list-style-type: disc;
+  .grid-cols-\[1\.25rem_1fr_auto\] {
+    grid-template-columns: 1.25rem 1fr auto;
   }
   .grid-cols-\[2\.75rem_1fr\] {
     grid-template-columns: 2.75rem 1fr;
   }
-  .grid-cols-\[2\.75rem_1fr_auto\] {
-    grid-template-columns: 2.75rem 1fr auto;
-  }
-  .grid-cols-\[3rem_1fr\] {
-    grid-template-columns: 3rem 1fr;
+  .grid-cols-\[2rem_1fr\] {
+    grid-template-columns: 2rem 1fr;
   }
   .flex-col {
     flex-direction: column;
@@ -607,9 +575,6 @@
   }
   .items-center {
     align-items: center;
-  }
-  .items-end {
-    align-items: flex-end;
   }
   .items-start {
     align-items: flex-start;
@@ -647,40 +612,21 @@
   .gap-8 {
     gap: calc(var(--spacing) * 8);
   }
-  :where(.space-y-1 > :not(:last-child)) {
-    --tw-space-y-reverse: 0;
-    margin-block-start: calc(var(--spacing) * var(--tw-space-y-reverse));
-    margin-block-end: calc(var(--spacing) * calc(1 - var(--tw-space-y-reverse)));
-  }
   :where(.space-y-2 > :not(:last-child)) {
     --tw-space-y-reverse: 0;
     margin-block-start: calc(calc(var(--spacing) * 2) * var(--tw-space-y-reverse));
     margin-block-end: calc(calc(var(--spacing) * 2) * calc(1 - var(--tw-space-y-reverse)));
-  }
-  :where(.space-y-3 > :not(:last-child)) {
-    --tw-space-y-reverse: 0;
-    margin-block-start: calc(calc(var(--spacing) * 3) * var(--tw-space-y-reverse));
-    margin-block-end: calc(calc(var(--spacing) * 3) * calc(1 - var(--tw-space-y-reverse)));
-  }
-  :where(.space-y-4 > :not(:last-child)) {
-    --tw-space-y-reverse: 0;
-    margin-block-start: calc(calc(var(--spacing) * 4) * var(--tw-space-y-reverse));
-    margin-block-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-y-reverse)));
   }
   :where(.space-y-5 > :not(:last-child)) {
     --tw-space-y-reverse: 0;
     margin-block-start: calc(calc(var(--spacing) * 5) * var(--tw-space-y-reverse));
     margin-block-end: calc(calc(var(--spacing) * 5) * calc(1 - var(--tw-space-y-reverse)));
   }
-  :where(.space-y-6 > :not(:last-child)) {
-    --tw-space-y-reverse: 0;
-    margin-block-start: calc(calc(var(--spacing) * 6) * var(--tw-space-y-reverse));
-    margin-block-end: calc(calc(var(--spacing) * 6) * calc(1 - var(--tw-space-y-reverse)));
+  .gap-x-4 {
+    column-gap: calc(var(--spacing) * 4);
   }
-  :where(.space-y-8 > :not(:last-child)) {
-    --tw-space-y-reverse: 0;
-    margin-block-start: calc(calc(var(--spacing) * 8) * var(--tw-space-y-reverse));
-    margin-block-end: calc(calc(var(--spacing) * 8) * calc(1 - var(--tw-space-y-reverse)));
+  .gap-x-5 {
+    column-gap: calc(var(--spacing) * 5);
   }
   .gap-x-6 {
     column-gap: calc(var(--spacing) * 6);
@@ -688,8 +634,27 @@
   .gap-x-8 {
     column-gap: calc(var(--spacing) * 8);
   }
+  .gap-y-1 {
+    row-gap: var(--spacing);
+  }
+  .gap-y-2 {
+    row-gap: calc(var(--spacing) * 2);
+  }
   .gap-y-3 {
     row-gap: calc(var(--spacing) * 3);
+  }
+  :where(.divide-y > :not(:last-child)) {
+    --tw-divide-y-reverse: 0;
+    border-bottom-style: var(--tw-border-style);
+    border-top-style: var(--tw-border-style);
+    border-top-width: calc(1px * var(--tw-divide-y-reverse));
+    border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+  }
+  :where(.divide-gray-200 > :not(:last-child)) {
+    border-color: var(--color-gray-200);
+  }
+  .self-start {
+    align-self: flex-start;
   }
   .truncate {
     overflow: hidden;
@@ -744,14 +709,15 @@
     border-bottom-style: var(--tw-border-style);
     border-bottom-width: 2px;
   }
+  .border-l-2 {
+    border-left-style: var(--tw-border-style);
+    border-left-width: 2px;
+  }
   .border-amber-200 {
     border-color: var(--color-amber-200);
   }
-  .border-blue-100 {
-    border-color: var(--color-blue-100);
-  }
-  .border-blue-200 {
-    border-color: var(--color-blue-200);
+  .border-amber-500 {
+    border-color: var(--color-amber-500);
   }
   .border-blue-500 {
     border-color: var(--color-blue-500);
@@ -774,6 +740,9 @@
   .border-red-200 {
     border-color: var(--color-red-200);
   }
+  .border-red-600 {
+    border-color: var(--color-red-600);
+  }
   .border-transparent {
     border-color: transparent;
   }
@@ -792,20 +761,11 @@
       background-color: color-mix(in oklab, var(--color-black) 50%, transparent);
     }
   }
-  .bg-blue-50 {
-    background-color: var(--color-blue-50);
-  }
   .bg-blue-100 {
     background-color: var(--color-blue-100);
   }
-  .bg-blue-400 {
-    background-color: var(--color-blue-400);
-  }
   .bg-blue-600 {
     background-color: var(--color-blue-600);
-  }
-  .bg-blue-700 {
-    background-color: var(--color-blue-700);
   }
   .bg-gray-50 {
     background-color: var(--color-gray-50);
@@ -816,20 +776,8 @@
   .bg-gray-200 {
     background-color: var(--color-gray-200);
   }
-  .bg-gray-900 {
-    background-color: var(--color-gray-900);
-  }
-  .bg-gray-950 {
-    background-color: var(--color-gray-950);
-  }
   .bg-green-50 {
     background-color: var(--color-green-50);
-  }
-  .bg-green-50\/40 {
-    background-color: color-mix(in srgb, oklch(98.2% 0.018 155.826) 40%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-green-50) 40%, transparent);
-    }
   }
   .bg-green-100 {
     background-color: var(--color-green-100);
@@ -843,20 +791,11 @@
   .bg-red-100 {
     background-color: var(--color-red-100);
   }
-  .bg-red-600 {
-    background-color: var(--color-red-600);
+  .bg-red-700 {
+    background-color: var(--color-red-700);
   }
   .bg-white {
     background-color: var(--color-white);
-  }
-  .bg-white\/60 {
-    background-color: color-mix(in srgb, #fff 60%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-white) 60%, transparent);
-    }
-  }
-  .bg-zinc-100 {
-    background-color: var(--color-zinc-100);
   }
   .p-1 {
     padding: var(--spacing);
@@ -867,23 +806,8 @@
   .p-3 {
     padding: calc(var(--spacing) * 3);
   }
-  .p-4 {
-    padding: calc(var(--spacing) * 4);
-  }
-  .p-5 {
-    padding: calc(var(--spacing) * 5);
-  }
   .p-6 {
     padding: calc(var(--spacing) * 6);
-  }
-  .p-8 {
-    padding: calc(var(--spacing) * 8);
-  }
-  .px-1 {
-    padding-inline: var(--spacing);
-  }
-  .px-2 {
-    padding-inline: calc(var(--spacing) * 2);
   }
   .px-2\.5 {
     padding-inline: calc(var(--spacing) * 2.5);
@@ -893,9 +817,6 @@
   }
   .px-4 {
     padding-inline: calc(var(--spacing) * 4);
-  }
-  .px-5 {
-    padding-inline: calc(var(--spacing) * 5);
   }
   .py-0\.5 {
     padding-block: calc(var(--spacing) * 0.5);
@@ -924,20 +845,20 @@
   .py-8 {
     padding-block: calc(var(--spacing) * 8);
   }
+  .py-10 {
+    padding-block: calc(var(--spacing) * 10);
+  }
   .py-12 {
     padding-block: calc(var(--spacing) * 12);
   }
   .py-16 {
     padding-block: calc(var(--spacing) * 16);
   }
+  .pt-0\.5 {
+    padding-top: calc(var(--spacing) * 0.5);
+  }
   .pt-1 {
     padding-top: var(--spacing);
-  }
-  .pt-4 {
-    padding-top: calc(var(--spacing) * 4);
-  }
-  .pt-5 {
-    padding-top: calc(var(--spacing) * 5);
   }
   .pt-6 {
     padding-top: calc(var(--spacing) * 6);
@@ -945,14 +866,11 @@
   .pt-8 {
     padding-top: calc(var(--spacing) * 8);
   }
+  .pt-10 {
+    padding-top: calc(var(--spacing) * 10);
+  }
   .pt-12 {
     padding-top: calc(var(--spacing) * 12);
-  }
-  .pt-14 {
-    padding-top: calc(var(--spacing) * 14);
-  }
-  .pr-4 {
-    padding-right: calc(var(--spacing) * 4);
   }
   .pb-0 {
     padding-bottom: 0px;
@@ -960,29 +878,20 @@
   .pb-2 {
     padding-bottom: calc(var(--spacing) * 2);
   }
-  .pb-4 {
-    padding-bottom: calc(var(--spacing) * 4);
-  }
   .pb-8 {
     padding-bottom: calc(var(--spacing) * 8);
   }
   .pb-10 {
     padding-bottom: calc(var(--spacing) * 10);
   }
-  .pb-12 {
-    padding-bottom: calc(var(--spacing) * 12);
-  }
   .pb-20 {
     padding-bottom: calc(var(--spacing) * 20);
   }
-  .pl-1 {
-    padding-left: var(--spacing);
+  .pl-4 {
+    padding-left: calc(var(--spacing) * 4);
   }
-  .pl-10 {
-    padding-left: calc(var(--spacing) * 10);
-  }
-  .pl-16 {
-    padding-left: calc(var(--spacing) * 16);
+  .pl-12 {
+    padding-left: calc(var(--spacing) * 12);
   }
   .text-center {
     text-align: center;
@@ -1024,10 +933,6 @@
     font-size: var(--text-sm);
     line-height: var(--tw-leading, var(--text-sm--line-height));
   }
-  .text-xl {
-    font-size: var(--text-xl);
-    line-height: var(--tw-leading, var(--text-xl--line-height));
-  }
   .text-xs {
     font-size: var(--text-xs);
     line-height: var(--tw-leading, var(--text-xs--line-height));
@@ -1060,6 +965,10 @@
     --tw-font-weight: var(--font-weight-medium);
     font-weight: var(--font-weight-medium);
   }
+  .font-normal {
+    --tw-font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight-normal);
+  }
   .font-semibold {
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
@@ -1068,25 +977,9 @@
     --tw-tracking: -0.02em;
     letter-spacing: -0.02em;
   }
-  .tracking-\[-0\.03em\] {
-    --tw-tracking: -0.03em;
-    letter-spacing: -0.03em;
-  }
-  .tracking-\[-0\.025em\] {
-    --tw-tracking: -0.025em;
-    letter-spacing: -0.025em;
-  }
-  .tracking-\[-0\.035em\] {
-    --tw-tracking: -0.035em;
-    letter-spacing: -0.035em;
-  }
   .tracking-\[-0\.045em\] {
     --tw-tracking: -0.045em;
     letter-spacing: -0.045em;
-  }
-  .tracking-\[0\.12em\] {
-    --tw-tracking: 0.12em;
-    letter-spacing: 0.12em;
   }
   .tracking-\[0\.16em\] {
     --tw-tracking: 0.16em;
@@ -1106,6 +999,9 @@
   .break-words {
     overflow-wrap: break-word;
   }
+  .break-all {
+    word-break: break-all;
+  }
   .text-amber-600 {
     color: var(--color-amber-600);
   }
@@ -1115,9 +1011,6 @@
   .text-amber-800 {
     color: var(--color-amber-800);
   }
-  .text-amber-950 {
-    color: var(--color-amber-950);
-  }
   .text-blue-600 {
     color: var(--color-blue-600);
   }
@@ -1126,15 +1019,6 @@
   }
   .text-blue-800 {
     color: var(--color-blue-800);
-  }
-  .text-blue-900 {
-    color: var(--color-blue-900);
-  }
-  .text-blue-950 {
-    color: var(--color-blue-950);
-  }
-  .text-gray-300 {
-    color: var(--color-gray-300);
   }
   .text-gray-400 {
     color: var(--color-gray-400);
@@ -1169,9 +1053,6 @@
   .text-green-900 {
     color: var(--color-green-900);
   }
-  .text-green-950 {
-    color: var(--color-green-950);
-  }
   .text-indigo-500 {
     color: var(--color-indigo-500);
   }
@@ -1187,14 +1068,8 @@
   .text-red-800 {
     color: var(--color-red-800);
   }
-  .text-red-900 {
-    color: var(--color-red-900);
-  }
   .text-white {
     color: var(--color-white);
-  }
-  .text-zinc-700 {
-    color: var(--color-zinc-700);
   }
   .lowercase {
     text-transform: lowercase;
@@ -1202,17 +1077,11 @@
   .uppercase {
     text-transform: uppercase;
   }
-  .line-through {
-    text-decoration-line: line-through;
-  }
   .underline {
     text-decoration-line: underline;
   }
   .decoration-blue-200 {
     text-decoration-color: var(--color-blue-200);
-  }
-  .decoration-gray-300 {
-    text-decoration-color: var(--color-gray-300);
   }
   .underline-offset-4 {
     text-underline-offset: 4px;
@@ -1263,10 +1132,6 @@
     user-select: all;
   }
   @media (hover: hover) {
-    .group-hover\:translate-x-0\.5:is(:where(.group):hover *) {
-      --tw-translate-x: calc(var(--spacing) * 0.5);
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
     .group-hover\:text-blue-700:is(:where(.group):hover *) {
       color: var(--color-blue-700);
     }
@@ -1293,35 +1158,17 @@
     outline-color: var(--color-blue-700);
   }
   @media (hover: hover) {
-    .hover\:border-blue-400:hover {
-      border-color: var(--color-blue-400);
-    }
-    .hover\:border-blue-500:hover {
-      border-color: var(--color-blue-500);
-    }
-    .hover\:bg-blue-500:hover {
-      background-color: var(--color-blue-500);
-    }
-    .hover\:bg-blue-600:hover {
-      background-color: var(--color-blue-600);
-    }
     .hover\:bg-gray-50:hover {
       background-color: var(--color-gray-50);
     }
     .hover\:bg-gray-100:hover {
       background-color: var(--color-gray-100);
     }
-    .hover\:bg-gray-700:hover {
-      background-color: var(--color-gray-700);
+    .hover\:bg-red-50:hover {
+      background-color: var(--color-red-50);
     }
-    .hover\:bg-red-500:hover {
-      background-color: var(--color-red-500);
-    }
-    .hover\:bg-white:hover {
-      background-color: var(--color-white);
-    }
-    .hover\:text-blue-500:hover {
-      color: var(--color-blue-500);
+    .hover\:bg-red-800:hover {
+      background-color: var(--color-red-800);
     }
     .hover\:text-blue-700:hover {
       color: var(--color-blue-700);
@@ -1338,20 +1185,14 @@
     .hover\:text-gray-900:hover {
       color: var(--color-gray-900);
     }
-    .hover\:text-gray-950:hover {
-      color: var(--color-gray-950);
-    }
     .hover\:no-underline:hover {
       text-decoration-line: none;
     }
     .hover\:underline:hover {
       text-decoration-line: underline;
     }
-    .hover\:decoration-blue-600:hover {
-      text-decoration-color: var(--color-blue-600);
-    }
-    .hover\:decoration-gray-950:hover {
-      text-decoration-color: var(--color-gray-950);
+    .hover\:decoration-blue-700:hover {
+      text-decoration-color: var(--color-blue-700);
     }
   }
   .focus\:border-blue-500:focus {
@@ -1384,20 +1225,14 @@
   .focus-visible\:outline-offset-4:focus-visible {
     outline-offset: 4px;
   }
-  .focus-visible\:outline-amber-700:focus-visible {
-    outline-color: var(--color-amber-700);
-  }
   .focus-visible\:outline-blue-700:focus-visible {
     outline-color: var(--color-blue-700);
   }
   .focus-visible\:outline-gray-700:focus-visible {
     outline-color: var(--color-gray-700);
   }
-  .focus-visible\:outline-green-700:focus-visible {
-    outline-color: var(--color-green-700);
-  }
-  .focus-visible\:outline-red-700:focus-visible {
-    outline-color: var(--color-red-700);
+  .focus-visible\:outline-red-600:focus-visible {
+    outline-color: var(--color-red-600);
   }
   .disabled\:opacity-50:disabled {
     opacity: 50%;
@@ -1415,21 +1250,6 @@
     .sm\:mt-16 {
       margin-top: calc(var(--spacing) * 16);
     }
-    .sm\:block {
-      display: block;
-    }
-    .sm\:flex {
-      display: flex;
-    }
-    .sm\:hidden {
-      display: none;
-    }
-    .sm\:inline {
-      display: inline;
-    }
-    .sm\:inline-flex {
-      display: inline-flex;
-    }
     .sm\:flex-1 {
       flex: 1;
     }
@@ -1442,8 +1262,8 @@
     .sm\:grid-cols-\[2\.75rem_1fr_auto\] {
       grid-template-columns: 2.75rem 1fr auto;
     }
-    .sm\:grid-cols-\[4rem_1fr\] {
-      grid-template-columns: 4rem 1fr;
+    .sm\:grid-cols-\[2rem_1fr_auto\] {
+      grid-template-columns: 2rem 1fr auto;
     }
     .sm\:grid-cols-\[minmax\(0\,1fr\)_auto\] {
       grid-template-columns: minmax(0,1fr) auto;
@@ -1481,28 +1301,17 @@
     .sm\:gap-10 {
       gap: calc(var(--spacing) * 10);
     }
-    .sm\:border-t-0 {
-      border-top-style: var(--tw-border-style);
-      border-top-width: 0px;
-    }
-    .sm\:border-l {
-      border-left-style: var(--tw-border-style);
-      border-left-width: 1px;
-    }
     .sm\:px-6 {
       padding-inline: calc(var(--spacing) * 6);
+    }
+    .sm\:py-12 {
+      padding-block: calc(var(--spacing) * 12);
     }
     .sm\:py-16 {
       padding-block: calc(var(--spacing) * 16);
     }
-    .sm\:pt-0 {
-      padding-top: 0px;
-    }
     .sm\:pt-3 {
       padding-top: calc(var(--spacing) * 3);
-    }
-    .sm\:pt-8 {
-      padding-top: calc(var(--spacing) * 8);
     }
     .sm\:pt-14 {
       padding-top: calc(var(--spacing) * 14);
@@ -1516,39 +1325,39 @@
     .sm\:pb-12 {
       padding-bottom: calc(var(--spacing) * 12);
     }
-    .sm\:pb-16 {
-      padding-bottom: calc(var(--spacing) * 16);
-    }
     .sm\:pb-28 {
       padding-bottom: calc(var(--spacing) * 28);
     }
-    .sm\:pl-6 {
-      padding-left: calc(var(--spacing) * 6);
+    .sm\:pl-10 {
+      padding-left: calc(var(--spacing) * 10);
     }
-    .sm\:pl-\[5\.5rem\] {
-      padding-left: 5.5rem;
-    }
-    .sm\:pl-\[5\.75rem\] {
-      padding-left: 5.75rem;
+    .sm\:pl-20 {
+      padding-left: calc(var(--spacing) * 20);
     }
     .sm\:text-3xl {
       font-size: var(--text-3xl);
       line-height: var(--tw-leading, var(--text-3xl--line-height));
-    }
-    .sm\:text-4xl {
-      font-size: var(--text-4xl);
-      line-height: var(--tw-leading, var(--text-4xl--line-height));
-    }
-    .sm\:text-5xl {
-      font-size: var(--text-5xl);
-      line-height: var(--tw-leading, var(--text-5xl--line-height));
     }
     .sm\:text-6xl {
       font-size: var(--text-6xl);
       line-height: var(--tw-leading, var(--text-6xl--line-height));
     }
   }
+  @media (width >= 48rem) {
+    .md\:flex {
+      display: flex;
+    }
+    .md\:hidden {
+      display: none;
+    }
+    .md\:inline-flex {
+      display: inline-flex;
+    }
+  }
   @media (width >= 64rem) {
+    .lg\:inline {
+      display: inline;
+    }
     .lg\:px-8 {
       padding-inline: calc(var(--spacing) * 8);
     }
@@ -1559,14 +1368,11 @@
   .dark\:hidden:where(.dark, .dark *) {
     display: none;
   }
+  :where(.dark\:divide-gray-700:where(.dark, .dark *) > :not(:last-child)) {
+    border-color: var(--color-gray-700);
+  }
   .dark\:border-amber-800:where(.dark, .dark *) {
     border-color: var(--color-amber-800);
-  }
-  .dark\:border-blue-800:where(.dark, .dark *) {
-    border-color: var(--color-blue-800);
-  }
-  .dark\:border-blue-900:where(.dark, .dark *) {
-    border-color: var(--color-blue-900);
   }
   .dark\:border-gray-500:where(.dark, .dark *) {
     border-color: var(--color-gray-500);
@@ -1577,14 +1383,14 @@
   .dark\:border-gray-700:where(.dark, .dark *) {
     border-color: var(--color-gray-700);
   }
-  .dark\:border-green-800:where(.dark, .dark *) {
-    border-color: var(--color-green-800);
-  }
   .dark\:border-green-800\/50:where(.dark, .dark *) {
     border-color: color-mix(in srgb, oklch(44.8% 0.119 151.328) 50%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       border-color: color-mix(in oklab, var(--color-green-800) 50%, transparent);
     }
+  }
+  .dark\:border-red-400:where(.dark, .dark *) {
+    border-color: var(--color-red-400);
   }
   .dark\:border-red-800:where(.dark, .dark *) {
     border-color: var(--color-red-800);
@@ -1598,35 +1404,8 @@
       background-color: color-mix(in oklab, var(--color-amber-900) 20%, transparent);
     }
   }
-  .dark\:bg-amber-950\/30:where(.dark, .dark *) {
-    background-color: color-mix(in srgb, oklch(27.9% 0.077 45.635) 30%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-amber-950) 30%, transparent);
-    }
-  }
-  .dark\:bg-blue-400:where(.dark, .dark *) {
-    background-color: var(--color-blue-400);
-  }
-  .dark\:bg-blue-500:where(.dark, .dark *) {
-    background-color: var(--color-blue-500);
-  }
   .dark\:bg-blue-900:where(.dark, .dark *) {
     background-color: var(--color-blue-900);
-  }
-  .dark\:bg-blue-950:where(.dark, .dark *) {
-    background-color: var(--color-blue-950);
-  }
-  .dark\:bg-blue-950\/30:where(.dark, .dark *) {
-    background-color: color-mix(in srgb, oklch(28.2% 0.091 267.935) 30%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-blue-950) 30%, transparent);
-    }
-  }
-  .dark\:bg-blue-950\/40:where(.dark, .dark *) {
-    background-color: color-mix(in srgb, oklch(28.2% 0.091 267.935) 40%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-blue-950) 40%, transparent);
-    }
   }
   .dark\:bg-gray-700:where(.dark, .dark *) {
     background-color: var(--color-gray-700);
@@ -1634,26 +1413,8 @@
   .dark\:bg-gray-800:where(.dark, .dark *) {
     background-color: var(--color-gray-800);
   }
-  .dark\:bg-gray-800\/50:where(.dark, .dark *) {
-    background-color: color-mix(in srgb, oklch(27.8% 0.033 256.848) 50%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-gray-800) 50%, transparent);
-    }
-  }
   .dark\:bg-gray-900:where(.dark, .dark *) {
     background-color: var(--color-gray-900);
-  }
-  .dark\:bg-gray-950\/20:where(.dark, .dark *) {
-    background-color: color-mix(in srgb, oklch(13% 0.028 261.692) 20%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-gray-950) 20%, transparent);
-    }
-  }
-  .dark\:bg-green-800\/40:where(.dark, .dark *) {
-    background-color: color-mix(in srgb, oklch(44.8% 0.119 151.328) 40%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-green-800) 40%, transparent);
-    }
   }
   .dark\:bg-green-900:where(.dark, .dark *) {
     background-color: var(--color-green-900);
@@ -1662,21 +1423,6 @@
     background-color: color-mix(in srgb, oklch(39.3% 0.095 152.535) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-green-900) 20%, transparent);
-    }
-  }
-  .dark\:bg-green-950:where(.dark, .dark *) {
-    background-color: var(--color-green-950);
-  }
-  .dark\:bg-green-950\/20:where(.dark, .dark *) {
-    background-color: color-mix(in srgb, oklch(26.6% 0.065 152.934) 20%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-green-950) 20%, transparent);
-    }
-  }
-  .dark\:bg-green-950\/30:where(.dark, .dark *) {
-    background-color: color-mix(in srgb, oklch(26.6% 0.065 152.934) 30%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-green-950) 30%, transparent);
     }
   }
   .dark\:bg-red-900:where(.dark, .dark *) {
@@ -1688,15 +1434,6 @@
       background-color: color-mix(in oklab, var(--color-red-900) 20%, transparent);
     }
   }
-  .dark\:bg-white:where(.dark, .dark *) {
-    background-color: var(--color-white);
-  }
-  .dark\:bg-zinc-800:where(.dark, .dark *) {
-    background-color: var(--color-zinc-800);
-  }
-  .dark\:text-amber-100:where(.dark, .dark *) {
-    color: var(--color-amber-100);
-  }
   .dark\:text-amber-200:where(.dark, .dark *) {
     color: var(--color-amber-200);
   }
@@ -1706,9 +1443,6 @@
   .dark\:text-amber-400:where(.dark, .dark *) {
     color: var(--color-amber-400);
   }
-  .dark\:text-blue-100:where(.dark, .dark *) {
-    color: var(--color-blue-100);
-  }
   .dark\:text-blue-200:where(.dark, .dark *) {
     color: var(--color-blue-200);
   }
@@ -1717,9 +1451,6 @@
   }
   .dark\:text-blue-400:where(.dark, .dark *) {
     color: var(--color-blue-400);
-  }
-  .dark\:text-blue-950:where(.dark, .dark *) {
-    color: var(--color-blue-950);
   }
   .dark\:text-gray-100:where(.dark, .dark *) {
     color: var(--color-gray-100);
@@ -1736,15 +1467,6 @@
   .dark\:text-gray-500:where(.dark, .dark *) {
     color: var(--color-gray-500);
   }
-  .dark\:text-gray-700:where(.dark, .dark *) {
-    color: var(--color-gray-700);
-  }
-  .dark\:text-gray-900:where(.dark, .dark *) {
-    color: var(--color-gray-900);
-  }
-  .dark\:text-gray-950:where(.dark, .dark *) {
-    color: var(--color-gray-950);
-  }
   .dark\:text-green-100:where(.dark, .dark *) {
     color: var(--color-green-100);
   }
@@ -1760,9 +1482,6 @@
   .dark\:text-orange-400:where(.dark, .dark *) {
     color: var(--color-orange-400);
   }
-  .dark\:text-red-100:where(.dark, .dark *) {
-    color: var(--color-red-100);
-  }
   .dark\:text-red-200:where(.dark, .dark *) {
     color: var(--color-red-200);
   }
@@ -1775,14 +1494,8 @@
   .dark\:text-white:where(.dark, .dark *) {
     color: var(--color-white);
   }
-  .dark\:text-zinc-300:where(.dark, .dark *) {
-    color: var(--color-zinc-300);
-  }
   .dark\:decoration-blue-800:where(.dark, .dark *) {
     text-decoration-color: var(--color-blue-800);
-  }
-  .dark\:decoration-gray-600:where(.dark, .dark *) {
-    text-decoration-color: var(--color-gray-600);
   }
   .dark\:ring-gray-700:where(.dark, .dark *) {
     --tw-ring-color: var(--color-gray-700);
@@ -1793,21 +1506,6 @@
     }
     .dark\:group-hover\/topic\:text-blue-300:where(.dark, .dark *):is(:where(.group\/topic):hover *) {
       color: var(--color-blue-300);
-    }
-    .dark\:hover\:border-blue-400:where(.dark, .dark *):hover {
-      border-color: var(--color-blue-400);
-    }
-    .dark\:hover\:border-blue-500:where(.dark, .dark *):hover {
-      border-color: var(--color-blue-500);
-    }
-    .dark\:hover\:bg-blue-300:where(.dark, .dark *):hover {
-      background-color: var(--color-blue-300);
-    }
-    .dark\:hover\:bg-blue-400:where(.dark, .dark *):hover {
-      background-color: var(--color-blue-400);
-    }
-    .dark\:hover\:bg-gray-200:where(.dark, .dark *):hover {
-      background-color: var(--color-gray-200);
     }
     .dark\:hover\:bg-gray-700:where(.dark, .dark *):hover {
       background-color: var(--color-gray-700);
@@ -1823,13 +1521,8 @@
         background-color: color-mix(in oklab, var(--color-gray-800) 50%, transparent);
       }
     }
-    .dark\:hover\:bg-gray-950\/40:where(.dark, .dark *):hover {
-      background-color: color-mix(in srgb, oklch(13% 0.028 261.692) 40%, transparent);
-    }
-    @supports (color: color-mix(in lab, red, red)) {
-      .dark\:hover\:bg-gray-950\/40:where(.dark, .dark *):hover {
-        background-color: color-mix(in oklab, var(--color-gray-950) 40%, transparent);
-      }
+    .dark\:hover\:bg-red-950:where(.dark, .dark *):hover {
+      background-color: var(--color-red-950);
     }
     .dark\:hover\:text-blue-300:where(.dark, .dark *):hover {
       color: var(--color-blue-300);
@@ -1846,18 +1539,309 @@
     .dark\:hover\:decoration-blue-300:where(.dark, .dark *):hover {
       text-decoration-color: var(--color-blue-300);
     }
-    .dark\:hover\:decoration-white:where(.dark, .dark *):hover {
-      text-decoration-color: var(--color-white);
-    }
   }
   .dark\:focus-visible\:outline-blue-300:where(.dark, .dark *):focus-visible {
     outline-color: var(--color-blue-300);
+  }
+  .dark\:focus-visible\:outline-gray-300:where(.dark, .dark *):focus-visible {
+    outline-color: var(--color-gray-300);
   }
   .\[\&\>p\]\:m-0 > p {
     margin: 0px;
   }
   .\[\&\>p\]\:inline > p {
     display: inline;
+  }
+}
+@layer components {
+  .page-title {
+    font-size: var(--text-3xl);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
+    --tw-leading: var(--leading-tight);
+    line-height: var(--leading-tight);
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    --tw-tracking: -0.03em;
+    letter-spacing: -0.03em;
+    text-wrap: balance;
+    color: var(--color-gray-950);
+    @media (width >= 40rem) {
+      font-size: var(--text-4xl);
+      line-height: var(--tw-leading, var(--text-4xl--line-height));
+    }
+    &:where(.dark, .dark *) {
+      color: var(--color-white);
+    }
+  }
+  .section-title {
+    font-size: var(--text-xl);
+    line-height: var(--tw-leading, var(--text-xl--line-height));
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    --tw-tracking: var(--tracking-tight);
+    letter-spacing: var(--tracking-tight);
+    color: var(--color-gray-950);
+    &:where(.dark, .dark *) {
+      color: var(--color-white);
+    }
+  }
+  .button-primary, .button-secondary {
+    display: inline-flex;
+    min-height: calc(var(--spacing) * 11);
+    align-items: center;
+    justify-content: center;
+    gap: calc(var(--spacing) * 2);
+    border-radius: var(--radius-md);
+    padding-inline: calc(var(--spacing) * 5);
+    padding-block: calc(var(--spacing) * 2.5);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+    &:focus-visible {
+      outline-style: var(--tw-outline-style);
+      outline-width: 2px;
+    }
+    &:focus-visible {
+      outline-offset: 4px;
+    }
+    &:focus-visible {
+      outline-color: var(--color-blue-700);
+    }
+    &:disabled {
+      cursor: not-allowed;
+    }
+    &:disabled {
+      opacity: 50%;
+    }
+    &:where(.dark, .dark *) {
+      &:focus-visible {
+        outline-color: var(--color-blue-300);
+      }
+    }
+  }
+  .button-primary {
+    background-color: var(--color-blue-700);
+    color: var(--color-white);
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-blue-800);
+      }
+    }
+    &:where(.dark, .dark *) {
+      background-color: var(--color-blue-300);
+    }
+    &:where(.dark, .dark *) {
+      color: var(--color-blue-950);
+    }
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          background-color: var(--color-blue-200);
+        }
+      }
+    }
+  }
+  .button-secondary {
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+    border-color: var(--color-gray-300);
+    color: var(--color-gray-700);
+    &:hover {
+      @media (hover: hover) {
+        border-color: var(--color-blue-700);
+      }
+    }
+    &:hover {
+      @media (hover: hover) {
+        color: var(--color-blue-700);
+      }
+    }
+    &:where(.dark, .dark *) {
+      border-color: var(--color-gray-600);
+    }
+    &:where(.dark, .dark *) {
+      color: var(--color-gray-200);
+    }
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          border-color: var(--color-blue-300);
+        }
+      }
+    }
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          color: var(--color-blue-300);
+        }
+      }
+    }
+  }
+  .text-link {
+    display: inline-flex;
+    min-height: calc(var(--spacing) * 11);
+    align-items: center;
+    gap: calc(var(--spacing) * 2);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-blue-700);
+    text-decoration-line: underline;
+    text-decoration-color: var(--color-blue-200);
+    text-underline-offset: 4px;
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+    &:hover {
+      @media (hover: hover) {
+        text-decoration-color: var(--color-blue-700);
+      }
+    }
+    &:focus-visible {
+      outline-style: var(--tw-outline-style);
+      outline-width: 2px;
+    }
+    &:focus-visible {
+      outline-offset: 4px;
+    }
+    &:focus-visible {
+      outline-color: var(--color-blue-700);
+    }
+    &:where(.dark, .dark *) {
+      color: var(--color-blue-300);
+    }
+    &:where(.dark, .dark *) {
+      text-decoration-color: var(--color-blue-800);
+    }
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          text-decoration-color: var(--color-blue-300);
+        }
+      }
+    }
+    &:where(.dark, .dark *) {
+      &:focus-visible {
+        outline-color: var(--color-blue-300);
+      }
+    }
+  }
+  .policy-content {
+    max-width: var(--container-2xl);
+    font-size: var(--text-base);
+    line-height: var(--tw-leading, var(--text-base--line-height));
+    --tw-leading: calc(var(--spacing) * 7);
+    line-height: calc(var(--spacing) * 7);
+    color: var(--color-gray-600);
+    &:where(.dark, .dark *) {
+      color: var(--color-gray-400);
+    }
+  }
+  .policy-content section {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
+    border-color: var(--color-gray-200);
+    padding-block: calc(var(--spacing) * 8);
+    &:where(.dark, .dark *) {
+      border-color: var(--color-gray-700);
+    }
+  }
+  .policy-content h2 {
+    margin-bottom: calc(var(--spacing) * 4);
+    font-size: var(--text-xl);
+    line-height: var(--tw-leading, var(--text-xl--line-height));
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    --tw-tracking: var(--tracking-tight);
+    letter-spacing: var(--tracking-tight);
+    color: var(--color-gray-950);
+    &:where(.dark, .dark *) {
+      color: var(--color-white);
+    }
+  }
+  .policy-content p + p, .policy-content ul + p {
+    margin-top: calc(var(--spacing) * 4);
+  }
+  .policy-content ul {
+    margin-top: calc(var(--spacing) * 4);
+    list-style-type: disc;
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 0;
+      margin-block-start: calc(calc(var(--spacing) * 2) * var(--tw-space-y-reverse));
+      margin-block-end: calc(calc(var(--spacing) * 2) * calc(1 - var(--tw-space-y-reverse)));
+    }
+    padding-left: calc(var(--spacing) * 5);
+  }
+  .policy-content strong {
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+    color: var(--color-gray-950);
+    &:where(.dark, .dark *) {
+      color: var(--color-gray-200);
+    }
+  }
+  .policy-content a {
+    overflow-wrap: anywhere;
+    color: var(--color-blue-700);
+    text-decoration-line: underline;
+    text-decoration-color: var(--color-blue-200);
+    text-underline-offset: 4px;
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+    &:hover {
+      @media (hover: hover) {
+        text-decoration-color: var(--color-blue-700);
+      }
+    }
+    &:focus-visible {
+      outline-style: var(--tw-outline-style);
+      outline-width: 2px;
+    }
+    &:focus-visible {
+      outline-offset: 4px;
+    }
+    &:focus-visible {
+      outline-color: var(--color-blue-700);
+    }
+    &:where(.dark, .dark *) {
+      color: var(--color-blue-300);
+    }
+    &:where(.dark, .dark *) {
+      text-decoration-color: var(--color-blue-800);
+    }
+    &:where(.dark, .dark *) {
+      &:hover {
+        @media (hover: hover) {
+          text-decoration-color: var(--color-blue-300);
+        }
+      }
+    }
+    &:where(.dark, .dark *) {
+      &:focus-visible {
+        outline-color: var(--color-blue-300);
+      }
+    }
+  }
+  .policy-content code {
+    border-radius: 0.25rem;
+    background-color: var(--color-gray-100);
+    padding-inline: var(--spacing);
+    padding-block: calc(var(--spacing) * 0.5);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    color: var(--color-gray-900);
+    &:where(.dark, .dark *) {
+      background-color: var(--color-gray-800);
+    }
+    &:where(.dark, .dark *) {
+      color: var(--color-gray-200);
+    }
   }
 }
 .htmx-indicator {
@@ -1896,14 +1880,14 @@
   min-width: 0;
 }
 .phase-description a {
-  color: oklch(54.6% 0.245 262.881);
+  color: #1264c0;
   text-decoration: underline;
 }
 .phase-description a:hover {
   text-decoration: none;
 }
 .dark .phase-description a {
-  color: oklch(70.7% 0.165 254.624);
+  color: #52b7fa;
 }
 .callout-tip {
   background-color: oklch(98.2% 0.018 155.826);
@@ -1936,14 +1920,14 @@
   color: oklch(88.5% 0.062 18.334);
 }
 .callout-note {
-  background-color: oklch(97% 0.014 254.604);
-  border-color: oklch(80.9% 0.105 251.813);
-  color: oklch(42.4% 0.199 265.638);
+  background-color: #f0f8ff;
+  border-color: #83dcff;
+  color: #103f7d;
 }
 .dark .callout-note {
-  background-color: color-mix(in srgb, oklch(37.9% 0.146 265.522) 20%, transparent);
-  border-color: oklch(48.8% 0.243 264.376);
-  color: oklch(88.2% 0.059 254.128);
+  background-color: color-mix(in srgb, #102f56 20%, transparent);
+  border-color: #124d99;
+  color: #b7d8f9;
 }
 @property --tw-rotate-x {
   syntax: "*";
@@ -1966,6 +1950,11 @@
   inherits: false;
 }
 @property --tw-space-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-divide-y-reverse {
   syntax: "*";
   inherits: false;
   initial-value: 0;
@@ -2143,6 +2132,7 @@
       --tw-skew-x: initial;
       --tw-skew-y: initial;
       --tw-space-y-reverse: 0;
+      --tw-divide-y-reverse: 0;
       --tw-border-style: solid;
       --tw-leading: initial;
       --tw-font-weight: initial;

--- a/api/src/learn_to_cloud/static/css/styles.css
+++ b/api/src/learn_to_cloud/static/css/styles.css
@@ -34,9 +34,7 @@
     --color-green-100: oklch(96.2% 0.044 156.743);
     --color-green-200: oklch(92.5% 0.084 155.995);
     --color-green-300: oklch(87.1% 0.15 154.449);
-    --color-green-400: oklch(79.2% 0.209 151.711);
     --color-green-500: oklch(72.3% 0.219 149.579);
-    --color-green-600: oklch(62.7% 0.194 149.214);
     --color-green-700: oklch(52.7% 0.154 150.069);
     --color-green-800: oklch(44.8% 0.119 151.328);
     --color-green-900: oklch(39.3% 0.095 152.535);
@@ -75,6 +73,7 @@
     --container-xs: 20rem;
     --container-sm: 24rem;
     --container-md: 28rem;
+    --container-lg: 32rem;
     --container-xl: 36rem;
     --container-2xl: 42rem;
     --container-3xl: 48rem;
@@ -98,15 +97,17 @@
     --text-5xl--line-height: 1;
     --text-6xl: 3.75rem;
     --text-6xl--line-height: 1;
+    --text-7xl: 4.5rem;
+    --text-7xl--line-height: 1;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
+    --tracking-tight: -0.025em;
     --tracking-wide: 0.025em;
     --radius-sm: 0.25rem;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --animate-spin: spin 1s linear infinite;
-    --blur-3xl: 64px;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
@@ -301,9 +302,6 @@
   .top-2 {
     top: calc(var(--spacing) * 2);
   }
-  .top-8 {
-    top: calc(var(--spacing) * 8);
-  }
   .top-full {
     top: 100%;
   }
@@ -312,9 +310,6 @@
   }
   .right-2 {
     right: calc(var(--spacing) * 2);
-  }
-  .-z-10 {
-    z-index: calc(10 * -1);
   }
   .z-50 {
     z-index: 50;
@@ -382,6 +377,9 @@
   .mt-8 {
     margin-top: calc(var(--spacing) * 8);
   }
+  .mt-9 {
+    margin-top: calc(var(--spacing) * 9);
+  }
   .mt-10 {
     margin-top: calc(var(--spacing) * 10);
   }
@@ -423,9 +421,6 @@
   }
   .ml-2 {
     margin-left: calc(var(--spacing) * 2);
-  }
-  .ml-auto {
-    margin-left: auto;
   }
   .block {
     display: block;
@@ -484,20 +479,20 @@
   .h-16 {
     height: calc(var(--spacing) * 16);
   }
-  .h-56 {
-    height: calc(var(--spacing) * 56);
-  }
   .h-full {
     height: 100%;
   }
   .h-px {
     height: 1px;
   }
-  .max-h-64 {
-    max-height: calc(var(--spacing) * 64);
+  .min-h-9 {
+    min-height: calc(var(--spacing) * 9);
   }
   .min-h-11 {
     min-height: calc(var(--spacing) * 11);
+  }
+  .min-h-12 {
+    min-height: calc(var(--spacing) * 12);
   }
   .w-4 {
     width: calc(var(--spacing) * 4);
@@ -526,9 +521,6 @@
   .w-48 {
     width: calc(var(--spacing) * 48);
   }
-  .w-56 {
-    width: calc(var(--spacing) * 56);
-  }
   .w-full {
     width: 100%;
   }
@@ -540,6 +532,9 @@
   }
   .max-w-content {
     max-width: var(--container-content);
+  }
+  .max-w-lg {
+    max-width: var(--container-lg);
   }
   .max-w-md {
     max-width: var(--container-md);
@@ -586,9 +581,6 @@
   .resize {
     resize: both;
   }
-  .scrollbar-thin {
-    scrollbar-width: thin;
-  }
   .list-inside {
     list-style-position: inside;
   }
@@ -603,9 +595,6 @@
   }
   .grid-cols-\[3rem_1fr\] {
     grid-template-columns: 3rem 1fr;
-  }
-  .grid-cols-\[3rem_1fr_auto\] {
-    grid-template-columns: 3rem 1fr auto;
   }
   .flex-col {
     flex-direction: column;
@@ -658,9 +647,6 @@
   .gap-8 {
     gap: calc(var(--spacing) * 8);
   }
-  .gap-12 {
-    gap: calc(var(--spacing) * 12);
-  }
   :where(.space-y-1 > :not(:last-child)) {
     --tw-space-y-reverse: 0;
     margin-block-start: calc(var(--spacing) * var(--tw-space-y-reverse));
@@ -681,6 +667,11 @@
     margin-block-start: calc(calc(var(--spacing) * 4) * var(--tw-space-y-reverse));
     margin-block-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-y-reverse)));
   }
+  :where(.space-y-5 > :not(:last-child)) {
+    --tw-space-y-reverse: 0;
+    margin-block-start: calc(calc(var(--spacing) * 5) * var(--tw-space-y-reverse));
+    margin-block-end: calc(calc(var(--spacing) * 5) * calc(1 - var(--tw-space-y-reverse)));
+  }
   :where(.space-y-6 > :not(:last-child)) {
     --tw-space-y-reverse: 0;
     margin-block-start: calc(calc(var(--spacing) * 6) * var(--tw-space-y-reverse));
@@ -691,18 +682,14 @@
     margin-block-start: calc(calc(var(--spacing) * 8) * var(--tw-space-y-reverse));
     margin-block-end: calc(calc(var(--spacing) * 8) * calc(1 - var(--tw-space-y-reverse)));
   }
+  .gap-x-6 {
+    column-gap: calc(var(--spacing) * 6);
+  }
   .gap-x-8 {
     column-gap: calc(var(--spacing) * 8);
   }
-  :where(.divide-y > :not(:last-child)) {
-    --tw-divide-y-reverse: 0;
-    border-bottom-style: var(--tw-border-style);
-    border-top-style: var(--tw-border-style);
-    border-top-width: calc(1px * var(--tw-divide-y-reverse));
-    border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
-  }
-  :where(.divide-blue-100 > :not(:last-child)) {
-    border-color: var(--color-blue-100);
+  .gap-y-3 {
+    row-gap: calc(var(--spacing) * 3);
   }
   .truncate {
     overflow: hidden;
@@ -714,9 +701,6 @@
   }
   .overflow-x-auto {
     overflow-x: auto;
-  }
-  .overflow-y-auto {
-    overflow-y: auto;
   }
   .overflow-y-scroll {
     overflow-y: scroll;
@@ -814,12 +798,6 @@
   .bg-blue-100 {
     background-color: var(--color-blue-100);
   }
-  .bg-blue-100\/70 {
-    background-color: color-mix(in srgb, oklch(93.2% 0.032 255.585) 70%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-blue-100) 70%, transparent);
-    }
-  }
   .bg-blue-400 {
     background-color: var(--color-blue-400);
   }
@@ -840,6 +818,9 @@
   }
   .bg-gray-900 {
     background-color: var(--color-gray-900);
+  }
+  .bg-gray-950 {
+    background-color: var(--color-gray-950);
   }
   .bg-green-50 {
     background-color: var(--color-green-50);
@@ -867,6 +848,12 @@
   }
   .bg-white {
     background-color: var(--color-white);
+  }
+  .bg-white\/60 {
+    background-color: color-mix(in srgb, #fff 60%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 60%, transparent);
+    }
   }
   .bg-zinc-100 {
     background-color: var(--color-zinc-100);
@@ -937,8 +924,14 @@
   .py-8 {
     padding-block: calc(var(--spacing) * 8);
   }
+  .py-12 {
+    padding-block: calc(var(--spacing) * 12);
+  }
   .py-16 {
     padding-block: calc(var(--spacing) * 16);
+  }
+  .pt-1 {
+    padding-top: var(--spacing);
   }
   .pt-4 {
     padding-top: calc(var(--spacing) * 4);
@@ -957,9 +950,6 @@
   }
   .pt-14 {
     padding-top: calc(var(--spacing) * 14);
-  }
-  .pt-16 {
-    padding-top: calc(var(--spacing) * 16);
   }
   .pr-4 {
     padding-right: calc(var(--spacing) * 4);
@@ -982,11 +972,14 @@
   .pb-12 {
     padding-bottom: calc(var(--spacing) * 12);
   }
-  .pb-16 {
-    padding-bottom: calc(var(--spacing) * 16);
+  .pb-20 {
+    padding-bottom: calc(var(--spacing) * 20);
   }
   .pl-1 {
     padding-left: var(--spacing);
+  }
+  .pl-10 {
+    padding-left: calc(var(--spacing) * 10);
   }
   .pl-16 {
     padding-left: calc(var(--spacing) * 16);
@@ -999,6 +992,9 @@
   }
   .text-right {
     text-align: right;
+  }
+  .font-mono {
+    font-family: var(--font-mono);
   }
   .text-2xl {
     font-size: var(--text-2xl);
@@ -1052,6 +1048,10 @@
     --tw-leading: calc(var(--spacing) * 8);
     line-height: calc(var(--spacing) * 8);
   }
+  .leading-\[1\.08\] {
+    --tw-leading: 1.08;
+    line-height: 1.08;
+  }
   .font-bold {
     --tw-font-weight: var(--font-weight-bold);
     font-weight: var(--font-weight-bold);
@@ -1080,6 +1080,10 @@
     --tw-tracking: -0.035em;
     letter-spacing: -0.035em;
   }
+  .tracking-\[-0\.045em\] {
+    --tw-tracking: -0.045em;
+    letter-spacing: -0.045em;
+  }
   .tracking-\[0\.12em\] {
     --tw-tracking: 0.12em;
     letter-spacing: 0.12em;
@@ -1087,6 +1091,10 @@
   .tracking-\[0\.16em\] {
     --tw-tracking: 0.16em;
     letter-spacing: 0.16em;
+  }
+  .tracking-tight {
+    --tw-tracking: var(--tracking-tight);
+    letter-spacing: var(--tracking-tight);
   }
   .tracking-wide {
     --tw-tracking: var(--tracking-wide);
@@ -1097,9 +1105,6 @@
   }
   .break-words {
     overflow-wrap: break-word;
-  }
-  .break-all {
-    word-break: break-all;
   }
   .text-amber-600 {
     color: var(--color-amber-600);
@@ -1155,14 +1160,14 @@
   .text-green-500 {
     color: var(--color-green-500);
   }
-  .text-green-600 {
-    color: var(--color-green-600);
-  }
   .text-green-700 {
     color: var(--color-green-700);
   }
   .text-green-800 {
     color: var(--color-green-800);
+  }
+  .text-green-900 {
+    color: var(--color-green-900);
   }
   .text-green-950 {
     color: var(--color-green-950);
@@ -1182,6 +1187,9 @@
   .text-red-800 {
     color: var(--color-red-800);
   }
+  .text-red-900 {
+    color: var(--color-red-900);
+  }
   .text-white {
     color: var(--color-white);
   }
@@ -1193,9 +1201,6 @@
   }
   .uppercase {
     text-transform: uppercase;
-  }
-  .italic {
-    font-style: italic;
   }
   .line-through {
     text-decoration-line: line-through;
@@ -1219,26 +1224,12 @@
     --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
-  .shadow-sm {
-    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
-    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-  }
   .ring-1 {
     --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
-  .shadow-blue-950\/20 {
-    --tw-shadow-color: color-mix(in srgb, oklch(28.2% 0.091 267.935) 20%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-blue-950) 20%, transparent) var(--tw-shadow-alpha), transparent);
-    }
-  }
   .ring-gray-200 {
     --tw-ring-color: var(--color-gray-200);
-  }
-  .blur-3xl {
-    --tw-blur: blur(var(--blur-3xl));
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
@@ -1276,18 +1267,8 @@
       --tw-translate-x: calc(var(--spacing) * 0.5);
       translate: var(--tw-translate-x) var(--tw-translate-y);
     }
-    .group-hover\:translate-x-1:is(:where(.group):hover *) {
-      --tw-translate-x: var(--spacing);
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
-    .group-hover\:bg-blue-100:is(:where(.group):hover *) {
-      background-color: var(--color-blue-100);
-    }
     .group-hover\:text-blue-700:is(:where(.group):hover *) {
       color: var(--color-blue-700);
-    }
-    .group-hover\:text-blue-900:is(:where(.group):hover *) {
-      color: var(--color-blue-900);
     }
     .group-hover\/topic\:translate-x-0\.5:is(:where(.group\/topic):hover *) {
       --tw-translate-x: calc(var(--spacing) * 0.5);
@@ -1312,9 +1293,6 @@
     outline-color: var(--color-blue-700);
   }
   @media (hover: hover) {
-    .hover\:border-blue-300:hover {
-      border-color: var(--color-blue-300);
-    }
     .hover\:border-blue-400:hover {
       border-color: var(--color-blue-400);
     }
@@ -1339,6 +1317,9 @@
     .hover\:bg-red-500:hover {
       background-color: var(--color-red-500);
     }
+    .hover\:bg-white:hover {
+      background-color: var(--color-white);
+    }
     .hover\:text-blue-500:hover {
       color: var(--color-blue-500);
     }
@@ -1351,8 +1332,14 @@
     .hover\:text-gray-700:hover {
       color: var(--color-gray-700);
     }
+    .hover\:text-gray-800:hover {
+      color: var(--color-gray-800);
+    }
     .hover\:text-gray-900:hover {
       color: var(--color-gray-900);
+    }
+    .hover\:text-gray-950:hover {
+      color: var(--color-gray-950);
     }
     .hover\:no-underline:hover {
       text-decoration-line: none;
@@ -1360,11 +1347,11 @@
     .hover\:underline:hover {
       text-decoration-line: underline;
     }
-    .hover\:decoration-blue-500:hover {
-      text-decoration-color: var(--color-blue-500);
-    }
     .hover\:decoration-blue-600:hover {
       text-decoration-color: var(--color-blue-600);
+    }
+    .hover\:decoration-gray-950:hover {
+      text-decoration-color: var(--color-gray-950);
     }
   }
   .focus\:border-blue-500:focus {
@@ -1403,6 +1390,15 @@
   .focus-visible\:outline-blue-700:focus-visible {
     outline-color: var(--color-blue-700);
   }
+  .focus-visible\:outline-gray-700:focus-visible {
+    outline-color: var(--color-gray-700);
+  }
+  .focus-visible\:outline-green-700:focus-visible {
+    outline-color: var(--color-green-700);
+  }
+  .focus-visible\:outline-red-700:focus-visible {
+    outline-color: var(--color-red-700);
+  }
   .disabled\:opacity-50:disabled {
     opacity: 50%;
   }
@@ -1440,14 +1436,14 @@
     .sm\:grid-cols-2 {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
+    .sm\:grid-cols-3 {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
     .sm\:grid-cols-\[2\.75rem_1fr_auto\] {
       grid-template-columns: 2.75rem 1fr auto;
     }
     .sm\:grid-cols-\[4rem_1fr\] {
       grid-template-columns: 4rem 1fr;
-    }
-    .sm\:grid-cols-\[4rem_1fr_auto\] {
-      grid-template-columns: 4rem 1fr auto;
     }
     .sm\:grid-cols-\[minmax\(0\,1fr\)_auto\] {
       grid-template-columns: minmax(0,1fr) auto;
@@ -1476,6 +1472,9 @@
     .sm\:gap-6 {
       gap: calc(var(--spacing) * 6);
     }
+    .sm\:gap-7 {
+      gap: calc(var(--spacing) * 7);
+    }
     .sm\:gap-8 {
       gap: calc(var(--spacing) * 8);
     }
@@ -1493,6 +1492,9 @@
     .sm\:px-6 {
       padding-inline: calc(var(--spacing) * 6);
     }
+    .sm\:py-16 {
+      padding-block: calc(var(--spacing) * 16);
+    }
     .sm\:pt-0 {
       padding-top: 0px;
     }
@@ -1501,9 +1503,6 @@
     }
     .sm\:pt-8 {
       padding-top: calc(var(--spacing) * 8);
-    }
-    .sm\:pt-12 {
-      padding-top: calc(var(--spacing) * 12);
     }
     .sm\:pt-14 {
       padding-top: calc(var(--spacing) * 14);
@@ -1520,8 +1519,8 @@
     .sm\:pb-16 {
       padding-bottom: calc(var(--spacing) * 16);
     }
-    .sm\:pb-20 {
-      padding-bottom: calc(var(--spacing) * 20);
+    .sm\:pb-28 {
+      padding-bottom: calc(var(--spacing) * 28);
     }
     .sm\:pl-6 {
       padding-left: calc(var(--spacing) * 6);
@@ -1531,6 +1530,10 @@
     }
     .sm\:pl-\[5\.75rem\] {
       padding-left: 5.75rem;
+    }
+    .sm\:text-3xl {
+      font-size: var(--text-3xl);
+      line-height: var(--tw-leading, var(--text-3xl--line-height));
     }
     .sm\:text-4xl {
       font-size: var(--text-4xl);
@@ -1544,15 +1547,8 @@
       font-size: var(--text-6xl);
       line-height: var(--tw-leading, var(--text-6xl--line-height));
     }
-    .sm\:leading-\[1\.05\] {
-      --tw-leading: 1.05;
-      line-height: 1.05;
-    }
   }
   @media (width >= 64rem) {
-    .lg\:grid-cols-\[minmax\(0\,1\.2fr\)_minmax\(17rem\,0\.8fr\)\] {
-      grid-template-columns: minmax(0,1.2fr) minmax(17rem,0.8fr);
-    }
     .lg\:px-8 {
       padding-inline: calc(var(--spacing) * 8);
     }
@@ -1562,9 +1558,6 @@
   }
   .dark\:hidden:where(.dark, .dark *) {
     display: none;
-  }
-  :where(.dark\:divide-blue-900:where(.dark, .dark *) > :not(:last-child)) {
-    border-color: var(--color-blue-900);
   }
   .dark\:border-amber-800:where(.dark, .dark *) {
     border-color: var(--color-amber-800);
@@ -1635,12 +1628,6 @@
       background-color: color-mix(in oklab, var(--color-blue-950) 40%, transparent);
     }
   }
-  .dark\:bg-blue-950\/50:where(.dark, .dark *) {
-    background-color: color-mix(in srgb, oklch(28.2% 0.091 267.935) 50%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-blue-950) 50%, transparent);
-    }
-  }
   .dark\:bg-gray-700:where(.dark, .dark *) {
     background-color: var(--color-gray-700);
   }
@@ -1655,6 +1642,12 @@
   }
   .dark\:bg-gray-900:where(.dark, .dark *) {
     background-color: var(--color-gray-900);
+  }
+  .dark\:bg-gray-950\/20:where(.dark, .dark *) {
+    background-color: color-mix(in srgb, oklch(13% 0.028 261.692) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-gray-950) 20%, transparent);
+    }
   }
   .dark\:bg-green-800\/40:where(.dark, .dark *) {
     background-color: color-mix(in srgb, oklch(44.8% 0.119 151.328) 40%, transparent);
@@ -1749,6 +1742,9 @@
   .dark\:text-gray-900:where(.dark, .dark *) {
     color: var(--color-gray-900);
   }
+  .dark\:text-gray-950:where(.dark, .dark *) {
+    color: var(--color-gray-950);
+  }
   .dark\:text-green-100:where(.dark, .dark *) {
     color: var(--color-green-100);
   }
@@ -1758,14 +1754,14 @@
   .dark\:text-green-300:where(.dark, .dark *) {
     color: var(--color-green-300);
   }
-  .dark\:text-green-400:where(.dark, .dark *) {
-    color: var(--color-green-400);
-  }
   .dark\:text-indigo-400:where(.dark, .dark *) {
     color: var(--color-indigo-400);
   }
   .dark\:text-orange-400:where(.dark, .dark *) {
     color: var(--color-orange-400);
+  }
+  .dark\:text-red-100:where(.dark, .dark *) {
+    color: var(--color-red-100);
   }
   .dark\:text-red-200:where(.dark, .dark *) {
     color: var(--color-red-200);
@@ -1792,12 +1788,6 @@
     --tw-ring-color: var(--color-gray-700);
   }
   @media (hover: hover) {
-    .dark\:group-hover\:bg-blue-900:where(.dark, .dark *):is(:where(.group):hover *) {
-      background-color: var(--color-blue-900);
-    }
-    .dark\:group-hover\:text-blue-100:where(.dark, .dark *):is(:where(.group):hover *) {
-      color: var(--color-blue-100);
-    }
     .dark\:group-hover\:text-blue-300:where(.dark, .dark *):is(:where(.group):hover *) {
       color: var(--color-blue-300);
     }
@@ -1809,9 +1799,6 @@
     }
     .dark\:hover\:border-blue-500:where(.dark, .dark *):hover {
       border-color: var(--color-blue-500);
-    }
-    .dark\:hover\:border-blue-700:where(.dark, .dark *):hover {
-      border-color: var(--color-blue-700);
     }
     .dark\:hover\:bg-blue-300:where(.dark, .dark *):hover {
       background-color: var(--color-blue-300);
@@ -1836,6 +1823,14 @@
         background-color: color-mix(in oklab, var(--color-gray-800) 50%, transparent);
       }
     }
+    .dark\:hover\:bg-gray-950\/40:where(.dark, .dark *):hover {
+      background-color: color-mix(in srgb, oklch(13% 0.028 261.692) 40%, transparent);
+    }
+    @supports (color: color-mix(in lab, red, red)) {
+      .dark\:hover\:bg-gray-950\/40:where(.dark, .dark *):hover {
+        background-color: color-mix(in oklab, var(--color-gray-950) 40%, transparent);
+      }
+    }
     .dark\:hover\:text-blue-300:where(.dark, .dark *):hover {
       color: var(--color-blue-300);
     }
@@ -1851,6 +1846,12 @@
     .dark\:hover\:decoration-blue-300:where(.dark, .dark *):hover {
       text-decoration-color: var(--color-blue-300);
     }
+    .dark\:hover\:decoration-white:where(.dark, .dark *):hover {
+      text-decoration-color: var(--color-white);
+    }
+  }
+  .dark\:focus-visible\:outline-blue-300:where(.dark, .dark *):focus-visible {
+    outline-color: var(--color-blue-300);
   }
   .\[\&\>p\]\:m-0 > p {
     margin: 0px;
@@ -1965,11 +1966,6 @@
   inherits: false;
 }
 @property --tw-space-y-reverse {
-  syntax: "*";
-  inherits: false;
-  initial-value: 0;
-}
-@property --tw-divide-y-reverse {
   syntax: "*";
   inherits: false;
   initial-value: 0;
@@ -2147,7 +2143,6 @@
       --tw-skew-x: initial;
       --tw-skew-y: initial;
       --tw-space-y-reverse: 0;
-      --tw-divide-y-reverse: 0;
       --tw-border-style: solid;
       --tw-leading: initial;
       --tw-font-weight: initial;

--- a/api/src/learn_to_cloud/templates/base.html
+++ b/api/src/learn_to_cloud/templates/base.html
@@ -155,7 +155,7 @@
     {% include "partials/navbar.html" %}
 
     <main
-        class="flex-1 w-full mx-auto max-w-content px-4 sm:px-6 lg:px-8 py-8"
+        class="flex-1 w-full mx-auto max-w-content px-4 sm:px-6 lg:px-8 py-10 sm:py-12"
         {% if frontend_telemetry %}data-telemetry-route="{{ frontend_telemetry.route_path }}"{% endif %}
     >
         {% block content %}{% endblock %}

--- a/api/src/learn_to_cloud/templates/layouts/content_page.html
+++ b/api/src/learn_to_cloud/templates/layouts/content_page.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 {# Page header: breadcrumb + title + optional description/progress #}
-<div class="mb-8">
+<div class="mb-10">
     {% block breadcrumb %}{% endblock %}
     {% block page_header %}{% endblock %}
 </div>

--- a/api/src/learn_to_cloud/templates/macros/badges.html
+++ b/api/src/learn_to_cloud/templates/macros/badges.html
@@ -1,24 +1,24 @@
 {# Reusable badge components for the curriculum UI.
 
 Macros:
-- action_badge(action) — colored pill for a StepAction enum value
-- step_number_badge(order, completed) — circular step-number badge
+- action_badge(action) — quiet label for a StepAction enum value
+- step_number_badge(order, completed) — step-number indicator
 - status_pill(label, variant) — top-right status indicator
   (variant ∈ "success" | "warning" | "error" | "info")
 #}
 
 {% macro action_badge(action) %}
 {% if action %}
-<span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold tracking-wide uppercase {{ action.badge_classes }}">
+<span class="inline-flex items-center text-xs font-medium tracking-wide text-gray-500 dark:text-gray-400 uppercase">
     {{ action.label }}
 </span>
 {% endif %}
 {% endmacro %}
 
 {% macro step_number_badge(order, completed) %}
-<span class="flex-shrink-0 flex items-center justify-center h-6 w-6 rounded-full text-xs font-bold
-    {% if completed %}bg-green-100 text-green-700 dark:bg-green-800/40 dark:text-green-300
-    {% else %}bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300{% endif %}">
+<span class="flex-shrink-0 flex items-center justify-center h-6 w-6 font-mono text-xs
+    {% if completed %}text-green-700 dark:text-green-300
+    {% else %}text-gray-500 dark:text-gray-400{% endif %}">
     {{ order }}
 </span>
 {% endmacro %}

--- a/api/src/learn_to_cloud/templates/pages/404.html
+++ b/api/src/learn_to_cloud/templates/pages/404.html
@@ -3,10 +3,10 @@
 
 {% block content %}
 <div class="text-center py-16">
-    <h1 class="text-6xl font-bold text-gray-300 dark:text-gray-700">404</h1>
-    <h2 class="mt-4 text-2xl font-semibold text-gray-900 dark:text-white">Page Not Found</h2>
+    <h1 class="text-6xl font-medium text-gray-500 dark:text-gray-400">404</h1>
+    <h2 class="section-title mt-4">Page Not Found</h2>
     <p class="mt-2 text-gray-600 dark:text-gray-400">The page you're looking for doesn't exist.</p>
-    <a href="/" class="mt-6 inline-block text-sm font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400">
+    <a href="/" class="text-link mt-6">
         ← Back to home
     </a>
 </div>

--- a/api/src/learn_to_cloud/templates/pages/account.html
+++ b/api/src/learn_to_cloud/templates/pages/account.html
@@ -2,19 +2,19 @@
 {% block title %}Account - Learn to Cloud{% endblock %}
 
 {% block page_header %}
-<h1 class="text-3xl font-bold text-gray-900 dark:text-white">Account</h1>
+<h1 class="page-title">Account</h1>
 {% endblock %}
 
 {% block page_body %}
 <div x-data="{ confirmDelete: false }">
-    <h2 class="text-sm font-semibold text-gray-900 dark:text-white mb-2">Delete Account</h2>
+    <h2 class="section-title mb-3">Delete Account</h2>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
         Deleting your account will permanently remove your profile, progress, and submissions. This cannot be undone.
     </p>
 
     <button
         @click="confirmDelete = true"
-        class="inline-flex items-center gap-2 rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white hover:bg-red-500 transition-colors"
+        class="inline-flex min-h-11 items-center gap-2 rounded-md border border-red-600 px-4 py-2.5 text-sm font-medium text-red-700 transition-colors hover:bg-red-50 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-red-600 dark:border-red-400 dark:text-red-300 dark:hover:bg-red-950"
     >
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -40,14 +40,14 @@
             <div class="flex gap-3 justify-end">
                 <button
                     @click="confirmDelete = false"
-                    class="rounded-md px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                    class="button-secondary"
                 >
                     Cancel
                 </button>
                 <button
                     hx-delete="/htmx/account"
                     hx-swap="none"
-                    class="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white hover:bg-red-500 transition-colors"
+                    class="min-h-11 rounded-md bg-red-700 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-800 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-red-600"
                 >
                     Delete my account
                 </button>

--- a/api/src/learn_to_cloud/templates/pages/community.html
+++ b/api/src/learn_to_cloud/templates/pages/community.html
@@ -4,126 +4,107 @@
 {% block description %}Meet the Learn to Cloud community, explore verified learner progress, celebrate curriculum graduates, and see the latest updates.{% endblock %}
 
 {% block content %}
-<header class="border-b border-gray-200 pb-12 pt-4 dark:border-gray-700 sm:pb-16 sm:pt-8">
-    <h1 class="text-balance text-4xl font-bold tracking-[-0.035em] text-gray-950 dark:text-white sm:text-5xl">Learn to Cloud community</h1>
-    <p class="mt-5 max-w-2xl text-lg leading-8 text-gray-600 dark:text-gray-300">
+<header class="pb-10">
+    <h1 class="page-title">Learn to Cloud community</h1>
+    <p class="mt-3 max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-400">
         Ask for help, learn in public, and see the verified work learners are completing across the curriculum.
     </p>
 </header>
 
-<section class="pt-12 sm:pt-16" aria-labelledby="connect-heading">
-    <div class="max-w-2xl">
-        <h2 id="connect-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Connect with the community</h2>
-        <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-300">Get unstuck, follow project updates, and find more ways to learn.</p>
-    </div>
-
-    <ul class="mt-8 grid gap-x-8 sm:grid-cols-2">
+<section aria-labelledby="connect-heading">
+    <h2 id="connect-heading" class="section-title">Connect with the community</h2>
+    <ul class="mt-5 grid gap-x-8 sm:grid-cols-2">
         {% for link in community_links %}
         <li class="border-t border-gray-200 dark:border-gray-700">
             <a href="{{ link.url }}" target="_blank" rel="noopener noreferrer"
-               class="group grid min-h-11 grid-cols-[2.75rem_1fr_auto] items-center gap-3 py-4 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700">
-                <span class="flex h-10 w-10 items-center justify-center rounded-md bg-gray-100 dark:bg-gray-800 {{ link.color }}" aria-hidden="true">
-                    {{ link.icon | safe }}
-                </span>
+               class="group grid min-h-11 grid-cols-[1.25rem_1fr_auto] items-center gap-4 py-5 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700">
+                <span class="text-gray-500 dark:text-gray-400" aria-hidden="true">{{ link.icon | safe }}</span>
                 <span>
-                    <span class="block text-sm font-bold text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ link.label }}</span>
+                    <span class="block text-base font-medium text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ link.label }}</span>
                     <span class="mt-1 block text-sm leading-5 text-gray-600 dark:text-gray-400">{{ link.description }}</span>
                 </span>
-                <svg class="h-4 w-4 text-gray-400 transition-transform group-hover:translate-x-0.5 group-hover:text-blue-700 dark:text-gray-500 dark:group-hover:text-blue-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
-                </svg>
+                <span class="text-gray-400 group-hover:text-blue-700 dark:group-hover:text-blue-300" aria-hidden="true">&rarr;</span>
             </a>
         </li>
         {% endfor %}
     </ul>
 </section>
 
-<section class="pt-14 sm:pt-16" aria-labelledby="activity-heading">
-    <div class="max-w-2xl">
-        <h2 id="activity-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">This week in the community</h2>
-    </div>
-
+<section class="mt-12 border-t border-gray-200 pt-10 dark:border-gray-700" aria-labelledby="activity-heading">
+    <h2 id="activity-heading" class="section-title">This week in the community</h2>
     {% if community.activity.active_learners or community.activity.projects_verified %}
-    <div class="mt-8 grid gap-6 rounded-lg border border-blue-200 bg-blue-50 p-6 dark:border-blue-900 dark:bg-blue-950/30 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+    <dl class="mt-6 grid grid-cols-3 gap-4 sm:gap-10">
         <div>
-            <p class="text-4xl font-bold tracking-[-0.035em] text-gray-950 dark:text-white">{{ community.activity.active_learners }} learner{% if community.activity.active_learners != 1 %}s{% endif %}</p>
-            <p class="mt-2 text-lg font-bold tracking-[-0.02em] text-gray-950 dark:text-white">worked on {{ community.activity.attempts }} verification{% if community.activity.attempts != 1 %}s{% endif %} in the past 7 days.</p>
+            <dt class="text-sm text-gray-500 dark:text-gray-400">Active learners</dt>
+            <dd class="mt-2 text-2xl font-medium text-gray-950 dark:text-white">{{ community.activity.active_learners }}</dd>
         </div>
-        <div class="border-t border-blue-200 pt-5 dark:border-blue-900 sm:border-l sm:border-t-0 sm:pl-6 sm:pt-0">
-            <p class="text-3xl font-bold tracking-[-0.035em] text-blue-700 dark:text-blue-300">{{ community.activity.projects_verified }}</p>
-            <p class="mt-1 text-sm leading-5 text-gray-600 dark:text-gray-300">projects verified</p>
+        <div>
+            <dt class="text-sm text-gray-500 dark:text-gray-400">Verification attempts</dt>
+            <dd class="mt-2 text-2xl font-medium text-gray-950 dark:text-white">{{ community.activity.attempts }}</dd>
         </div>
-    </div>
-
+        <div>
+            <dt class="text-sm text-gray-500 dark:text-gray-400">Projects verified</dt>
+            <dd class="mt-2 text-2xl font-medium text-gray-950 dark:text-white">{{ community.activity.projects_verified }}</dd>
+        </div>
+    </dl>
     {% if community.phase_activity %}
-    <div class="mt-10 max-w-3xl">
-        <h3 class="text-lg font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Where learners are working</h3>
-        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">Active learners and newly verified projects in the past 7 days.</p>
+    <div class="mt-8">
+        <h3 class="text-sm font-medium text-gray-600 dark:text-gray-400">Where learners are working</h3>
         <ul class="mt-4 border-y border-gray-200 dark:border-gray-700">
             {% for phase in community.phase_activity %}
-            <li class="grid gap-1 border-b border-gray-200 py-4 last:border-b-0 sm:grid-cols-[minmax(11rem,1fr)_minmax(11rem,1fr)_auto] sm:items-center sm:gap-4">
-                <p class="font-bold text-gray-950 dark:text-white">{{ phase.label }}</p>
-                <p class="text-sm text-gray-600 dark:text-gray-300">{{ phase.active_learners }} learner{% if phase.active_learners != 1 %}s{% endif %} &middot; {{ phase.attempts }} attempt{% if phase.attempts != 1 %}s{% endif %}</p>
-                <p class="text-sm font-bold text-blue-700 dark:text-blue-300">{{ phase.projects_verified }} verified</p>
+            <li class="grid gap-1 border-b border-gray-200 py-4 last:border-b-0 dark:border-gray-700 sm:grid-cols-[minmax(11rem,1fr)_minmax(11rem,1fr)_auto] sm:items-center sm:gap-4">
+                <p class="text-base font-medium text-gray-950 dark:text-white">{{ phase.label }}</p>
+                <p class="text-sm text-gray-600 dark:text-gray-400">{{ phase.active_learners }} learner{% if phase.active_learners != 1 %}s{% endif %} &middot; {{ phase.attempts }} attempt{% if phase.attempts != 1 %}s{% endif %}</p>
+                <p class="text-sm text-gray-600 dark:text-gray-400">{{ phase.projects_verified }} verified</p>
             </li>
             {% endfor %}
         </ul>
     </div>
     {% endif %}
     {% else %}
-    <div class="mt-8 rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
-        <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">No verification activity has been recorded in the past 7 days.</p>
-    </div>
+    <p class="mt-5 text-sm leading-6 text-gray-600 dark:text-gray-400">No verification activity has been recorded in the past 7 days.</p>
     {% endif %}
 </section>
 
-<section class="pt-14 sm:pt-16" aria-labelledby="graduates-heading">
-    <h2 id="graduates-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">
+<section class="mt-12 border-t border-gray-200 pt-10 dark:border-gray-700" aria-labelledby="graduates-heading">
+    <h2 id="graduates-heading" class="section-title">
         Curriculum graduates
-        <span class="ml-1 text-lg font-medium text-gray-500 dark:text-gray-400">({{ community.graduates | length }})</span>
+        <span class="ml-1 text-base font-normal text-gray-500 dark:text-gray-400">({{ community.graduates | length }})</span>
     </h2>
-    <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-300">Learners who have verified every project across all phases.</p>
-
+    <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">Learners who have verified every project across all phases.</p>
     {% if community.graduates %}
-    <ul class="mt-6 flex flex-wrap gap-2">
+    <ul class="mt-6 flex flex-wrap gap-x-6 gap-y-3">
         {% for member in community.graduates %}
         <li>
-            <a href="https://github.com/{{ member.github_username }}" target="_blank" rel="noopener noreferrer"
-               class="inline-flex min-h-11 items-center gap-2 rounded-full border border-gray-300 py-1 pl-1 pr-4 transition-colors hover:border-blue-400 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:hover:border-blue-500 dark:hover:text-blue-300">
+            <a href="https://github.com/{{ member.github_username }}" target="_blank" rel="noopener noreferrer" class="text-link">
                 {% if member.avatar_url %}
                 <img src="{{ member.avatar_url }}" alt="" class="h-9 w-9 rounded-full" loading="lazy">
                 {% else %}
-                <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-gray-200 text-sm font-bold text-gray-700 dark:bg-gray-700 dark:text-gray-200" aria-hidden="true">{{ member.github_username[0] | upper }}</span>
+                <span class="inline-flex h-9 w-9 items-center justify-center rounded-full bg-gray-100 text-sm text-gray-600 dark:bg-gray-800 dark:text-gray-300" aria-hidden="true">{{ member.github_username[0] | upper }}</span>
                 {% endif %}
-                <span class="text-sm font-bold">{{ member.github_username }}</span>
+                <span>{{ member.github_username }}</span>
                 <span class="sr-only">on GitHub</span>
             </a>
         </li>
         {% endfor %}
     </ul>
     {% else %}
-    <div class="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
-        <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">No learner has verified the entire curriculum yet. The first graduate will appear here.</p>
-    </div>
+    <p class="mt-5 text-sm leading-6 text-gray-600 dark:text-gray-400">No learner has verified the entire curriculum yet. The first graduate will appear here.</p>
     {% endif %}
 </section>
 
-<section class="pt-14 sm:pt-16" aria-labelledby="updates-heading">
-    <h2 id="updates-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Latest curriculum updates</h2>
-
+<details class="mt-12 border-t border-gray-200 pt-6 dark:border-gray-700">
+    <summary class="min-h-11 cursor-pointer rounded-sm py-3 text-base font-medium text-gray-950 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:text-white">Latest curriculum updates</summary>
     {% if community.repo_updates %}
-    <ul class="mt-6 border-y border-gray-200 dark:border-gray-700">
+    <ul class="mt-4">
         {% for repo in community.repo_updates %}
-        <li class="{% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %} py-5">
+        <li class="border-b border-gray-200 py-5 dark:border-gray-700">
             <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start sm:gap-6">
                 <div class="min-w-0">
-                    <a href="{{ repo.url }}" target="_blank" rel="noopener noreferrer"
-                       class="inline-flex min-h-11 items-center break-words text-base font-bold text-gray-950 transition-colors hover:text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-white dark:hover:text-blue-300">
-                        {{ repo.name }}
-                    </a>
+                    <a href="{{ repo.url }}" target="_blank" rel="noopener noreferrer" class="text-link break-words">{{ repo.name }}</a>
                     {% if repo.available %}
                     <a href="{{ repo.commit_url }}" target="_blank" rel="noopener noreferrer"
-                       class="inline-flex min-h-11 items-center break-words text-sm leading-6 text-gray-700 transition-colors hover:text-blue-700 focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-blue-300">
+                       class="flex min-h-11 items-center break-words text-sm leading-6 text-gray-600 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-400 dark:hover:text-blue-300">
                         {{ repo.commit_message or "(no commit message)" }}
                     </a>
                     {% else %}
@@ -133,9 +114,7 @@
                 {% if repo.available and (repo.commit_author or repo.committed_at) %}
                 <p class="text-xs text-gray-500 dark:text-gray-400 sm:pt-3">
                     {% if repo.commit_author %}{{ repo.commit_author }}{% endif %}
-                    {% if repo.committed_at %}
-                    <span class="mx-1">&middot;</span>{{ repo.committed_at.strftime('%b %d, %Y') }}
-                    {% endif %}
+                    {% if repo.committed_at %}<span class="mx-1">&middot;</span>{{ repo.committed_at.strftime('%b %d, %Y') }}{% endif %}
                 </p>
                 {% endif %}
             </div>
@@ -143,19 +122,17 @@
         {% endfor %}
     </ul>
     {% else %}
-    <div class="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
-        <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">Curriculum updates are temporarily unavailable.</p>
-    </div>
+    <p class="mt-5 text-sm leading-6 text-gray-600 dark:text-gray-400">Curriculum updates are temporarily unavailable.</p>
     {% endif %}
-</section>
+</details>
 
 {% if not user %}
-<section class="pb-0 pt-14 text-center sm:pt-16" aria-labelledby="join-heading">
-    <h2 id="join-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Build your own verified progress.</h2>
-    <p class="mx-auto mt-3 max-w-xl text-base leading-7 text-gray-600 dark:text-gray-300">Browse the curriculum freely. Sign in when you want to save progress and submit verification work.</p>
-    <div class="mt-6 flex flex-wrap justify-center gap-3">
-        <a href="/curriculum" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-5 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">Explore the curriculum</a>
-        <a href="/auth/login" hx-boost="false" class="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-300 px-5 py-2.5 text-sm font-bold text-gray-900 hover:border-blue-400 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:text-white dark:hover:border-blue-500 dark:hover:text-blue-300">Sign in with GitHub</a>
+<section class="mt-10 border-t border-gray-200 pt-10 dark:border-gray-700" aria-labelledby="join-heading">
+    <h2 id="join-heading" class="section-title">Build your own verified progress.</h2>
+    <p class="mt-3 max-w-xl text-base leading-7 text-gray-600 dark:text-gray-400">Browse the curriculum overview. Sign in when you want to learn, save progress, and submit verification work.</p>
+    <div class="mt-6 flex flex-wrap gap-5">
+        <a href="/curriculum" class="button-primary">Explore the curriculum</a>
+        <a href="/auth/login" hx-boost="false" class="text-link">Sign in with GitHub</a>
     </div>
 </section>
 {% endif %}

--- a/api/src/learn_to_cloud/templates/pages/curriculum.html
+++ b/api/src/learn_to_cloud/templates/pages/curriculum.html
@@ -4,50 +4,49 @@
 {% block description %}Explore the complete Learn to Cloud curriculum, from technical foundations through cloud deployment, DevOps, security, and career preparation.{% endblock %}
 
 {% block content %}
-<header class="border-b border-gray-200 pb-12 pt-4 dark:border-gray-700 sm:pb-16 sm:pt-8">
+<header class="border-b border-gray-200 pb-10 dark:border-gray-700">
     <div class="grid gap-8 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
         <div class="max-w-3xl">
-            <h1 class="text-balance text-4xl font-bold tracking-[-0.035em] text-gray-950 dark:text-white sm:text-5xl">
+            <h1 class="page-title">
                 The complete cloud curriculum.
             </h1>
-            <p class="mt-5 max-w-2xl text-lg leading-8 text-gray-600 dark:text-gray-300">
+            <p class="mt-3 max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-400">
                 Build your foundation first, then use it to create, deploy, automate, secure, and explain real cloud work.
             </p>
         </div>
         {% if user %}
-        <a href="/dashboard" class="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-300 px-4 py-2.5 text-sm font-bold text-gray-900 transition-colors hover:border-blue-500 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:text-white dark:hover:border-blue-400 dark:hover:text-blue-300">
+        <a href="/dashboard" class="text-link">
             View your progress
         </a>
         {% endif %}
     </div>
 
-    <div class="mt-8 grid gap-4 border-y border-blue-100 py-5 text-sm dark:border-blue-900 sm:grid-cols-2 sm:gap-8">
-        <p class="leading-6 text-blue-950 dark:text-blue-100">
-            <strong class="font-bold">Learn in sequence.</strong>
+    <div class="mt-6 grid gap-4 text-sm sm:grid-cols-2 sm:gap-8">
+        <p class="leading-6 text-gray-600 dark:text-gray-400">
+            <strong class="font-medium text-gray-950 dark:text-white">Learn in sequence.</strong>
             Each phase builds on skills introduced earlier in the path.
         </p>
-        <p class="leading-6 text-blue-950 dark:text-blue-100">
-            <strong class="font-bold">Prove the work.</strong>
+        <p class="leading-6 text-gray-600 dark:text-gray-400">
+            <strong class="font-medium text-gray-950 dark:text-white">Prove the work.</strong>
             A dedicated verification workspace keeps submissions and feedback separate from learning content.
         </p>
     </div>
 </header>
 
 {% if phases %}
-<section class="pb-0 pt-12 sm:pt-16" aria-label="Curriculum phases">
+<section class="pt-10" aria-label="Curriculum phases">
     {% for phase in phases %}
     {% if loop.index0 == 0 or loop.index0 == 3 or loop.index0 == 6 %}
-    <div class="{% if not loop.first %}mt-14{% endif %} mb-3 flex items-center gap-5">
-        <h2 class="text-xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">
+    <div class="{% if not loop.first %}mt-10{% endif %} mb-3">
+        <h2 class="section-title">
             {% if loop.index0 == 0 %}Learn the systems{% elif loop.index0 == 3 %}Build and deploy{% else %}Secure and advance{% endif %}
         </h2>
-        <div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>
     </div>
     {% endif %}
 
     <section x-data="{ open: false }" class="{% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %}">
-        <div class="grid grid-cols-[3rem_1fr] gap-4 py-6 sm:grid-cols-[4rem_1fr] sm:gap-6">
-            <span class="flex h-11 w-11 items-center justify-center rounded-full {% if loop.first %}bg-blue-700 text-white dark:bg-blue-400 dark:text-blue-950{% else %}bg-blue-50 text-blue-800 dark:bg-blue-950 dark:text-blue-200{% endif %} text-sm font-bold">
+        <div class="grid grid-cols-[2rem_1fr] gap-4 py-5">
+            <span class="flex h-11 items-center font-mono text-sm text-gray-500 dark:text-gray-400">
                 {{ phase.order }}
             </span>
             <div class="min-w-0">
@@ -56,7 +55,7 @@
                         <button
                             type="button"
                             @click="open = !open"
-                            class="group inline-flex min-h-11 cursor-pointer items-center gap-2 rounded-md text-left text-lg font-bold text-gray-950 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-white dark:hover:text-blue-300"
+                            class="group inline-flex min-h-11 cursor-pointer items-center gap-3 rounded-md text-left text-base font-medium text-gray-950 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-white dark:hover:text-blue-300"
                             :aria-expanded="open"
                             aria-controls="phase-{{ phase.order }}-content"
                             aria-describedby="phase-{{ phase.order }}-description phase-{{ phase.order }}-topic-count"
@@ -76,20 +75,20 @@
                         </button>
                     </h3>
                     {% if loop.first %}
-                    <span class="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-bold text-blue-800 dark:bg-blue-950 dark:text-blue-200">Start here</span>
+                    <span class="text-xs text-blue-700 dark:text-blue-300">Start here</span>
                     {% endif %}
                 </div>
                 <span id="phase-{{ phase.order }}-description" class="mt-2 block max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
                     {{ phase.short_description | default(phase.description) }}
                 </span>
-                <span id="phase-{{ phase.order }}-topic-count" class="mt-3 block text-xs font-bold uppercase tracking-[0.12em] text-gray-500 dark:text-gray-400">
+                <span id="phase-{{ phase.order }}-topic-count" class="mt-3 block text-xs text-gray-500 dark:text-gray-400">
                     {{ phase.topics | length }} topic{% if phase.topics | length != 1 %}s{% endif %}
                 </span>
             </div>
         </div>
 
         <div x-show="open" x-collapse x-cloak id="phase-{{ phase.order }}-content">
-            <div class="pb-8 pl-16 sm:pl-[5.5rem]">
+            <div class="pb-8 pl-12">
                 {% if phase.topics %}
                 <p class="mb-3 text-sm font-bold text-gray-950 dark:text-white">Topics in this phase</p>
                 <ul class="grid gap-x-8 sm:grid-cols-2">
@@ -108,7 +107,7 @@
                 <p class="text-sm leading-6 text-gray-600 dark:text-gray-400">Topics for this phase are being prepared.</p>
                 {% endif %}
 
-                <a href="/phase/{{ phase.order }}" class="mt-5 inline-flex min-h-11 items-center font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 transition-colors hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300">
+                <a href="/phase/{{ phase.order }}" class="text-link mt-5">
                     Open Phase {{ phase.order }}
                 </a>
             </div>
@@ -118,16 +117,16 @@
 </section>
 {% else %}
 <section class="pb-0 pt-12 sm:pt-16" aria-labelledby="curriculum-unavailable">
-    <div class="rounded-lg border border-gray-200 bg-gray-50 p-8 dark:border-gray-700 dark:bg-gray-800/50">
-        <h2 id="curriculum-unavailable" class="text-2xl font-bold text-gray-950 dark:text-white">The curriculum is temporarily unavailable.</h2>
+    <div>
+        <h2 id="curriculum-unavailable" class="section-title">The curriculum is temporarily unavailable.</h2>
         <p class="mt-3 max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-300">
             The curriculum did not load. Try again, or visit the FAQ for more information about Learn to Cloud.
         </p>
         <div class="mt-5 flex flex-wrap items-center gap-4">
-            <a href="/curriculum" hx-boost="false" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
+            <a href="/curriculum" hx-boost="false" class="button-primary">
                 Try again
             </a>
-            <a href="/faq" class="inline-flex min-h-11 items-center font-semibold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">
+            <a href="/faq" class="text-link">
                 Visit the FAQ
             </a>
         </div>
@@ -136,12 +135,12 @@
 {% endif %}
 
 {% if not user and phases %}
-<section class="pb-0 pt-12 text-center sm:pt-16" aria-labelledby="save-progress-heading">
-    <h2 id="save-progress-heading" class="text-2xl font-bold text-gray-950 dark:text-white">Keep your place as you learn.</h2>
-    <p class="mx-auto mt-3 max-w-xl text-base leading-7 text-gray-600 dark:text-gray-300">
-        Browse the full curriculum without an account. Sign in when you want to track progress and submit verification work.
+<section class="mt-10 border-t border-gray-200 pt-10 dark:border-gray-700" aria-labelledby="save-progress-heading">
+    <h2 id="save-progress-heading" class="section-title">Keep your place as you learn.</h2>
+    <p class="mt-3 max-w-xl text-base leading-7 text-gray-600 dark:text-gray-400">
+        Browse the curriculum overview without an account. Sign in to learn, track progress, and submit verification work.
     </p>
-    <a href="/auth/login" hx-boost="false" class="mt-6 inline-flex min-h-11 items-center justify-center rounded-md bg-gray-900 px-5 py-2.5 text-sm font-bold text-white transition-colors hover:bg-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200">
+    <a href="/auth/login" hx-boost="false" class="button-primary mt-6">
         Sign in with GitHub
     </a>
 </section>

--- a/api/src/learn_to_cloud/templates/pages/dashboard.html
+++ b/api/src/learn_to_cloud/templates/pages/dashboard.html
@@ -3,41 +3,41 @@
 {% block title %}Dashboard - Learn to Cloud{% endblock %}
 
 {% block page_header %}
-<h1 class="text-3xl font-bold tracking-[-0.025em] text-gray-950 dark:text-white">Dashboard</h1>
-<p class="mt-2 break-words text-base text-gray-600 dark:text-gray-300">
+<h1 class="page-title">Dashboard</h1>
+<p class="mt-3 break-words text-base text-gray-600 dark:text-gray-400">
     Welcome back, {{ user.first_name or user.github_username }}.
 </p>
 {% endblock %}
 
 {% block page_body %}
 {% if dashboard.continue_phase %}
-<section class="mb-10 rounded-lg border border-blue-200 bg-blue-50 p-5 dark:border-blue-800 dark:bg-blue-950/40" aria-labelledby="continue-heading">
+<section class="border-b border-gray-200 pb-10 dark:border-gray-700" aria-labelledby="continue-heading">
     <div class="flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-center">
         <div class="min-w-0">
-            <h2 id="continue-heading" class="text-xl font-bold text-blue-950 dark:text-blue-100">Continue your path</h2>
-            <p class="mt-1 break-words text-sm leading-6 text-blue-800 dark:text-blue-200">{{ dashboard.continue_phase.label }}</p>
+            <h2 id="continue-heading" class="section-title">Continue your path</h2>
+            <p class="mt-2 break-words text-base text-gray-600 dark:text-gray-400">{{ dashboard.continue_phase.label }}</p>
         </div>
-        <a href="{{ dashboard.continue_phase.destination_url }}" class="inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">
+        <a href="{{ dashboard.continue_phase.destination_url }}" class="button-primary shrink-0">
             Resume
-            <svg class="ml-2 h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+            <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
             </svg>
         </a>
     </div>
 </section>
 {% elif dashboard.is_program_complete and dashboard.phases %}
-<section class="mb-10 rounded-lg border border-green-200 bg-green-50 p-5 dark:border-green-800 dark:bg-green-950/30" aria-labelledby="complete-heading">
-    <h2 id="complete-heading" class="text-xl font-bold text-green-950 dark:text-green-100">You completed the program.</h2>
-    <p class="mt-2 text-sm leading-6 text-green-800 dark:text-green-200">Every phase verification is complete. Your dashboard remains available as a record of your work.</p>
+<section class="border-b border-gray-200 pb-10 dark:border-gray-700" aria-labelledby="complete-heading">
+    <h2 id="complete-heading" class="section-title">You completed the program.</h2>
+    <p class="mt-2 text-base leading-7 text-gray-600 dark:text-gray-400">Your learning steps and verifications are complete. Your dashboard remains a record of your work.</p>
 </section>
 {% elif dashboard.phases %}
-<section class="mb-10 rounded-lg border border-blue-200 bg-blue-50 p-5 dark:border-blue-800 dark:bg-blue-950/40" aria-labelledby="start-heading">
+<section class="border-b border-gray-200 pb-10 dark:border-gray-700" aria-labelledby="start-heading">
     <div class="flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-center">
         <div>
-            <h2 id="start-heading" class="text-xl font-bold text-blue-950 dark:text-blue-100">Start the curriculum</h2>
-            <p class="mt-1 text-sm leading-6 text-blue-800 dark:text-blue-200">Begin with Phase {{ dashboard.phases[0].order }}: {{ dashboard.phases[0].name }}.</p>
+            <h2 id="start-heading" class="section-title">Start the curriculum</h2>
+            <p class="mt-2 text-base text-gray-600 dark:text-gray-400">Begin with Phase {{ dashboard.phases[0].order }}: {{ dashboard.phases[0].name }}.</p>
         </div>
-        <a href="/phase/{{ dashboard.phases[0].order }}" class="inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">
+        <a href="/phase/{{ dashboard.phases[0].order }}" class="button-primary shrink-0">
             Start Phase {{ dashboard.phases[0].order }}
         </a>
     </div>
@@ -45,122 +45,53 @@
 {% endif %}
 
 {% if dashboard.phases %}
-<section class="mb-12" aria-labelledby="progress-heading">
-    <div class="flex flex-col justify-between gap-3 sm:flex-row sm:items-end">
+<section class="py-10" aria-labelledby="progress-heading">
+    <h2 id="progress-heading" class="section-title">Your progress</h2>
+    <dl class="mt-6 grid grid-cols-3 gap-4 sm:gap-10">
         <div>
-            <h2 id="progress-heading" class="text-xl font-bold text-gray-950 dark:text-white">Your progress</h2>
-            <p class="mt-1 text-sm leading-6 text-gray-600 dark:text-gray-400">
-                {{ dashboard.phases_completed }} of {{ dashboard.total_phases }} phases complete. Complete each phase's verification to progress.
-            </p>
+            <dt class="text-sm text-gray-600 dark:text-gray-400">Phases complete</dt>
+            <dd class="mt-2 text-2xl font-medium text-gray-950 dark:text-white">{{ dashboard.phases_completed }} <span class="text-base font-normal text-gray-500 dark:text-gray-400">of {{ dashboard.total_phases }}</span></dd>
         </div>
-        <a href="/verifications" class="inline-flex min-h-11 items-center text-sm font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300">
-            Open verification workspace
-        </a>
-    </div>
-
-    <div class="mt-5 grid gap-6 border-y border-gray-200 py-6 dark:border-gray-700 sm:grid-cols-2 sm:gap-10">
         <div>
-            <div class="flex items-baseline justify-between gap-4">
-                <p class="text-sm font-bold text-gray-950 dark:text-white">Verification progress</p>
-                <p class="text-sm font-bold text-blue-700 dark:text-blue-300">{{ dashboard.verification_percentage | round(0) | int }}%</p>
-            </div>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Requirements verified</p>
-            <div
-                class="mt-3 h-2.5 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
-                role="progressbar"
-                aria-valuenow="{{ dashboard.verification_percentage | round(0) | int }}"
-                aria-valuemin="0"
-                aria-valuemax="100"
-                aria-label="Requirements verified: {{ dashboard.verification_percentage | round(0) | int }} percent"
-            >
-                <div class="h-full rounded-full {{ 'bg-green-500' if dashboard.is_program_complete else 'bg-blue-600' }} transition-all" style="width: {{ dashboard.verification_percentage }}%"></div>
-            </div>
-            <p class="sr-only">Verification progress — {{ dashboard.verification_percentage | round(0) | int }}% of requirements</p>
+            <dt class="text-sm text-gray-600 dark:text-gray-400">Learning progress</dt>
+            <dd class="mt-2 text-2xl font-medium text-gray-950 dark:text-white">{{ dashboard.learning_percentage | round(0) | int }}%</dd>
+            <dd class="mt-1 text-xs text-gray-500 dark:text-gray-400">Learning steps checked</dd>
         </div>
-
         <div>
-            <div class="flex items-baseline justify-between gap-4">
-                <p class="text-sm font-bold text-gray-950 dark:text-white">Learning progress</p>
-                <p class="text-sm font-bold text-blue-700 dark:text-blue-300">{{ dashboard.learning_percentage | round(0) | int }}%</p>
-            </div>
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Learning steps checked</p>
-            <div
-                class="mt-3 h-2.5 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
-                role="progressbar"
-                aria-valuenow="{{ dashboard.learning_percentage | round(0) | int }}"
-                aria-valuemin="0"
-                aria-valuemax="100"
-                aria-label="Learning steps checked: {{ dashboard.learning_percentage | round(0) | int }} percent"
-            >
-                <div class="h-full rounded-full bg-blue-400 transition-all dark:bg-blue-500" style="width: {{ dashboard.learning_percentage }}%"></div>
-            </div>
-            <p class="sr-only">Learning progress — {{ dashboard.learning_percentage | round(0) | int }}% of learning steps</p>
+            <dt class="text-sm text-gray-600 dark:text-gray-400">Verification progress</dt>
+            <dd class="mt-2 text-2xl font-medium text-gray-950 dark:text-white">{{ dashboard.verification_percentage | round(0) | int }}%</dd>
+            <dd class="mt-1 text-xs text-gray-500 dark:text-gray-400">Requirements verified</dd>
         </div>
-    </div>
+    </dl>
+    <p class="mt-5 text-sm text-gray-500 dark:text-gray-400">Complete learning steps and verifications in each phase.</p>
 </section>
 
 <section aria-labelledby="phase-progress-heading">
-    <div class="flex items-end justify-between gap-4">
-        <div>
-            <h2 id="phase-progress-heading" class="text-xl font-bold text-gray-950 dark:text-white">Phases</h2>
-            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">Open a phase to continue learning. Use the verification workspace to submit hands-on work.</p>
-        </div>
+    <div class="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
+        <h2 id="phase-progress-heading" class="section-title">Your phases</h2>
+        <a href="/verifications" class="text-link">Open verification workspace</a>
     </div>
 
-    <div class="mt-8">
+    <div class="mt-4 border-t border-gray-200 dark:border-gray-700">
         {% for phase in dashboard.phases %}
         {% set p = phase.progress %}
-        {% if loop.index0 == 0 or loop.index0 == 3 or loop.index0 == 6 %}
-        <div class="{% if not loop.first %}mt-10{% endif %} mb-2 flex items-center gap-4">
-            <h3 class="text-base font-bold text-gray-950 dark:text-white">
-                {% if loop.index0 == 0 %}Learn the systems{% elif loop.index0 == 3 %}Build and deploy{% else %}Secure and advance{% endif %}
-            </h3>
-            <div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>
-        </div>
-        {% endif %}
-
-        <a href="/phase/{{ phase.order }}" class="group grid min-h-11 grid-cols-[2.75rem_1fr] gap-4 {% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %} py-4 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 sm:grid-cols-[2.75rem_1fr_auto] sm:items-center">
-            {% if p and p.status == 'completed' %}
-            <span class="flex h-9 w-9 items-center justify-center rounded-full bg-green-100 text-xs font-bold text-green-800 dark:bg-green-950 dark:text-green-200">
-                {{ phase.order }}
-            </span>
-            {% elif p and p.status != 'not_started' %}
-            <span class="flex h-9 w-9 items-center justify-center rounded-full bg-blue-100 text-xs font-bold text-blue-800 dark:bg-blue-950 dark:text-blue-200">
-                {{ phase.order }}
-            </span>
-            {% else %}
-            <span class="flex h-9 w-9 items-center justify-center rounded-full bg-zinc-100 text-xs font-bold text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
-                {{ phase.order }}
-            </span>
-            {% endif %}
+        <a href="/phase/{{ phase.order }}" class="group grid min-h-11 grid-cols-[2rem_1fr] gap-x-4 gap-y-1 border-b border-gray-200 py-5 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-700 sm:grid-cols-[2rem_1fr_auto] sm:items-center">
+            <span class="pt-0.5 font-mono text-sm text-gray-500 dark:text-gray-400">{{ phase.order }}</span>
             <span class="min-w-0">
-                <span class="block text-sm font-bold text-gray-950 transition-colors group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ phase.name }}</span>
+                <span class="block text-base font-medium text-gray-950 transition-colors group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ phase.name }}</span>
                 {% if p and (p.verification.requirements_required > 0 or p.learning.steps_required > 0) %}
                 <span class="mt-1 block text-xs leading-5 text-gray-500 dark:text-gray-400">
-                    {%- if p.verification.requirements_required > 0 -%}
-                    {{ p.verification.requirements_verified }}/{{ p.verification.requirements_required }} requirements verified
-                    {%- endif -%}
-                    {%- if p.verification.requirements_required > 0 and p.learning.steps_required > 0 %} · {% endif -%}
                     {%- if p.learning.steps_required > 0 -%}
                     {{ p.learning.steps_completed }}/{{ p.learning.steps_required }} steps checked
                     {%- endif -%}
+                    {%- if p.verification.requirements_required > 0 and p.learning.steps_required > 0 %} &middot; {% endif -%}
+                    {%- if p.verification.requirements_required > 0 -%}
+                    {{ p.verification.requirements_verified }}/{{ p.verification.requirements_required }} requirements verified
+                    {%- endif -%}
                 </span>
                 {% endif %}
-                <span class="mt-1 block text-xs font-bold sm:hidden {% if p and p.status == 'completed' %}text-green-700 dark:text-green-300{% elif p and p.status != 'not_started' %}text-blue-700 dark:text-blue-300{% else %}text-gray-500 dark:text-gray-400{% endif %}">
-                    {% if not p or p.status == 'not_started' %}
-                    Not started
-                    {% elif p.status == 'completed' %}
-                    Complete
-                    {% elif p.status == 'learning_complete' %}
-                    Ready for verification
-                    {% elif p.status == 'verification_complete' %}
-                    Steps remaining
-                    {% else %}
-                    In progress
-                    {% endif %}
-                </span>
             </span>
-            <span class="hidden text-xs font-bold sm:block {% if p and p.status == 'completed' %}text-green-700 dark:text-green-300{% elif p and p.status != 'not_started' %}text-blue-700 dark:text-blue-300{% else %}text-gray-500 dark:text-gray-400{% endif %}">
+            <span class="col-start-2 text-xs sm:col-start-auto {% if p and p.status == 'completed' %}text-green-700 dark:text-green-300{% elif p and p.status != 'not_started' %}text-blue-700 dark:text-blue-300{% else %}text-gray-500 dark:text-gray-400{% endif %}">
                 {% if not p or p.status == 'not_started' %}
                 Not started
                 {% elif p.status == 'completed' %}
@@ -176,22 +107,21 @@
         </a>
         {% endfor %}
     </div>
-
 </section>
 {% else %}
-<section class="rounded-lg border border-gray-200 bg-gray-50 p-8 dark:border-gray-700 dark:bg-gray-800/50" aria-labelledby="dashboard-empty-heading">
-    <h2 id="dashboard-empty-heading" class="text-xl font-bold text-gray-950 dark:text-white">Progress is temporarily unavailable.</h2>
-    <p class="mt-2 max-w-xl text-sm leading-6 text-gray-600 dark:text-gray-300">The curriculum did not load. Try again, or open the curriculum to keep learning.</p>
+<section class="border-y border-gray-200 py-8 dark:border-gray-700" aria-labelledby="dashboard-empty-heading">
+    <h2 id="dashboard-empty-heading" class="section-title">Progress is temporarily unavailable.</h2>
+    <p class="mt-2 max-w-xl text-base leading-7 text-gray-600 dark:text-gray-400">The curriculum did not load. Try again, or open the curriculum to keep learning.</p>
     <div class="mt-5 flex flex-wrap gap-4">
-        <a href="/dashboard" hx-boost="false" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">Try again</a>
-        <a href="/curriculum" class="inline-flex min-h-11 items-center text-sm font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">Open curriculum</a>
+        <a href="/dashboard" hx-boost="false" class="button-primary">Try again</a>
+        <a href="/curriculum" class="text-link">Open curriculum</a>
     </div>
 </section>
 {% endif %}
 
-<section class="mt-14 border-t border-gray-200 pt-8 dark:border-gray-700" aria-labelledby="help-heading">
-    <h2 id="help-heading" class="text-lg font-bold text-gray-950 dark:text-white">Need help?</h2>
-    <div class="mt-4 flex flex-wrap gap-3">
+<section class="mt-12" aria-labelledby="help-heading">
+    <div class="flex flex-wrap items-center gap-x-6 gap-y-2">
+        <h2 id="help-heading" class="text-sm font-medium text-gray-600 dark:text-gray-400">Need help?</h2>
         {% for link in help_links %}
         {% if link.label == "Discord" or link.label == "Report an Issue" %}
         <a
@@ -199,21 +129,10 @@
             {% if link.label == "Report an Issue" %}data-report-issue data-issue-title="Issue: Dashboard" data-issue-labels="bug" data-issue-context="page=dashboard"{% endif %}
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex min-h-11 items-center gap-2 rounded-md border border-gray-300 px-3 py-2 text-sm font-bold text-gray-700 transition-colors hover:border-blue-400 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:text-gray-200 dark:hover:border-blue-500 dark:hover:text-blue-300"
-        >
-            <span class="h-5 w-5 shrink-0 {{ link.color }}" aria-hidden="true">{{ link.icon | safe }}</span>
-            <span>{% if link.label == "Discord" %}Ask on Discord{% else %}{{ link.label }}{% endif %}</span>
-        </a>
+            class="text-link"
+        >{% if link.label == "Discord" %}Ask on Discord{% else %}{{ link.label }}{% endif %}</a>
         {% endif %}
         {% endfor %}
     </div>
-    <p class="mt-5 text-sm text-gray-500 dark:text-gray-400">
-        Updates:
-        {% for link in help_links %}
-        {% if link.label != "Discord" and link.label != "Report an Issue" %}
-        <a href="{{ link.url }}" target="_blank" rel="noopener noreferrer" class="ml-2 inline-flex min-h-11 items-center font-medium underline underline-offset-4 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:text-blue-300">{{ link.label }}</a>
-        {% endif %}
-        {% endfor %}
-    </p>
 </section>
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/faq.html
+++ b/api/src/learn_to_cloud/templates/pages/faq.html
@@ -2,15 +2,15 @@
 {% block title %}FAQ - Learn to Cloud{% endblock %}
 
 {% block page_header %}
-<h1 class="text-3xl font-bold text-gray-900 dark:text-white text-center">Frequently Asked Questions</h1>
+<h1 class="page-title">Frequently Asked Questions</h1>
 {% endblock %}
 
 {% block page_body %}
-<div class="space-y-6">
+<div class="border-t border-gray-200 dark:border-gray-700">
     {% for question, answer in faqs %}
-    <div>
-        <h3 class="font-medium text-gray-900 dark:text-white">{{ question }}</h3>
-        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ answer|safe }}</p>
+    <div class="border-b border-gray-200 py-6 dark:border-gray-700">
+        <h2 class="text-base font-medium text-gray-950 dark:text-white">{{ question }}</h2>
+        <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">{{ answer|safe }}</p>
     </div>
     {% endfor %}
 </div>

--- a/api/src/learn_to_cloud/templates/pages/home.html
+++ b/api/src/learn_to_cloud/templates/pages/home.html
@@ -1,157 +1,103 @@
 {% extends "base.html" %}
 {% set footer_margin = "mt-8" %}
-{% block title %}Learn to Cloud - Your Path to Cloud Computing{% endblock %}
-{% block description %}Learn cloud computing through a structured path of fundamentals, hands-on projects, and verified skills.{% endblock %}
+{% block title %}Learn to Cloud - Build real understanding{% endblock %}
+{% block description %}Learn cloud engineering through hands-on work, independent thinking, and AI. A self-paced program built on agency, discipline, and deep understanding.{% endblock %}
 
 {% block content %}
-<section class="relative overflow-hidden border-b border-gray-200 pb-16 pt-6 dark:border-gray-700 sm:pb-20 sm:pt-12">
-    <div class="absolute right-0 top-8 -z-10 h-56 w-56 rounded-full bg-blue-100/70 blur-3xl dark:bg-blue-950/50" aria-hidden="true"></div>
+<section class="pb-20 pt-12 sm:pb-28 sm:pt-20" aria-labelledby="home-heading">
+    <p class="text-xs font-medium uppercase tracking-[0.16em] text-gray-600 dark:text-gray-400">
+        Cloud engineering. Human understanding.
+    </p>
+    <h1 id="home-heading" class="mt-8 max-w-3xl text-balance text-4xl font-medium leading-[1.08] tracking-[-0.045em] text-gray-950 dark:text-white sm:text-6xl">
+        Information is everywhere.
+        <span class="block text-gray-500 dark:text-gray-400">Understanding is earned.</span>
+    </h1>
+    <p class="mt-8 max-w-xl text-lg leading-8 text-gray-600 dark:text-gray-300">
+        Learn to Cloud is a hands-on program for people who want to understand
+        what they build. Use AI, think for yourself, and develop the discipline
+        to solve real cloud engineering problems.
+    </p>
 
-    <div class="grid items-center gap-12 lg:grid-cols-[minmax(0,1.2fr)_minmax(17rem,0.8fr)]">
-        <div>
-            <h1 class="max-w-3xl text-balance text-4xl font-bold tracking-[-0.035em] text-gray-950 dark:text-white sm:text-6xl sm:leading-[1.05]">
-                From first command to production cloud system.
-            </h1>
-            <p class="mt-6 max-w-2xl text-lg leading-8 text-gray-600 dark:text-gray-300">
-                Build an API, deploy it to your cloud, automate it, harden it, and prove your skills along the way.
-            </p>
-
-            <div class="mt-8 flex flex-col items-start gap-3 sm:flex-row sm:items-center">
-                {% if user %}
-                <a href="/dashboard" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-5 py-2.5 text-base font-semibold text-white shadow-sm shadow-blue-950/20 transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
-                    Continue to your dashboard
-                    <svg class="ml-2 h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
-                    </svg>
-                </a>
-                {% else %}
-                <a href="#journey-heading" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-5 py-2.5 text-base font-semibold text-white shadow-sm shadow-blue-950/20 transition-colors hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
-                    See the curriculum
-                    <svg class="ml-2 h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
-                    </svg>
-                </a>
-                {% endif %}
-                {% if user %}
-                <a href="#journey-heading" class="inline-flex min-h-11 items-center px-2 text-base font-semibold text-gray-700 underline decoration-gray-300 underline-offset-4 transition-colors hover:text-blue-700 hover:decoration-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-200 dark:decoration-gray-600 dark:hover:text-blue-300">
-                    Review the curriculum
-                </a>
-                {% endif %}
-            </div>
-        </div>
-
-        <div class="mx-auto w-full max-w-sm">
-            <h2 class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">A complete learning system.</h2>
-            <ul class="mt-5 divide-y divide-blue-100 border-y border-blue-100 dark:divide-blue-900 dark:border-blue-900">
-                {% set capabilities = [
-                    ("Curriculum", "Follow a phase-by-phase route from foundations to career."),
-                    ("Progress tracking", "Resume from your dashboard and see what is complete."),
-                    ("Hands-on labs", "Build with Linux, cloud CLIs, APIs, and infrastructure."),
-                    ("Verification", "Submit proof and get your work checked.")
-                ] %}
-                {% for title, detail in capabilities %}
-                <li class="grid grid-cols-[2.75rem_1fr] gap-4 py-4">
-                    <span class="flex h-10 w-10 items-center justify-center rounded-md bg-blue-50 text-blue-800 dark:bg-blue-950 dark:text-blue-200" aria-hidden="true">
-                        {% if loop.index == 1 %}
-                        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 4.5h4.25A2.75 2.75 0 0 1 11 7.25V16a2.75 2.75 0 0 0-2.75-2.75H4V4.5Zm12 0h-2.25A2.75 2.75 0 0 0 11 7.25V16a2.75 2.75 0 0 1 2.75-2.75H16V4.5Z"/>
-                        </svg>
-                        {% elif loop.index == 2 %}
-                        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M4 15V9m4 6V5m4 10v-4m4 4V7"/>
-                        </svg>
-                        {% elif loop.index == 3 %}
-                        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="m7 5-4 5 4 5m6-10 4 5-4 5m-3.5 1.5 2-13"/>
-                        </svg>
-                        {% else %}
-                        <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M10 2.75 16 5v4.5c0 3.5-2.5 6.25-6 7.75-3.5-1.5-6-4.25-6-7.75V5l6-2.25Z"/>
-                            <path stroke-linecap="round" stroke-linejoin="round" d="m7.25 10 1.75 1.75 3.75-4"/>
-                        </svg>
-                        {% endif %}
-                    </span>
-                    <span>
-                        <span class="block text-base font-bold text-gray-950 dark:text-white">{{ title }}</span>
-                        <span class="mt-1 block text-sm leading-5 text-gray-600 dark:text-gray-400">{{ detail }}</span>
-                    </span>
-                </li>
-                {% endfor %}
-            </ul>
-        </div>
-    </div>
-</section>
-
-{% if phases %}
-<section class="pb-0 pt-16 sm:pt-20" aria-labelledby="journey-heading">
-    <div class="max-w-2xl">
-        <h2 id="journey-heading" class="text-balance text-3xl font-bold tracking-[-0.025em] text-gray-950 dark:text-white sm:text-4xl">
-            The curriculum, phase by phase.
-        </h2>
-        <p class="mt-4 text-lg leading-8 text-gray-600 dark:text-gray-300">
-            Begin with the fundamentals, then use them to build, deploy, secure, and explain real cloud work.
-        </p>
-    </div>
-
-    <div class="mt-12">
-        {% for phase in phases %}
-        {% if loop.index0 == 0 or loop.index0 == 3 or loop.index0 == 6 %}
-        <div class="{% if not loop.first %}mt-12{% endif %} mb-3 flex items-center gap-4" aria-hidden="true">
-            <p class="text-xs font-bold uppercase tracking-[0.16em] text-blue-700 dark:text-blue-300">
-                {% if loop.index0 == 0 %}Learn the systems{% elif loop.index0 == 3 %}Build and deploy{% else %}Secure and advance{% endif %}
-            </p>
-            <div class="h-px flex-1 bg-gray-200 dark:bg-gray-700"></div>
-        </div>
+    <div class="mt-9 flex flex-wrap items-center gap-x-6 gap-y-3">
+        {% if user or phases %}
+        <a href="{% if user %}/dashboard{% else %}/phase/{{ phases[0].order }}{% endif %}" class="inline-flex min-h-12 items-center justify-center gap-3 rounded-md bg-gray-950 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-700 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus-visible:outline-blue-300">
+            {% if user %}Continue learning{% else %}Start learning{% endif %}
+            <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
+            </svg>
+        </a>
         {% endif %}
-        <a href="/phase/{{ phase.order }}" class="group grid grid-cols-[3rem_1fr_auto] gap-4 {% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %} py-6 transition-colors hover:border-blue-300 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:hover:border-blue-700 sm:grid-cols-[4rem_1fr_auto] sm:gap-6">
-            <span class="flex h-11 w-11 items-center justify-center rounded-full {% if loop.first %}bg-blue-700 text-white dark:bg-blue-400 dark:text-blue-950{% else %}bg-blue-50 text-blue-800 group-hover:bg-blue-100 group-hover:text-blue-900 dark:bg-blue-950 dark:text-blue-200 dark:group-hover:bg-blue-900 dark:group-hover:text-blue-100{% endif %} text-sm font-bold transition-colors">
-                {{ phase.order }}
-            </span>
-            <div class="min-w-0">
-                <div class="flex flex-wrap items-center gap-2">
-                    <h3 class="text-lg font-bold text-gray-950 dark:text-white">{{ phase.name }}</h3>
-                    {% if loop.first %}
-                    <span class="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-bold text-blue-800 dark:bg-blue-950 dark:text-blue-200">Start here</span>
-                    {% endif %}
-                </div>
-                <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
-                    {{ phase.short_description | default(phase.description[:160] + '...' if phase.description | length > 160 else phase.description) }}
-                </p>
-            </div>
-            <span class="mt-3 hidden text-blue-700 transition-transform group-hover:translate-x-1 dark:text-blue-300 sm:block" aria-hidden="true">
-                <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
-                </svg>
-            </span>
-        </a>
-        {% endfor %}
-    </div>
-
-    <div class="mt-6 flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-center">
-        <p class="max-w-xl text-base leading-7 text-gray-600 dark:text-gray-300">
-            Ready to see every topic, project, and verification challenge?
-        </p>
-        <a href="/curriculum" class="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-300 px-4 py-2.5 text-sm font-bold text-gray-900 transition-colors hover:border-blue-500 hover:text-blue-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:text-white dark:hover:border-blue-400 dark:hover:text-blue-300">
-            View the full curriculum
+        <a href="/curriculum" class="inline-flex min-h-12 items-center text-sm font-medium text-gray-600 underline decoration-gray-300 underline-offset-4 transition-colors hover:text-gray-950 hover:decoration-gray-950 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:text-gray-300 dark:decoration-gray-600 dark:hover:text-white dark:hover:decoration-white dark:focus-visible:outline-blue-300">
+            Explore the curriculum
         </a>
     </div>
 </section>
-{% else %}
-<section class="pb-0 pt-16 sm:pt-20" aria-labelledby="journey-heading">
-    <div class="rounded-lg border border-gray-200 bg-gray-50 p-8 dark:border-gray-700 dark:bg-gray-800/50">
-        <h2 id="journey-heading" class="text-2xl font-bold text-gray-950 dark:text-white">The learning path is temporarily unavailable.</h2>
-        <p class="mt-3 max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-300">
-            The curriculum did not load. Try again, or visit the FAQ for more information about Learn to Cloud.
-        </p>
-        <div class="mt-5 flex flex-wrap items-center gap-4">
-            <a href="/" hx-boost="false" class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-500 dark:text-blue-950 dark:hover:bg-blue-400">
-                Try again
-            </a>
-            <a href="/faq" class="inline-flex min-h-11 items-center font-semibold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">
-                Visit the FAQ
-            </a>
+
+<section class="border-t border-gray-200 py-12 dark:border-gray-700 sm:py-16" aria-labelledby="approach-heading">
+    <h2 id="approach-heading" class="text-2xl font-medium tracking-tight text-gray-950 dark:text-white sm:text-3xl">
+        The tools have changed. The work is still yours.
+    </h2>
+    <div class="mt-9 grid gap-8 sm:grid-cols-3 sm:gap-7">
+        <div>
+            <h3 class="text-base font-semibold text-gray-950 dark:text-white">Own your learning.</h3>
+            <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">
+                We give you a path, not every answer. Read the docs, ask better
+                questions, and get comfortable figuring things out.
+            </p>
+        </div>
+        <div>
+            <h3 class="text-base font-semibold text-gray-950 dark:text-white">Practice with discipline.</h3>
+            <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">
+                Build real systems. Debug what breaks. Return to what you
+                don't understand. Progress comes from doing the work.
+            </p>
+        </div>
+        <div>
+            <h3 class="text-base font-semibold text-gray-950 dark:text-white">Think with AI. Not less.</h3>
+            <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">
+                Use AI to explore ideas and get feedback. Question its answers.
+                If you can't explain the result, keep learning.
+            </p>
         </div>
     </div>
 </section>
-{% endif %}
+
+<section class="border-t border-gray-200 pb-8 pt-12 dark:border-gray-700 sm:pt-16" aria-labelledby="journey-heading">
+    {% if phases %}
+    <div class="flex flex-col items-start justify-between gap-6 sm:flex-row sm:items-center sm:gap-10">
+        <div class="max-w-lg">
+            <h2 id="journey-heading" class="text-2xl font-medium tracking-tight text-gray-950 dark:text-white sm:text-3xl">
+                Learn it. Build it. Prove it.
+            </h2>
+            <p class="mt-4 text-base leading-7 text-gray-600 dark:text-gray-400">
+                From Linux and networking to deploying and securing your own
+                cloud systems. One structured path, at your pace, with your
+                work verified along the way.
+            </p>
+        </div>
+        <a href="/curriculum" class="inline-flex min-h-12 shrink-0 items-center gap-3 text-sm font-semibold text-gray-950 underline decoration-gray-300 underline-offset-4 transition-colors hover:decoration-gray-950 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:text-white dark:decoration-gray-600 dark:hover:decoration-white dark:focus-visible:outline-blue-300">
+            See the full path
+            <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
+            </svg>
+        </a>
+    </div>
+    {% else %}
+    <h2 id="journey-heading" class="text-2xl font-medium tracking-tight text-gray-950 dark:text-white">
+        The learning path is temporarily unavailable.
+    </h2>
+    <p class="mt-4 max-w-xl text-base leading-7 text-gray-600 dark:text-gray-400">
+        The curriculum did not load. Try again, or visit the FAQ for more
+        information about Learn to Cloud.
+    </p>
+    <div class="mt-5 flex flex-wrap items-center gap-6">
+        <a href="/" hx-boost="false" class="inline-flex min-h-12 items-center text-sm font-semibold text-gray-950 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:text-white dark:focus-visible:outline-blue-300">
+            Try again
+        </a>
+        <a href="/faq" class="inline-flex min-h-12 items-center text-sm font-medium text-gray-600 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:text-gray-300 dark:focus-visible:outline-blue-300">
+            Visit the FAQ
+        </a>
+    </div>
+    {% endif %}
+</section>
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/home.html
+++ b/api/src/learn_to_cloud/templates/pages/home.html
@@ -1,21 +1,22 @@
 {% extends "base.html" %}
 {% set footer_margin = "mt-8" %}
 {% block title %}Learn to Cloud - Build real understanding{% endblock %}
-{% block description %}Learn cloud engineering through hands-on work, independent thinking, and AI. A self-paced program built on agency, discipline, and deep understanding.{% endblock %}
+{% block description %}A free, self-paced cloud engineering program. Build real systems, improve with automated checks and AI-powered feedback, and learn to work independently.{% endblock %}
 
 {% block content %}
 <section class="pb-20 pt-12 sm:pb-28 sm:pt-20" aria-labelledby="home-heading">
     <p class="text-xs font-medium uppercase tracking-[0.16em] text-gray-600 dark:text-gray-400">
-        Cloud engineering. Human understanding.
+        Cloud engineering. Learned by doing.
     </p>
     <h1 id="home-heading" class="mt-8 max-w-3xl text-balance text-4xl font-medium leading-[1.08] tracking-[-0.045em] text-gray-950 dark:text-white sm:text-6xl">
         Information is everywhere.
         <span class="block text-gray-500 dark:text-gray-400">Understanding is earned.</span>
     </h1>
     <p class="mt-8 max-w-xl text-lg leading-8 text-gray-600 dark:text-gray-300">
-        Learn to Cloud is a hands-on program for people who want to understand
-        what they build. Use AI, think for yourself, and develop the discipline
-        to solve real cloud engineering problems.
+        Learn cloud engineering through real work. Follow a structured path,
+        build and troubleshoot cloud systems, and improve with automated checks
+        and AI-powered feedback. Develop the understanding to explain your
+        decisions and the independence to make your own.
     </p>
 
     <div class="mt-9 flex flex-wrap items-center gap-x-6 gap-y-3">
@@ -35,28 +36,31 @@
 
 <section class="border-t border-gray-200 py-12 dark:border-gray-700 sm:py-16" aria-labelledby="approach-heading">
     <h2 id="approach-heading" class="text-2xl font-medium tracking-tight text-gray-950 dark:text-white sm:text-3xl">
-        The tools have changed. The work is still yours.
+        Structure, practice, and feedback.
     </h2>
     <div class="mt-9 grid gap-8 sm:grid-cols-3 sm:gap-7">
         <div>
-            <h3 class="text-base font-semibold text-gray-950 dark:text-white">Own your learning.</h3>
+            <h3 class="text-base font-semibold text-gray-950 dark:text-white">Learn with direction.</h3>
             <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">
-                We give you a path, not every answer. Read the docs, ask better
-                questions, and get comfortable figuring things out.
+                Follow a structured curriculum with resources, practical
+                challenges, and clear goals. Learn at your own pace, with a
+                community to turn to when you're stuck.
             </p>
         </div>
         <div>
-            <h3 class="text-base font-semibold text-gray-950 dark:text-white">Practice with discipline.</h3>
+            <h3 class="text-base font-semibold text-gray-950 dark:text-white">Build with purpose.</h3>
             <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">
-                Build real systems. Debug what breaks. Return to what you
-                don't understand. Progress comes from doing the work.
+                Research what you don't know, troubleshoot what breaks, and
+                explain your decisions. Use AI to challenge your understanding,
+                not replace it.
             </p>
         </div>
         <div>
-            <h3 class="text-base font-semibold text-gray-950 dark:text-white">Think with AI. Not less.</h3>
+            <h3 class="text-base font-semibold text-gray-950 dark:text-white">Improve with feedback.</h3>
             <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">
-                Use AI to explore ideas and get feedback. Question its answers.
-                If you can't explain the result, keep learning.
+                Submit your work for automated checks and AI-assisted reviews.
+                See what needs attention, make changes, and try again. Progress
+                means more than checking off lessons.
             </p>
         </div>
     </div>
@@ -67,12 +71,13 @@
     <div class="flex flex-col items-start justify-between gap-6 sm:flex-row sm:items-center sm:gap-10">
         <div class="max-w-lg">
             <h2 id="journey-heading" class="text-2xl font-medium tracking-tight text-gray-950 dark:text-white sm:text-3xl">
-                Learn it. Build it. Prove it.
+                Build it. Then take it further.
             </h2>
             <p class="mt-4 text-base leading-7 text-gray-600 dark:text-gray-400">
-                From Linux and networking to deploying and securing your own
-                cloud systems. One structured path, at your pace, with your
-                work verified along the way.
+                Start with Linux and networking. Build an AI-powered journal
+                API, then deploy, automate, and secure that same application on
+                your chosen cloud. Learn to explain how it works and why you
+                built it that way.
             </p>
         </div>
         <a href="/curriculum" class="inline-flex min-h-12 shrink-0 items-center gap-3 text-sm font-semibold text-gray-950 underline decoration-gray-300 underline-offset-4 transition-colors hover:decoration-gray-950 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:text-white dark:decoration-gray-600 dark:hover:decoration-white dark:focus-visible:outline-blue-300">

--- a/api/src/learn_to_cloud/templates/pages/home.html
+++ b/api/src/learn_to_cloud/templates/pages/home.html
@@ -70,24 +70,16 @@
 
 <section class="border-t border-gray-200 pb-8 pt-12 dark:border-gray-700 sm:pt-16" aria-labelledby="journey-heading">
     {% if phases %}
-    <div class="flex flex-col items-start justify-between gap-6 sm:flex-row sm:items-center sm:gap-10">
-        <div class="max-w-lg">
-            <h2 id="journey-heading" class="text-2xl font-medium tracking-tight text-gray-950 dark:text-white sm:text-3xl">
-                Build it. Then take it further.
-            </h2>
-            <p class="mt-4 text-base leading-7 text-gray-600 dark:text-gray-400">
-                Start with Linux and networking. Build an AI-powered API,
-                then deploy, automate, and secure that same application on
-                your chosen cloud. Learn to explain how it works and why you
-                built it that way.
-            </p>
-        </div>
-        <a href="/curriculum" class="text-link min-h-12 shrink-0 gap-3">
-            See the full path
-            <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
-            </svg>
-        </a>
+    <div class="max-w-lg">
+        <h2 id="journey-heading" class="text-2xl font-medium tracking-tight text-gray-950 dark:text-white sm:text-3xl">
+            Build it. Then take it further.
+        </h2>
+        <p class="mt-4 text-base leading-7 text-gray-600 dark:text-gray-400">
+            Start with Linux and networking. Build an AI-powered API,
+            then deploy, automate, and secure that same application on
+            your chosen cloud. Learn to explain how it works and why you
+            built it that way.
+        </p>
     </div>
     {% else %}
     <h2 id="journey-heading" class="text-2xl font-medium tracking-tight text-gray-950 dark:text-white">

--- a/api/src/learn_to_cloud/templates/pages/home.html
+++ b/api/src/learn_to_cloud/templates/pages/home.html
@@ -33,9 +33,6 @@
             Explore the curriculum
         </a>
     </div>
-    <p class="mt-4 max-w-xl text-xs leading-5 text-gray-500 dark:text-gray-400">
-        Cloud resources and some learning materials may cost extra.
-    </p>
 </section>
 
 <section class="border-t border-gray-200 py-12 dark:border-gray-700 sm:py-16" aria-labelledby="approach-heading">
@@ -78,8 +75,8 @@
                 Build it. Then take it further.
             </h2>
             <p class="mt-4 text-base leading-7 text-gray-600 dark:text-gray-400">
-                Start with Linux and networking. Build an AI-powered journal
-                API, then deploy, automate, and secure that same application on
+                Start with Linux and networking. Build an AI-powered API,
+                then deploy, automate, and secure that same application on
                 your chosen cloud. Learn to explain how it works and why you
                 built it that way.
             </p>

--- a/api/src/learn_to_cloud/templates/pages/home.html
+++ b/api/src/learn_to_cloud/templates/pages/home.html
@@ -1,22 +1,23 @@
 {% extends "base.html" %}
 {% set footer_margin = "mt-8" %}
 {% block title %}Learn to Cloud - Build real understanding{% endblock %}
-{% block description %}A free, self-paced cloud engineering program. Build real systems, improve with automated checks and AI-powered feedback, and learn to work independently.{% endblock %}
+{% block description %}A free, open-source cloud engineering program built on accessible technical education, hands-on practice, AI-powered feedback, and independent learning.{% endblock %}
 
 {% block content %}
 <section class="pb-20 pt-12 sm:pb-28 sm:pt-20" aria-labelledby="home-heading">
     <p class="text-xs font-medium uppercase tracking-[0.16em] text-gray-600 dark:text-gray-400">
-        Cloud engineering. Learned by doing.
+        Free and open source cloud engineering.
     </p>
     <h1 id="home-heading" class="mt-8 max-w-3xl text-balance text-4xl font-medium leading-[1.08] tracking-[-0.045em] text-gray-950 dark:text-white sm:text-6xl">
-        Information is everywhere.
-        <span class="block text-gray-500 dark:text-gray-400">Understanding is earned.</span>
+        Information is now abundant.
+        <span class="block text-gray-500 dark:text-gray-400">Access to education should be too.</span>
     </h1>
     <p class="mt-8 max-w-xl text-lg leading-8 text-gray-600 dark:text-gray-300">
-        Learn cloud engineering through real work. Follow a structured path,
-        build and troubleshoot cloud systems, and improve with automated checks
-        and AI-powered feedback. Develop the understanding to explain your
-        decisions and the independence to make your own.
+        At Learn to Cloud, we believe in open source, accessible technical
+        education, and the power of high agency, self-sufficiency, and discipline.
+        That's why we've built a free cloud engineering program around hands-on
+        practice and AI-powered feedback, so you can learn deeply and work
+        independently.
     </p>
 
     <div class="mt-9 flex flex-wrap items-center gap-x-6 gap-y-3">
@@ -32,6 +33,9 @@
             Explore the curriculum
         </a>
     </div>
+    <p class="mt-4 max-w-xl text-xs leading-5 text-gray-500 dark:text-gray-400">
+        Cloud resources and some learning materials may cost extra.
+    </p>
 </section>
 
 <section class="border-t border-gray-200 py-12 dark:border-gray-700 sm:py-16" aria-labelledby="approach-heading">

--- a/api/src/learn_to_cloud/templates/pages/home.html
+++ b/api/src/learn_to_cloud/templates/pages/home.html
@@ -6,7 +6,7 @@
 {% block content %}
 <section class="pb-20 pt-12 sm:pb-28 sm:pt-20" aria-labelledby="home-heading">
     <p class="text-xs font-medium uppercase tracking-[0.16em] text-gray-600 dark:text-gray-400">
-        Free and open source cloud engineering.
+        Free, open-source cloud engineering education.
     </p>
     <h1 id="home-heading" class="mt-8 max-w-3xl text-balance text-4xl font-medium leading-[1.08] tracking-[-0.045em] text-gray-950 dark:text-white sm:text-6xl">
         Information is now abundant.
@@ -22,14 +22,14 @@
 
     <div class="mt-9 flex flex-wrap items-center gap-x-6 gap-y-3">
         {% if user or phases %}
-        <a href="{% if user %}/dashboard{% else %}/phase/{{ phases[0].order }}{% endif %}" class="inline-flex min-h-12 items-center justify-center gap-3 rounded-md bg-gray-950 px-5 py-3 text-sm font-semibold text-white transition-colors hover:bg-gray-700 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-200 dark:focus-visible:outline-blue-300">
+        <a href="{% if user %}/dashboard{% else %}/phase/{{ phases[0].order }}{% endif %}" class="button-primary min-h-12 gap-3">
             {% if user %}Continue learning{% else %}Start learning{% endif %}
             <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>
             </svg>
         </a>
         {% endif %}
-        <a href="/curriculum" class="inline-flex min-h-12 items-center text-sm font-medium text-gray-600 underline decoration-gray-300 underline-offset-4 transition-colors hover:text-gray-950 hover:decoration-gray-950 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:text-gray-300 dark:decoration-gray-600 dark:hover:text-white dark:hover:decoration-white dark:focus-visible:outline-blue-300">
+        <a href="/curriculum" class="text-link min-h-12">
             Explore the curriculum
         </a>
     </div>
@@ -81,7 +81,7 @@
                 built it that way.
             </p>
         </div>
-        <a href="/curriculum" class="inline-flex min-h-12 shrink-0 items-center gap-3 text-sm font-semibold text-gray-950 underline decoration-gray-300 underline-offset-4 transition-colors hover:decoration-gray-950 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:text-white dark:decoration-gray-600 dark:hover:decoration-white dark:focus-visible:outline-blue-300">
+        <a href="/curriculum" class="text-link min-h-12 shrink-0 gap-3">
             See the full path
             <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4 10h12m-5-5 5 5-5 5"/>

--- a/api/src/learn_to_cloud/templates/pages/home.html
+++ b/api/src/learn_to_cloud/templates/pages/home.html
@@ -37,7 +37,7 @@
 
 <section class="border-t border-gray-200 py-12 dark:border-gray-700 sm:py-16" aria-labelledby="approach-heading">
     <h2 id="approach-heading" class="text-2xl font-medium tracking-tight text-gray-950 dark:text-white sm:text-3xl">
-        Structure, practice, and feedback.
+        Structure, feedback, and real-world relevance.
     </h2>
     <div class="mt-9 grid gap-8 sm:grid-cols-3 sm:gap-7">
         <div>
@@ -49,19 +49,20 @@
             </p>
         </div>
         <div>
-            <h3 class="text-base font-semibold text-gray-950 dark:text-white">Build with purpose.</h3>
-            <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">
-                Research what you don't know, troubleshoot what breaks, and
-                explain your decisions. Use AI to challenge your understanding,
-                not replace it.
-            </p>
-        </div>
-        <div>
             <h3 class="text-base font-semibold text-gray-950 dark:text-white">Improve with feedback.</h3>
             <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">
                 Submit your work for automated checks and AI-assisted reviews.
                 See what needs attention, make changes, and try again. Progress
                 means more than checking off lessons.
+            </p>
+        </div>
+        <div>
+            <h3 class="text-base font-semibold text-gray-950 dark:text-white">Learn what's current.</h3>
+            <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">
+                Cloud engineering doesn't stand still. Neither does this
+                curriculum. People working in the field continually update
+                the platform and learning material to reflect how cloud
+                engineering is practiced today.
             </p>
         </div>
     </div>

--- a/api/src/learn_to_cloud/templates/pages/phase.html
+++ b/api/src/learn_to_cloud/templates/pages/phase.html
@@ -14,7 +14,7 @@
 
 <header class="border-b border-gray-200 pb-10 dark:border-gray-700 sm:pb-12">
     <div class="flex flex-wrap items-center gap-3">
-        <h1 class="text-balance text-3xl font-bold tracking-[-0.03em] text-gray-950 dark:text-white sm:text-4xl">
+        <h1 class="page-title">
             Phase {{ phase.order }}: {{ phase.name }}
         </h1>
         {% if phase_progress %}
@@ -37,38 +37,24 @@
     {% endfor %}
 
     {% if next_topic.item %}
-    <div class="mt-7 flex flex-col items-start justify-between gap-4 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/40 sm:flex-row sm:items-center">
+    <div class="mt-8 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
         <div class="min-w-0">
-            <p class="text-sm font-bold text-blue-950 dark:text-blue-100">Continue learning</p>
-            <p class="mt-1 break-words text-sm text-blue-800 dark:text-blue-200">{{ next_topic.item.name }}</p>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Continue learning</p>
+            <p class="mt-2 break-words text-base font-medium text-gray-950 dark:text-white">{{ next_topic.item.name }}</p>
         </div>
-        <a href="/phase/{{ phase.order }}/{{ next_topic.item.slug }}" class="inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">
+        <a href="/phase/{{ phase.order }}/{{ next_topic.item.slug }}" class="button-primary shrink-0">
             Open topic
         </a>
     </div>
     {% endif %}
 
     {% if phase_progress %}
-    <div class="mt-6 grid gap-4 sm:grid-cols-2 sm:gap-8">
-        {% if phase_progress.verification.requirements_required > 0 %}
-        {% with
-            value=phase_progress.verification.percentage,
-            label='Verification progress — ' ~ phase_progress.verification.requirements_verified ~ '/' ~ phase_progress.verification.requirements_required ~ ' requirements',
-            complete=phase_progress.verification.is_complete,
-            aria_label='Requirements verified: ' ~ phase_progress.verification.requirements_verified ~ ' of ' ~ phase_progress.verification.requirements_required
-        %}
-        {% include "partials/progress_bar.html" %}
-        {% endwith %}
-        {% endif %}
+    <div class="mt-6 flex flex-wrap gap-x-6 gap-y-2 text-sm text-gray-500 dark:text-gray-400" aria-label="Phase progress">
         {% if phase_progress.learning.steps_required > 0 %}
-        {% with
-            value=phase_progress.learning.percentage,
-            label='Learning progress — ' ~ phase_progress.learning.steps_completed ~ '/' ~ phase_progress.learning.steps_required ~ ' steps',
-            complete=phase_progress.learning.is_complete,
-            aria_label='Learning steps checked: ' ~ phase_progress.learning.steps_completed ~ ' of ' ~ phase_progress.learning.steps_required
-        %}
-        {% include "partials/progress_bar.html" %}
-        {% endwith %}
+        <p>{{ phase_progress.learning.steps_completed }}/{{ phase_progress.learning.steps_required }} steps checked</p>
+        {% endif %}
+        {% if phase_progress.verification.requirements_required > 0 %}
+        <p>{{ phase_progress.verification.requirements_verified }}/{{ phase_progress.verification.requirements_required }} requirements verified</p>
         {% endif %}
     </div>
     {% endif %}
@@ -76,18 +62,17 @@
 
 <section class="pt-12 sm:pt-14" aria-labelledby="topics-heading">
     <div>
-        <h2 id="topics-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Topics</h2>
-        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Work through the learning steps in order, then open the verification workspace when you are ready.</p>
+        <h2 id="topics-heading" class="section-title">Topics</h2>
     </div>
 
     {% if topics %}
     <div class="mt-6 border-y border-gray-200 dark:border-gray-700">
         {% for topic in topics %}
         <a href="/phase/{{ phase.order }}/{{ topic.slug }}" class="group grid min-h-11 grid-cols-[2.75rem_1fr] gap-3 {% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %} py-4 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 sm:grid-cols-[2.75rem_1fr_auto] sm:items-center sm:gap-4">
-            <span class="flex h-9 w-9 items-center justify-center rounded-full bg-blue-50 text-xs font-bold text-blue-800 dark:bg-blue-950 dark:text-blue-200">{{ loop.index }}</span>
-            <span class="min-w-0 break-words text-sm font-bold text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ topic.name }}</span>
+            <span class="flex h-9 w-9 items-center justify-center font-mono text-sm text-gray-500 dark:text-gray-400">{{ loop.index }}</span>
+            <span class="min-w-0 break-words text-base font-medium text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ topic.name }}</span>
             {% if topic.progress %}
-            <span class="col-start-2 text-xs font-bold sm:col-start-auto {% if topic.progress.completed == topic.progress.total and topic.progress.total > 0 %}text-green-700 dark:text-green-300{% else %}text-gray-500 dark:text-gray-400{% endif %}">
+            <span class="col-start-2 text-xs sm:col-start-auto {% if topic.progress.completed == topic.progress.total and topic.progress.total > 0 %}text-green-700 dark:text-green-300{% else %}text-gray-500 dark:text-gray-400{% endif %}">
                 {% if topic.progress.completed == topic.progress.total and topic.progress.total > 0 %}
                 Complete
                 {% else %}
@@ -99,7 +84,7 @@
         {% endfor %}
     </div>
     {% else %}
-    <div class="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
+    <div class="mt-6 border-t border-gray-200 py-6 dark:border-gray-700">
         <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">Topics for this phase are being prepared.</p>
     </div>
     {% endif %}
@@ -109,17 +94,12 @@
 <section id="verification-section" class="mt-14 border-t border-gray-200 pt-12 dark:border-gray-700 sm:mt-16 sm:pt-14" aria-labelledby="verification-heading">
     <div class="flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-center">
         <div>
-            <h2 id="verification-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Hands-on verification</h2>
+            <h2 id="verification-heading" class="section-title">Hands-on verification</h2>
             <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
                 Submit work, follow active checks, and review feedback in the dedicated workspace.
             </p>
-            {% if phase_progress.verification.requirements_required > 0 %}
-            <p class="mt-2 text-sm font-bold {% if phase_progress.verification.is_complete %}text-green-700 dark:text-green-300{% else %}text-blue-700 dark:text-blue-300{% endif %}">
-                {{ phase_progress.verification.requirements_verified }}/{{ phase_progress.verification.requirements_required }} requirements verified
-            </p>
-            {% endif %}
         </div>
-        <a href="/verifications/phase/{{ phase.order }}" class="inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">
+        <a href="/verifications/phase/{{ phase.order }}" class="{{ 'button-secondary' if next_topic.item else 'button-primary' }} shrink-0">
             {% if phase_progress.verification.is_complete %}Review verification{% elif phase_progress.verification.requirements_verified > 0 %}Continue verification{% else %}Start verification{% endif %}
         </a>
     </div>
@@ -128,9 +108,9 @@
 
 {% if phase_progress and phase_progress.status == 'completed' %}
 <section class="mt-14 border-t border-gray-200 pt-8 dark:border-gray-700" aria-labelledby="phase-complete-heading">
-    <h2 id="phase-complete-heading" class="text-xl font-bold text-gray-950 dark:text-white">Phase complete</h2>
+    <h2 id="phase-complete-heading" class="section-title">Phase complete</h2>
     <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Your learning steps and verification work are complete.</p>
-    <a href="/dashboard" class="mt-4 inline-flex min-h-11 items-center font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">Return to dashboard</a>
+    <a href="/dashboard" class="text-link mt-4">Return to dashboard</a>
 </section>
 {% endif %}
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/privacy.html
+++ b/api/src/learn_to_cloud/templates/pages/privacy.html
@@ -2,16 +2,16 @@
 {% block title %}Privacy Policy - Learn to Cloud{% endblock %}
 
 {% block page_header %}
-<h1 class="text-3xl font-bold text-gray-900 dark:text-white text-center">Privacy Policy</h1>
-<p class="mt-2 text-sm text-gray-500 dark:text-gray-400 text-center">Last updated: May 7, 2026</p>
+<h1 class="page-title">Privacy Policy</h1>
+<p class="mt-3 text-sm text-gray-500 dark:text-gray-400">Last updated: May 7, 2026</p>
 {% endblock %}
 
 {% block page_body %}
-<div class="prose prose-gray dark:prose-invert max-w-none space-y-8">
+<article class="policy-content">
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Overview</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>Overview</h2>
+        <p>
             Learn to Cloud is a free, open-source educational platform that helps you learn cloud computing through
             structured, hands-on exercises. We are committed to protecting your privacy and being transparent about
             the data we collect and how we use it.
@@ -19,21 +19,21 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Data We Collect</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>Data We Collect</h2>
+        <p>
             When you sign in with GitHub, we collect only the following from your <strong>public</strong> GitHub profile:
         </p>
-        <ul class="mt-2 list-disc list-inside text-sm text-gray-600 dark:text-gray-400 space-y-1">
+        <ul>
             <li><strong>GitHub user ID</strong> — used as your account identifier</li>
             <li><strong>Username</strong> — used to identify your account</li>
             <li><strong>Display name</strong> — used to greet you on your dashboard</li>
             <li><strong>Avatar URL</strong> — shown in the navigation bar</li>
         </ul>
-        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+        <p>
             We do <strong>not</strong> collect your email address, password, private repositories, or any other personal
             information beyond what is listed above.
         </p>
-        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+        <p>
             We collect basic browser telemetry, such as page views, performance timings, and client-side errors, to
             diagnose reliability issues. Browser telemetry is not linked to your GitHub account, username, or internal
             user ID.
@@ -41,9 +41,9 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">GitHub OAuth Scope</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
-            We request the <code class="text-xs bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded">read:user</code>
+        <h2>GitHub OAuth Scope</h2>
+        <p>
+            We request the <code>read:user</code>
             OAuth scope, which grants read-only access to your public profile information. We do not request access to
             your repositories, organizations, or any private data. Your GitHub access token is used only during
             sign-in and is never stored.
@@ -51,8 +51,8 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Data You Submit</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>Data You Submit</h2>
+        <p>
             As part of hands-on verification, you voluntarily submit URLs and tokens (such as GitHub repository URLs,
             deployed application URLs, and CTF tokens) to prove completion of exercises. This submitted data is stored
             alongside your account.
@@ -60,9 +60,9 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">How We Use Your Data</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">Your data is used solely to:</p>
-        <ul class="mt-2 list-disc list-inside text-sm text-gray-600 dark:text-gray-400 space-y-1">
+        <h2>How We Use Your Data</h2>
+        <p>Your data is used solely to:</p>
+        <ul>
             <li>Identify your account and maintain your session</li>
             <li>Track your learning progress across phases</li>
             <li>Verify completion of hands-on exercises</li>
@@ -72,8 +72,8 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">What We Do Not Do</h2>
-        <ul class="mt-2 list-disc list-inside text-sm text-gray-600 dark:text-gray-400 space-y-1">
+        <h2>What We Do Not Do</h2>
+        <ul>
             <li>We do not sell, rent, or share your personal information with third parties</li>
             <li>We do not use your data for advertising, recruiting, or marketing purposes</li>
             <li>We do not send unsolicited emails (we don't even collect your email)</li>
@@ -83,8 +83,8 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Cookies</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>Cookies</h2>
+        <p>
             We use a single session cookie to keep you signed in. This cookie is signed, HTTP-only, and contains only
             your user ID. We do not use tracking cookies, analytics cookies, or any third-party cookies. Browser
             telemetry is configured without cookies or browser storage.
@@ -92,21 +92,21 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Data Retention &amp; Deletion</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>Data Retention &amp; Deletion</h2>
+        <p>
             Your data is retained as long as your account exists. You can permanently delete your account and all
             associated data (progress and submissions) at any time from your
-            <a href="/account" class="text-blue-600 dark:text-blue-400 underline">Account page</a>.
+            <a href="/account">Account page</a>.
             Deletion is immediate and irreversible.
         </p>
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Third-Party Services</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>Third-Party Services</h2>
+        <p>
             We interact with the following external services on your behalf, only when you initiate a verification:
         </p>
-        <ul class="mt-2 list-disc list-inside text-sm text-gray-600 dark:text-gray-400 space-y-1">
+        <ul>
             <li><strong>GitHub API</strong> — to verify repositories and profiles you submit</li>
             <li><strong>Azure OpenAI</strong> — to analyze code you submit for verification (code is not stored by the LLM)</li>
             <li><strong>Azure Application Insights</strong> — to collect server and browser diagnostics</li>
@@ -114,30 +114,30 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Open Source</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>Open Source</h2>
+        <p>
             This application is open source. You can review the full source code to verify our data practices at
-            <a href="https://github.com/learntocloud/learn-to-cloud-app" target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-400 underline">github.com/learntocloud/learn-to-cloud-app</a>.
+            <a href="https://github.com/learntocloud/learn-to-cloud-app" target="_blank" rel="noopener noreferrer">github.com/learntocloud/learn-to-cloud-app</a>.
         </p>
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Changes to This Policy</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>Changes to This Policy</h2>
+        <p>
             We may update this policy from time to time. Changes will be reflected on this page with an updated date.
             Continued use of the platform after changes constitutes acceptance of the revised policy.
         </p>
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">Contact</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>Contact</h2>
+        <p>
             If you have questions about this privacy policy, please open an issue on our
-            <a href="https://github.com/learntocloud/learn-to-cloud-app/issues" target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-400 underline">GitHub repository</a>
+            <a href="https://github.com/learntocloud/learn-to-cloud-app/issues" target="_blank" rel="noopener noreferrer">GitHub repository</a>
             or start a discussion in our
-            <a href="https://github.com/learntocloud/learn-to-cloud-app/discussions" target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-400 underline">GitHub Discussions</a>.
+            <a href="https://github.com/learntocloud/learn-to-cloud-app/discussions" target="_blank" rel="noopener noreferrer">GitHub Discussions</a>.
         </p>
     </section>
 
-</div>
+</article>
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/terms.html
+++ b/api/src/learn_to_cloud/templates/pages/terms.html
@@ -2,42 +2,42 @@
 {% block title %}Terms of Service - Learn to Cloud{% endblock %}
 
 {% block page_header %}
-<h1 class="text-3xl font-bold text-gray-900 dark:text-white text-center">Terms of Service</h1>
-<p class="mt-2 text-sm text-gray-500 dark:text-gray-400 text-center">Last updated: February 15, 2026</p>
+<h1 class="page-title">Terms of Service</h1>
+<p class="mt-3 text-sm text-gray-500 dark:text-gray-400">Last updated: February 15, 2026</p>
 {% endblock %}
 
 {% block page_body %}
-<div class="prose prose-gray dark:prose-invert max-w-none space-y-8">
+<article class="policy-content">
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">1. Acceptance of Terms</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>1. Acceptance of Terms</h2>
+        <p>
             By accessing or using Learn to Cloud ("the Platform"), you agree to be bound by these Terms of Service.
             If you do not agree to these terms, do not use the Platform.
         </p>
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">2. Description of Service</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>2. Description of Service</h2>
+        <p>
             Learn to Cloud is a free, open-source educational platform that provides a structured guide to learning
             cloud computing. The Platform includes learning content, hands-on verification exercises, and progress tracking.
         </p>
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">3. Account &amp; Authentication</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>3. Account &amp; Authentication</h2>
+        <p>
             You sign in using your GitHub account via OAuth. By signing in, you authorize us to access your public
-            GitHub profile information as described in our <a href="/privacy" class="text-blue-600 dark:text-blue-400 underline">Privacy Policy</a>.
+            GitHub profile information as described in our <a href="/privacy">Privacy Policy</a>.
             You are responsible for maintaining the security of your GitHub account.
         </p>
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">4. Acceptable Use</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">You agree not to:</p>
-        <ul class="mt-2 list-disc list-inside text-sm text-gray-600 dark:text-gray-400 space-y-1">
+        <h2>4. Acceptable Use</h2>
+        <p>You agree not to:</p>
+        <ul>
             <li>Submit fraudulent, plagiarized, or misleading content for verification</li>
             <li>Attempt to bypass or manipulate the verification system</li>
             <li>Share, publish, or encourage methods to cheat, circumvent, or reverse-engineer the verification system</li>
@@ -50,22 +50,22 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">5. Academic Integrity</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>5. Academic Integrity</h2>
+        <p>
             Learn to Cloud is built on trust. The verification system exists to validate genuine learning, not to
             be a security challenge. Sharing or promoting ways to cheat, bypass, or reverse-engineer the
             verification process — whether on social media, Discord, GitHub issues, or any other channel — undermines
             the community and the value of the curriculum for everyone.
         </p>
-        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-            <strong class="text-gray-900 dark:text-white">Users who encourage or distribute methods to circumvent
+        <p>
+            <strong>Users who encourage or distribute methods to circumvent
             the verification system will be permanently banned from the Platform.</strong>
         </p>
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">6. Content &amp; Submissions</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>6. Content &amp; Submissions</h2>
+        <p>
             When you submit URLs, code, or other materials for hands-on verification, you represent that you have
             the right to share that content and that it is your own work. Submitted content is used solely for
             verification purposes.
@@ -73,16 +73,16 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">7. Privacy</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
-            Your use of the Platform is also governed by our <a href="/privacy" class="text-blue-600 dark:text-blue-400 underline">Privacy Policy</a>,
+        <h2>7. Privacy</h2>
+        <p>
+            Your use of the Platform is also governed by our <a href="/privacy">Privacy Policy</a>,
             which describes what data we collect, how we use it, and your rights regarding your data.
         </p>
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">8. Availability &amp; Changes</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>8. Availability &amp; Changes</h2>
+        <p>
             The Platform is provided on an "as is" basis. We do not guarantee uninterrupted availability.
             We may modify, suspend, or discontinue any part of the Platform at any time. We may also update
             the curriculum, verification requirements, or these terms. Continued use after changes constitutes
@@ -91,8 +91,8 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">9. Limitation of Liability</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>9. Limitation of Liability</h2>
+        <p>
             Learn to Cloud is a free educational project. To the maximum extent permitted by law, the Platform
             and its contributors shall not be liable for any indirect, incidental, special, or consequential
             damages arising from your use of the Platform.
@@ -100,9 +100,9 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">10. Account Termination</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
-            You may delete your account at any time from your <a href="/account" class="text-blue-600 dark:text-blue-400 underline">Account page</a>.
+        <h2>10. Account Termination</h2>
+        <p>
+            You may delete your account at any time from your <a href="/account">Account page</a>.
             We reserve the right to suspend or permanently ban accounts that violate these terms, including but
             not limited to sharing methods to cheat the verification system. Bans are at our sole discretion
             and may be applied without prior warning.
@@ -110,23 +110,23 @@
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">11. Open Source</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>11. Open Source</h2>
+        <p>
             The Platform's source code is available under an open-source license at
-            <a href="https://github.com/learntocloud/learn-to-cloud-app" target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-400 underline">github.com/learntocloud/learn-to-cloud-app</a>.
+            <a href="https://github.com/learntocloud/learn-to-cloud-app" target="_blank" rel="noopener noreferrer">github.com/learntocloud/learn-to-cloud-app</a>.
             These Terms of Service govern your use of the hosted Platform, not the source code itself.
         </p>
     </section>
 
     <section>
-        <h2 class="text-xl font-semibold text-gray-900 dark:text-white">12. Contact</h2>
-        <p class="text-sm text-gray-600 dark:text-gray-400">
+        <h2>12. Contact</h2>
+        <p>
             If you have questions about these terms, please open an issue on our
-            <a href="https://github.com/learntocloud/learn-to-cloud-app/issues" target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-400 underline">GitHub repository</a>
+            <a href="https://github.com/learntocloud/learn-to-cloud-app/issues" target="_blank" rel="noopener noreferrer">GitHub repository</a>
             or start a discussion in our
-            <a href="https://github.com/learntocloud/learn-to-cloud-app/discussions" target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-400 underline">GitHub Discussions</a>.
+            <a href="https://github.com/learntocloud/learn-to-cloud-app/discussions" target="_blank" rel="noopener noreferrer">GitHub Discussions</a>.
         </p>
     </section>
 
-</div>
+</article>
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/topic.html
+++ b/api/src/learn_to_cloud/templates/pages/topic.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block page_header %}
-<h1 class="text-balance text-3xl font-bold tracking-[-0.03em] text-gray-950 dark:text-white sm:text-4xl">{{ topic.name }}</h1>
+<h1 class="page-title">{{ topic.name }}</h1>
 {% if topic.description %}
 <p class="mt-3 max-w-3xl text-base leading-7 text-gray-600 dark:text-gray-300">{{ topic.description }}</p>
 {% endif %}
@@ -35,12 +35,12 @@
 
 {% block page_body %}
 {% if topic.learning_objectives %}
-<section class="mb-10 border-y border-blue-100 py-5 dark:border-blue-900" aria-labelledby="objectives-heading">
-    <h2 id="objectives-heading" class="text-base font-bold text-blue-950 dark:text-blue-100">Learning objectives</h2>
+<section class="mb-8" aria-labelledby="objectives-heading">
+    <h2 id="objectives-heading" class="section-title">Learning objectives</h2>
     <ul class="mt-3 space-y-2">
         {% for objective in topic.learning_objectives %}
-        <li class="flex items-start gap-3 text-sm leading-6 text-blue-900 dark:text-blue-200">
-            <svg class="mt-1 h-4 w-4 shrink-0" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m5 10 3 3 7-7"/></svg>
+        <li class="flex items-start gap-3 text-base leading-7 text-gray-600 dark:text-gray-400">
+            <span class="text-gray-400" aria-hidden="true">&middot;</span>
             <span>{{ objective.text }}</span>
         </li>
         {% endfor %}
@@ -64,7 +64,7 @@
 {% endif %}
 
 {% if steps %}
-<div id="topic-steps" class="space-y-4">
+<div id="topic-steps" class="border-b border-gray-200 dark:border-gray-700">
     {% set ns = namespace(opened=false) %}
     {% for step in steps %}
     {% set step_complete = step.uuid in completed_steps %}
@@ -76,7 +76,7 @@
     {% endfor %}
 </div>
 {% else %}
-<div class="rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
+<div class="border-y border-gray-200 py-6 dark:border-gray-700">
     <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">Learning steps for this topic are being prepared.</p>
 </div>
 {% endif %}

--- a/api/src/learn_to_cloud/templates/pages/verification_phase.html
+++ b/api/src/learn_to_cloud/templates/pages/verification_phase.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <nav class="mb-6 flex min-h-11 flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400" aria-label="Breadcrumb">
-    <a href="/verifications" class="inline-flex min-h-11 items-center font-medium hover:text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:text-blue-300">Verifications</a>
+    <a href="/verifications" class="text-link">Verifications</a>
     <svg class="h-4 w-4" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="m8 5 5 5-5 5"/>
     </svg>
@@ -14,7 +14,7 @@
 
 <header class="border-b border-gray-200 pb-10 dark:border-gray-700 sm:pb-12">
     <div class="flex flex-wrap items-center gap-3">
-        <h1 class="text-balance text-3xl font-bold tracking-[-0.03em] text-gray-950 dark:text-white sm:text-4xl">
+        <h1 class="page-title text-balance">
             Phase {{ phase.order }} verification
         </h1>
         {% if verification_locked %}
@@ -25,12 +25,12 @@
         {{ status_pill("In progress", "info") }}
         {% endif %}
     </div>
-    <p class="mt-3 text-lg font-medium text-gray-700 dark:text-gray-200">{{ phase.name }}</p>
+    <p class="mt-3 text-base text-gray-700 dark:text-gray-300">{{ phase.name }}</p>
     <p class="mt-3 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
         Submit proof of your hands-on work. Requirements unlock in sequence, and completed attempts remain available below.
     </p>
     <div class="mt-5 flex flex-wrap gap-4">
-        <a href="/phase/{{ phase.order }}" class="inline-flex min-h-11 items-center font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300">
+        <a href="/phase/{{ phase.order }}" class="text-link">
             Review Phase {{ phase.order }} learning
         </a>
     </div>
@@ -51,46 +51,46 @@
 
 {% if requirements %}
 <section class="pt-12 sm:pt-14" aria-labelledby="requirements-heading">
-    <h2 id="requirements-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Requirements</h2>
+    <h2 id="requirements-heading" class="section-title">Requirements</h2>
     <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">Complete the current requirement to unlock the next one.</p>
 
     {% if verification_locked %}
-    <div class="mb-6 mt-6 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/30">
+    <div class="mb-6 mt-6 border-l-2 border-amber-500 pl-4">
         <div class="flex items-start gap-3">
             <svg class="mt-0.5 h-5 w-5 shrink-0 text-amber-700 dark:text-amber-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
                 <rect x="4.5" y="8.5" width="11" height="8" rx="1.5"/>
                 <path stroke-linecap="round" d="M7 8.5V6a3 3 0 0 1 6 0v2.5"/>
             </svg>
             <div>
-                <p class="text-sm font-bold text-amber-950 dark:text-amber-100">Phase {{ prerequisite_phase_id }} verification required</p>
-                <p class="mt-1 text-sm leading-6 text-amber-800 dark:text-amber-200">
+                <p class="text-sm font-medium text-gray-900 dark:text-gray-100">Phase {{ prerequisite_phase_id }} verification required</p>
+                <p class="mt-1 text-sm leading-6 text-gray-600 dark:text-gray-300">
                     Complete every hands-on verification in
-                    <a href="/verifications/phase/{{ prerequisite_phase_id }}" class="font-bold underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-700">Phase {{ prerequisite_phase_id }}</a>
+                    <a href="/verifications/phase/{{ prerequisite_phase_id }}" class="text-link">Phase {{ prerequisite_phase_id }}</a>
                     before submitting here.
                 </p>
             </div>
         </div>
     </div>
-    <div class="space-y-3">
+    <div>
         {% for req in requirements %}
         {% set card = card_contexts_by_req[req.slug] %}
         {% if card.kind == 'passed' %}
         {% include "partials/verified_requirement_row.html" %}
         {% else %}
-        <div class="flex min-h-11 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+        <div class="flex min-h-11 items-center gap-3 border-b border-gray-200 py-4 dark:border-gray-700">
             <svg class="h-5 w-5 shrink-0 text-gray-500 dark:text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
                 <rect x="4.5" y="8.5" width="11" height="8" rx="1.5"/>
                 <path stroke-linecap="round" d="M7 8.5V6a3 3 0 0 1 6 0v2.5"/>
             </svg>
             <span class="min-w-0 flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">{{ req.name }}</span>
-            <span class="text-xs font-bold text-gray-500 dark:text-gray-400">Locked</span>
+            <span class="text-xs text-gray-500 dark:text-gray-400">Locked</span>
         </div>
         {% endif %}
         {% endfor %}
     </div>
     {% else %}
     {% set ns = namespace(found_active=false) %}
-    <div class="mt-6 space-y-3">
+    <div class="mt-6">
         {% for req in requirements %}
         {% set card = card_contexts_by_req[req.slug] %}
         {% if card.kind == 'passed' %}
@@ -99,10 +99,10 @@
         {% set ns.found_active = true %}
         {% include "partials/requirement_card.html" %}
         {% else %}
-        <div class="flex min-h-11 items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 dark:border-gray-700 dark:bg-gray-800/50">
+        <div class="flex min-h-11 items-center gap-3 border-b border-gray-200 py-4 dark:border-gray-700">
             <span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-gray-400 text-xs text-gray-500 dark:border-gray-500 dark:text-gray-400" aria-hidden="true">{{ loop.index }}</span>
             <span class="min-w-0 flex-1 text-sm font-medium text-gray-700 dark:text-gray-300">{{ req.name }}</span>
-            <span class="text-xs font-bold text-gray-500 dark:text-gray-400">Up next</span>
+            <span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">Up next</span>
         </div>
         {% endif %}
         {% endfor %}
@@ -111,8 +111,8 @@
 </section>
 {% else %}
 <section class="pt-12 sm:pt-14" aria-labelledby="requirements-empty-heading">
-    <div class="rounded-lg border border-gray-200 bg-gray-50 p-6 dark:border-gray-700 dark:bg-gray-800/50">
-        <h2 id="requirements-empty-heading" class="text-xl font-bold text-gray-950 dark:text-white">No verification requirements are available.</h2>
+    <div>
+        <h2 id="requirements-empty-heading" class="section-title">No verification requirements are available.</h2>
         <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">Return to the phase curriculum while this workspace is prepared.</p>
     </div>
 </section>
@@ -120,19 +120,19 @@
 
 <section class="mt-14 border-t border-gray-200 pt-12 dark:border-gray-700 sm:mt-16 sm:pt-14" aria-labelledby="attempt-history-heading">
     <div>
-        <h2 id="attempt-history-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Attempt history</h2>
+        <h2 id="attempt-history-heading" class="section-title">Attempt history</h2>
         <p class="mt-2 max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
             Completed attempts are kept as a private record. Sensitive submitted values and internal grading metadata are not shown.
         </p>
     </div>
 
     {% if history.items %}
-    <div class="mt-6 space-y-3">
+    <div class="mt-6 divide-y divide-gray-200 dark:divide-gray-700">
         {% for item in history.items %}
-        <article class="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+        <article class="py-5">
             <div class="flex flex-wrap items-start justify-between gap-3">
                 <div>
-                    <h3 class="text-sm font-bold text-gray-950 dark:text-white">{{ item.requirement.name }}</h3>
+                    <h3 class="text-sm font-medium text-gray-800 dark:text-gray-200">{{ item.requirement.name }}</h3>
                     {% if item.completed_at %}
                     <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ item.completed_at.strftime('%b %d, %Y at %H:%M %Z') }}</p>
                     {% endif %}
@@ -160,22 +160,22 @@
     </div>
 
     {% if history.has_previous or history.has_next %}
-    <nav class="mt-6 flex items-center justify-between gap-4" aria-label="Attempt history pages">
+    <nav class="mt-6 flex flex-wrap items-center justify-between gap-4" aria-label="Attempt history pages">
         {% if history.has_previous %}
-        <a href="/verifications/phase/{{ phase.order }}?history_page={{ history.page - 1 }}" class="inline-flex min-h-11 items-center font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">Newer attempts</a>
+        <a href="/verifications/phase/{{ phase.order }}?history_page={{ history.page - 1 }}" class="text-link">Newer attempts</a>
         {% else %}
         <span></span>
         {% endif %}
         {% if history.has_next %}
-        <a href="/verifications/phase/{{ phase.order }}?history_page={{ history.page + 1 }}" class="inline-flex min-h-11 items-center font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">Older attempts</a>
+        <a href="/verifications/phase/{{ phase.order }}?history_page={{ history.page + 1 }}" class="text-link">Older attempts</a>
         {% endif %}
     </nav>
     {% endif %}
     {% else %}
-    <div class="mt-6 rounded-lg border border-gray-200 bg-gray-50 p-5 dark:border-gray-700 dark:bg-gray-800/50">
+    <div class="mt-6">
         <p class="text-sm leading-6 text-gray-600 dark:text-gray-300">No completed attempts yet. Your results and allowed feedback will appear here after verification finishes.</p>
         {% if history.has_previous %}
-        <a href="/verifications/phase/{{ phase.order }}?history_page={{ history.page - 1 }}" class="mt-3 inline-flex min-h-11 items-center font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">View newer attempts</a>
+        <a href="/verifications/phase/{{ phase.order }}?history_page={{ history.page - 1 }}" class="text-link mt-3">View newer attempts</a>
         {% endif %}
     </div>
     {% endif %}

--- a/api/src/learn_to_cloud/templates/pages/verifications.html
+++ b/api/src/learn_to_cloud/templates/pages/verifications.html
@@ -7,30 +7,27 @@
 {% block page_header %}
 <div class="flex flex-col justify-between gap-5 sm:flex-row sm:items-end">
     <div class="max-w-2xl">
-        <p class="text-sm font-bold uppercase tracking-[0.12em] text-blue-700 dark:text-blue-300">Hands-on work</p>
-        <h1 class="mt-2 text-3xl font-bold tracking-[-0.025em] text-gray-950 dark:text-white sm:text-4xl">Verification workspace</h1>
+        <p class="text-sm text-gray-500 dark:text-gray-400">Hands-on work</p>
+        <h1 class="page-title mt-2">Verification workspace</h1>
         <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-300">
             Submit your work, follow active checks, and review feedback history for every phase.
         </p>
     </div>
-    <a href="/curriculum" class="inline-flex min-h-11 items-center font-bold text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300">
-        Browse curriculum
-    </a>
 </div>
 {% endblock %}
 
 {% block page_body %}
 {% if overview.phases %}
 <section aria-labelledby="overall-verification-heading">
-    <div class="rounded-lg border border-gray-200 p-5 dark:border-gray-700">
-        <div class="flex items-baseline justify-between gap-4">
+    <div class="max-w-2xl">
+        <div class="flex flex-wrap items-baseline justify-between gap-4">
             <div>
-                <h2 id="overall-verification-heading" class="text-lg font-bold text-gray-950 dark:text-white">Overall progress</h2>
+                <h2 id="overall-verification-heading" class="section-title">Overall progress</h2>
                 <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
                     {{ overview.requirements_verified }} of {{ overview.requirements_required }} current requirements verified
                 </p>
             </div>
-            <span class="text-lg font-bold text-blue-700 dark:text-blue-300">{{ overview.percentage | round(0) | int }}%</span>
+            <span class="text-lg font-medium text-gray-700 dark:text-gray-300">{{ overview.percentage | round(0) | int }}%</span>
         </div>
         {% with
             value=overview.percentage,
@@ -44,42 +41,42 @@
 </section>
 
 {% if overview.next_phase %}
-<section class="mt-8 rounded-lg border border-blue-200 bg-blue-50 p-5 dark:border-blue-800 dark:bg-blue-950/40" aria-labelledby="next-verification-heading">
+<section class="mt-8 border-y border-gray-200 py-6 dark:border-gray-700" aria-labelledby="next-verification-heading">
     <div class="flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-center">
         <div>
-            <h2 id="next-verification-heading" class="text-lg font-bold text-blue-950 dark:text-blue-100">
+            <h2 id="next-verification-heading" class="section-title">
                 {% if overview.next_phase.progress.requirements_verified > 0 %}Continue verification{% else %}Start verification{% endif %}
             </h2>
-            <p class="mt-1 text-sm text-blue-800 dark:text-blue-200">
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
                 Phase {{ overview.next_phase.phase.order }}: {{ overview.next_phase.phase.name }}
             </p>
         </div>
-        <a href="/verifications/phase/{{ overview.next_phase.phase.order }}" class="inline-flex min-h-11 shrink-0 items-center justify-center rounded-md bg-blue-700 px-4 py-2.5 text-sm font-bold text-white hover:bg-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-blue-400 dark:text-blue-950 dark:hover:bg-blue-300">
+        <a href="/verifications/phase/{{ overview.next_phase.phase.order }}" class="button-primary shrink-0">
             Open workspace
         </a>
     </div>
 </section>
 {% elif overview.is_complete %}
-<section class="mt-8 rounded-lg border border-green-200 bg-green-50 p-5 dark:border-green-800 dark:bg-green-950/30" aria-labelledby="verification-complete-heading">
-    <h2 id="verification-complete-heading" class="text-lg font-bold text-green-950 dark:text-green-100">All current verifications complete</h2>
-    <p class="mt-1 text-sm text-green-800 dark:text-green-200">You can still open any phase to review the work and feedback that was recorded.</p>
+<section class="mt-8 border-y border-gray-200 py-6 dark:border-gray-700" aria-labelledby="verification-complete-heading">
+    <h2 id="verification-complete-heading" class="section-title">All current verifications complete</h2>
+    <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">You can still open any phase to review the work and feedback that was recorded.</p>
 </section>
 {% endif %}
 
 <section class="mt-12" aria-labelledby="verification-phases-heading">
     <div>
-        <h2 id="verification-phases-heading" class="text-2xl font-bold tracking-[-0.02em] text-gray-950 dark:text-white">Phases</h2>
+        <h2 id="verification-phases-heading" class="section-title">Phases</h2>
         <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Each workspace keeps submissions, processing state, and private feedback history together.</p>
     </div>
 
     <div class="mt-6 border-y border-gray-200 dark:border-gray-700">
         {% for item in overview.phases %}
         <a href="/verifications/phase/{{ item.phase.order }}" class="group grid min-h-11 grid-cols-[2.75rem_1fr] gap-4 py-4 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 sm:grid-cols-[2.75rem_1fr_auto] sm:items-center {% if not loop.last %}border-b border-gray-200 dark:border-gray-700{% endif %}">
-            <span class="flex h-9 w-9 items-center justify-center rounded-full {% if item.status == 'complete' %}bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200{% elif item.status == 'locked' %}bg-amber-100 text-amber-800 dark:bg-amber-950/30 dark:text-amber-200{% else %}bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200{% endif %} text-xs font-bold">
+            <span class="flex h-9 w-9 items-center justify-center rounded-full border border-gray-200 text-xs font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400">
                 {{ item.phase.order }}
             </span>
             <span class="min-w-0">
-                <span class="block text-sm font-bold text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ item.phase.name }}</span>
+                <span class="block text-sm font-medium text-gray-800 group-hover:text-blue-700 dark:text-gray-200 dark:group-hover:text-blue-300">{{ item.phase.name }}</span>
                 <span class="mt-1 block text-xs leading-5 text-gray-500 dark:text-gray-400">
                     {{ item.progress.requirements_verified }}/{{ item.progress.requirements_required }} requirements verified
                     {% if item.is_locked %} · Complete Phase {{ item.prerequisite_phase_id }} verification first{% endif %}
@@ -101,10 +98,9 @@
     </div>
 </section>
 {% else %}
-<section class="rounded-lg border border-gray-200 bg-gray-50 p-8 dark:border-gray-700 dark:bg-gray-800/50" aria-labelledby="verification-empty-heading">
-    <h2 id="verification-empty-heading" class="text-xl font-bold text-gray-950 dark:text-white">No verification requirements are available.</h2>
+<section aria-labelledby="verification-empty-heading">
+    <h2 id="verification-empty-heading" class="section-title">No verification requirements are available.</h2>
     <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">Open the curriculum to continue learning while new hands-on work is prepared.</p>
-    <a href="/curriculum" class="mt-5 inline-flex min-h-11 items-center font-bold text-blue-700 underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">Browse curriculum</a>
 </section>
 {% endif %}
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/partials/footer.html
+++ b/api/src/learn_to_cloud/templates/partials/footer.html
@@ -1,13 +1,12 @@
 <footer class="border-t border-gray-200 dark:border-gray-700 {{ footer_margin | default('mt-16') }}">
     <div class="mx-auto max-w-content px-4 sm:px-6 lg:px-8 py-8">
-        <p class="text-sm text-gray-500 dark:text-gray-400 text-center">
-            &copy; {{ now.year }} Learn to Cloud
-            <span class="mx-1">&middot;</span>
-            <a href="/curriculum" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Program overview</a>
-            <span class="mx-1">&middot;</span>
-            <a href="/privacy" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Privacy</a>
-            <span class="mx-1">&middot;</span>
-            <a href="/terms" class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors">Terms</a>
-        </p>
+        <div class="flex flex-col items-center justify-between gap-3 text-sm text-gray-500 dark:text-gray-400 sm:flex-row">
+            <p>&copy; {{ now.year }} Learn to Cloud</p>
+            <nav class="flex flex-wrap justify-center gap-x-5" aria-label="Footer">
+                {% for url, label in [('/curriculum', 'Program overview'), ('/faq', 'FAQ'), ('/privacy', 'Privacy'), ('/terms', 'Terms')] %}
+                <a href="{{ url }}" class="inline-flex min-h-11 items-center transition-colors hover:text-blue-700 focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-blue-700 dark:hover:text-blue-300 dark:focus-visible:outline-blue-300">{{ label }}</a>
+                {% endfor %}
+            </nav>
+        </div>
     </div>
 </footer>

--- a/api/src/learn_to_cloud/templates/partials/navbar.html
+++ b/api/src/learn_to_cloud/templates/partials/navbar.html
@@ -3,10 +3,7 @@
         <div class="flex h-16 items-center justify-between">
             <div class="flex min-w-0 items-center gap-8">
                 <a href="/" class="flex min-h-11 items-center gap-2 text-lg font-bold tracking-[-0.02em] text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">
-                    <svg class="h-7 w-7 shrink-0" viewBox="0 0 28 28" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M8.5 21.5h11a5 5 0 0 0 .8-9.94A7.25 7.25 0 0 0 6.65 10.1 5.75 5.75 0 0 0 8.5 21.5Z"/>
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M14 8.25v5.5m-3.25 3.5h6.5M14 13.75v3.5"/>
-                    </svg>
+                    <img src="{{ static_url('favicon.svg') }}" alt="" width="44" height="44" class="h-11 w-11 shrink-0">
                     <span class="truncate">Learn to Cloud</span>
                 </a>
                 <div class="hidden sm:flex items-center gap-4">

--- a/api/src/learn_to_cloud/templates/partials/navbar.html
+++ b/api/src/learn_to_cloud/templates/partials/navbar.html
@@ -1,44 +1,38 @@
+{% set navigation_links = [('/dashboard', 'Dashboard'), ('/verifications', 'Verifications'), ('/community', 'Community')] if user else [('/community', 'Community')] %}
 <nav class="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900" x-data="{ mobileOpen: false }">
     <div class="mx-auto max-w-content px-4 sm:px-6 lg:px-8">
         <div class="flex h-16 items-center justify-between">
-            <div class="flex min-w-0 items-center gap-8">
-                <a href="/" class="flex min-h-11 items-center gap-2 text-lg font-bold tracking-[-0.02em] text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">
+            <div class="flex min-w-0 items-center gap-6">
+                <a href="/" class="flex min-h-11 min-w-0 items-center gap-2 text-lg font-bold tracking-[-0.02em] text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300">
                     <img src="{{ static_url('favicon.svg') }}" alt="" width="44" height="44" class="h-11 w-11 shrink-0">
                     <span class="truncate">Learn to Cloud</span>
                 </a>
-                <div class="hidden sm:flex items-center gap-4">
-                    {% if user %}
-                    <a href="/dashboard" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
-                        Dashboard
+                <div class="hidden md:flex items-center gap-4">
+                    {% for url, label in navigation_links %}
+                    {% set active = request.url.path == url or request.url.path.startswith(url ~ '/') %}
+                    <a href="{{ url }}" {% if active %}aria-current="page"{% endif %} class="inline-flex min-h-11 items-center text-sm font-medium {% if active %}text-blue-700 dark:text-blue-300{% else %}text-gray-600 dark:text-gray-300{% endif %} hover:text-blue-700 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:text-blue-300">
+                        {{ label }}
                     </a>
-                    <a href="/verifications" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
-                        Verifications
-                    </a>
-                    {% endif %}
-                    <a href="/community" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
-                        Community
-                    </a>
-                    <a href="/faq" class="inline-flex min-h-11 items-center text-sm font-medium text-gray-600 hover:text-gray-900 focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:text-white">
-                        FAQ
-                    </a>
+                    {% endfor %}
                 </div>
             </div>
 
-            <div class="flex items-center gap-4">
+            <div class="flex shrink-0 items-center gap-1 sm:gap-3">
                 {% include "partials/theme_toggle.html" %}
 
                 {% if user %}
                 <div class="relative flex items-center gap-3" x-data="{ open: false }">
-                    <button @click="open = !open" class="flex min-h-11 cursor-pointer items-center gap-2 rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700">
+                    <button type="button" @click="open = !open" :aria-expanded="open" aria-controls="account-navigation" aria-label="Account menu" class="flex min-h-11 cursor-pointer items-center gap-2 rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700">
                         {% if user.avatar_url %}
                         <img src="{{ user.avatar_url }}" alt="{{ user.github_username }}" class="h-8 w-8 rounded-full">
                         {% endif %}
-                        <span class="text-sm font-medium hidden sm:inline">{{ user.github_username }}</span>
+                        <span class="hidden max-w-32 truncate text-sm font-medium lg:inline">{{ user.github_username }}</span>
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
                         </svg>
                     </button>
                     <div
+                        id="account-navigation"
                         x-show="open"
                         @click.outside="open = false"
                         x-cloak
@@ -56,7 +50,7 @@
                     </div>
                 </div>
                 {% else %}
-                <a href="/auth/login" hx-boost="false" class="hidden min-h-11 items-center gap-2 rounded-md bg-gray-900 px-3 py-2 text-sm font-semibold text-white hover:bg-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 sm:inline-flex">
+                <a href="/auth/login" hx-boost="false" class="button-primary hidden px-3 md:inline-flex">
                     <svg class="h-4 w-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                     Sign in with GitHub
                 </a>
@@ -64,7 +58,7 @@
 
                 <button
                     type="button"
-                    class="inline-flex h-11 w-11 items-center justify-center rounded-md text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white sm:hidden"
+                    class="inline-flex h-11 w-11 items-center justify-center rounded-md text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white md:hidden"
                     @click="mobileOpen = !mobileOpen"
                     :aria-expanded="mobileOpen"
                     aria-controls="mobile-navigation"
@@ -80,16 +74,14 @@
             </div>
         </div>
 
-        <div id="mobile-navigation" x-show="mobileOpen" x-collapse x-cloak class="border-t border-gray-200 py-3 dark:border-gray-700 sm:hidden">
+        <div id="mobile-navigation" x-show="mobileOpen" x-collapse x-cloak class="border-t border-gray-200 py-3 dark:border-gray-700 md:hidden">
             <div class="grid gap-1">
-                {% if user %}
-                <a href="/dashboard" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">Dashboard</a>
-                <a href="/verifications" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">Verifications</a>
-                {% endif %}
-                <a href="/community" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">Community</a>
-                <a href="/faq" @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-semibold text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:text-gray-200 dark:hover:bg-gray-800">FAQ</a>
+                {% for url, label in navigation_links %}
+                {% set active = request.url.path == url or request.url.path.startswith(url ~ '/') %}
+                <a href="{{ url }}" {% if active %}aria-current="page"{% endif %} @click="mobileOpen = false" class="flex min-h-11 items-center rounded-md px-3 text-sm font-medium {% if active %}text-blue-700 dark:text-blue-300{% else %}text-gray-700 dark:text-gray-200{% endif %} hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-inset focus-visible:outline-blue-700 dark:hover:bg-gray-800">{{ label }}</a>
+                {% endfor %}
                 {% if not user %}
-                <a href="/auth/login" hx-boost="false" class="mt-2 flex min-h-11 items-center justify-center rounded-md bg-gray-900 px-3 text-sm font-semibold text-white hover:bg-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200">
+                <a href="/auth/login" hx-boost="false" class="button-primary mt-2">
                     Sign in with GitHub
                 </a>
                 {% endif %}

--- a/api/src/learn_to_cloud/templates/partials/requirement_card.html
+++ b/api/src/learn_to_cloud/templates/partials/requirement_card.html
@@ -1,8 +1,8 @@
 {# Required context: ``card`` is one RequirementCardContext variant. #}
 {% from "macros/badges.html" import status_pill %}
 {% from "macros/callouts.html" import banner %}
-<div id="requirement-{{ card.requirement.slug }}" class="border border-gray-200 dark:border-gray-700 rounded-lg p-4">
-    <div class="flex items-center justify-between mb-2">
+<div id="requirement-{{ card.requirement.slug }}" class="border-y border-gray-200 py-6 dark:border-gray-700">
+    <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
         <h3 class="font-medium text-gray-900 dark:text-gray-100">{{ card.requirement.name }}</h3>
         {% if card.kind == 'passed' %}
         {{ status_pill("Verified", "success") }}
@@ -71,7 +71,7 @@
         x-init="valid = $el.checkValidity()"
         @input="valid = $el.checkValidity()"
         @change="valid = $el.checkValidity()"
-        class="flex flex-col gap-3 {% if card.verification_form.kind == 'reflection' %}gap-4{% else %}sm:flex-row sm:items-start{% endif %}"
+        class="mt-4 flex flex-col gap-3 {% if card.verification_form.kind == 'reflection' %}gap-4{% else %}sm:flex-row sm:items-start{% endif %}"
     >
         {% with verification_form=card.verification_form, requirement=card.requirement %}
         {% include card.verification_form.template %}
@@ -80,11 +80,11 @@
         <button
             type="submit"
             :disabled="!valid"
-            class="inline-flex min-h-11 items-center justify-center rounded-md bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 disabled:opacity-50"
+            class="button-primary self-start disabled:opacity-50"
         >
             Verify
         </button>
-        <span id="spinner-{{ card.requirement.slug }}" class="htmx-indicator inline-flex items-center text-sm text-gray-500">
+        <span id="spinner-{{ card.requirement.slug }}" class="htmx-indicator inline-flex min-h-11 items-center text-sm text-gray-500 dark:text-gray-400">
             Checking...
         </span>
     </form>
@@ -95,7 +95,7 @@
     {% endif %}
     {% if card.verification_form.kind == 'derived' %}
     <details class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-        <summary class="min-h-11 cursor-pointer py-3 font-medium text-blue-700 hover:underline dark:text-blue-300">
+        <summary class="min-h-11 cursor-pointer rounded-md py-3 font-medium text-blue-700 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:focus-visible:outline-blue-300">
             Why can't I edit this URL?
         </summary>
         <p class="pb-2 leading-5">

--- a/api/src/learn_to_cloud/templates/partials/topic_step.html
+++ b/api/src/learn_to_cloud/templates/partials/topic_step.html
@@ -11,10 +11,10 @@
 <section
     id="step-{{ step.uuid }}"
     data-step
-    class="rounded-lg border {% if is_completed %}border-green-200 bg-green-50/40 dark:border-green-800/50 dark:bg-green-950/20{% else %}border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800/50{% endif %}"
+    class="border-t border-gray-200 dark:border-gray-700"
     x-data="{ expanded: {{ 'true' if initially_open else 'false' }} }"
 >
-    <div class="flex items-start gap-2 p-3 sm:items-center">
+    <div class="flex items-start gap-2 py-4 sm:items-center">
         {% if user %}
         <label class="flex h-11 w-11 shrink-0 cursor-pointer items-center justify-center rounded-md hover:bg-gray-100 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-blue-700 dark:hover:bg-gray-800">
             <span class="sr-only">Mark {{ step_label }} complete</span>
@@ -48,9 +48,9 @@
             <div class="flex flex-wrap items-center gap-2">
                 {{ action_badge(step.action) }}
                 {% if step.title and step.url %}
-                <a href="{{ step.url }}" target="_blank" rel="noopener" hx-boost="false" class="inline-flex min-h-11 items-center break-words text-sm font-bold underline underline-offset-4 hover:text-blue-700 focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:text-blue-300">{{ step.title }}</a>
+                <a href="{{ step.url }}" target="_blank" rel="noopener" hx-boost="false" class="inline-flex min-h-11 items-center break-words text-base font-medium text-blue-700 underline decoration-blue-200 underline-offset-4 hover:decoration-blue-700 focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-blue-300 dark:decoration-blue-800 dark:hover:decoration-blue-300">{{ step.title }}</a>
                 {% elif step.title %}
-                <h2 class="break-words text-sm font-bold {% if is_completed %}text-gray-500 line-through dark:text-gray-400{% else %}text-gray-950 dark:text-white{% endif %}">{{ step.title }}</h2>
+                <h2 class="break-words text-base font-medium {% if is_completed %}text-gray-500 dark:text-gray-400{% else %}text-gray-950 dark:text-white{% endif %}">{{ step.title }}</h2>
                 {% endif %}
             </div>
         </div>
@@ -73,9 +73,9 @@
 
     {% if has_body %}
     <div id="step-{{ step.uuid }}-body" x-show="expanded" x-collapse x-cloak>
-        <div class="px-4 pb-4 sm:pl-[5.75rem]">
+        <div class="pb-8 sm:pl-20">
             {% if step.description %}
-            <div class="prose prose-sm max-w-none text-sm text-gray-600 dark:prose-invert dark:text-gray-400" x-data="proseCopyButtons">
+            <div class="prose max-w-none text-base leading-7 text-gray-700 dark:prose-invert dark:text-gray-300" x-data="proseCopyButtons">
                 {{ step.description | md | safe }}
             </div>
             {% endif %}

--- a/api/src/learn_to_cloud/templates/partials/verification_feedback.html
+++ b/api/src/learn_to_cloud/templates/partials/verification_feedback.html
@@ -22,7 +22,7 @@
 {% set _panel_id = 'feedback-panel-' ~ (requirement_slug | default('default')) %}
 
 <div
-    class="mt-4 border-t {% if all_passed %}border-green-200 dark:border-green-800{% else %}border-red-200 dark:border-red-800{% endif %}"
+    class="mt-4 border-t border-gray-200 dark:border-gray-700"
     x-data="{ expanded: {{ 'false' if all_passed else 'true' }} }"
 >
     <button
@@ -30,16 +30,15 @@
         @click="expanded = !expanded"
         :aria-expanded="expanded"
         aria-controls="{{ _panel_id }}"
-        class="flex min-h-11 w-full items-center justify-between gap-3 py-3 text-left text-sm font-bold
-               {% if all_passed %}text-green-900 dark:text-green-100{% else %}text-red-900 dark:text-red-100{% endif %}
+        class="flex min-h-11 w-full items-center justify-between gap-3 py-3 text-left text-sm font-medium text-gray-800 dark:text-gray-200
                focus-visible:rounded-md focus-visible:outline-2 focus-visible:outline-offset-2
-               {% if all_passed %}focus-visible:outline-green-700{% else %}focus-visible:outline-red-700{% endif %}"
+               focus-visible:outline-blue-700 dark:focus-visible:outline-blue-300"
     >
         <span class="flex min-w-0 items-center gap-2">
             {% if all_passed %}
-            <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+            <svg class="h-4 w-4 shrink-0 text-green-700 dark:text-green-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
             {% else %}
-            <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            <svg class="h-4 w-4 shrink-0 text-red-700 dark:text-red-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
             {% endif %}
             <span>
                 {% if counts.structured and all_passed %}
@@ -73,10 +72,16 @@
 
             {% if counts.structured %}
             <section aria-label="Required checks">
-                <h4 class="text-xs font-bold uppercase tracking-wide text-gray-600 dark:text-gray-300">Required checks</h4>
+                <h4 class="text-sm font-medium text-gray-600 dark:text-gray-300">Required checks</h4>
                 <div class="mt-2 space-y-2">
                     {% for task in feedback_tasks %}
                     {% for criterion in task.criteria if criterion.kind == 'required' %}
+                    {% if criterion.status == 'met' and not all_passed %}
+                    <details>
+                        <summary class="min-h-11 cursor-pointer rounded-md py-3 text-sm text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-400 dark:focus-visible:outline-blue-300">
+                            Passed: {{ criterion.label or criterion.id }}
+                        </summary>
+                    {% endif %}
                     <div class="flex items-start gap-3 py-3">
                         <span class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full
                                      {% if criterion.status == 'met' %}bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300
@@ -85,24 +90,24 @@
                             {{ '✓' if criterion.status == 'met' else '✕' }}
                         </span>
                         <div class="min-w-0">
-                            <p class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ criterion.label or criterion.id }}</p>
+                            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ criterion.label or criterion.id }}</p>
                             {% if criterion.explanation %}
                             <p class="mt-1 max-w-3xl text-sm leading-6 text-gray-600 dark:text-gray-300">{{ criterion.explanation }}</p>
                             {% endif %}
                             {% if criterion.next_steps %}
-                            <p class="mt-2 max-w-3xl text-sm font-medium leading-6 text-amber-800 dark:text-amber-300">
+                            <p class="mt-2 max-w-3xl text-sm font-medium leading-6 text-gray-800 dark:text-gray-200">
                                 Next step: {{ criterion.next_steps }}
                             </p>
                             {% endif %}
                             {% if criterion.evidence %}
                             <details class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-                                <summary class="cursor-pointer font-medium underline underline-offset-4">Evidence reviewed</summary>
+                                <summary class="min-h-11 cursor-pointer rounded-md py-3 font-medium underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:focus-visible:outline-blue-300">Evidence reviewed</summary>
                                 <div class="mt-2 flex flex-wrap gap-2">
                                     {% for evidence in criterion.evidence %}
                                         {% if evidence.url %}
-                                        <a href="{{ evidence.url }}" target="_blank" rel="noopener noreferrer" class="rounded bg-gray-100 px-2 py-1 font-mono text-blue-700 hover:underline dark:bg-gray-800 dark:text-blue-300">{{ evidence.label }}</a>
+                                        <a href="{{ evidence.url }}" target="_blank" rel="noopener noreferrer" class="text-link min-w-0 break-all font-mono">{{ evidence.label }}</a>
                                         {% else %}
-                                        <span class="rounded bg-gray-100 px-2 py-1 font-mono dark:bg-gray-800">{{ evidence.label }}</span>
+                                        <span class="min-w-0 break-all py-1 font-mono">{{ evidence.label }}</span>
                                         {% endif %}
                                     {% endfor %}
                                 </div>
@@ -110,6 +115,9 @@
                             {% endif %}
                         </div>
                     </div>
+                    {% if criterion.status == 'met' and not all_passed %}
+                    </details>
+                    {% endif %}
                     {% endfor %}
                     {% endfor %}
                 </div>
@@ -117,19 +125,19 @@
 
             {% if counts.suggestions %}
             <section aria-label="Suggestions">
-                <h4 class="text-xs font-bold uppercase tracking-wide text-gray-600 dark:text-gray-300">Suggestions</h4>
+                <h4 class="text-sm font-medium text-gray-600 dark:text-gray-300">Suggestions</h4>
                 <div class="mt-2 space-y-2">
                     {% for task in feedback_tasks %}
                     {% for criterion in task.criteria if criterion.kind != 'required' and criterion.status != 'met' %}
                     <div class="flex items-start gap-3 py-3">
                         <span class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-300" aria-hidden="true">→</span>
                         <div class="min-w-0">
-                            <p class="text-sm font-bold text-gray-900 dark:text-gray-100">{{ criterion.label or criterion.id }}</p>
+                            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ criterion.label or criterion.id }}</p>
                             {% if criterion.explanation %}
                             <p class="mt-1 max-w-3xl text-sm leading-6 text-gray-600 dark:text-gray-300">{{ criterion.explanation }}</p>
                             {% endif %}
                             {% if criterion.next_steps %}
-                            <p class="mt-2 max-w-3xl text-sm font-medium leading-6 text-amber-800 dark:text-amber-300">{{ criterion.next_steps }}</p>
+                            <p class="mt-2 max-w-3xl text-sm font-medium leading-6 text-gray-800 dark:text-gray-200">{{ criterion.next_steps }}</p>
                             {% endif %}
                         </div>
                     </div>
@@ -144,25 +152,34 @@
             {% if legacy %}
             <section aria-label="Automated checks">
                 {% if counts.structured %}
-                <h4 class="text-xs font-bold uppercase tracking-wide text-gray-600 dark:text-gray-300">Automated checks</h4>
+                <h4 class="text-sm font-medium text-gray-600 dark:text-gray-300">Automated checks</h4>
                 {% endif %}
                 <div class="{% if counts.structured %}mt-2{% endif %} space-y-2">
                     {% for task in legacy | sort(attribute='passed') %}
+                    {% if task.passed and not all_passed %}
+                    <details>
+                        <summary class="min-h-11 cursor-pointer rounded-md py-3 text-sm text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:text-gray-400 dark:focus-visible:outline-blue-300">
+                            Passed: {{ task.name }}
+                        </summary>
+                    {% endif %}
                     <div class="flex items-start gap-3 py-3 text-sm">
                         <span class="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full
                                      {% if task.passed %}bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300
                                      {% else %}bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300{% endif %}"
                               aria-hidden="true">{{ '✓' if task.passed else '✕' }}</span>
                         <div class="min-w-0">
-                            <p class="font-bold text-gray-900 dark:text-gray-100">{{ task.name }}</p>
+                            <p class="font-medium text-gray-900 dark:text-gray-100">{{ task.name }}</p>
                             {% if task.message %}
                             <p class="mt-1 max-w-3xl leading-6 text-gray-600 dark:text-gray-300">{{ task.message }}</p>
                             {% endif %}
                             {% if task.next_steps %}
-                            <p class="mt-2 font-medium leading-6 text-amber-800 dark:text-amber-300">Next step: {{ task.next_steps }}</p>
+                            <p class="mt-2 font-medium leading-6 text-gray-800 dark:text-gray-200">Next step: {{ task.next_steps }}</p>
                             {% endif %}
                         </div>
                     </div>
+                    {% if task.passed and not all_passed %}
+                    </details>
+                    {% endif %}
                     {% endfor %}
                 </div>
             </section>

--- a/api/src/learn_to_cloud/templates/partials/verification_forms/deployed_url.html
+++ b/api/src/learn_to_cloud/templates/partials/verification_forms/deployed_url.html
@@ -10,5 +10,5 @@
     autocomplete="url"
     inputmode="url"
     required
-    class="min-h-11 flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+    class="min-h-11 min-w-0 w-full flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
 >

--- a/api/src/learn_to_cloud/templates/partials/verification_forms/derived.html
+++ b/api/src/learn_to_cloud/templates/partials/verification_forms/derived.html
@@ -5,5 +5,5 @@
     value="{{ verification_form.url }}"
     readonly
     aria-readonly="true"
-    class="min-h-11 flex-1 cursor-default select-all rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-300"
+    class="min-h-11 min-w-0 w-full flex-1 cursor-default select-all rounded-md border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:focus-visible:outline-blue-300"
 >

--- a/api/src/learn_to_cloud/templates/partials/verification_forms/reflection.html
+++ b/api/src/learn_to_cloud/templates/partials/verification_forms/reflection.html
@@ -11,7 +11,7 @@
         maxlength="{{ verification_form.max_answer_length }}"
         placeholder="Write your response."
         required
-        class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+        class="min-h-11 w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
     ></textarea>
 </div>
 {% endfor %}

--- a/api/src/learn_to_cloud/templates/partials/verification_forms/token.html
+++ b/api/src/learn_to_cloud/templates/partials/verification_forms/token.html
@@ -11,5 +11,5 @@
     autocapitalize="none"
     spellcheck="false"
     required
-    class="min-h-11 flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+    class="min-h-11 min-w-0 w-full flex-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
 >

--- a/api/src/learn_to_cloud/templates/partials/verified_requirement_row.html
+++ b/api/src/learn_to_cloud/templates/partials/verified_requirement_row.html
@@ -11,35 +11,35 @@
      card  – a PassedCardContext
 #}
 <div id="requirement-{{ card.requirement.slug }}">
-    <div class="rounded-lg border border-green-200 bg-green-50 px-5 py-4 dark:border-green-800 dark:bg-green-900/20">
+    <div class="border-b border-gray-200 py-4 dark:border-gray-700">
         <div class="flex flex-wrap items-start justify-between gap-3">
             <div class="flex min-w-0 items-start gap-3">
-                <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300">
+                <span class="flex h-7 w-7 shrink-0 items-center justify-center text-green-700 dark:text-green-300">
                     <svg class="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="m5 10 3 3 7-7"/>
                     </svg>
                 </span>
                 <div class="min-w-0">
-                    <p class="text-sm font-bold text-green-900 dark:text-green-100">{{ card.requirement.name }}</p>
-                    <p class="mt-1 text-xs font-medium text-green-700 dark:text-green-300">Verified</p>
+                    <p class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ card.requirement.name }}</p>
+                    <p class="mt-1 text-xs text-green-900 dark:text-green-100">Verified</p>
                 </div>
             </div>
             {% if card.submission and card.submission.validated_at %}
-            <span class="text-xs text-green-700 dark:text-green-300">
+            <span class="text-xs text-gray-500 dark:text-gray-400">
                 Verified {{ card.submission.validated_at.strftime('%b %d, %Y') }}
             </span>
             {% endif %}
         </div>
 
-        <div class="mt-4 flex flex-wrap items-center justify-between gap-3 pl-10 text-xs">
+        <div class="mt-2 flex flex-wrap items-center justify-between gap-x-4 sm:pl-10">
             {% if card.graded_url %}
             <a
                 href="{{ card.graded_url }}"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-flex min-h-9 items-center gap-2 rounded-md border border-green-200 bg-white/60 px-3 py-2 font-bold text-gray-800 hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-green-700 dark:border-green-800 dark:bg-gray-950/20 dark:text-gray-100 dark:hover:bg-gray-950/40"
+                class="text-link min-w-0 gap-2 break-all"
             >
-                <svg class="h-4 w-4 text-gray-500 dark:text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
+                <svg class="h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M3.5 5.5h5l1.5 2h6.5v7.5h-13z"/>
                 </svg>
                 {{ card.graded_label }}
@@ -54,7 +54,7 @@
                 data-issue-context="requirement={{ card.requirement.slug }}"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="text-gray-500 underline underline-offset-4 hover:text-gray-800 hover:no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                class="inline-flex min-h-11 items-center text-xs text-gray-500 underline underline-offset-4 hover:text-gray-800 hover:no-underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-700 dark:text-gray-400 dark:hover:text-gray-200 dark:focus-visible:outline-gray-300"
             >Report a problem</a>
         </div>
 

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -659,8 +659,8 @@ def test_phase_progress_uses_distinct_labels_without_explanatory_copy():
         has_verification=False,
     )
 
-    assert "Verification progress — 1/2 requirements" in html
-    assert "Learning progress — 2/5 steps" in html
+    assert "1/2 requirements verified" in html
+    assert "2/5 steps checked" in html
     assert "Verification is what counts" not in html
 
 
@@ -852,6 +852,7 @@ def test_dashboard_help_section_links_to_discord():
 
     assert 'href="https://discord.gg/st7g2Hp77r"' in html
     assert "Ask the Community" not in html
+    assert "Project updates" not in html
 
 
 @pytest.mark.unit
@@ -930,18 +931,23 @@ class TestDashboardPrimaryState:
 
 
 @pytest.mark.unit
-def test_primary_links_are_in_navbar_and_footer_is_minimal():
-    navbar = _render("partials/navbar.html")
+@pytest.mark.parametrize("signed_in", [False, True])
+def test_primary_links_are_in_navbar_and_footer_is_minimal(signed_in):
+    ctx = {} if signed_in else {"user": None}
+    navbar = _render("partials/navbar.html", **ctx)
     footer = _render("partials/footer.html")
 
     assert 'src="/static/favicon.svg" alt=""' in navbar
     assert "Learn to Cloud" in navbar
 
-    for path in ("/verifications", "/community", "/faq"):
-        assert f'href="{path}"' in navbar
-        assert f'href="{path}"' not in footer
+    assert ('href="/verifications"' in navbar) is signed_in
+    assert 'href="/verifications"' not in footer
+    assert 'href="/community"' in navbar
+    assert 'href="/community"' not in footer
 
     assert 'href="/curriculum"' not in navbar
+    assert 'href="/faq"' not in navbar
+    assert 'href="/faq"' in footer
     assert 'href="/curriculum"' in footer
     assert "Program overview" in footer
     assert 'href="/privacy"' in footer
@@ -950,6 +956,18 @@ def test_primary_links_are_in_navbar_and_footer_is_minimal():
     assert "GitHub" not in footer
     assert "YouTube" not in footer
     assert "Sponsor" not in footer
+
+
+@pytest.mark.unit
+def test_navbar_marks_the_current_verification_section_in_both_menus():
+    html = _render(
+        "partials/navbar.html",
+        request=SimpleNamespace(url=SimpleNamespace(path="/verifications/phase/3")),
+    )
+
+    assert html.count('href="/verifications" aria-current="page"') == 2
+    assert 'href="/dashboard" aria-current="page"' not in html
+    assert 'href="/community" aria-current="page"' not in html
 
 
 @pytest.mark.unit
@@ -1014,9 +1032,12 @@ class TestDashboardPhaseRow:
             requirements_required=2,
         )
         html = self._render_dashboard(progress)
-        assert "Complete each phase's verification to progress." in html
-        assert "Verification progress — 3% of requirements" in html
-        assert "Learning progress — 3% of learning steps" in html
+        assert "Complete learning steps and verifications in each phase." in html
+        assert "Verification progress" in html
+        assert "Learning progress" in html
+        assert "Requirements verified" in html
+        assert "Learning steps checked" in html
+        assert html.count(">3%</dd>") == 2
         assert "Verification is the measure that counts" not in html
 
     def test_step_progress_phase_shows_both_counts(self):

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -37,6 +37,44 @@ def _render(template_name: str, **ctx: object) -> str:
     return _ENV.get_template(template_name).render(**_base_ctx(**ctx))
 
 
+@pytest.mark.unit
+class TestHomePage:
+    def test_anonymous_learner_starts_at_first_available_phase(self):
+        html = _render(
+            "pages/home.html",
+            user=None,
+            phases=[SimpleNamespace(order=0), SimpleNamespace(order=1)],
+        )
+        main = html.split("<main", 1)[1].split("</main>", 1)[0]
+
+        assert 'href="/phase/0"' in main
+        assert "Start learning" in main
+        assert 'href="/curriculum"' in main
+        assert 'href="/phase/1"' not in main
+        assert "Continue learning" not in main
+
+    def test_returning_learner_continues_from_dashboard(self):
+        html = _render("pages/home.html", phases=[SimpleNamespace(order=0)])
+        main = html.split("<main", 1)[1].split("</main>", 1)[0]
+
+        assert 'href="/dashboard"' in main
+        assert "Continue learning" in main
+        assert 'href="/curriculum"' in main
+        assert 'href="/phase/0"' not in main
+
+    @pytest.mark.parametrize("signed_in", [False, True])
+    def test_missing_curriculum_keeps_recovery_and_dashboard_access(self, signed_in):
+        ctx = {} if signed_in else {"user": None}
+        html = _render("pages/home.html", phases=[], **ctx)
+        main = html.split("<main", 1)[1].split("</main>", 1)[0]
+
+        assert "The learning path is temporarily unavailable." in main
+        assert 'href="/" hx-boost="false"' in main
+        assert 'href="/faq"' in main
+        assert 'href="/phase/' not in main
+        assert ('href="/dashboard"' in main) is signed_in
+
+
 def _requirement(slug: str, name: str, description: str = ""):
     from learn_to_cloud_shared.testing.requirement_factories import (
         ctf_token_requirement,

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -49,7 +49,10 @@ class TestHomePage:
 
         assert 'href="/phase/0"' in main
         assert "Start learning" in main
-        assert 'href="/curriculum"' in main
+        assert main.count('href="/curriculum"') == 1
+        assert main.count("<a ") == 2
+        assert "Explore the curriculum" in main
+        assert "See the full path" not in main
         assert 'href="/phase/1"' not in main
         assert "Continue learning" not in main
 
@@ -59,7 +62,10 @@ class TestHomePage:
 
         assert 'href="/dashboard"' in main
         assert "Continue learning" in main
-        assert 'href="/curriculum"' in main
+        assert main.count('href="/curriculum"') == 1
+        assert main.count("<a ") == 2
+        assert "Explore the curriculum" in main
+        assert "See the full path" not in main
         assert 'href="/phase/0"' not in main
 
     @pytest.mark.parametrize("signed_in", [False, True])

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -934,6 +934,9 @@ def test_primary_links_are_in_navbar_and_footer_is_minimal():
     navbar = _render("partials/navbar.html")
     footer = _render("partials/footer.html")
 
+    assert 'src="/static/favicon.svg" alt=""' in navbar
+    assert "Learn to Cloud" in navbar
+
     for path in ("/verifications", "/community", "/faq"):
         assert f'href="{path}"' in navbar
         assert f'href="{path}"' not in footer

--- a/api/tests/rendering/test_verification_visuals.py
+++ b/api/tests/rendering/test_verification_visuals.py
@@ -1,0 +1,98 @@
+"""Disclosure behavior for mixed verification results."""
+
+from html.parser import HTMLParser
+
+import pytest
+
+from learn_to_cloud.core.templates import templates
+
+
+class _FeedbackParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.tags: list[str] = []
+        self.text_contexts: dict[str, tuple[str, ...]] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.tags.append(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        assert self.tags.pop() == tag
+
+    def handle_data(self, data: str) -> None:
+        text = " ".join(data.split())
+        if text:
+            self.text_contexts[text] = tuple(self.tags)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("structured", [False, True])
+def test_mixed_feedback_discloses_passed_checks_but_keeps_fixes_visible(
+    structured: bool,
+) -> None:
+    if structured:
+        tasks = [
+            {
+                "name": "Repository review",
+                "passed": False,
+                "criteria": [
+                    {
+                        "id": "readme",
+                        "label": "Readme",
+                        "kind": "required",
+                        "status": "met",
+                        "explanation": "Readme is present.",
+                        "evidence": [
+                            {
+                                "label": "README.md",
+                                "url": "https://github.com/tester/repo/blob/main/README.md",
+                            }
+                        ],
+                    },
+                    {
+                        "id": "health",
+                        "label": "Health endpoint",
+                        "kind": "required",
+                        "status": "unmet",
+                        "explanation": "Health endpoint is missing.",
+                        "next_steps": "Add a health endpoint.",
+                    },
+                ],
+            }
+        ]
+        passed = 0
+    else:
+        tasks = [
+            {
+                "name": "Readme",
+                "passed": True,
+                "message": "Readme is present.",
+            },
+            {
+                "name": "Health endpoint",
+                "passed": False,
+                "message": "Health endpoint is missing.",
+                "next_steps": "Add a health endpoint.",
+            },
+        ]
+        passed = 1
+
+    html = templates.env.get_template("partials/verification_feedback.html").render(
+        feedback_tasks=tasks,
+        feedback_passed=passed,
+        requirement_slug="journal-api",
+    )
+    parser = _FeedbackParser()
+    parser.feed(html)
+    parser.close()
+
+    assert not parser.tags
+    assert 'x-data="{ expanded: true }"' in html
+    assert 'aria-controls="feedback-panel-journal-api"' in html
+    assert 'id="feedback-panel-journal-api" x-show="expanded" x-collapse' in html
+    assert "summary" in parser.text_contexts["Passed: Readme"]
+    assert "details" in parser.text_contexts["Readme is present."]
+    assert "details" not in parser.text_contexts["Health endpoint is missing."]
+    assert "details" not in parser.text_contexts["Next step: Add a health endpoint."]
+    if structured:
+        assert parser.text_contexts["README.md"].count("details") == 2

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -233,8 +233,10 @@ class TestPublicPageSmoke:
         assert "high agency, self-sufficiency, and discipline." in response.text
         assert (
             "Cloud resources and some learning materials may cost extra."
-            in response.text
+            not in response.text
         )
+        assert "Build an AI-powered API," in response.text
+        assert "AI-powered journal" not in response.text
         assert "Structure, practice, and feedback." in response.text
         assert "automated checks and AI-assisted reviews" in response.text
         assert "Build it. Then take it further." in response.text

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -237,7 +237,14 @@ class TestPublicPageSmoke:
         )
         assert "Build an AI-powered API," in response.text
         assert "AI-powered journal" not in response.text
-        assert "Structure, practice, and feedback." in response.text
+        assert "Structure, feedback, and real-world relevance." in response.text
+        assert (
+            response.text.index("Learn with direction.")
+            < response.text.index("Improve with feedback.")
+            < response.text.index("Learn what's current.")
+        )
+        assert "People working in the field continually update" in response.text
+        assert "Build with purpose." not in response.text
         assert "automated checks and AI-assisted reviews" in response.text
         assert "Build it. Then take it further." in response.text
 

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -229,8 +229,9 @@ class TestPublicPageSmoke:
         assert response.status_code == 200
         assert "Information is everywhere." in response.text
         assert "Understanding is earned." in response.text
-        assert "Think with AI. Not less." in response.text
-        assert "Learn it. Build it. Prove it." in response.text
+        assert "Structure, practice, and feedback." in response.text
+        assert "automated checks and AI-assisted reviews" in response.text
+        assert "Build it. Then take it further." in response.text
 
     async def test_curriculum_page_renders(self, anon_client: AsyncClient):
         """GET /curriculum renders the phase hierarchy and progress CTA."""

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -229,7 +229,7 @@ class TestPublicPageSmoke:
         assert response.status_code == 200
         assert "Information is now abundant." in response.text
         assert "Access to education should be too." in response.text
-        assert "Free and open source cloud engineering." in response.text
+        assert "Free, open-source cloud engineering education." in response.text
         assert "high agency, self-sufficiency, and discipline." in response.text
         assert (
             "Cloud resources and some learning materials may cost extra."

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -227,10 +227,10 @@ class TestPublicPageSmoke:
         """GET / renders the home page template."""
         response = await anon_client.get("/")
         assert response.status_code == 200
-        assert "From first command to production cloud system." in response.text
-        assert "Progress tracking" in response.text
-        assert "Hands-on labs" in response.text
-        assert "The curriculum, phase by phase." in response.text
+        assert "Information is everywhere." in response.text
+        assert "Understanding is earned." in response.text
+        assert "Think with AI. Not less." in response.text
+        assert "Learn it. Build it. Prove it." in response.text
 
     async def test_curriculum_page_renders(self, anon_client: AsyncClient):
         """GET /curriculum renders the phase hierarchy and progress CTA."""

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -227,8 +227,14 @@ class TestPublicPageSmoke:
         """GET / renders the home page template."""
         response = await anon_client.get("/")
         assert response.status_code == 200
-        assert "Information is everywhere." in response.text
-        assert "Understanding is earned." in response.text
+        assert "Information is now abundant." in response.text
+        assert "Access to education should be too." in response.text
+        assert "Free and open source cloud engineering." in response.text
+        assert "high agency, self-sufficiency, and discipline." in response.text
+        assert (
+            "Cloud resources and some learning materials may cost extra."
+            in response.text
+        )
         assert "Structure, practice, and feedback." in response.text
         assert "automated checks and AI-assisted reviews" in response.text
         assert "Build it. Then take it further." in response.text


### PR DESCRIPTION
Refresh the home page and learner pages with more space, quieter typography, fewer competing panels, and Learn to Cloud blue accents. The home page makes clear that this is free, open-source cloud engineering education, with the headline: Information is now abundant. Access to education should be too.

The dashboard emphasizes continuing learning and keeps learning progress separate from verified work. Phase, topic, curriculum, and community pages use simpler layouts. Verification pages keep failed checks and next steps visible while making passed checks and supporting evidence expandable.

Move FAQ to the footer, remove Project updates from the dashboard, and remove Browse curriculum from the verification page. Keep Program overview available in the footer. The navbar uses the official cloud-and-book mark.

Privacy and Terms now use a narrower reading column, larger body text, lighter headings, subtle section dividers, and branded links. Their legal wording and links are unchanged.

Existing learning, submission, verification, and navigation behavior is preserved, with responsive layouts and light and dark themes.