### PR TITLE
Unify authentication and fix login/logout response handling

### DIFF
--- a/.github/agents/dog-food.agent.md
+++ b/.github/agents/dog-food.agent.md
@@ -36,7 +36,8 @@ floor, not the plan.
 
 Report as a **defect** anything with objective evidence:
 
-- an HTTP status of 400 or higher;
+- an unexpected HTTP status of 400 or higher (anonymous/expired-session 401s can
+  be normal; see the authentication response contract in the reference);
 - an unhandled traceback in a server log;
 - a JavaScript console error;
 - visible failure text such as `Internal Server Error`, `500`, `404`, or
@@ -137,6 +138,13 @@ confirm you are signed in.
 If session generation or authentication fails, record it as a defect with the
 script's error output, and continue against public pages only.
 
+The session needs both `user_id` and `github_username`; use the helper rather
+than minting an ID-only cookie. Do not paste cookie values or identity data into
+logs or reports. Session data is signed, not encrypted.
+
+Expected login navigation and repeatable logout behavior are described in
+[the authentication response contract](dog-food/reference.md#authentication-response-contract).
+
 ## Diagnose every failure
 
 The browser tells you *that* something broke; the logs tell you *why*. Never
@@ -157,9 +165,10 @@ rendered error page. Two specifics about these logs:
   per-request access lines: `uvicorn.access` is pinned to `WARNING` in
   `learn_to_cloud_shared.core.logger`. Correlate by exception and ordering, not
   by looking for a request line.
-- A user-visible failure with *no* corresponding log entry is itself a defect
-  worth reporting: it means the failure is invisible to anyone debugging from
-  the server side.
+- An unexpected server failure with *no* corresponding log entry is itself a
+  defect worth reporting. Normal authentication 401s and login redirects are
+  request telemetry, not unhandled exceptions; they do not require a traceback
+  or an additional auth error log.
 
 ## Submitting a phase requirement
 

--- a/.github/agents/dog-food/reference.md
+++ b/.github/agents/dog-food/reference.md
@@ -31,6 +31,34 @@ rendered, not the full definition of working.
 | Phase 7 | `/phase/7` | Navigation, main content, no server error |
 | First topic | First `/phase/1/*` link | Learning steps and checkboxes |
 
+## Authentication response contract
+
+Use these expectations when the learner's goal involves signing in, session
+expiry, or signing out. They are not all product defects merely because an
+HTTP request was rejected.
+
+| Situation | Expected behavior |
+|-----------|-------------------|
+| Anonymous user opens a protected page | 303 to `/auth/login`; subsequent login navigation uses GET |
+| Anonymous API request | 401 without a login redirect |
+| HTMX action with a missing or expired session | 401; the existing browser handler navigates to login |
+| HTMX endpoint called without the HTMX header | Still 401, not a login redirect |
+| Logout with a valid, missing, or rejected cookie | Session/cookie cleared, 303 to `/`; safe to repeat |
+| Public page without a session | Remains available |
+
+A fresh, valid local session unexpectedly rejected by a protected route is a
+defect. Normal expired-session navigation is not; report friction if it is
+confusing or leaves the learner stuck.
+
+Logout clears this browser's cookie, not every copy of an issued signed cookie.
+Do not report missing global revocation as a new regression; it is tracked in
+[#828](https://github.com/learntocloud/learn-to-cloud-app/issues/828). Do report
+new behavior that differs from the documented response contract.
+
+See [Authentication and sessions](../../../docs/contributing.md#authentication-and-sessions)
+for the underlying design. Record sanitized routes, statuses, and visible
+outcomes, never cookies, tokens, or user identities.
+
 ## Submission requirements
 
 Source of truth is `packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,14 @@ Keep docstrings short and useful. One line is enough for most functions.
 - Don't add `# noqa`, `# type: ignore`, `try/except: pass`, or rule exclusions to make CI green. Same applies to inserting "make the warning happy" code that wouldn't otherwise belong.
 - If a real fix would require a bigger refactor, don't quietly patch around the symptom instead. Tell the user and let them choose.
 
+## Authentication
+
+- Use `CurrentUser` for protected routes and `OptionalCurrentUser` for public routes. Both supply `AuthenticatedUser`; use its `.user_id` or `.github_username` rather than adding ID-only dependencies.
+- Keep identity loading separate from navigation. Page routers use `LoginRedirectRoute`; API and HTMX endpoints retain 401 responses. Do not infer this policy from URL prefixes or `Accept`.
+- Logout clears the local cookie but does not revoke copied signed cookies. Do not claim server-side revocation exists.
+- Keep expected auth responses in request telemetry, without logging identities, cookies, or tokens.
+- Follow [Authentication and sessions](../docs/contributing.md#authentication-and-sessions) for the complete contract and test boundaries.
+
 ## Docker in WSL
 
 - **Before saying Docker is unavailable, run the preflight check:**

--- a/.github/prompts/new-route.prompt.md
+++ b/.github/prompts/new-route.prompt.md
@@ -5,12 +5,15 @@ description: Scaffold a new feature with Route, Service, and Repository followin
 
 Create a new feature following the **Routes > Services > Repositories** architecture.
 
+Follow the [authentication contract](../../docs/contributing.md#authentication-and-sessions)
+when adding or changing protected routes.
+
 ## What I need from you
 
 1. **Feature name** and a brief description of what it does.
 2. Whether it needs **database access** (new model/table, or existing model).
 3. Whether it's a **page route** (TemplateResponse), **HTMX route** (HTMLResponse fragment), or **API route** (JSON).
-4. Whether it requires **authentication** (`UserId` or `OptionalUserId`).
+4. Whether it requires **authentication** (`CurrentUser` or `OptionalCurrentUser`).
 
 ## What to generate
 
@@ -18,7 +21,8 @@ Create a new feature following the **Routes > Services > Repositories** architec
 - Add to an existing route file or create a new one with `APIRouter(prefix="...", tags=[...])`.
 - Use `async def` for all handlers.
 - Use `DbSession` or `DbSessionReadOnly` from `core.database` for database access.
-- Use `UserId` or `OptionalUserId` from `core.auth` for authentication.
+- Use `CurrentUser` or `OptionalCurrentUser` from `core.auth`; access `.user_id` or `.github_username` on the identity.
+- Page routers use `route_class=LoginRedirectRoute` from `core.routing` for login navigation. API and HTMX routers retain 401 responses.
 - Keep routes thin - delegate business logic to the service layer.
 - Add a module-level docstring explaining the routes.
 

--- a/.github/skills/check-prod/SKILL.md
+++ b/.github/skills/check-prod/SKILL.md
@@ -35,7 +35,14 @@ below 10.
 **Warning:** P95 above 500 ms; failed availability test; recurring exception;
 other dependency failure; DB CPU 50-80%, memory/storage 70-85%, or credits
 10-30; Container App CPU/memory above 80%; unhealthy replicas without matching
-scale events; auth failures above 50% when login activity exists.
+scale events; OAuth callback failures above 50% of observed OAuth callback
+outcomes when login activity exists.
+
+Use `auth.login.success` and `auth.callback.*` failure events for OAuth outcomes.
+Expected request 401s for missing sessions and 303 login redirects are not OAuth
+callback failures or unhandled application errors. Request URL attributes should
+use route templates, including router prefixes; `/unmatched` is reserved for
+requests without a known route template.
 
 Otherwise report **Healthy**. Missing telemetry is `Unknown`, not healthy.
 

--- a/.github/skills/validate/SKILL.md
+++ b/.github/skills/validate/SKILL.md
@@ -25,6 +25,16 @@ After Python application changes, start a fresh API process on
 Track the exact process ID and always terminate that process during cleanup.
 Do not kill unrelated listeners. Report startup logs if any endpoint fails.
 
+For authentication or route-policy changes, preserve the real-route coverage in
+`api/tests/routes/test_auth_http.py`: API/HTMX 401s, page 303s, redirect methods,
+signed-session success, and repeatable logout. Do not bypass authentication
+with dependency overrides when testing authentication itself. The same file
+checks exported request spans; `api/tests/core/test_middleware.py` covers nested
+router templates. These tests already run in `uv run poe check`.
+
+See [Authentication and sessions](../../../docs/contributing.md#authentication-and-sessions)
+for the response and session-lifecycle contract.
+
 For workflow changes that add a Python command, also run that exact command
 with only the environment variables supplied by the workflow. Do not assume
 the local WSL environment is available in CI.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ A web application for tracking your progress through the [Learn to Cloud](https:
 | **Infra** | Azure Container Apps, Azure Functions, Azure PostgreSQL, Terraform |
 | **CI/CD** | GitHub Actions |
 
+GitHub login establishes signed-cookie sessions. See
+[Authentication and sessions](docs/contributing.md#authentication-and-sessions)
+for route dependencies, login redirects, and logout limitations.
+
 ## Quick Start
 
 ### WSL / Linux Setup

--- a/api/src/learn_to_cloud/core/auth.py
+++ b/api/src/learn_to_cloud/core/auth.py
@@ -6,7 +6,7 @@ Provides:
 - Authlib OAuth client configuration for GitHub
 
 Session data is stored in signed cookies (via Starlette).
-The session contains: user_id (GitHub numeric ID).
+The session contains user_id (GitHub numeric ID) and github_username.
 """
 
 from __future__ import annotations
@@ -22,6 +22,7 @@ from learn_to_cloud_shared.core.config import OAuthConfig
 logger = logging.getLogger(__name__)
 
 oauth = OAuth()
+SESSION_COOKIE_NAME = "session"
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,6 +31,13 @@ class AuthenticatedUser:
 
     user_id: int
     github_username: str
+
+
+class AuthenticationRequired(HTTPException):
+    """The request has no authenticated session identity."""
+
+    def __init__(self) -> None:
+        super().__init__(status_code=401, detail="Unauthorized")
 
 
 def init_oauth(settings: OAuthConfig) -> None:
@@ -56,38 +64,14 @@ def init_oauth(settings: OAuthConfig) -> None:
     )
 
 
-def get_user_id_from_session(request: Request) -> int | None:
-    """Read user_id from the session cookie.
-
-    Returns the GitHub numeric user ID or None if not authenticated.
-    """
-    user_id = request.session.get("user_id")
-    if user_id is not None:
-        return int(user_id)
-    return None
-
-
-def get_github_username_from_session(request: Request) -> str | None:
-    """Read github_username from the session cookie."""
-    github_username = request.session.get("github_username")
-    if isinstance(github_username, str) and github_username:
-        return github_username
-    return None
-
-
 def get_authenticated_user_from_session(request: Request) -> AuthenticatedUser | None:
-    """Read authenticated identity from the session cookie.
-
-    Returns None when either the user ID or the GitHub username is missing.
-    The username is always written to the session at login, so a missing
-    username means a stale cookie (for example, a user whose row predates the
-    NOT NULL backfill); returning None forces a clean re-login.
-    """
-    user_id = get_user_id_from_session(request)
+    """Read the session identity, requiring both an ID and a nonempty username."""
+    user_id = request.session.get("user_id")
     if user_id is None:
         return None
-    github_username = get_github_username_from_session(request)
-    if github_username is None:
+    user_id = int(user_id)
+    github_username = request.session.get("github_username")
+    if not isinstance(github_username, str) or not github_username:
         return None
     return AuthenticatedUser(
         user_id=user_id,
@@ -95,39 +79,11 @@ def get_authenticated_user_from_session(request: Request) -> AuthenticatedUser |
     )
 
 
-def _unauthenticated_exception(request: Request) -> HTTPException:
-    is_htmx = request.headers.get("hx-request") == "true"
-    if is_htmx:
-        return HTTPException(status_code=401, detail="Unauthorized")
-    return HTTPException(
-        status_code=307,
-        headers={"Location": "/auth/login"},
-    )
-
-
-def require_auth(request: Request) -> int:
-    """Dependency: raises 401 if not authenticated. Sets request.state.user_id.
-
-    For HTMX requests, returns 401 so the htmx:responseError handler
-    can redirect client-side. For regular browser page requests,
-    redirects to /auth/login directly.
-    """
-    return require_authenticated_user(request).user_id
-
-
-def optional_auth(request: Request) -> int | None:
-    """Dependency: returns user_id or None. Does not raise."""
-    authenticated_user = optional_authenticated_user(request)
-    if authenticated_user is None:
-        return None
-    return authenticated_user.user_id
-
-
 def require_authenticated_user(request: Request) -> AuthenticatedUser:
-    """Dependency: returns session identity or raises if not authenticated."""
+    """Require a session identity, returning 401 when unauthenticated."""
     authenticated_user = optional_authenticated_user(request)
     if authenticated_user is None:
-        raise _unauthenticated_exception(request)
+        raise AuthenticationRequired()
     return authenticated_user
 
 
@@ -140,8 +96,6 @@ def optional_authenticated_user(request: Request) -> AuthenticatedUser | None:
     return authenticated_user
 
 
-UserId = Annotated[int, Depends(require_auth)]
-OptionalUserId = Annotated[int | None, Depends(optional_auth)]
 CurrentUser = Annotated[AuthenticatedUser, Depends(require_authenticated_user)]
 OptionalCurrentUser = Annotated[
     AuthenticatedUser | None, Depends(optional_authenticated_user)

--- a/api/src/learn_to_cloud/core/middleware.py
+++ b/api/src/learn_to_cloud/core/middleware.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+from fastapi.routing import iter_route_contexts
 from opentelemetry import trace
 from starlette.routing import Match
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -68,7 +69,7 @@ class TelemetrySanitizationMiddleware:
         partial_match: str | None = None
         app = scope.get("app")
         router = getattr(app, "router", None)
-        for route in getattr(router, "routes", ()):
+        for route in iter_route_contexts(getattr(router, "routes", ())):
             match, _ = route.matches(scope)
             route_path = getattr(route, "path", None)
             if not isinstance(route_path, str):

--- a/api/src/learn_to_cloud/core/routing.py
+++ b/api/src/learn_to_cloud/core/routing.py
@@ -1,0 +1,27 @@
+"""Response policies for browser page routes."""
+
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from fastapi import Request, Response
+from fastapi.responses import RedirectResponse
+from fastapi.routing import APIRoute
+
+from learn_to_cloud.core.auth import AuthenticationRequired
+
+
+class LoginRedirectRoute(APIRoute):
+    """Redirect unauthenticated page navigation to login, keeping HTMX errors."""
+
+    def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+        handler = super().get_route_handler()
+
+        async def handle(request: Request) -> Response:
+            try:
+                return await handler(request)
+            except AuthenticationRequired:
+                if request.headers.get("hx-request") == "true":
+                    raise
+                return RedirectResponse("/auth/login", status_code=303)
+
+        return handle

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -27,7 +27,7 @@ from learn_to_cloud_shared.core.logger import configure_logging
 from learn_to_cloud_shared.core.observability import configure_observability
 from starlette.middleware.sessions import SessionMiddleware
 
-from learn_to_cloud.core.auth import init_oauth
+from learn_to_cloud.core.auth import SESSION_COOKIE_NAME, init_oauth
 from learn_to_cloud.core.middleware import (
     SecurityHeadersMiddleware,
     TelemetrySanitizationMiddleware,
@@ -178,7 +178,7 @@ app.add_middleware(TelemetrySanitizationMiddleware)
 app.add_middleware(
     SessionMiddleware,
     secret_key=_settings.session.secret_key,
-    session_cookie="session",
+    session_cookie=SESSION_COOKIE_NAME,
     max_age=60 * 60 * 24 * 30,
     same_site="lax",
     https_only=_settings.web_security.require_https,

--- a/api/src/learn_to_cloud/routes/auth_routes.py
+++ b/api/src/learn_to_cloud/routes/auth_routes.py
@@ -15,7 +15,7 @@ from fastapi.responses import RedirectResponse
 from learn_to_cloud_shared.core.config import get_web_settings
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from learn_to_cloud.core.auth import UserId, oauth
+from learn_to_cloud.core.auth import SESSION_COOKIE_NAME, oauth
 from learn_to_cloud.services.users_service import (
     get_or_create_user_from_github,
     parse_display_name,
@@ -136,7 +136,16 @@ async def callback(request: Request) -> RedirectResponse:
     summary="Log out and clear session",
     include_in_schema=False,
 )
-async def logout(request: Request, user_id: UserId) -> RedirectResponse:
+async def logout(request: Request) -> RedirectResponse:
     """Clear the session cookie and redirect to home."""
     request.session.clear()
-    return RedirectResponse(url="/", status_code=302)
+    response = RedirectResponse(url="/", status_code=303)
+    # Rejected cookies look like empty sessions to SessionMiddleware.
+    response.delete_cookie(
+        SESSION_COOKIE_NAME,
+        path="/",
+        secure=get_web_settings().web_security.require_https,
+        httponly=True,
+        samesite="lax",
+    )
+    return response

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -31,7 +31,7 @@ from learn_to_cloud_shared.submission_values import (
 )
 from pydantic import BaseModel, ValidationError
 
-from learn_to_cloud.core.auth import AuthenticatedUser, CurrentUser, UserId
+from learn_to_cloud.core.auth import AuthenticatedUser, CurrentUser
 from learn_to_cloud.rendering.htmx_responses import (
     reload_page_response,
     render_input_error,
@@ -101,12 +101,12 @@ router = APIRouter(prefix="/htmx", tags=["htmx"], include_in_schema=False)
 async def htmx_complete_step(
     request: Request,
     db: DbSession,
-    user_id: UserId,
+    current_user: CurrentUser,
     step_uuid: Annotated[UUID, Form()],
 ) -> HTMLResponse:
     """Complete a step and return the updated step partial."""
     try:
-        _, topic, completed = await complete_step(db, user_id, step_uuid)
+        _, topic, completed = await complete_step(db, current_user.user_id, step_uuid)
     except StepValidationError:
         # Step UUID doesn't exist in current content (stale cached page).
         # Force a full page reload so the user gets the current steps.
@@ -115,7 +115,9 @@ async def htmx_complete_step(
         return response
 
     step = next(s for s in topic.learning_steps if s.uuid == step_uuid)
-    return await render_step_toggle(request, user_id, topic, step, completed, db)
+    return await render_step_toggle(
+        request, current_user.user_id, topic, step, completed, db
+    )
 
 
 @router.delete("/steps/{step_uuid}", response_class=HTMLResponse)
@@ -123,17 +125,21 @@ async def htmx_uncomplete_step(
     request: Request,
     step_uuid: UUID,
     db: DbSession,
-    user_id: UserId,
+    current_user: CurrentUser,
 ) -> HTMLResponse:
     """Uncomplete a step and return the updated step partial."""
     try:
-        _, topic, step, completed = await uncomplete_step(db, user_id, step_uuid)
+        _, topic, step, completed = await uncomplete_step(
+            db, current_user.user_id, step_uuid
+        )
     except StepValidationError:
         response = HTMLResponse("")
         response.headers["HX-Refresh"] = "true"
         return response
 
-    return await render_step_toggle(request, user_id, topic, step, completed, db)
+    return await render_step_toggle(
+        request, current_user.user_id, topic, step, completed, db
+    )
 
 
 async def _parse_verification_form[FormModel: BaseModel](
@@ -446,11 +452,11 @@ async def htmx_verification_attempt_status(
 async def htmx_delete_account(
     request: Request,
     db: DbSession,
-    user_id: UserId,
+    current_user: CurrentUser,
 ) -> HTMLResponse:
     """Delete the current user's account and redirect to home via HTMX."""
     try:
-        await delete_user_account(db, user_id)
+        await delete_user_account(db, current_user.user_id)
     except UserNotFoundError:
         return HTMLResponse(
             '<p class="text-sm text-red-600">Account not found.</p>',

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -17,7 +17,12 @@ from learn_to_cloud_shared.content_service import (
 from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.models import User
 
-from learn_to_cloud.core.auth import OptionalUserId, UserId
+from learn_to_cloud.core.auth import (
+    AuthenticatedUser,
+    CurrentUser,
+    OptionalCurrentUser,
+)
+from learn_to_cloud.core.routing import LoginRedirectRoute
 from learn_to_cloud.core.templates import templates
 from learn_to_cloud.rendering.context import (
     COMMUNITY_LINKS,
@@ -39,14 +44,18 @@ from learn_to_cloud.services.verification_page_service import (
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(tags=["pages"], include_in_schema=False)
+router = APIRouter(
+    tags=["pages"], include_in_schema=False, route_class=LoginRedirectRoute
+)
 
 
-async def _get_user_or_none(db: DbSession, user_id: int | None) -> User | None:
+async def _get_user_or_none(
+    db: DbSession, current_user: AuthenticatedUser | None
+) -> User | None:
     """Get user from DB if authenticated, else None."""
-    if user_id is None:
+    if current_user is None:
         return None
-    return await get_user_by_id(db, user_id)
+    return await get_user_by_id(db, current_user.user_id)
 
 
 def _template_context(
@@ -64,10 +73,10 @@ def _template_context(
 async def home_page(
     request: Request,
     db: DbSession,
-    user_id: OptionalUserId,
+    current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Home page with phase overview."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
     phases = get_curriculum_overview()
 
     return templates.TemplateResponse(
@@ -81,10 +90,10 @@ async def home_page(
 async def curriculum_page(
     request: Request,
     db: DbSession,
-    user_id: OptionalUserId,
+    current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Full curriculum overview with all phases and topics."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
     phases = get_curriculum_overview()
 
     return templates.TemplateResponse(
@@ -103,10 +112,10 @@ async def phase_page(
     request: Request,
     phase_id: int,
     db: DbSession,
-    user_id: UserId,
+    current_user: CurrentUser,
 ) -> HTMLResponse:
     """Single phase learning detail (requires auth)."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
     phase = get_phase_by_slug(f"phase{phase_id}")
     if phase is None:
         return templates.TemplateResponse(
@@ -116,7 +125,7 @@ async def phase_page(
             status_code=404,
         )
 
-    detail = await fetch_phase_progress(db, user_id, phase)
+    detail = await fetch_phase_progress(db, current_user.user_id, phase)
     topics = build_phase_topics(phase, detail)
     has_verification = bool(
         phase.hands_on_verification and phase.hands_on_verification.requirements
@@ -144,10 +153,10 @@ async def phase_page(
 async def verifications_page(
     request: Request,
     db: DbSession,
-    user_id: UserId,
+    current_user: CurrentUser,
 ) -> HTMLResponse:
     """Verification progress and phase navigation (requires auth)."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
     if user is None:
         return templates.TemplateResponse(
             request,
@@ -156,7 +165,7 @@ async def verifications_page(
             status_code=404,
         )
 
-    overview = await get_verifications_overview(db, user_id)
+    overview = await get_verifications_overview(db, current_user.user_id)
     return templates.TemplateResponse(
         request,
         "pages/verifications.html",
@@ -173,11 +182,11 @@ async def phase_verification_page(
     request: Request,
     phase_id: int,
     db: DbSession,
-    user_id: UserId,
+    current_user: CurrentUser,
     history_page: Annotated[int, Query(ge=1)] = 1,
 ) -> HTMLResponse:
     """One phase's verification requirements and feedback (requires auth)."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
     phase = get_phase_by_slug(f"phase{phase_id}")
     if user is None or phase is None:
         return templates.TemplateResponse(
@@ -189,7 +198,7 @@ async def phase_verification_page(
 
     workspace = await get_phase_verification_workspace(
         db,
-        user_id,
+        current_user.user_id,
         phase,
         user.github_username,
         history_page=history_page,
@@ -221,10 +230,10 @@ async def topic_page(
     phase_id: int,
     topic_slug: str,
     db: DbSession,
-    user_id: UserId,
+    current_user: CurrentUser,
 ) -> HTMLResponse:
     """Single topic with learning steps (requires auth)."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
     phase_slug = f"phase{phase_id}"
     phase = get_phase_by_slug(phase_slug)
     topic = None
@@ -239,7 +248,9 @@ async def topic_page(
             status_code=404,
         )
 
-    completed_step_uuids = await get_valid_completed_steps(db, user_id, topic)
+    completed_step_uuids = await get_valid_completed_steps(
+        db, current_user.user_id, topic
+    )
 
     all_topics = phase.topics
     prev_topic, next_topic = build_topic_nav(
@@ -276,10 +287,10 @@ async def topic_page(
 async def dashboard_page(
     request: Request,
     db: DbSession,
-    user_id: UserId,
+    current_user: CurrentUser,
 ) -> HTMLResponse:
     """Authenticated dashboard with progress."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
     if user is None:
         return templates.TemplateResponse(
             request,
@@ -288,7 +299,7 @@ async def dashboard_page(
             status_code=404,
         )
 
-    dashboard = await get_dashboard_data(db, user_id)
+    dashboard = await get_dashboard_data(db, current_user.user_id)
 
     return templates.TemplateResponse(
         request,
@@ -306,10 +317,10 @@ async def dashboard_page(
 async def account_page(
     request: Request,
     db: DbSession,
-    user_id: UserId,
+    current_user: CurrentUser,
 ) -> HTMLResponse:
     """Account settings page."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
     if user is None:
         return templates.TemplateResponse(
             request,
@@ -329,10 +340,10 @@ async def account_page(
 async def community_page(
     request: Request,
     db: DbSession,
-    user_id: OptionalUserId,
+    current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Public community progress, graduates, and curriculum updates."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
     community = await get_community_page_data(db)
 
     return templates.TemplateResponse(
@@ -357,10 +368,10 @@ async def stats_page_redirect() -> RedirectResponse:
 async def faq_page(
     request: Request,
     db: DbSession,
-    user_id: OptionalUserId,
+    current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """FAQ page."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
 
     return templates.TemplateResponse(
         request,
@@ -373,10 +384,10 @@ async def faq_page(
 async def privacy_page(
     request: Request,
     db: DbSession,
-    user_id: OptionalUserId,
+    current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Privacy policy page."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
 
     return templates.TemplateResponse(
         request,
@@ -389,10 +400,10 @@ async def privacy_page(
 async def terms_page(
     request: Request,
     db: DbSession,
-    user_id: OptionalUserId,
+    current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Terms of service page."""
-    user = await _get_user_or_none(db, user_id)
+    user = await _get_user_or_none(db, current_user)
 
     return templates.TemplateResponse(
         request,

--- a/api/src/learn_to_cloud/routes/users_routes.py
+++ b/api/src/learn_to_cloud/routes/users_routes.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, HTTPException, Request
 from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.schemas import UserResponse
 
-from learn_to_cloud.core.auth import UserId
+from learn_to_cloud.core.auth import CurrentUser
 from learn_to_cloud.services.users_service import (
     UserNotFoundError,
     delete_user_account,
@@ -22,10 +22,10 @@ router = APIRouter(prefix="/api/user", tags=["users"])
     responses={401: {"description": "Not authenticated"}},
 )
 async def get_current_user(
-    request: Request, user_id: UserId, db: DbSession
+    request: Request, current_user: CurrentUser, db: DbSession
 ) -> UserResponse:
     """Get current user info."""
-    user = await get_user_by_id(db, user_id)
+    user = await get_user_by_id(db, current_user.user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     return UserResponse.model_validate(user)
@@ -41,10 +41,12 @@ async def get_current_user(
         404: {"description": "User not found"},
     },
 )
-async def delete_current_user(request: Request, user_id: UserId, db: DbSession) -> None:
+async def delete_current_user(
+    request: Request, current_user: CurrentUser, db: DbSession
+) -> None:
     """Permanently delete the authenticated user's account and all associated data."""
     try:
-        await delete_user_account(db, user_id)
+        await delete_user_account(db, current_user.user_id)
     except UserNotFoundError as exc:
         raise HTTPException(status_code=404, detail="User not found") from exc
 

--- a/api/tests/core/test_auth.py
+++ b/api/tests/core/test_auth.py
@@ -1,29 +1,19 @@
-"""Unit tests for core.auth module.
-
-Tests session-based authentication utilities:
-- get_user_id_from_session reads user_id from session
-- require_auth raises HTTPException when unauthenticated
-- optional_auth returns user_id or None without raising
-- init_oauth registers GitHub OAuth provider
-"""
+"""Tests for session identities, authentication policies, and OAuth registration."""
 
 from importlib import import_module, util
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi import HTTPException, Request
+from fastapi import Request
 from learn_to_cloud_shared.core.config import OAuthConfig
 
 from learn_to_cloud.core.auth import (
     AuthenticatedUser,
+    AuthenticationRequired,
     get_authenticated_user_from_session,
-    get_github_username_from_session,
-    get_user_id_from_session,
     init_oauth,
     oauth,
-    optional_auth,
     optional_authenticated_user,
-    require_auth,
     require_authenticated_user,
 )
 
@@ -51,86 +41,39 @@ def _make_request(session: dict | None = None, headers: dict | None = None) -> R
 
 
 @pytest.mark.unit
-class TestGetUserIdFromSession:
-    """Test get_user_id_from_session reads session correctly."""
-
-    def test_returns_int_when_user_id_present(self):
-        request = _make_request(session={"user_id": 12345})
-        result = get_user_id_from_session(request)
-        assert result == 12345
-
-    def test_returns_int_when_user_id_is_string(self):
-        request = _make_request(session={"user_id": "67890"})
-        result = get_user_id_from_session(request)
-        assert result == 67890
-
-    def test_returns_none_when_user_id_missing(self):
-        request = _make_request(session={})
-        result = get_user_id_from_session(request)
-        assert result is None
-
-
-@pytest.mark.unit
-class TestGetGitHubUsernameFromSession:
-    """Test get_github_username_from_session reads session correctly."""
-
-    def test_returns_username_when_present(self):
-        request = _make_request(session={"github_username": "testuser"})
-        result = get_github_username_from_session(request)
-        assert result == "testuser"
-
-    def test_returns_none_when_missing_or_empty(self):
-        request = _make_request(session={"github_username": ""})
-        result = get_github_username_from_session(request)
-        assert result is None
-
-
-@pytest.mark.unit
 class TestGetAuthenticatedUserFromSession:
     """Test session identity extraction."""
 
-    def test_returns_identity_when_user_id_present(self):
-        request = _make_request(session={"user_id": 42, "github_username": "testuser"})
+    @pytest.mark.parametrize("user_id", [42, "42"])
+    def test_returns_identity_with_integer_id(self, user_id):
+        request = _make_request(
+            session={"user_id": user_id, "github_username": "testuser"}
+        )
         result = get_authenticated_user_from_session(request)
         assert result == AuthenticatedUser(user_id=42, github_username="testuser")
 
     def test_returns_none_without_username(self):
-        # Username is always written to the session at login. A missing
-        # username means a stale cookie, so we force a clean re-login.
         request = _make_request(session={"user_id": 42})
         result = get_authenticated_user_from_session(request)
         assert result is None
 
-    def test_returns_none_when_user_id_missing(self):
-        request = _make_request(session={"github_username": "testuser"})
+    @pytest.mark.parametrize("username", [None, "", 42, []])
+    def test_returns_none_for_invalid_username(self, username):
+        request = _make_request(session={"user_id": 42, "github_username": username})
+        assert get_authenticated_user_from_session(request) is None
+
+    @pytest.mark.parametrize(
+        "session",
+        [
+            {},
+            {"github_username": "testuser"},
+            {"user_id": None, "github_username": "testuser"},
+        ],
+    )
+    def test_returns_none_when_user_id_missing(self, session):
+        request = _make_request(session=session)
         result = get_authenticated_user_from_session(request)
         assert result is None
-
-
-@pytest.mark.unit
-class TestRequireAuth:
-    """Test require_auth dependency."""
-
-    def test_returns_user_id_and_sets_state(self):
-        request = _make_request(session={"user_id": 42, "github_username": "user"})
-        result = require_auth(request)
-        assert result == 42
-        assert request.state.user_id == 42
-
-    def test_raises_401_for_htmx_requests(self):
-        request = _make_request(session={}, headers={"hx-request": "true"})
-        with pytest.raises(HTTPException) as exc_info:
-            require_auth(request)
-        assert exc_info.value.status_code == 401
-
-    def test_raises_307_redirect_for_regular_requests(self):
-        request = _make_request(session={}, headers={})
-        with pytest.raises(HTTPException) as exc_info:
-            require_auth(request)
-        assert exc_info.value.status_code == 307
-        headers = exc_info.value.headers
-        assert headers is not None
-        assert headers["Location"] == "/auth/login"
 
 
 @pytest.mark.unit
@@ -144,27 +87,16 @@ class TestRequireAuthenticatedUser:
         assert request.state.user_id == 42
         assert request.state.github_username == "testuser"
 
-    def test_raises_401_for_htmx_requests(self):
-        request = _make_request(session={}, headers={"hx-request": "true"})
-        with pytest.raises(HTTPException) as exc_info:
+    @pytest.mark.parametrize("session", [{}, {"user_id": 42}])
+    @pytest.mark.parametrize("htmx", [False, True])
+    def test_raises_401_when_unauthenticated(self, session, htmx):
+        request = _make_request(
+            session=session, headers={"hx-request": "true"} if htmx else {}
+        )
+        with pytest.raises(AuthenticationRequired) as exc_info:
             require_authenticated_user(request)
         assert exc_info.value.status_code == 401
-
-
-@pytest.mark.unit
-class TestOptionalAuth:
-    """Test optional_auth dependency."""
-
-    def test_returns_user_id_and_sets_state(self):
-        request = _make_request(session={"user_id": 99, "github_username": "user"})
-        result = optional_auth(request)
-        assert result == 99
-        assert request.state.user_id == 99
-
-    def test_returns_none_when_not_authenticated(self):
-        request = _make_request(session={})
-        result = optional_auth(request)
-        assert result is None
+        assert exc_info.value.headers is None
 
 
 @pytest.mark.unit

--- a/api/tests/core/test_middleware.py
+++ b/api/tests/core/test_middleware.py
@@ -7,16 +7,17 @@ Tests ASGI middleware:
 - TelemetrySanitizationMiddleware removes raw URLs and query strings
 """
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from starlette.routing import Match
+from fastapi import APIRouter, FastAPI
+from fastapi.routing import APIRoute
 
 from learn_to_cloud.core.middleware import (
     SecurityHeadersMiddleware,
     TelemetrySanitizationMiddleware,
 )
+from learn_to_cloud.core.routing import LoginRedirectRoute
 
 
 async def _noop_receive():
@@ -158,16 +159,15 @@ class TestTelemetrySanitizationMiddleware:
         span.is_recording.return_value = True
         mock_trace.get_current_span.return_value = span
 
-        route = SimpleNamespace(
-            path="/steps/{step_uuid}",
-            matches=MagicMock(return_value=(Match.FULL, {})),
-        )
+        app = FastAPI()
+        app.add_api_route("/steps/{step_uuid}", lambda: None)
         middleware = TelemetrySanitizationMiddleware(_make_app_that_sends_response)
         scope = {
             "type": "http",
+            "method": "GET",
             "path": "/steps/2ea4225e",
             "query_string": b"token=sensitive",
-            "app": SimpleNamespace(router=SimpleNamespace(routes=[route])),
+            "app": app,
         }
 
         await middleware(scope, _noop_receive, _noop_send)
@@ -191,9 +191,32 @@ class TestTelemetrySanitizationMiddleware:
             "type": "http",
             "path": "/arbitrary",
             "query_string": b"code=secret",
-            "app": SimpleNamespace(router=SimpleNamespace(routes=[])),
+            "method": "GET",
+            "app": FastAPI(),
         }
 
         await middleware(scope, _noop_receive, _noop_send)
 
         span.set_attribute.assert_any_call("url.full", "/unmatched")
+
+    @pytest.mark.parametrize("route_class", [APIRoute, LoginRedirectRoute])
+    @pytest.mark.parametrize("method", ["GET", "POST"])
+    def test_resolves_nested_router_prefixes_for_full_and_partial_matches(
+        self, route_class, method
+    ):
+        app = FastAPI()
+        child = APIRouter(prefix="/child", route_class=route_class)
+        child.add_api_route("/items/{item_id}", lambda: None, methods=["GET"])
+        parent = APIRouter(prefix="/parent")
+        parent.include_router(child, prefix="/nested")
+        app.include_router(parent, prefix="/api")
+        scope = {
+            "type": "http",
+            "method": method,
+            "path": "/api/parent/nested/child/items/private-item",
+            "app": app,
+        }
+
+        assert TelemetrySanitizationMiddleware._route_template(scope) == (
+            "/api/parent/nested/child/items/{item_id}"
+        )

--- a/api/tests/routes/test_auth_http.py
+++ b/api/tests/routes/test_auth_http.py
@@ -1,0 +1,423 @@
+"""Authentication contracts through real routes and signed-cookie middleware."""
+
+import json
+from base64 import b64encode
+from datetime import UTC, datetime
+from http.cookies import SimpleCookie
+from time import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import APIRouter, FastAPI, HTTPException
+from fastapi.responses import PlainTextResponse, RedirectResponse
+from httpx import ASGITransport, AsyncClient
+from itsdangerous import TimestampSigner
+from learn_to_cloud_shared.core.database import get_db
+from learn_to_cloud_shared.models import User
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, StatusCode
+from starlette.middleware.sessions import SessionMiddleware
+
+from learn_to_cloud.core.auth import SESSION_COOKIE_NAME, CurrentUser
+from learn_to_cloud.core.middleware import TelemetrySanitizationMiddleware
+from learn_to_cloud.core.routing import LoginRedirectRoute
+from learn_to_cloud.routes import (
+    auth_router,
+    htmx_router,
+    pages_router,
+    users_router,
+)
+
+pytestmark = pytest.mark.unit
+
+_SECRET = "auth-http-test-only-secret"
+_PAGE_PATHS = [
+    "/phase/1",
+    "/phase/1/introduction",
+    "/dashboard",
+    "/account",
+    "/verifications",
+    "/verifications/phase/1",
+]
+
+
+def _session_cookie(session: dict, *, expired: bool = False) -> str:
+    payload = b64encode(json.dumps(session).encode())
+    timestamp = int(time()) - (120 if expired else 0)
+    with patch.object(TimestampSigner, "get_timestamp", return_value=timestamp):
+        return TimestampSigner(_SECRET).sign(payload).decode()
+
+
+@pytest.fixture
+def user():
+    return User(
+        id=42,
+        first_name="Test",
+        last_name="User",
+        github_username="testuser",
+        avatar_url=None,
+        is_admin=False,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+
+@pytest.fixture
+def api_services(user):
+    with (
+        patch(
+            "learn_to_cloud.routes.users_routes.get_user_by_id",
+            autospec=True,
+            return_value=user,
+        ) as get_user,
+        patch(
+            "learn_to_cloud.routes.users_routes.delete_user_account",
+            autospec=True,
+        ) as delete_user,
+    ):
+        yield get_user, delete_user
+
+
+@pytest.fixture
+def github():
+    with patch("learn_to_cloud.routes.auth_routes.oauth") as oauth:
+        client = oauth.create_client.return_value
+        client.authorize_redirect = AsyncMock(
+            return_value=RedirectResponse("/oauth-finished", status_code=302)
+        )
+        yield client
+
+
+@pytest.fixture
+def app(test_settings, user, api_services, github):
+    app = FastAPI()
+    app.add_middleware(TelemetrySanitizationMiddleware)
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=_SECRET,
+        session_cookie=SESSION_COOKIE_NAME,
+        max_age=60,
+    )
+    for router in (auth_router, users_router, htmx_router, pages_router):
+        app.include_router(router)
+
+    @app.get("/oauth-finished")
+    async def oauth_finished():
+        return PlainTextResponse("Login reached with GET")
+
+    browser_router = APIRouter(route_class=LoginRedirectRoute)
+
+    @browser_router.api_route("/browser-mutation", methods=["POST", "DELETE"])
+    async def browser_mutation(current_user: CurrentUser):
+        return PlainTextResponse(str(current_user.user_id))
+
+    @browser_router.get("/unrelated-error/{status_code:int}")
+    async def unrelated_error(status_code: int):
+        raise HTTPException(status_code=status_code, detail="Unrelated error")
+
+    app.include_router(browser_router)
+
+    async def database():
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = database
+    with (
+        patch(
+            "learn_to_cloud.routes.auth_routes.get_web_settings",
+            return_value=test_settings,
+        ),
+        patch(
+            "learn_to_cloud.routes.pages_routes.get_user_by_id",
+            autospec=True,
+            return_value=user,
+        ),
+        patch(
+            "learn_to_cloud.routes.pages_routes.get_curriculum_overview",
+            return_value=(),
+        ),
+    ):
+        yield app
+
+
+@pytest.fixture
+async def client(app):
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as http:
+        yield http
+
+
+@pytest.fixture
+async def telemetry_client(app):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=provider)
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            yield client, exporter
+    finally:
+        FastAPIInstrumentor.uninstrument_app(app)
+        provider.shutdown()
+
+
+@pytest.mark.parametrize("method", ["GET", "DELETE"])
+@pytest.mark.parametrize("accept", [None, "application/json", "text/html"])
+@pytest.mark.parametrize("htmx", [False, True])
+async def test_api_auth_failure(client, api_services, method, accept, htmx):
+    client.headers.pop("accept", None)
+    headers = {"HX-Request": "true"} if htmx else {}
+    if accept is not None:
+        headers["Accept"] = accept
+    response = await client.request(
+        method, "/api/user/me", headers=headers, follow_redirects=True
+    )
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Unauthorized"}
+    assert "location" not in response.headers
+    assert response.history == []
+    for service in api_services:
+        service.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "data"),
+    [
+        ("GET", "/htmx/verification/attempts/status?token=test", None),
+        ("POST", "/htmx/github/submit", None),
+        (
+            "POST",
+            "/htmx/steps/complete",
+            {"step_uuid": "00000000-0000-0000-0000-000000000001"},
+        ),
+        ("DELETE", "/htmx/account", None),
+    ],
+)
+@pytest.mark.parametrize("htmx", [False, True])
+async def test_htmx_endpoint_auth_failure(client, method, path, data, htmx):
+    response = await client.request(
+        method,
+        path,
+        data=data,
+        headers={"HX-Request": "true"} if htmx else {},
+        follow_redirects=True,
+    )
+    assert response.status_code == 401
+    assert "location" not in response.headers
+    assert response.history == []
+
+
+@pytest.mark.parametrize("path", _PAGE_PATHS)
+async def test_browser_pages_follow_login_with_get(client, github, path):
+    response = await client.get(path, follow_redirects=True)
+    first, login = response.history
+    assert first.status_code == 303
+    assert first.headers["location"] == "/auth/login"
+    assert login.request.url.path == "/auth/login"
+    assert login.request.method == "GET"
+    assert response.status_code == 200
+    assert response.request.method == "GET"
+    assert response.request.url.path == "/oauth-finished"
+    github.authorize_redirect.assert_awaited_once()
+
+
+@pytest.mark.parametrize("path", _PAGE_PATHS)
+@pytest.mark.parametrize("boosted", [False, True])
+async def test_htmx_browser_navigation_returns_401(client, github, path, boosted):
+    headers = {"HX-Request": "true"}
+    if boosted:
+        headers["HX-Boosted"] = "true"
+    response = await client.get(path, headers=headers, follow_redirects=True)
+    assert response.status_code == 401
+    assert "location" not in response.headers
+    assert response.history == []
+    github.authorize_redirect.assert_not_awaited()
+
+
+@pytest.mark.parametrize("htmx", [False, True])
+async def test_incomplete_session_requires_login_on_browser_page(client, htmx):
+    client.cookies.set(
+        SESSION_COOKIE_NAME,
+        _session_cookie({"user_id": 42}),
+        domain="testserver.local",
+        path="/",
+    )
+    response = await client.get(
+        "/account", headers={"HX-Request": "true"} if htmx else {}
+    )
+    assert response.status_code == (401 if htmx else 303)
+    assert response.headers.get("location") == (None if htmx else "/auth/login")
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 422, 500])
+async def test_page_policy_does_not_redirect_unrelated_errors(
+    client, github, status_code
+):
+    response = await client.get(
+        f"/unrelated-error/{status_code}", follow_redirects=True
+    )
+    assert response.status_code == status_code
+    assert response.json() == {"detail": "Unrelated error"}
+    assert "location" not in response.headers
+    assert response.history == []
+    github.authorize_redirect.assert_not_awaited()
+
+
+@pytest.mark.parametrize("method", ["POST", "DELETE"])
+async def test_browser_mutation_redirect_changes_method_to_get(client, method):
+    response = await client.request(method, "/browser-mutation", follow_redirects=True)
+    first, login = response.history
+    assert first.request.method == method
+    assert first.status_code == 303
+    assert first.headers["location"] == "/auth/login"
+    assert login.request.url.path == "/auth/login"
+    assert login.request.method == "GET"
+    assert response.status_code == 200
+    assert response.request.method == "GET"
+
+
+@pytest.mark.parametrize(
+    "cookie_kind", ["missing", "valid", "stale", "expired", "invalid"]
+)
+async def test_logout_expires_cookie_and_is_repeatable(client, github, cookie_kind):
+    if cookie_kind != "missing":
+        session = {"user_id": 42}
+        if cookie_kind != "stale":
+            session["github_username"] = "testuser"
+        cookie = (
+            "invalid-signature"
+            if cookie_kind == "invalid"
+            else _session_cookie(session, expired=cookie_kind == "expired")
+        )
+        client.cookies.set(
+            SESSION_COOKIE_NAME, cookie, domain="testserver.local", path="/"
+        )
+
+    for _ in range(2):
+        response = await client.post("/auth/logout", follow_redirects=True)
+        (logout,) = response.history
+        assert logout.request.method == "POST"
+        assert logout.status_code == 303
+        assert logout.headers["location"] == "/"
+        cookies = logout.headers.get_list("set-cookie")
+        assert cookies
+        for header in cookies:
+            expired = SimpleCookie(header)[SESSION_COOKIE_NAME]
+            assert expired["path"] == "/"
+            assert expired["httponly"]
+            assert expired["samesite"] == "lax"
+            assert expired["max-age"] == "0" or "1970" in expired["expires"]
+        assert SESSION_COOKIE_NAME not in client.cookies
+        assert response.status_code == 200
+        assert response.request.method == "GET"
+        assert response.request.url.path == "/"
+    github.authorize_redirect.assert_not_awaited()
+
+
+@pytest.mark.parametrize("path", ["/api/user/me", "/account"])
+async def test_signed_session_authenticates_real_routes(client, path):
+    client.cookies.set(
+        SESSION_COOKIE_NAME,
+        _session_cookie({"user_id": 42, "github_username": "testuser"}),
+        domain="testserver.local",
+        path="/",
+    )
+    response = await client.get(path, follow_redirects=True)
+    assert response.status_code == 200
+    assert response.history == []
+    if path == "/api/user/me":
+        assert response.json()["id"] == 42
+    else:
+        assert "testuser" in response.text
+
+
+async def test_authenticated_api_delete_keeps_204_contract(client, api_services):
+    client.cookies.set(
+        SESSION_COOKIE_NAME,
+        _session_cookie({"user_id": 42, "github_username": "testuser"}),
+        domain="testserver.local",
+        path="/",
+    )
+    response = await client.delete("/api/user/me", follow_redirects=True)
+    assert response.status_code == 204
+    assert response.content == b""
+    assert response.history == []
+    assert SESSION_COOKIE_NAME not in client.cookies
+    api_services[1].assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "htmx", "authenticated", "status", "route"),
+    [
+        ("GET", "/api/user/me", False, False, 401, "/api/user/me"),
+        ("DELETE", "/api/user/me", False, False, 401, "/api/user/me"),
+        (
+            "GET",
+            "/phase/1/private-topic-probe",
+            False,
+            False,
+            303,
+            "/phase/{phase_id:int}/{topic_slug}",
+        ),
+        (
+            "GET",
+            "/phase/1/private-topic-probe",
+            True,
+            False,
+            401,
+            "/phase/{phase_id:int}/{topic_slug}",
+        ),
+        ("GET", "/account", False, True, 200, "/account"),
+        ("GET", "/api/user/me", False, True, 200, "/api/user/me"),
+        ("GET", "/private-unmatched-probe", False, False, 404, None),
+    ],
+)
+async def test_auth_request_telemetry_is_bounded_and_has_no_exception_events(
+    telemetry_client, method, path, htmx, authenticated, status, route
+):
+    client, exporter = telemetry_client
+    cookie = _session_cookie({"user_id": 42, "github_username": "testuser"})
+    if authenticated:
+        client.cookies.set(
+            SESSION_COOKIE_NAME, cookie, domain="testserver.local", path="/"
+        )
+
+    response = await client.request(
+        method,
+        path,
+        params={"token": "private-token-probe"},
+        headers={"HX-Request": "true"} if htmx else {},
+    )
+
+    assert response.status_code == status
+    spans = exporter.get_finished_spans()
+    (server,) = [span for span in spans if span.kind == SpanKind.SERVER]
+    attributes = server.attributes
+    assert attributes.get("http.route") == route
+    assert (
+        attributes.get("http.response.status_code", attributes.get("http.status_code"))
+        == status
+    )
+    assert server.status.status_code == StatusCode.UNSET
+    for attribute in ("http.target", "http.url", "url.full", "url.path"):
+        assert attributes[attribute] == (route or "/unmatched")
+    assert attributes["url.query"] == ""
+
+    for span in spans:
+        assert not any(event.name == "exception" for event in span.events)
+        assert not {"user_id", "github_username", "user.id", "session.id"} & set(
+            span.attributes
+        )
+    telemetry = "\n".join(span.to_json() for span in spans)
+    for prohibited in (
+        "private-topic-probe",
+        "private-unmatched-probe",
+        "private-token-probe",
+        "testuser",
+        cookie,
+    ):
+        assert prohibited not in telemetry

--- a/api/tests/routes/test_auth_routes.py
+++ b/api/tests/routes/test_auth_routes.py
@@ -13,6 +13,7 @@ Testing approach:
 These are unit tests: no HTTP client, no real OAuth, no database.
 """
 
+from http.cookies import SimpleCookie
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx2
@@ -20,6 +21,7 @@ import pytest
 from authlib.integrations.starlette_client import OAuthError
 from fastapi.responses import RedirectResponse
 
+from learn_to_cloud.core.auth import SESSION_COOKIE_NAME
 from learn_to_cloud.routes.auth_routes import callback, login, logout
 
 
@@ -316,13 +318,27 @@ class TestCallbackRoute:
 class TestLogoutRoute:
     """Tests for POST /auth/logout."""
 
-    async def test_logout_clears_session_and_redirects(self):
+    @pytest.mark.parametrize(
+        "session", [{}, {"user_id": 42}, {"user_id": 42, "github_username": "testuser"}]
+    )
+    @pytest.mark.parametrize("secure", [False, True])
+    async def test_logout_clears_session_and_redirects(self, session, secure):
         """Logout clears session data and redirects to /."""
-        request = _mock_request(session={"user_id": 42, "github_username": "testuser"})
+        request = _mock_request(session=session.copy())
 
-        result = await logout(request, user_id=42)
+        with patch(
+            "learn_to_cloud.routes.auth_routes.get_web_settings"
+        ) as mock_settings:
+            mock_settings.return_value.web_security.require_https = secure
+            result = await logout(request)
 
         assert isinstance(result, RedirectResponse)
-        assert result.status_code == 302
+        assert result.status_code == 303
         assert result.headers["location"] == "/"
         assert request.session == {}
+        cookie = SimpleCookie(result.headers["set-cookie"])[SESSION_COOKIE_NAME]
+        assert cookie["max-age"] == "0"
+        assert cookie["path"] == "/"
+        assert cookie["httponly"]
+        assert cookie["samesite"] == "lax"
+        assert bool(cookie["secure"]) is secure

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -117,7 +117,7 @@ class TestHtmxCompleteStep:
             result = await htmx_complete_step(
                 request,
                 mock_db,
-                user_id=1,
+                current_user=AuthenticatedUser(user_id=1, github_username="user"),
                 step_uuid=step_uuid,
             )
 
@@ -138,7 +138,7 @@ class TestHtmxCompleteStep:
             result = await htmx_complete_step(
                 request,
                 mock_db,
-                user_id=1,
+                current_user=AuthenticatedUser(user_id=1, github_username="user"),
                 step_uuid=step_uuid,
             )
 
@@ -176,7 +176,7 @@ class TestHtmxUncompleteStep:
                 request,
                 step_uuid,
                 mock_db,
-                user_id=1,
+                current_user=AuthenticatedUser(user_id=1, github_username="user"),
             )
 
         mock_uncomplete.assert_awaited_once_with(mock_db, 1, step_uuid)
@@ -197,7 +197,7 @@ class TestHtmxUncompleteStep:
                 request,
                 step_uuid,
                 mock_db,
-                user_id=1,
+                current_user=AuthenticatedUser(user_id=1, github_username="user"),
             )
 
         assert result.headers.get("HX-Refresh") == "true"
@@ -1239,7 +1239,9 @@ class TestHtmxDeleteAccount:
         with patch(
             "learn_to_cloud.routes.htmx_routes.delete_user_account", autospec=True
         ):
-            result = await htmx_delete_account(request, mock_db, user_id=42)
+            result = await htmx_delete_account(
+                request, mock_db, current_user=AuthenticatedUser(42, "testuser")
+            )
 
         assert result.headers.get("HX-Redirect") == "/"
         assert request.session == {}
@@ -1254,7 +1256,9 @@ class TestHtmxDeleteAccount:
             autospec=True,
             side_effect=UserNotFoundError(999),
         ):
-            result = await htmx_delete_account(request, mock_db, user_id=999)
+            result = await htmx_delete_account(
+                request, mock_db, current_user=AuthenticatedUser(999, "testuser")
+            )
 
         assert result.status_code == 404
 

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -26,6 +26,7 @@ from uuid import uuid4
 
 import pytest
 
+from learn_to_cloud.core.auth import AuthenticatedUser
 from learn_to_cloud.routes.pages_routes import (
     account_page,
     community_page,
@@ -99,7 +100,7 @@ class TestHomePage:
                 return_value=None,
             ),
         ):
-            await home_page(request, mock_db, user_id=None)
+            await home_page(request, mock_db, current_user=None)
 
         template.assert_called_once()
         ctx = template.call_args[0][2]
@@ -126,7 +127,9 @@ class TestHomePage:
                 return_value=mock_user,
             ),
         ):
-            await home_page(request, mock_db, user_id=42)
+            await home_page(
+                request, mock_db, current_user=AuthenticatedUser(42, "testuser")
+            )
 
         ctx = template.call_args[0][2]
         assert ctx["user"] is mock_user
@@ -153,7 +156,7 @@ class TestCurriculumPage:
                 return_value=None,
             ),
         ):
-            await curriculum_page(request, mock_db, user_id=None)
+            await curriculum_page(request, mock_db, current_user=None)
 
         assert template.call_args[0][1] == "pages/curriculum.html"
         ctx = template.call_args[0][2]
@@ -180,7 +183,12 @@ class TestPhasePage:
                 return_value=None,
             ),
         ):
-            await phase_page(request, phase_id=999, db=mock_db, user_id=1)
+            await phase_page(
+                request,
+                phase_id=999,
+                db=mock_db,
+                current_user=AuthenticatedUser(1, "testuser"),
+            )
 
         assert template.call_args[0][1] == "pages/404.html"
         # Verify 404 status code is set
@@ -214,7 +222,12 @@ class TestPhasePage:
                 return_value=[],
             ),
         ):
-            await phase_page(request, phase_id=1, db=mock_db, user_id=42)
+            await phase_page(
+                request,
+                phase_id=1,
+                db=mock_db,
+                current_user=AuthenticatedUser(42, "testuser"),
+            )
 
         assert template.call_args[0][1] == "pages/phase.html"
         ctx = template.call_args[0][2]
@@ -245,7 +258,9 @@ class TestVerificationsPage:
                 return_value=mock_overview,
             ),
         ):
-            await verifications_page(request, mock_db, user_id=42)
+            await verifications_page(
+                request, mock_db, current_user=AuthenticatedUser(42, "testuser")
+            )
 
         assert template.call_args[0][1] == "pages/verifications.html"
         ctx = template.call_args[0][2]
@@ -260,7 +275,9 @@ class TestVerificationsPage:
             autospec=True,
             return_value=None,
         ):
-            await verifications_page(request, AsyncMock(), user_id=999)
+            await verifications_page(
+                request, AsyncMock(), current_user=AuthenticatedUser(999, "testuser")
+            )
 
         assert template.call_args[0][1] == "pages/404.html"
 
@@ -284,7 +301,10 @@ class TestPhaseVerificationPage:
             ),
         ):
             await phase_verification_page(
-                request, phase_id=999, db=AsyncMock(), user_id=42
+                request,
+                phase_id=999,
+                db=AsyncMock(),
+                current_user=AuthenticatedUser(42, "testuser"),
             )
 
         assert template.call_args[0][1] == "pages/404.html"
@@ -320,7 +340,12 @@ class TestPhaseVerificationPage:
                 return_value=workspace,
             ) as get_workspace,
         ):
-            await phase_verification_page(request, phase_id=4, db=mock_db, user_id=42)
+            await phase_verification_page(
+                request,
+                phase_id=4,
+                db=mock_db,
+                current_user=AuthenticatedUser(42, "testuser"),
+            )
 
         get_workspace.assert_awaited_once_with(
             mock_db,
@@ -358,7 +383,11 @@ class TestTopicPage:
             ),
         ):
             await topic_page(
-                request, phase_id=1, topic_slug="bad-topic", db=mock_db, user_id=1
+                request,
+                phase_id=1,
+                topic_slug="bad-topic",
+                db=mock_db,
+                current_user=AuthenticatedUser(1, "testuser"),
             )
 
         assert template.call_args[0][1] == "pages/404.html"
@@ -382,7 +411,11 @@ class TestTopicPage:
             ),
         ):
             await topic_page(
-                request, phase_id=1, topic_slug="bad-topic", db=mock_db, user_id=1
+                request,
+                phase_id=1,
+                topic_slug="bad-topic",
+                db=mock_db,
+                current_user=AuthenticatedUser(1, "testuser"),
             )
 
         assert template.call_args[0][1] == "pages/404.html"
@@ -416,7 +449,11 @@ class TestTopicPage:
             ),
         ):
             await topic_page(
-                request, phase_id=1, topic_slug="linux-basics", db=mock_db, user_id=1
+                request,
+                phase_id=1,
+                topic_slug="linux-basics",
+                db=mock_db,
+                current_user=AuthenticatedUser(1, "testuser"),
             )
 
         assert template.call_args[0][1] == "pages/topic.html"
@@ -447,7 +484,9 @@ class TestDashboardPage:
                 return_value=mock_dashboard,
             ),
         ):
-            await dashboard_page(request, mock_db, user_id=42)
+            await dashboard_page(
+                request, mock_db, current_user=AuthenticatedUser(42, "testuser")
+            )
 
         assert template.call_args[0][1] == "pages/dashboard.html"
         ctx = template.call_args[0][2]
@@ -464,7 +503,9 @@ class TestDashboardPage:
             autospec=True,
             return_value=None,
         ):
-            await dashboard_page(request, mock_db, user_id=999)
+            await dashboard_page(
+                request, mock_db, current_user=AuthenticatedUser(999, "testuser")
+            )
 
         assert template.call_args[0][1] == "pages/404.html"
         call_kwargs = template.call_args[1] if template.call_args[1] else {}
@@ -486,7 +527,9 @@ class TestAccountPage:
             autospec=True,
             return_value=mock_user,
         ):
-            await account_page(request, mock_db, user_id=42)
+            await account_page(
+                request, mock_db, current_user=AuthenticatedUser(42, "testuser")
+            )
 
         assert template.call_args[0][1] == "pages/account.html"
         ctx = template.call_args[0][2]
@@ -502,7 +545,9 @@ class TestAccountPage:
             autospec=True,
             return_value=None,
         ):
