### PR TITLE
fix(auth): validate session identity without coercion

### DIFF
--- a/api/src/learn_to_cloud/core/auth.py
+++ b/api/src/learn_to_cloud/core/auth.py
@@ -1,13 +1,4 @@
-"""Session-based authentication utilities.
-
-Provides:
-- Session cookie auth via Starlette SessionMiddleware
-- FastAPI dependencies for authenticated routes
-- Authlib OAuth client configuration for GitHub
-
-Session data is stored in signed cookies (via Starlette).
-The session contains user_id (GitHub numeric ID) and github_username.
-"""
+"""Session identity validation, authentication dependencies, and GitHub OAuth setup."""
 
 from __future__ import annotations
 
@@ -24,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 oauth = OAuth()
 SESSION_COOKIE_NAME = "session"
+MAX_GITHUB_USER_ID = 2**63 - 1
+MAX_USERNAME_LENGTH = 255
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,22 +31,22 @@ class IdentityRejectionReason(StrEnum):
     INCOMPLETE_IDENTITY = "incomplete_identity"
     INVALID_USER_ID = "invalid_user_id"
     INVALID_GITHUB_USERNAME = "invalid_github_username"
-    INVALID_PROFILE = "invalid_profile"
+    INVALID_RESPONSE_FORMAT = "invalid_response_format"
 
 
 def validate_identity(
     user_id: object, github_username: object
 ) -> AuthenticatedUser | IdentityRejectionReason:
-    """Validate identity data without coercion or GitHub naming rules."""
+    """Return a valid user identity or the reason it was rejected."""
     if (
         not isinstance(user_id, int)
         or isinstance(user_id, bool)
-        or not 0 < user_id < 2**63
+        or not 0 < user_id <= MAX_GITHUB_USER_ID
     ):
         return IdentityRejectionReason.INVALID_USER_ID
     if (
         not isinstance(github_username, str)
-        or not 0 < len(github_username) <= 255
+        or not 0 < len(github_username) <= MAX_USERNAME_LENGTH
         or not github_username.strip()
         or "\x00" in github_username
     ):
@@ -73,11 +66,7 @@ class AuthenticationRequired(HTTPException):
 
 
 def init_oauth(settings: OAuthConfig) -> None:
-    """Register GitHub as an OAuth provider.
-
-    Call once at app startup (in lifespan). Uses Authlib's built-in
-    GitHub integration which knows the authorize/token/userinfo URLs.
-    """
+    """Configure the GitHub OAuth client."""
     if not settings.client_id:
         logger.warning(
             "auth.github_oauth_disabled",
@@ -97,7 +86,7 @@ def init_oauth(settings: OAuthConfig) -> None:
 
 
 def get_authenticated_user_from_session(request: Request) -> AuthenticatedUser | None:
-    """Read valid identity, removing malformed identity but preserving OAuth state."""
+    """Return the session user, removing invalid identity fields."""
     session = request.session
     if "user_id" not in session and "github_username" not in session:
         return None
@@ -118,7 +107,7 @@ def get_authenticated_user_from_session(request: Request) -> AuthenticatedUser |
 
 
 def require_authenticated_user(request: Request) -> AuthenticatedUser:
-    """Require a session identity, returning 401 when unauthenticated."""
+    """Return the session user or raise a 401 authentication error."""
     authenticated_user = optional_authenticated_user(request)
     if authenticated_user is None:
         raise AuthenticationRequired()
@@ -126,7 +115,7 @@ def require_authenticated_user(request: Request) -> AuthenticatedUser:
 
 
 def optional_authenticated_user(request: Request) -> AuthenticatedUser | None:
-    """Dependency: returns session identity or None. Does not raise."""
+    """Return the session user and populate request state when authenticated."""
     authenticated_user = get_authenticated_user_from_session(request)
     if authenticated_user is not None:
         request.state.user_id = authenticated_user.user_id

--- a/api/src/learn_to_cloud/core/auth.py
+++ b/api/src/learn_to_cloud/core/auth.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Annotated
 
 from authlib.integrations.starlette_client import OAuth
@@ -31,6 +32,37 @@ class AuthenticatedUser:
 
     user_id: int
     github_username: str
+
+
+class IdentityRejectionReason(StrEnum):
+    INCOMPLETE_IDENTITY = "incomplete_identity"
+    INVALID_USER_ID = "invalid_user_id"
+    INVALID_GITHUB_USERNAME = "invalid_github_username"
+    INVALID_PROFILE = "invalid_profile"
+
+
+def validate_identity(
+    user_id: object, github_username: object
+) -> AuthenticatedUser | IdentityRejectionReason:
+    """Validate identity data without coercion or GitHub naming rules."""
+    if (
+        not isinstance(user_id, int)
+        or isinstance(user_id, bool)
+        or not 0 < user_id < 2**63
+    ):
+        return IdentityRejectionReason.INVALID_USER_ID
+    if (
+        not isinstance(github_username, str)
+        or not 0 < len(github_username) <= 255
+        or not github_username.strip()
+        or "\x00" in github_username
+    ):
+        return IdentityRejectionReason.INVALID_GITHUB_USERNAME
+    try:
+        github_username.encode("utf-8")
+    except UnicodeEncodeError:
+        return IdentityRejectionReason.INVALID_GITHUB_USERNAME
+    return AuthenticatedUser(user_id=user_id, github_username=github_username)
 
 
 class AuthenticationRequired(HTTPException):
@@ -65,18 +97,24 @@ def init_oauth(settings: OAuthConfig) -> None:
 
 
 def get_authenticated_user_from_session(request: Request) -> AuthenticatedUser | None:
-    """Read the session identity, requiring both an ID and a nonempty username."""
-    user_id = request.session.get("user_id")
-    if user_id is None:
+    """Read valid identity, removing malformed identity but preserving OAuth state."""
+    session = request.session
+    if "user_id" not in session and "github_username" not in session:
         return None
-    user_id = int(user_id)
-    github_username = request.session.get("github_username")
-    if not isinstance(github_username, str) or not github_username:
-        return None
-    return AuthenticatedUser(
-        user_id=user_id,
-        github_username=github_username,
+    identity = (
+        IdentityRejectionReason.INCOMPLETE_IDENTITY
+        if "user_id" not in session or "github_username" not in session
+        else validate_identity(session["user_id"], session["github_username"])
     )
+    if isinstance(identity, AuthenticatedUser):
+        return identity
+    session.pop("user_id", None)
+    session.pop("github_username", None)
+    logger.warning(
+        "auth.session.identity_rejected",
+        extra={"auth.identity.reason": identity.value},
+    )
+    return None
 
 
 def require_authenticated_user(request: Request) -> AuthenticatedUser:

--- a/api/src/learn_to_cloud/routes/auth_routes.py
+++ b/api/src/learn_to_cloud/routes/auth_routes.py
@@ -7,6 +7,7 @@ Handles:
 """
 
 import logging
+from json import JSONDecodeError
 
 import httpx2
 from authlib.integrations.starlette_client import OAuthError
@@ -15,15 +16,30 @@ from fastapi.responses import RedirectResponse
 from learn_to_cloud_shared.core.config import get_web_settings
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from learn_to_cloud.core.auth import SESSION_COOKIE_NAME, oauth
+from learn_to_cloud.core.auth import (
+    SESSION_COOKIE_NAME,
+    AuthenticatedUser,
+    IdentityRejectionReason,
+    oauth,
+    validate_identity,
+)
 from learn_to_cloud.services.users_service import (
     get_or_create_user_from_github,
+    normalize_github_username,
     parse_display_name,
 )
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def _reject_identity(reason: IdentityRejectionReason) -> RedirectResponse:
+    logger.warning(
+        "auth.callback.identity_rejected",
+        extra={"auth.identity.reason": reason.value},
+    )
+    return RedirectResponse(url="/", status_code=302)
 
 
 @router.get(
@@ -84,7 +100,7 @@ async def callback(request: Request) -> RedirectResponse:
 
     try:
         resp = await github.get("user", token=token)
-        github_user = resp.json()
+        resp.raise_for_status()
     except httpx2.HTTPError as exc:
         logger.warning(
             "auth.callback.profile_fetch_failed",
@@ -92,21 +108,21 @@ async def callback(request: Request) -> RedirectResponse:
         )
         return RedirectResponse(url="/", status_code=302)
 
-    github_id = github_user.get("id")
-    if github_id is None:
-        logger.error(
-            "auth.callback.missing_github_id",
-            extra={"http.response.status_code": getattr(resp, "status_code", None)},
-        )
-        return RedirectResponse(url="/", status_code=302)
+    try:
+        github_user = resp.json()
+    except (JSONDecodeError, UnicodeDecodeError):
+        return _reject_identity(IdentityRejectionReason.INVALID_PROFILE)
+    if not isinstance(github_user, dict):
+        return _reject_identity(IdentityRejectionReason.INVALID_PROFILE)
 
-    github_username = github_user.get("login", "")
-    if not github_username:
-        logger.error(
-            "auth.callback.missing_github_login",
-            extra={"http.response.status_code": getattr(resp, "status_code", None)},
-        )
-        return RedirectResponse(url="/", status_code=302)
+    identity = validate_identity(github_user.get("id"), github_user.get("login"))
+    if not isinstance(identity, AuthenticatedUser):
+        return _reject_identity(identity)
+    normalized_identity = validate_identity(
+        identity.user_id, normalize_github_username(identity.github_username)
+    )
+    if not isinstance(normalized_identity, AuthenticatedUser):
+        return _reject_identity(normalized_identity)
 
     avatar_url = github_user.get("avatar_url")
     first_name, last_name = parse_display_name(github_user.get("name", ""))
@@ -116,16 +132,24 @@ async def callback(request: Request) -> RedirectResponse:
     async with sm() as db:
         user = await get_or_create_user_from_github(
             db=db,
-            github_id=github_id,
+            github_id=normalized_identity.user_id,
             first_name=first_name,
             last_name=last_name,
             avatar_url=avatar_url,
-            github_username=github_username.lower(),
+            github_username=normalized_identity.github_username,
         )
+        persisted_identity = validate_identity(user.id, user.github_username)
+        if (
+            not isinstance(persisted_identity, AuthenticatedUser)
+            or persisted_identity != normalized_identity
+        ):
+            raise RuntimeError(
+                "Persisted OAuth identity does not match validated identity"
+            )
         await db.commit()
 
-    request.session["user_id"] = user.id
-    request.session["github_username"] = user.github_username or ""
+    request.session["user_id"] = persisted_identity.user_id
+    request.session["github_username"] = persisted_identity.github_username
     logger.info("auth.login.success")
 
     return RedirectResponse(url="/dashboard", status_code=302)

--- a/api/src/learn_to_cloud/routes/auth_routes.py
+++ b/api/src/learn_to_cloud/routes/auth_routes.py
@@ -1,10 +1,4 @@
-"""GitHub OAuth authentication routes.
-
-Handles:
-- GET /auth/login — redirect to GitHub OAuth authorize
-- GET /auth/callback — exchange code for token, create session
-- POST /auth/logout — clear session, redirect to home
-"""
+"""GitHub OAuth login, callback, and logout routes."""
 
 import logging
 from json import JSONDecodeError
@@ -48,11 +42,7 @@ def _reject_identity(reason: IdentityRejectionReason) -> RedirectResponse:
     include_in_schema=False,
 )
 async def login(request: Request) -> RedirectResponse:
-    """Initiate GitHub OAuth flow.
-
-    Redirects the user to GitHub's authorization page.
-    After granting access, GitHub redirects back to /auth/callback.
-    """
+    """Redirect to GitHub to start OAuth login."""
     github = oauth.create_client("github")
     if github is None:
         logger.error("auth.login.github_not_configured")
@@ -75,15 +65,7 @@ async def login(request: Request) -> RedirectResponse:
     include_in_schema=False,
 )
 async def callback(request: Request) -> RedirectResponse:
-    """Handle GitHub OAuth callback.
-
-    Exchanges the authorization code for an access token, fetches the
-    user's GitHub profile, creates or updates the user in the database,
-    and sets the session cookie.
-
-    DB session is acquired only after GitHub API calls complete to avoid
-    holding a connection idle during external HTTP round-trips.
-    """
+    """Validate the user ID and username, save the user, and create a session."""
     github = oauth.create_client("github")
     if github is None:
         logger.error("auth.callback.github_not_configured")
@@ -111,9 +93,9 @@ async def callback(request: Request) -> RedirectResponse:
     try:
         github_user = resp.json()
     except (JSONDecodeError, UnicodeDecodeError):
-        return _reject_identity(IdentityRejectionReason.INVALID_PROFILE)
+        return _reject_identity(IdentityRejectionReason.INVALID_RESPONSE_FORMAT)
     if not isinstance(github_user, dict):
-        return _reject_identity(IdentityRejectionReason.INVALID_PROFILE)
+        return _reject_identity(IdentityRejectionReason.INVALID_RESPONSE_FORMAT)
 
     identity = validate_identity(github_user.get("id"), github_user.get("login"))
     if not isinstance(identity, AuthenticatedUser):
@@ -127,7 +109,6 @@ async def callback(request: Request) -> RedirectResponse:
     avatar_url = github_user.get("avatar_url")
     first_name, last_name = parse_display_name(github_user.get("name", ""))
 
-    # Acquire DB session only now — GitHub API calls are done.
     sm: async_sessionmaker[AsyncSession] = request.app.state.session_maker
     async with sm() as db:
         user = await get_or_create_user_from_github(

--- a/api/src/learn_to_cloud/services/users_service.py
+++ b/api/src/learn_to_cloud/services/users_service.py
@@ -10,11 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 def normalize_github_username(username: str | None) -> str | None:
-    """Normalize GitHub username to lowercase for consistency.
-
-    GitHub usernames are case-insensitive, so we normalize to lowercase
-    to avoid duplicate accounts and enable case-insensitive lookups.
-    """
+    """Return the lowercase username, or None if it is missing or empty."""
     return username.lower() if username else None
 
 

--- a/api/tests/core/test_auth.py
+++ b/api/tests/core/test_auth.py
@@ -6,15 +6,18 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi import Request
 from learn_to_cloud_shared.core.config import OAuthConfig
+from starlette.datastructures import State
 
 from learn_to_cloud.core.auth import (
     AuthenticatedUser,
     AuthenticationRequired,
+    IdentityRejectionReason,
     get_authenticated_user_from_session,
     init_oauth,
     oauth,
     optional_authenticated_user,
     require_authenticated_user,
+    validate_identity,
 )
 
 
@@ -34,9 +37,9 @@ def test_authlib_uses_supported_http_client() -> None:
 def _make_request(session: dict | None = None, headers: dict | None = None) -> Request:
     """Create a mock Request with session and headers support."""
     request = MagicMock(spec=Request)
-    request.session = session or {}
+    request.session = session if session is not None else {}
     request.headers = headers or {}
-    request.state = MagicMock()
+    request.state = State()
     return request
 
 
@@ -44,13 +47,13 @@ def _make_request(session: dict | None = None, headers: dict | None = None) -> R
 class TestGetAuthenticatedUserFromSession:
     """Test session identity extraction."""
 
-    @pytest.mark.parametrize("user_id", [42, "42"])
+    @pytest.mark.parametrize("user_id", [1, 42, 2**63 - 1])
     def test_returns_identity_with_integer_id(self, user_id):
         request = _make_request(
             session={"user_id": user_id, "github_username": "testuser"}
         )
         result = get_authenticated_user_from_session(request)
-        assert result == AuthenticatedUser(user_id=42, github_username="testuser")
+        assert result == AuthenticatedUser(user_id=user_id, github_username="testuser")
 
     def test_returns_none_without_username(self):
         request = _make_request(session={"user_id": 42})
@@ -74,6 +77,115 @@ class TestGetAuthenticatedUserFromSession:
         request = _make_request(session=session)
         result = get_authenticated_user_from_session(request)
         assert result is None
+
+
+@pytest.mark.unit
+class TestValidateIdentity:
+    @pytest.mark.parametrize(
+        "user_id",
+        [
+            True,
+            False,
+            42.0,
+            42.5,
+            "42",
+            "private-invalid-id",
+            None,
+            [],
+            {},
+            0,
+            -1,
+            2**63,
+        ],
+    )
+    def test_rejects_invalid_ids_without_coercion(self, user_id):
+        assert (
+            validate_identity(user_id, "testuser")
+            == IdentityRejectionReason.INVALID_USER_ID
+        )
+
+    @pytest.mark.parametrize(
+        "username",
+        [
+            None,
+            True,
+            42,
+            [],
+            {},
+            "",
+            " ",
+            "\t\r\n",
+            "\u2003",
+            "a" * 256,
+            "private\x00name",
+            "private\ud800name",
+        ],
+    )
+    def test_rejects_unusable_usernames(self, username):
+        assert (
+            validate_identity(42, username)
+            == IdentityRejectionReason.INVALID_GITHUB_USERNAME
+        )
+
+    @pytest.mark.parametrize(
+        "username",
+        ["a", "a" * 255, "\u00e9" * 255, "MiXeD", "name_company", " user ", "a.b"],
+    )
+    def test_preserves_names_without_signup_rules(self, username):
+        assert validate_identity(42, username) == AuthenticatedUser(42, username)
+
+
+@pytest.mark.unit
+class TestSessionIdentityCleanup:
+    @pytest.mark.parametrize(
+        ("identity", "reason"),
+        [
+            ({"user_id": 42}, "incomplete_identity"),
+            ({"github_username": "private-name"}, "incomplete_identity"),
+            ({"user_id": None, "github_username": "private-name"}, "invalid_user_id"),
+            ({"user_id": "private-id", "github_username": []}, "invalid_user_id"),
+            ({"user_id": 42, "github_username": "\ud800"}, "invalid_github_username"),
+        ],
+    )
+    def test_cleans_in_place_preserves_oauth_and_logs_once(
+        self, caplog, identity, reason
+    ):
+        unrelated = {"_state_github_probe": {"data": {"state": "private-state"}}}
+        session = {**unrelated, **identity}
+        request = _make_request(session)
+        assert optional_authenticated_user(request) is None
+        assert request.session is session
+        assert session == unrelated
+        assert not hasattr(request.state, "user_id")
+        assert not hasattr(request.state, "github_username")
+        assert optional_authenticated_user(request) is None
+        (record,) = caplog.records
+        assert record.getMessage() == "auth.session.identity_rejected"
+        assert record.__dict__["auth.identity.reason"] == reason
+        assert record.args == ()
+        assert record.exc_info is None
+        assert (
+            not {"user_id", "github_username", "session", "cookie"}
+            & record.__dict__.keys()
+        )
+
+    @pytest.mark.parametrize(
+        "session", [{}, {"_state_github_probe": {"data": {"state": "private-state"}}}]
+    )
+    def test_absent_identity_does_not_mutate_or_log(self, caplog, session):
+        original = session.copy()
+        assert optional_authenticated_user(_make_request(session)) is None
+        assert session == original
+        assert caplog.records == []
+
+    def test_valid_identity_does_not_mutate_or_log(self, caplog):
+        session = {"user_id": 42, "github_username": "MiXeD", "other": "private-state"}
+        original = session.copy()
+        assert get_authenticated_user_from_session(_make_request(session)) == (
+            AuthenticatedUser(42, "MiXeD")
+        )
+        assert session == original
+        assert caplog.records == []
 
 
 @pytest.mark.unit

--- a/api/tests/routes/test_auth_http.py
+++ b/api/tests/routes/test_auth_http.py
@@ -1,12 +1,13 @@
 """Authentication contracts through real routes and signed-cookie middleware."""
 
 import json
-from base64 import b64encode
+from base64 import b64decode, b64encode
 from datetime import UTC, datetime
 from http.cookies import SimpleCookie
 from time import time
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx2
 import pytest
 from fastapi import APIRouter, FastAPI, HTTPException
 from fastapi.responses import PlainTextResponse, RedirectResponse
@@ -42,6 +43,36 @@ _PAGE_PATHS = [
     "/verifications",
     "/verifications/phase/1",
 ]
+_INVALID_IDENTITIES = (
+    [
+        pytest.param(
+            {"user_id": value, "github_username": "private-name"}, id=f"id-{index}"
+        )
+        for index, value in enumerate(
+            [True, False, 42.0, 42.5, "42", "private-id", None, [], {}, 0, -1, 2**63]
+        )
+    ]
+    + [
+        pytest.param({"user_id": 42, "github_username": value}, id=f"name-{index}")
+        for index, value in enumerate(
+            [
+                None,
+                True,
+                [],
+                {},
+                "",
+                "\t \u2003",
+                "a" * 256,
+                "private\x00name",
+                "private\ud800name",
+            ]
+        )
+    ]
+    + [
+        pytest.param({"user_id": 42}, id="missing-name"),
+        pytest.param({"github_username": "private-name"}, id="missing-id"),
+    ]
+)
 
 
 def _session_cookie(session: dict, *, expired: bool = False) -> str:
@@ -132,12 +163,13 @@ def app(test_settings, user, api_services, github):
             "learn_to_cloud.routes.pages_routes.get_user_by_id",
             autospec=True,
             return_value=user,
-        ),
+        ) as page_user,
         patch(
             "learn_to_cloud.routes.pages_routes.get_curriculum_overview",
             return_value=(),
         ),
     ):
+        app.state.page_user = page_user
         yield app
 
 
@@ -348,6 +380,210 @@ async def test_authenticated_api_delete_keeps_204_contract(client, api_services)
     assert response.history == []
     assert SESSION_COOKIE_NAME not in client.cookies
     api_services[1].assert_awaited_once()
+
+
+@pytest.mark.parametrize("identity", _INVALID_IDENTITIES)
+@pytest.mark.parametrize("preserve_oauth", [False, True])
+@pytest.mark.parametrize(
+    ("path", "htmx", "status"),
+    [
+        ("/", False, 200),
+        ("/curriculum", False, 200),
+        ("/api/user/me", False, 401),
+        ("/account", False, 303),
+        ("/account", True, 401),
+        ("/htmx/verification/attempts/status?token=private-token", False, 401),
+        ("/htmx/verification/attempts/status?token=private-token", True, 401),
+    ],
+)
+async def test_malformed_identity_is_cleaned_over_http(
+    client, app, api_services, caplog, identity, preserve_oauth, path, htmx, status
+):
+    unrelated = (
+        {"_state_github_probe": {"data": {"state": "private-oauth-state"}}}
+        if preserve_oauth
+        else {}
+    )
+    client.cookies.set(
+        SESSION_COOKIE_NAME,
+        _session_cookie({**unrelated, **identity}),
+        domain="testserver.local",
+        path="/",
+    )
+    headers = {"HX-Request": "true"} if htmx else {}
+
+    response = await client.get(path, headers=headers)
+
+    assert response.status_code == status
+    assert response.headers.get("location") == (
+        "/auth/login" if status == 303 else None
+    )
+    assert response.headers.get_list("set-cookie")
+    if preserve_oauth:
+        cookie = client.cookies.get(SESSION_COOKIE_NAME)
+        cleaned = json.loads(b64decode(TimestampSigner(_SECRET).unsign(cookie)))
+        assert cleaned == unrelated
+    else:
+        assert SESSION_COOKIE_NAME not in client.cookies
+        expired = SimpleCookie(response.headers["set-cookie"])[SESSION_COOKIE_NAME]
+        assert "1970" in expired["expires"]
+    for service in api_services:
+        service.assert_not_awaited()
+    app.state.page_user.assert_not_awaited()
+
+    again = await client.get(path, headers=headers)
+    assert again.status_code == status
+    assert "set-cookie" not in again.headers
+    (record,) = [r for r in caplog.records if r.name == "learn_to_cloud.core.auth"]
+    assert record.getMessage() == "auth.session.identity_rejected"
+    assert record.args == ()
+    assert record.exc_info is None
+    assert set(key for key in record.__dict__ if key.startswith("auth.")) == {
+        "auth.identity.reason"
+    }
+
+
+@pytest.mark.parametrize(
+    "kind", ["missing", "valid", "expired", "tampered", "oauth-only"]
+)
+@pytest.mark.parametrize("path", ["/", "/curriculum", "/api/user/me", "/account"])
+async def test_session_cookie_lifecycle_on_real_routes(client, caplog, kind, path):
+    if kind != "missing":
+        session = (
+            {"_state_github_probe": {"data": {"state": "private-state"}}}
+            if kind == "oauth-only"
+            else {"user_id": 42, "github_username": "testuser"}
+        )
+        cookie = _session_cookie(session, expired=kind == "expired")
+        if kind == "tampered":
+            payload, timestamp, signature = cookie.split(".")
+            cookie = ".".join((payload, timestamp, "a" if signature != "a" else "b"))
+        client.cookies.set(
+            SESSION_COOKIE_NAME, cookie, domain="testserver.local", path="/"
+        )
+    response = await client.get(path)
+    status = 200
+    if kind != "valid" and path == "/api/user/me":
+        status = 401
+    elif kind != "valid" and path == "/account":
+        status = 303
+    assert response.status_code == status
+    assert "set-cookie" not in response.headers
+    assert not [r for r in caplog.records if r.name == "learn_to_cloud.core.auth"]
+
+
+@pytest.fixture
+def oauth_callback(app, github, user):
+    database = AsyncMock()
+    context = AsyncMock()
+    context.__aenter__.return_value = database
+    context.__aexit__.return_value = False
+    app.state.session_maker = MagicMock(return_value=context)
+    github.authorize_access_token = AsyncMock(
+        return_value={"access_token": "private-oauth-token"}
+    )
+    github.get = AsyncMock(
+        return_value=httpx2.Response(
+            200,
+            json={"id": 42, "login": "TestUser"},
+            request=httpx2.Request("GET", "https://api.github.com/user"),
+        )
+    )
+    with patch(
+        "learn_to_cloud.routes.auth_routes.get_or_create_user_from_github",
+        autospec=True,
+        return_value=user,
+    ) as upsert:
+        yield database, upsert
+
+
+async def test_oauth_issued_cookie_authenticates_next_request(client, oauth_callback):
+    database, upsert = oauth_callback
+    unrelated = {"_state_github_other": {"data": {"state": "private-other-state"}}}
+    client.cookies.set(
+        SESSION_COOKIE_NAME,
+        _session_cookie(unrelated),
+        domain="testserver.local",
+        path="/",
+    )
+    response = await client.get("/auth/callback")
+    assert response.status_code == 302
+    assert response.headers["location"] == "/dashboard"
+    cookie = client.cookies.get(SESSION_COOKIE_NAME)
+    identity = json.loads(b64decode(TimestampSigner(_SECRET).unsign(cookie)))
+    assert identity == {**unrelated, "user_id": 42, "github_username": "testuser"}
+    database.commit.assert_awaited_once()
+    assert upsert.call_args.kwargs["github_id"] == identity["user_id"]
+    assert upsert.call_args.kwargs["github_username"] == identity["github_username"]
+    authenticated = await client.get("/api/user/me")
+    assert authenticated.status_code == 200
+    assert authenticated.json()["id"] == 42
+
+
+async def test_oauth_invariant_failure_remains_500(app, oauth_callback, user, caplog):
+    database, _ = oauth_callback
+    user.id = 43
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/auth/callback")
+    assert response.status_code == 500
+    assert "set-cookie" not in response.headers
+    assert "location" not in response.headers
+    database.commit.assert_not_awaited()
+    assert "auth.callback.identity_rejected" not in caplog.text
+    assert "auth.login.success" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("path", "htmx", "status"),
+    [
+        ("/", False, 200),
+        ("/api/user/me", False, 401),
+        ("/account", False, 303),
+        ("/account", True, 401),
+    ],
+)
+async def test_malformed_identity_telemetry_has_no_private_values(
+    telemetry_client, caplog, path, htmx, status
+):
+    client, exporter = telemetry_client
+    cookie = _session_cookie(
+        {"user_id": "private-user-id", "github_username": "private-username"}
+    )
+    client.cookies.set(SESSION_COOKIE_NAME, cookie, domain="testserver.local", path="/")
+    response = await client.get(
+        path,
+        params={"token": "private-token"},
+        headers={"HX-Request": "true"} if htmx else {},
+    )
+    assert response.status_code == status
+    spans = exporter.get_finished_spans()
+    (server,) = [span for span in spans if span.kind == SpanKind.SERVER]
+    assert server.status.status_code == StatusCode.UNSET
+    assert server.attributes["http.route"] == path
+    assert (
+        server.attributes.get(
+            "http.response.status_code", server.attributes.get("http.status_code")
+        )
+        == status
+    )
+    for attribute in ("http.target", "http.url", "url.full", "url.path"):
+        assert server.attributes[attribute] == path
+    assert server.attributes["url.query"] == ""
+    for span in spans:
+        assert not any(event.name == "exception" for event in span.events)
+        assert (
+            not {"user_id", "github_username", "user.id", "session.id"}
+            & span.attributes.keys()
+        )
+    records = [r for r in caplog.records if r.name == "learn_to_cloud.core.auth"]
+    assert len(records) == 1
+    log_payload = json.dumps(records[0].__dict__, default=str)
+    telemetry = "\n".join(span.to_json() for span in spans) + log_payload
+    for prohibited in ("private-user-id", "private-username", "private-token", cookie):
+        assert prohibited not in telemetry
 
 
 @pytest.mark.parametrize(

--- a/api/tests/routes/test_auth_routes.py
+++ b/api/tests/routes/test_auth_routes.py
@@ -369,9 +369,9 @@ class TestCallbackIdentityContract:
             ({"id": 42, "login": "\u0130" * 128}, "invalid_github_username"),
             ({"id": 42, "login": "private\x00name"}, "invalid_github_username"),
             ({"id": 42, "login": "private\ud800name"}, "invalid_github_username"),
-            (None, "invalid_profile"),
-            ([], "invalid_profile"),
-            ("private-profile", "invalid_profile"),
+            (None, "invalid_response_format"),
+            ([], "invalid_response_format"),
+            ("private-profile", "invalid_response_format"),
         ],
     )
     async def test_rejects_before_persistence_and_preserves_session(

--- a/api/tests/routes/test_auth_routes.py
+++ b/api/tests/routes/test_auth_routes.py
@@ -13,7 +13,9 @@ Testing approach:
 These are unit tests: no HTTP client, no real OAuth, no database.
 """
 
+import json
 from http.cookies import SimpleCookie
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx2
@@ -143,7 +145,7 @@ class TestCallbackRoute:
         mock_github.get = AsyncMock(return_value=mock_response)
 
         mock_user = MagicMock()
-        mock_user.id = 42
+        mock_user.id = 12345
         mock_user.github_username = "testuser"
 
         with (
@@ -159,7 +161,7 @@ class TestCallbackRoute:
             result = await callback(request)
 
         # Session should be populated
-        assert request.session["user_id"] == 42
+        assert request.session["user_id"] == 12345
         assert request.session["github_username"] == "testuser"
 
         # Should redirect to /dashboard
@@ -294,7 +296,7 @@ class TestCallbackRoute:
         mock_github.get = AsyncMock(return_value=mock_response)
 
         mock_user = MagicMock()
-        mock_user.id = 1
+        mock_user.id = 999
         mock_user.github_username = "mixedcase"
 
         with (
@@ -312,6 +314,172 @@ class TestCallbackRoute:
         # Verify github_username was lowercased before being passed
         call_kwargs = mock_get_or_create.call_args.kwargs
         assert call_kwargs["github_username"] == "mixedcase"
+
+
+@pytest.fixture
+def callback_context():
+    request = _mock_request(
+        session={
+            "user_id": 99,
+            "github_username": "existing-user",
+            "_state_github_other": {"data": {"state": "private-state"}},
+        }
+    )
+    github = MagicMock()
+    github.authorize_access_token = AsyncMock(
+        return_value={"access_token": "private-oauth-token"}
+    )
+    github.get = AsyncMock(
+        return_value=httpx2.Response(
+            200,
+            json={"id": 42, "login": "testuser"},
+            request=httpx2.Request("GET", "https://api.github.com/user"),
+        )
+    )
+    user = SimpleNamespace(id=42, github_username="testuser")
+    with (
+        patch("learn_to_cloud.routes.auth_routes.oauth") as oauth,
+        patch(
+            "learn_to_cloud.routes.auth_routes.get_or_create_user_from_github",
+            autospec=True,
+            return_value=user,
+        ) as upsert,
+    ):
+        oauth.create_client.return_value = github
+        yield request, github, user, upsert
+
+
+@pytest.mark.unit
+class TestCallbackIdentityContract:
+    @pytest.mark.parametrize(
+        ("profile", "reason"),
+        [
+            ({}, "invalid_user_id"),
+            ({"id": True, "login": "testuser"}, "invalid_user_id"),
+            ({"id": 42.0, "login": "testuser"}, "invalid_user_id"),
+            ({"id": "42", "login": "testuser"}, "invalid_user_id"),
+            ({"id": 0, "login": "testuser"}, "invalid_user_id"),
+            ({"id": -1, "login": "testuser"}, "invalid_user_id"),
+            ({"id": 2**63, "login": "testuser"}, "invalid_user_id"),
+            ({"id": [], "login": "testuser"}, "invalid_user_id"),
+            ({"id": 42}, "invalid_github_username"),
+            ({"id": 42, "login": []}, "invalid_github_username"),
+            ({"id": 42, "login": " \t"}, "invalid_github_username"),
+            ({"id": 42, "login": "x" * 256}, "invalid_github_username"),
+            ({"id": 42, "login": "\u0130" * 128}, "invalid_github_username"),
+            ({"id": 42, "login": "private\x00name"}, "invalid_github_username"),
+            ({"id": 42, "login": "private\ud800name"}, "invalid_github_username"),
+            (None, "invalid_profile"),
+            ([], "invalid_profile"),
+            ("private-profile", "invalid_profile"),
+        ],
+    )
+    async def test_rejects_before_persistence_and_preserves_session(
+        self, callback_context, caplog, profile, reason
+    ):
+        request, github, _, upsert = callback_context
+        original = request.session.copy()
+        github.get.return_value = httpx2.Response(
+            200,
+            content=json.dumps(profile).encode(),
+            request=httpx2.Request("GET", "https://api.github.com/user"),
+        )
+
+        response = await callback(request)
+
+        assert response.status_code == 302
+        assert response.headers["location"] == "/"
+        assert request.session == original
+        request.app.state.session_maker.assert_not_called()
+        upsert.assert_not_awaited()
+        (record,) = caplog.records
+        assert record.getMessage() == "auth.callback.identity_rejected"
+        assert record.__dict__["auth.identity.reason"] == reason
+        assert record.args == ()
+        assert record.exc_info is None
+
+    @pytest.mark.parametrize(
+        ("status", "body"),
+        [
+            (200, b"private-provider-body"),
+            (200, b"\xff"),
+            (401, b"private-provider-body"),
+            (403, b"private-provider-body"),
+            (500, b"private-provider-body"),
+        ],
+    )
+    async def test_bad_provider_response_does_not_issue_identity(
+        self, callback_context, caplog, status, body
+    ):
+        request, github, _, upsert = callback_context
+        original = request.session.copy()
+        github.get.return_value = httpx2.Response(
+            status,
+            content=body,
+            request=httpx2.Request("GET", "https://api.github.com/user"),
+        )
+        response = await callback(request)
+        assert response.status_code == 302
+        assert request.session == original
+        request.app.state.session_maker.assert_not_called()
+        upsert.assert_not_awaited()
+        assert "private-provider-body" not in caplog.text
+        assert all(record.exc_info is None for record in caplog.records)
+
+    @pytest.mark.parametrize(
+        ("user_id", "username"), [(42, None), (43, "testuser"), (42, "different-user")]
+    )
+    async def test_invalid_persisted_identity_is_an_internal_failure(
+        self, callback_context, caplog, user_id, username
+    ):
+        request, _, user, _ = callback_context
+        original = request.session.copy()
+        user.id, user.github_username = user_id, username
+        with pytest.raises(
+            RuntimeError,
+            match="^Persisted OAuth identity does not match validated identity$",
+        ):
+            await callback(request)
+        request._mock_db_session.commit.assert_not_awaited()
+        exit_args = (
+            request.app.state.session_maker.return_value.__aexit__.call_args.args
+        )
+        assert exit_args[0] is RuntimeError
+        assert request.session == original
+        assert caplog.records == []
+
+    @pytest.mark.parametrize("stage", ["upsert", "commit"])
+    async def test_database_failure_does_not_issue_identity(
+        self, callback_context, caplog, stage
+    ):
+        request, _, _, upsert = callback_context
+        original = request.session.copy()
+        operation = upsert if stage == "upsert" else request._mock_db_session.commit
+        operation.side_effect = RuntimeError("database-failure-probe")
+        with pytest.raises(RuntimeError, match="database-failure-probe"):
+            await callback(request)
+        assert request.session == original
+        assert "auth.login.success" not in caplog.text
+
+    async def test_commit_precedes_session_issuance(self, callback_context, caplog):
+        request, _, _, upsert = callback_context
+        original = request.session.copy()
+
+        async def commit():
+            assert request.session == original
+            upsert.assert_awaited_once()
+
+        request._mock_db_session.commit.side_effect = commit
+        with caplog.at_level("INFO", logger="learn_to_cloud.routes.auth_routes"):
+            response = await callback(request)
+        assert response.status_code == 302
+        assert request.session == {
+            **original,
+            "user_id": 42,
+            "github_username": "testuser",
+        }
+        request._mock_db_session.commit.assert_awaited_once()
+        assert [r.getMessage() for r in caplog.records] == ["auth.login.success"]
 
 
 @pytest.mark.unit

--- a/api/tests/test_telemetry_contracts.py
+++ b/api/tests/test_telemetry_contracts.py
@@ -19,6 +19,7 @@ _PYTHON_TELEMETRY_ROOTS = (
 
 _ALLOWED_APPLICATION_ATTRIBUTES = {
     "auth.configuration.reason",
+    "auth.identity.reason",
     "content.artifact.hash",
     "content.artifact_schema.version",
     "content.curriculum.version",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -307,6 +307,38 @@ GitHub OAuth establishes a signed client-side session cookie containing
 age on subsequent requests; those requests do not contact GitHub again.
 The cookie is signed, not encrypted, so do not store secrets in its payload.
 
+OAuth issuance and session reads share `validate_identity` from
+`learn_to_cloud.core.auth`. It requires:
+
+- An integer GitHub ID from 1 through `2**63 - 1`. Booleans, floats, numeric
+  strings, zero, negative values, and larger integers are rejected, not converted.
+- A username string of 1 through 255 characters containing non-whitespace text,
+  representable as UTF-8 and containing no NUL character. The length is the
+  existing database capacity, not a GitHub naming rule.
+
+GitHub's authenticated profile response establishes account identity. We do not
+duplicate signup rules, check reserved names, or requery GitHub on each request.
+Session reads preserve accepted values without trimming or changing case.
+OAuth retains lowercase normalization and validates the normalized value before
+database access, since lowercasing can increase a Unicode string's length.
+The returned database identity must match that validated identity, and the
+transaction must commit before a new cookie identity is written. A mismatch
+is an internal error, not an ordinary rejected login.
+
+Missing both identity fields is normal anonymous access, including a session
+containing only OAuth state. Partial or malformed identity is also treated as
+anonymous, but both identity fields are removed from the existing session object.
+Unrelated entries, including OAuth state, are preserved. Middleware persists the
+cleaned cookie or expires it if nothing remains.
+
+Rejecting numeric-string IDs is an intentional change from the previous
+coercing reader. Valid sessions remain valid; rejected sessions require login
+again. Local tools such as `scripts/dogfood_session.py` must also supply valid
+identity values. No migration, backfill, or cookie-key rotation is needed.
+Malformed cookie encoding, JSON, or top-level session shapes are a separate
+middleware concern tracked in
+[#834](https://github.com/learntocloud/learn-to-cloud-app/issues/834).
+
 The API uses one identity type:
 
 | Name | Purpose |
@@ -354,6 +386,9 @@ redirects in `api/tests/routes/test_auth_http.py`. Auth overrides are useful
 for unrelated rendering tests, but must not replace authentication in tests
 of the auth contract itself. Request telemetry records handled 401/303 outcomes;
 it must not add usernames, user IDs, cookie values, or session identifiers.
+Handled identity rejection emits a bounded warning without exception details;
+ordinary anonymous access does not. Failed OAuth attempts do not clear an
+existing valid login or unrelated authorization state.
 See the [telemetry schema](observability/telemetry-schema.html).
 
 ## Conventions

--- a/docs/observability/telemetry-schema.md
+++ b/docs/observability/telemetry-schema.md
@@ -181,7 +181,7 @@ attribute is `auth.identity.reason`:
 | `incomplete_identity` | A session contains only one application identity field. |
 | `invalid_user_id` | The ID fails the strict positive signed-64-bit integer contract. |
 | `invalid_github_username` | The username fails the type, nonblank, length, or storage-encoding contract, including after OAuth normalization. |
-| `invalid_profile` | The provider response has invalid JSON/character encoding or is not a JSON object. |
+| `invalid_response_format` | The provider response has invalid JSON/character encoding or is not a JSON object. |
 
 These events replace the callback's former `auth.callback.missing_github_id`
 and `auth.callback.missing_github_login` events. Existing provider transport

--- a/docs/observability/telemetry-schema.md
+++ b/docs/observability/telemetry-schema.md
@@ -167,9 +167,38 @@ alert notifications, and must not be added to general request spans.
 | `repo` | `github.repository` | Identify a failed curriculum repository lookup | Fixed public repository set | Operational | Rename; only approved curriculum repositories |
 | `status_code` on auth events | `http.response.status_code` | GitHub OAuth response status | Bounded integer | Operational | Rename |
 | `reason` on auth events | `auth.configuration.reason` | Explain disabled OAuth | Fixed enum | Operational | Rename |
+| `auth.identity.reason` | `auth.identity.reason` | Explain rejected session or provider identity | Fixed enum below | Operational | Keep |
 
 Authentication telemetry never includes GitHub usernames, GitHub IDs, internal
 user IDs, OAuth tokens, claims, or session identifiers.
+
+`auth.session.identity_rejected` and `auth.callback.identity_rejected` are
+warning-level logs for handled identity rejection. Their only application
+attribute is `auth.identity.reason`:
+
+| Value | Meaning |
+| --- | --- |
+| `incomplete_identity` | A session contains only one application identity field. |
+| `invalid_user_id` | The ID fails the strict positive signed-64-bit integer contract. |
+| `invalid_github_username` | The username fails the type, nonblank, length, or storage-encoding contract, including after OAuth normalization. |
+| `invalid_profile` | The provider response has invalid JSON/character encoding or is not a JSON object. |
+
+These events replace the callback's former `auth.callback.missing_github_id`
+and `auth.callback.missing_github_login` events. Existing provider transport
+failures retain `auth.callback.profile_fetch_failed` and bounded `error.type`.
+
+Rejection does not attach exception details or identity values. Empty sessions,
+OAuth-state-only sessions, and cookies rejected by middleware do not produce
+identity warnings. Cleaning an invalid session prevents another warning when
+that cleaned session is read again; this is not cross-request deduplication if
+a client keeps replaying the original cookie.
+
+Handled rejection keeps the normal public-page 200, protected API/HTMX 401, and
+browser 303 request telemetry. An invalid or mismatched persisted OAuth identity
+after validated input is instead an internal invariant failure. It reaches
+the existing `unhandled.exception` boundary with a fixed identity-free message,
+not an additional identity-rejection warning. Never suppress that failure to
+make authentication telemetry look healthy.
 
 ## Metrics
 
@@ -219,7 +248,7 @@ names are bounded code constants and never contain learner values.
 
 The following event families are retained:
 
-- `auth.*`: OAuth configuration and bounded callback outcomes.
+- `auth.*`: OAuth configuration, bounded callback outcomes, and identity rejection.
 - `content.*`: failures loading bundled curriculum artifacts.
 - `db.*`: database lifecycle and rollback failures.
 - `health.*`: readiness and schema drift signals.

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -77,6 +77,30 @@ after a deployment. Do not suppress the exception or disable the alert. If a
 dependency is transiently unavailable, restore that dependency and confirm the
 exact exception alert returns to a healthy state.
 
+## Rejected session or OAuth identity
+
+`auth.session.identity_rejected` and `auth.callback.identity_rejected` are
+handled warnings, not unhandled-exception alerts. Inspect their bounded
+`auth.identity.reason` and the associated request outcome; do not request or
+copy the cookie, user identity, OAuth state, or provider response body.
+
+Session rejection removes only the application identity. Public pages remain
+available, protected API/HTMX routes return 401, and browser page navigation
+redirects to login. OAuth rejection redirects home without replacing an existing
+valid login. Ordinary anonymous requests do not emit these warnings.
+
+Compare an increase with the deployed revision and recent authentication
+changes. An old malformed signed cookie, a faulty session-producing tool, or
+unexpected provider data can explain a rejection; the warning alone does not
+prove cookie forgery or account compromise. Reauthentication can replace a
+malformed identity. Do not disable validation or restore numeric-ID coercion.
+
+A persisted OAuth identity that differs from the validated provider identity is
+an application invariant failure. It should not commit or issue a new session;
+investigate it through the existing unhandled-exception guide above. Malformed
+cookie decoding occurs earlier in middleware and is tracked separately in #834.
+See the [telemetry schema](../observability/telemetry-schema.html) for reason values.
+
 ## Telemetry pipeline failure
 
 ### Meaning


### PR DESCRIPTION
Share strict identity validation between session reads and OAuth issuance. Preserve unrelated OAuth state, keep existing response policies, and document bounded rejection diagnostics.

## Summary

<!-- What does this PR do and why? -->

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.