-            await account_page(request, mock_db, user_id=999)
+            await account_page(
+                request, mock_db, current_user=AuthenticatedUser(999, "testuser")
+            )
 
         assert template.call_args[0][1] == "pages/404.html"
 
@@ -529,7 +574,7 @@ class TestPublicPages:
             autospec=True,
             return_value=None,
         ):
-            await handler(request, mock_db, user_id=None)
+            await handler(request, mock_db, current_user=None)
 
         assert template.call_args[0][1] == template_name
 
@@ -555,7 +600,7 @@ class TestCommunityPage:
                 return_value=mock_community,
             ),
         ):
-            await community_page(request, mock_db, user_id=None)
+            await community_page(request, mock_db, current_user=None)
 
         assert template.call_args[0][1] == "pages/community.html"
         ctx = template.call_args[0][2]

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -40,8 +40,7 @@ from learn_to_cloud_shared.schemas import (
 
 from learn_to_cloud.core.auth import (
     AuthenticatedUser,
-    optional_auth,
-    require_auth,
+    optional_authenticated_user,
     require_authenticated_user,
 )
 
@@ -152,12 +151,12 @@ async def anon_client(_patched_content):
     async def _override_get_db_readonly():
         yield mock_db
 
-    def _override_optional_auth():
+    def _override_optional_user():
         return None
 
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_db_readonly] = _override_get_db_readonly
-    app.dependency_overrides[optional_auth] = _override_optional_auth
+    app.dependency_overrides[optional_authenticated_user] = _override_optional_user
 
     # Mark app as initialized so /ready doesn't 503
     app.state.init_done = True
@@ -175,7 +174,7 @@ async def anon_client(_patched_content):
 async def auth_client(_patched_content):
     """HTTP client for authenticated requests.
 
-    Overrides auth to return user_id=1, mocks DB and user service.
+    Overrides auth to return an identity, mocks DB and user service.
     """
     from learn_to_cloud.main import app
 
@@ -187,19 +186,12 @@ async def auth_client(_patched_content):
     async def _override_get_db_readonly():
         yield mock_db
 
-    def _override_require_auth():
-        return 1
-
-    def _override_optional_auth():
-        return 1
-
     def _override_current_user():
         return AuthenticatedUser(user_id=1, github_username="testuser")
 
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_db_readonly] = _override_get_db_readonly
-    app.dependency_overrides[require_auth] = _override_require_auth
-    app.dependency_overrides[optional_auth] = _override_optional_auth
+    app.dependency_overrides[optional_authenticated_user] = _override_current_user
     app.dependency_overrides[require_authenticated_user] = _override_current_user
 
     app.state.init_done = True
@@ -562,5 +554,5 @@ class TestRedirectSmoke:
     ):
         """Authenticated pages redirect anonymous visitors to login."""
         response = await anon_client.get(path, follow_redirects=False)
-        assert response.status_code == 307
+        assert response.status_code == 303
         assert "/auth/login" in response.headers["location"]

--- a/api/tests/routes/test_users_routes.py
+++ b/api/tests/routes/test_users_routes.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi import HTTPException
 from learn_to_cloud_shared.models import User
 
+from learn_to_cloud.core.auth import AuthenticatedUser
 from learn_to_cloud.routes.users_routes import (
     delete_current_user,
     get_current_user,
@@ -42,7 +43,9 @@ class TestGetCurrentUser:
             autospec=True,
             return_value=user,
         ) as mock_service:
-            result = await get_current_user(mock_request, user_id=1, db=mock_db)
+            result = await get_current_user(
+                mock_request, current_user=AuthenticatedUser(1, "testuser"), db=mock_db
+            )
 
         mock_service.assert_awaited_once_with(mock_db, 1)
         assert result.id == 1
@@ -61,7 +64,11 @@ class TestGetCurrentUser:
             ),
             pytest.raises(HTTPException) as exc_info,
         ):
-            await get_current_user(mock_request, user_id=999, db=mock_db)
+            await get_current_user(
+                mock_request,
+                current_user=AuthenticatedUser(999, "testuser"),
+                db=mock_db,
+            )
 
         assert exc_info.value.status_code == 404
 
@@ -79,7 +86,9 @@ class TestDeleteCurrentUser:
             "learn_to_cloud.routes.users_routes.delete_user_account",
             autospec=True,
         ) as mock_service:
-            result = await delete_current_user(mock_request, user_id=42, db=mock_db)
+            result = await delete_current_user(
+                mock_request, current_user=AuthenticatedUser(42, "testuser"), db=mock_db
+            )
 
         assert result is None
         mock_service.assert_awaited_once_with(mock_db, 42)
@@ -98,6 +107,8 @@ class TestDeleteCurrentUser:
             ),
             pytest.raises(HTTPException) as exc_info,
         ):
-            await delete_current_user(mock_request, user_id=42, db=mock_db)
+            await delete_current_user(
+                mock_request, current_user=AuthenticatedUser(42, "testuser"), db=mock_db
+            )
 
         assert exc_info.value.status_code == 404

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -300,6 +300,62 @@ Routes (HTTP) → Services (Business Logic) → Repositories (Database)
 - **Services** contain business rules — no HTTP knowledge
 - **Repositories** execute queries — return ORM models or primitives
 
+### Authentication and sessions
+
+GitHub OAuth establishes a signed client-side session cookie containing
+`user_id` and `github_username`. Session middleware verifies its signature and
+age on subsequent requests; those requests do not contact GitHub again.
+The cookie is signed, not encrypted, so do not store secrets in its payload.
+
+The API uses one identity type:
+
+| Name | Purpose |
+|------|---------|
+| `AuthenticatedUser` | Plain identity data: numeric user ID and GitHub username. Use it in helpers receiving an existing identity. |
+| `CurrentUser` | An `Annotated` alias that tells FastAPI to call `require_authenticated_user` and supply that identity to a protected route. |
+| `OptionalCurrentUser` | Supplies the same identity or `None` to a public route. |
+
+Import these from `learn_to_cloud.core.auth`. Routes access
+`current_user.user_id` or `current_user.github_username`; do not introduce
+ID-only dependencies or a separate browser-user type.
+`require_authenticated_user` raises `AuthenticationRequired` when the session
+has no complete identity. It does not choose a browser redirect or check
+whether the application account still exists. Account-validity work is tracked
+in [#829](https://github.com/learntocloud/learn-to-cloud-app/issues/829).
+
+Browser navigation is a route policy, separate from identity loading.
+Page routers select `LoginRedirectRoute` from `learn_to_cloud.core.routing`
+using `APIRouter(route_class=LoginRedirectRoute, ...)`. That route class uses
+FastAPI's supported route-handler extension and catches only
+`AuthenticationRequired`; unrelated errors keep their normal behavior.
+
+| Unauthenticated request | Response |
+|-------------------------|----------|
+| JSON API endpoint | 401, without a login redirect |
+| HTMX endpoint, with or without `HX-Request` | 401, without a login redirect |
+| Protected page navigation | 303 to `/auth/login` |
+| Protected page requested with `HX-Request: true` | 401; the existing frontend handler navigates to login |
+
+A browser mutation that intentionally redirects uses 303 so the next request
+is GET, not a replay of POST or DELETE. Do not infer auth response policy from
+URL prefixes or `Accept` headers.
+
+POST `/auth/logout` needs no authenticated dependency. It clears the session,
+explicitly expires the browser cookie, and returns 303 to `/`, including when
+the cookie is missing, rejected, or already cleared. Explicit cookie deletion
+also handles rejected cookies that middleware presents as an empty session.
+The signed session lifetime is currently 30 days. Logout removes this browser's
+cookie but does not revoke a previously copied valid cookie; session-revocation
+and expiry guarantees are tracked in
+[#828](https://github.com/learntocloud/learn-to-cloud-app/issues/828).
+
+Auth behavior is covered through real routes, session middleware, and HTTP
+redirects in `api/tests/routes/test_auth_http.py`. Auth overrides are useful
+for unrelated rendering tests, but must not replace authentication in tests
+of the auth contract itself. Request telemetry records handled 401/303 outcomes;
+it must not add usernames, user IDs, cookie values, or session identifiers.
+See the [telemetry schema](observability/telemetry-schema.html).
+
 ## Conventions
 
 - Async/await everywhere -- no sync database calls

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ Architecture, contributor, and operations documentation for the
 - [Database migrations](migrations.html)
 - [Telemetry schema](observability/telemetry-schema.html)
 - [Contributing](contributing.html)
+- [Authentication and sessions](contributing.html#authentication-and-sessions)
 - [GitHub Powering Your AI SDLC presentation](scaling-with-github/)
 
 Application users should start at [learntocloud.guide](https://learntocloud.guide).

--- a/docs/observability/telemetry-schema.md
+++ b/docs/observability/telemetry-schema.md
@@ -58,6 +58,11 @@ Inbound API paths must be FastAPI route templates such as
 `/steps/{step_uuid}`, never the concrete request path. Outbound HTTP dependency
 URLs retain only the destination origin and replace the path with `/`.
 
+Route discovery uses FastAPI's public route contexts so included and nested
+router prefixes remain part of the template. Unmatched requests use `/unmatched`.
+Expected authentication responses (401 or a 303 login redirect) remain request
+telemetry, not unhandled exceptions or additional identity-bearing auth events.
+
 The application currently writes both current and legacy OpenTelemetry HTTP
 names because the Azure exporter and instrumentations can read different
 generations of the convention. These are intentional compatibility aliases,


### PR DESCRIPTION
## Summary

Unauthenticated API requests now return 401 instead of redirecting to a login endpoint that cannot accept their original HTTP method. Browser pages still lead to login, and logout clears the browser cookie even when the session is missing or expired.

Closes #826.

## What changes

- Use one `AuthenticatedUser` identity throughout the routes, supplied by `CurrentUser` or `OptionalCurrentUser`. Remove the ID-only authentication wrappers.
- Separate identity loading from browser navigation. Missing identity raises `AuthenticationRequired`; the page-specific `LoginRedirectRoute` turns only that error into a 303 login redirect. API and HTMX requests retain 401 responses.
- Make logout public and repeatable: clear session data, explicitly expire the cookie, and redirect home with 303. A 303 makes the next request GET rather than repeating POST or DELETE.
- Fix a telemetry bug found during the auth review: included and nested routes were being labeled `/unmatched`. Resolve their full route templates without exposing raw paths, query values, cookies, or identities.
- Update the contributor guide, repository instructions, route prompt, dog-food guidance, relevant skills, and telemetry documentation.

## Coverage

Real-route HTTP coverage exercises API/HTMX failures, all protected pages, redirect-following methods, unrelated errors, signed-session success, and repeated logout with missing, incomplete, expired, or invalid cookies. Exported-span coverage checks route labels and sensitive-data exclusion.

`uv run poe check` passes. Fresh API smoke requests and a local before/after telemetry comparison were also completed: 11 known-route span labels were corrected without changing HTTP responses or redirect locations. The existing HTMX JavaScript is unchanged; browser automation was not run.

## Scope and rollout

No migration, infrastructure, dependency, or configuration changes are needed. The GitHub OAuth flow, cookie format, and 30-day lifetime stay the same.

Logout clears this browser's cookie; it does not revoke a copied cookie. Session revocation (#828) and rejecting sessions for deleted accounts (#829) remain separate work.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.
