### PR TITLE
chore: remove legacy name columns after profile cutover

### DIFF
--- a/api/alembic/versions/0059_drop_user_legacy_names.py
+++ b/api/alembic/versions/0059_drop_user_legacy_names.py
@@ -1,0 +1,31 @@
+"""Remove obsolete name components after the display-name application cutover.
+
+Downgrade restores empty legacy columns, not their discarded values.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0059_drop_user_legacy_names"
+down_revision: str | None = "0058_add_user_display_name"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Drop legacy storage without changing canonical display names."""
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+    op.drop_column("users", "first_name")
+    op.drop_column("users", "last_name")
+
+
+def downgrade() -> None:
+    """Restore nullable legacy columns without inferring name components."""
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+    op.add_column("users", sa.Column("first_name", sa.String(255), nullable=True))
+    op.add_column("users", sa.Column("last_name", sa.String(255), nullable=True))

--- a/api/tests/test_migration_chain.py
+++ b/api/tests/test_migration_chain.py
@@ -19,8 +19,12 @@ from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
 import pytest
+from alembic.autogenerate import compare_metadata
 from alembic.config import Config
+from alembic.migration import MigrationContext
+from learn_to_cloud_shared.core.database import Base
 from learn_to_cloud_shared.models import LearnerStepCompletion, User
+from learn_to_cloud_shared.repositories import user_repository
 from learn_to_cloud_shared.repositories.user_repository import UserRepository
 from pytest_alembic.tests import (
     test_model_definitions_match_ddl,
@@ -28,8 +32,20 @@ from pytest_alembic.tests import (
     test_up_down_consistency,
     test_upgrade,
 )
-from sqlalchemy import Text, create_engine, event, inspect, select, text
+from sqlalchemy import (
+    Column,
+    MetaData,
+    String,
+    Text,
+    create_engine,
+    event,
+    inspect,
+    select,
+    text,
+)
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import registry
 
 from alembic import command
 
@@ -199,6 +215,7 @@ def test_head_removes_unused_attempt_traceparent(
 
 _PRE_DISPLAY_NAME = "0057_drop_verification_attempt_traceparent"
 _DISPLAY_NAME_EXPANSION = "0058_add_user_display_name"
+_DISPLAY_NAME_CONTRACT = "0059_drop_user_legacy_names"
 _LEGACY_USER_COLUMNS = (
     "id, first_name, last_name, avatar_url, github_username, "
     "is_admin, created_at, updated_at"
@@ -216,6 +233,39 @@ _WHITESPACE_CODEPOINTS = (
     0x205F,
     0x3000,
 )
+
+
+def _expanded_metadata() -> MetaData:
+    """Reconstruct transitional metadata without restoring runtime dependencies."""
+    metadata = MetaData()
+    for table in Base.metadata.sorted_tables:
+        table.to_metadata(metadata)
+    for name in ("first_name", "last_name"):
+        metadata.tables["users"].append_column(Column(name, String(255), nullable=True))
+    return metadata
+
+
+@pytest.fixture()
+def historical_user_models():
+    """Keep the A/B subset mappings executable after their runtime cleanup."""
+    registries = []
+    models = {}
+    for layer, excluded in (
+        ("expansion", ["display_name"]),
+        ("cutover", ["first_name", "last_name"]),
+    ):
+        mapper_registry = registry(metadata=_expanded_metadata())
+        model = type(f"Historical{layer.title()}User", (), {})
+        mapper_registry.map_imperatively(
+            model,
+            mapper_registry.metadata.tables["users"],
+            exclude_properties=excluded,
+        )
+        registries.append(mapper_registry)
+        models[layer] = model
+    yield models
+    for mapper_registry in registries:
+        mapper_registry.dispose()
 
 
 def test_display_name_offline_sql_is_atomic_and_bounded() -> None:
@@ -241,6 +291,148 @@ def test_display_name_offline_sql_is_atomic_and_bounded() -> None:
     assert "UPDATE users" in upgrade_sql.getvalue()
     assert "DROP COLUMN display_name" in downgrade_sql.getvalue()
     assert "UPDATE users" not in downgrade_sql.getvalue()
+
+
+def test_display_name_contract_offline_sql_is_atomic_and_bounded() -> None:
+    config = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    config.set_main_option(
+        "script_location", str(Path(__file__).parent.parent / "alembic")
+    )
+    upgrade_sql = StringIO()
+    config.output_buffer = upgrade_sql
+    command.upgrade(
+        config, f"{_DISPLAY_NAME_EXPANSION}:{_DISPLAY_NAME_CONTRACT}", sql=True
+    )
+    downgrade_sql = StringIO()
+    config.output_buffer = downgrade_sql
+    command.downgrade(
+        config, f"{_DISPLAY_NAME_CONTRACT}:{_DISPLAY_NAME_EXPANSION}", sql=True
+    )
+    for sql in (upgrade_sql.getvalue(), downgrade_sql.getvalue()):
+        assert sql.count("BEGIN;") == sql.count("COMMIT;") == 1
+        assert "SET LOCAL lock_timeout = '5s';" in sql
+        assert "SET LOCAL statement_timeout = '2min';" in sql
+        assert sql.index("SET LOCAL statement_timeout") < sql.index("ALTER TABLE users")
+        assert "UPDATE users" not in sql
+        assert "SET display_name" not in sql
+        assert "COLUMN display_name" not in sql
+    for legacy in ("first_name", "last_name"):
+        assert f"DROP COLUMN {legacy}" in upgrade_sql.getvalue()
+        assert f"ADD COLUMN {legacy} VARCHAR(255);" in downgrade_sql.getvalue()
+
+
+def test_display_name_contract_preserves_populated_data_and_downgrade_is_empty(
+    alembic_runner, alembic_engine
+) -> None:
+    alembic_runner.migrate_up_to(_DISPLAY_NAME_EXPANSION)
+    names = [None, "  李  e\u0301 👩🏽‍💻  ", "a" * 600, "<b>Exact</b>", "One"]
+    created_at = datetime(2024, 1, 2, tzinfo=UTC)
+    updated_at = datetime(2025, 2, 3, tzinfo=UTC)
+    canonical_columns = (
+        "id, display_name, avatar_url, github_username, "
+        "is_admin, created_at, updated_at"
+    )
+    with alembic_engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users "
+                f"({canonical_columns}, first_name, last_name) VALUES "
+                "(:id, :display_name, :avatar_url, :github_username, :is_admin, "
+                ":created_at, :updated_at, 'Stale', 'Legacy')"
+            ),
+            [
+                {
+                    "id": user_id,
+                    "display_name": name,
+                    "avatar_url": f"https://example.com/{user_id}.png",
+                    "github_username": f"contract-user-{user_id}",
+                    "is_admin": user_id % 2 == 0,
+                    "created_at": created_at,
+                    "updated_at": updated_at,
+                }
+                for user_id, name in enumerate(names, start=8000)
+            ],
+        )
+        conn.execute(
+            text(
+                "INSERT INTO learner_step_completions "
+                "(user_id, step_uuid, completed_at) "
+                "VALUES (:user_id, :step_uuid, :completed_at)"
+            ),
+            [
+                {
+                    "user_id": user_id,
+                    "step_uuid": UUID(int=user_id),
+                    "completed_at": created_at,
+                }
+                for user_id in range(8000, 8000 + len(names))
+            ],
+        )
+        before_users = conn.execute(
+            text(f"SELECT {canonical_columns} FROM users ORDER BY id")
+        ).all()
+        before_progress = conn.execute(
+            text("SELECT * FROM learner_step_completions ORDER BY user_id")
+        ).all()
+        before_grants = conn.execute(
+            text("SELECT relacl FROM pg_class WHERE oid = 'users'::regclass")
+        ).scalar_one()
+
+    for revision in (
+        _DISPLAY_NAME_CONTRACT,
+        _DISPLAY_NAME_EXPANSION,
+        _DISPLAY_NAME_CONTRACT,
+    ):
+        contracted = revision == _DISPLAY_NAME_CONTRACT
+        if contracted:
+            alembic_runner.migrate_up_to(revision)
+        else:
+            alembic_runner.migrate_down_to(revision)
+        with alembic_engine.connect() as conn:
+            assert (
+                conn.execute(
+                    text(f"SELECT {canonical_columns} FROM users ORDER BY id")
+                ).all()
+                == before_users
+            )
+            assert conn.execute(text("SELECT count(*) FROM users")).scalar_one() == len(
+                names
+            )
+            assert (
+                conn.execute(
+                    text("SELECT * FROM learner_step_completions ORDER BY user_id")
+                ).all()
+                == before_progress
+            )
+            assert (
+                conn.execute(
+                    text("SELECT relacl FROM pg_class WHERE oid = 'users'::regclass")
+                ).scalar_one()
+                == before_grants
+            )
+            columns = {c["name"]: c for c in inspect(conn).get_columns("users")}
+            assert isinstance(columns["display_name"]["type"], Text)
+            assert columns["display_name"]["nullable"] is True
+            assert columns["display_name"]["default"] is None
+            for legacy in ("first_name", "last_name"):
+                assert legacy not in User.__table__.c
+                assert legacy not in inspect(User).column_attrs
+                if contracted:
+                    assert legacy not in columns
+                else:
+                    assert isinstance(columns[legacy]["type"], String)
+                    assert columns[legacy]["type"].length == 255
+                    assert columns[legacy]["nullable"] is True
+                    assert columns[legacy]["default"] is None
+            if not contracted:
+                assert conn.execute(
+                    text("SELECT first_name, last_name FROM users ORDER BY id")
+                ).all() == [(None, None)] * len(names)
+            context = MigrationContext.configure(
+                conn, opts={"compare_type": True, "compare_server_default": True}
+            )
+            metadata = Base.metadata if contracted else _expanded_metadata()
+            assert compare_metadata(context, metadata) == []
 
 
 def test_display_name_populated_upgrade_and_loss_aware_downgrade(
@@ -381,9 +573,134 @@ def test_display_name_populated_upgrade_and_loss_aware_downgrade(
                 )
 
 
+@pytest.mark.parametrize("revision", [_PRE_DISPLAY_NAME, _DISPLAY_NAME_EXPANSION])
+async def test_display_name_expansion_historical_runtime_compatibility(
+    alembic_runner, alembic_engine, revision, historical_user_models
+) -> None:
+    """Execute A's legacy ORM/RETURNING shapes without reverting today's repository."""
+    alembic_runner.migrate_up_to(_PRE_DISPLAY_NAME)
+    with alembic_engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users "
+                "(id, github_username, first_name, last_name, is_admin, "
+                "created_at, updated_at) VALUES "
+                "(7004, 'stored', 'Stored', 'Legacy', true, :now, :now)"
+            ),
+            {"now": datetime(2024, 1, 1, tzinfo=UTC)},
+        )
+    alembic_runner.migrate_up_to(revision)
+    user_model = historical_user_models["expansion"]
+    assert "display_name" in user_model.__table__.c
+    assert "display_name" not in inspect(user_model).column_attrs
+    async_engine = create_async_engine(
+        alembic_engine.url.set(drivername="postgresql+asyncpg")
+    )
+    statements = []
+
+    def record_statement(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement.lower())
+
+    event.listen(async_engine.sync_engine, "before_cursor_execute", record_statement)
+    try:
+        async with AsyncSession(
+            async_engine, autoflush=False, expire_on_commit=False
+        ) as db:
+            created = (
+                await db.execute(
+                    pg_insert(user_model)
+                    .values(id=7001, github_username="legacy", first_name="First")
+                    .on_conflict_do_nothing(index_elements=["id"])
+                    .returning(user_model)
+                )
+            ).scalar_one()
+            assert isinstance(created, user_model)
+            assert (created.first_name, created.last_name) == ("First", None)
+            conflict = (
+                await db.execute(
+                    pg_insert(user_model)
+                    .values(id=7001, github_username="ignored", first_name="Ignored")
+                    .on_conflict_do_nothing(index_elements=["id"])
+                    .returning(user_model)
+                )
+            ).scalar_one_or_none()
+            assert conflict is None
+            assert (
+                await db.scalar(select(user_model).where(user_model.id == 7001))
+                is created
+            )
+            assert created.first_name == "First"
+            stored = await db.get(user_model, 7004)
+            assert stored is not None
+            created_at = stored.created_at
+            for first_name, last_name in (("Later", "Write"), (None, None)):
+                statement = pg_insert(user_model).values(
+                    id=7004,
+                    github_username="stored",
+                    first_name=first_name,
+                    last_name=last_name,
+                )
+                updated = (
+                    await db.execute(
+                        statement.on_conflict_do_update(
+                            index_elements=["id"],
+                            set_={
+                                "first_name": statement.excluded.first_name,
+                                "last_name": statement.excluded.last_name,
+                            },
+                        ).returning(user_model),
+                        execution_options={"populate_existing": True},
+                    )
+                ).scalar_one()
+                assert updated is stored
+                assert (updated.first_name, updated.last_name) == (
+                    first_name,
+                    last_name,
+                )
+                assert updated.is_admin is True
+                assert updated.created_at == created_at
+            normal = user_model(id=7003, github_username="normal", first_name="Normal")
+            db.add(normal)
+            await db.flush()
+            normal.last_name = "Write"
+            await db.flush()
+            await db.commit()
+            db.expunge_all()
+            selected = await db.get(user_model, 7003)
+            assert selected is not None
+            assert (selected.first_name, selected.last_name) == ("Normal", "Write")
+            await db.delete(selected)
+            await db.commit()
+    finally:
+        event.remove(
+            async_engine.sync_engine, "before_cursor_execute", record_statement
+        )
+        await async_engine.dispose()
+    assert statements
+    assert all("display_name" not in statement for statement in statements)
+    assert any("on conflict (id) do update" in statement for statement in statements)
+    assert any(
+        statement.startswith("insert into users") and "returning" not in statement
+        for statement in statements
+    )
+    if revision == _DISPLAY_NAME_EXPANSION:
+        with alembic_engine.connect() as conn:
+            assert conn.execute(
+                text("SELECT display_name FROM users ORDER BY id")
+            ).scalars().all() == [None, "Stored Legacy"]
+
+
+@pytest.mark.parametrize(
+    "legacy_metadata", [False, True], ids=["current-C", "historical-B"]
+)
 @pytest.mark.parametrize("contracted", [False, True])
 async def test_display_name_cutover_runtime_compatibility(
-    alembic_runner, alembic_engine, contracted
+    alembic_runner,
+    alembic_engine,
+    contracted,
+    legacy_metadata,
+    historical_user_models,
+    monkeypatch,
 ) -> None:
     """Execute real ORM SQL on both rollout schemas, not standalone compilation."""
     alembic_runner.migrate_up_to(_PRE_DISPLAY_NAME)
@@ -399,15 +716,14 @@ async def test_display_name_cutover_runtime_compatibility(
         )
     alembic_runner.migrate_up_to(_DISPLAY_NAME_EXPANSION)
     if contracted:
-        with alembic_engine.begin() as conn:
-            conn.execute(
-                text("ALTER TABLE users DROP COLUMN first_name, DROP COLUMN last_name")
-            )
-    assert "display_name" in User.__table__.c
-    assert "display_name" in inspect(User).column_attrs
+        alembic_runner.migrate_up_to(_DISPLAY_NAME_CONTRACT)
+    user_model = historical_user_models["cutover"] if legacy_metadata else User
+    monkeypatch.setattr(user_repository, "User", user_model)
+    assert "display_name" in user_model.__table__.c
+    assert "display_name" in inspect(user_model).column_attrs
     for legacy in ("first_name", "last_name"):
-        assert legacy in User.__table__.c
-        assert legacy not in inspect(User).column_attrs
+        assert (legacy in user_model.__table__.c) is legacy_metadata
+        assert legacy not in inspect(user_model).column_attrs
     async_engine = create_async_engine(
         alembic_engine.url.set(drivername="postgresql+asyncpg")
     )
@@ -425,7 +741,7 @@ async def test_display_name_cutover_runtime_compatibility(
             created = await repo.get_or_create(
                 7001, github_username="profile", display_name="  First  Last 李  "
             )
-            assert isinstance(created, User)
+            assert isinstance(created, user_model)
             assert created.display_name == "  First  Last 李  "
             existing = await repo.get_or_create(
                 7001, github_username="ignored", display_name="Ignored"
@@ -437,7 +753,7 @@ async def test_display_name_cutover_runtime_compatibility(
             inserted = await repo.upsert(
                 7002, github_username="inserted", display_name="Original"
             )
-            assert isinstance(inserted, User)
+            assert isinstance(inserted, user_model)
             created_at = inserted.created_at
             updated_at = inserted.updated_at
             updated = await repo.upsert(
@@ -446,7 +762,7 @@ async def test_display_name_cutover_runtime_compatibility(
                 display_name="Updated Profile",
                 avatar_url="https://example.com/updated.png",
             )
-            assert isinstance(updated, User)
+            assert isinstance(updated, user_model)
             assert updated is inserted
             assert (updated.id, updated.github_username) == (7002, "updated")
             assert updated.display_name == "Updated Profile"
@@ -467,7 +783,9 @@ async def test_display_name_cutover_runtime_compatibility(
             assert stored.is_admin is True
             assert stored.created_at == datetime(2024, 1, 1, tzinfo=UTC)
 
-            normal = User(id=7003, github_username="normal", display_name="Normal")
+            normal = user_model(
+                id=7003, github_username="normal", display_name="Normal"
+            )
             db.add(normal)
             await db.flush()
             normal.display_name = "Normal Write"
@@ -503,7 +821,7 @@ async def test_display_name_cutover_runtime_compatibility(
             await db.commit()
             db.expunge_all()
             selected = (
-                await db.execute(select(User).where(User.id == 7003))
+                await db.execute(select(user_model).where(user_model.id == 7003))
             ).scalar_one()
             assert selected.display_name == "Normal Write"
             await repo.delete(7003)

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -54,7 +54,7 @@ storage in a separate cleanup release. Merging requires separate authorization.
 | Release | Database | Application |
 | --- | --- | --- |
 | Profile release (`0058_add_user_display_name`) | Adds nullable `users.display_name` as unrestricted `Text`, with no default, index, or uniqueness constraint; retains both legacy columns | Uses `display_name` for profiles and greetings |
-| Cleanup (later PR) | Removes `first_name` and `last_name` | Removes legacy model metadata and temporary mapper exclusions |
+| Cleanup (`0059_drop_user_legacy_names`) | Removes `first_name` and `last_name`; leaves canonical display names unchanged | Removes legacy model metadata and temporary mapper exclusions |
 
 Deployment applies the migration and checks schema agreement before starting
 the new API image. `display_name` is a normal mapped attribute; the new app
@@ -72,6 +72,9 @@ clearing, and deletion with progress cascades. They cover expanded storage and
 a manually contracted disposable database while legacy metadata is retained;
 they do not require the future cleanup migration. The deployed profile schema must
 still retain all three columns to pass strict migration metadata comparison.
+Cleanup retains compatibility tests for old and new application mappings,
+exercises the real cleanup migration, and requires exact model/schema equality
+at the contracted head.
 
 Expansion backfills once. Each legacy component containing non-whitespace text
 is preserved exactly, and populated components are joined with one space.
@@ -95,6 +98,11 @@ the profile. Do not add a trigger, dual write, legacy read fallback, or another
 `WHERE display_name IS NULL` backfill: NULL may be an intentional name removal
 after cutover.
 
+Cleanup drops only the two obsolete columns in one transaction, with the same local
+5-second lock timeout and 2-minute per-statement timeout. It performs no backfill
+or display-name update. A lock timeout fails the migration instead of waiting
+indefinitely; investigate the blocker before a separately authorized retry.
+
 ### Deployment gates and recovery
 
 - **Profile release:** after an authorized merge, wait for the entire
@@ -104,21 +112,33 @@ after cutover.
   checks. All old API replicas must retire, with no rollback outstanding,
   before cleanup may merge. A passing `/ready` alone does not prove that old
   readers are gone; revision drift is warning-only.
-- **Cleanup:** after a separately authorized merge, require the full deployment plus
-  authenticated profile/dashboard and public community checks.
+- **Cleanup:** after a separately authorized merge, require the full deployment,
+  expected API image and Functions artifact, plus authenticated profile/dashboard
+  and public community checks.
 
 Downgrading the addition drops `display_name` and loses any refreshed canonical
 names; legacy columns remain unchanged. The new app must not be running during
 that downgrade. Reapplying the addition reconstructs only the old legacy values,
-not discarded display names. Cleanup's future downgrade restores empty nullable legacy columns,
-not their discarded contents, and must not split the canonical name.
+not discarded display names. Cleanup's downgrade to
+`0058_add_user_display_name` restores both legacy
+columns as nullable `String(255)`, with no default and SQL `NULL` in every row.
+It preserves canonical display names and unrelated account/progress data,
+does not split names, and cannot recover discarded legacy values. Reapplying cleanup
+only drops those columns again; it never repeats the backfill. If the addition is later
+downgraded after this schema-only recovery, canonical names are lost and the
+recreated legacy columns contain no recovery copy.
 
 After cleanup, pre-cutover code is not an allowed image-only rollback. Prefer a
 forward fix. Even if the profile release's runtime supports the contracted table,
 its older migration files do not know the cleanup revision and its metadata still expects legacy
 columns. Any compatible image-only recovery must retain schema-aware migration
 tooling and account for revision-drift warnings; do not rerun an old deployment
-workflow as an assumed rollback.
+workflow as an assumed rollback. Runtime/image compatibility is not old-pipeline
+compatibility: schema-aware tooling must still know the current revision and
+match its metadata. If pre-cutover code must be restored, separately authorize a
+schema-aware recovery, restore its required schema with cleanup-aware tooling before
+serving that code, and accept that recreated legacy values are empty. Do not
+deploy the old image first or describe schema restoration as data recovery.
 
 Use a disposable database matching the checked-out release for local reviews.
 Before switching from cleanup to an earlier branch, downgrade that disposable database

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -8,7 +8,6 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    Column,
     DateTime,
     ForeignKey,
     Index,
@@ -44,13 +43,7 @@ class User(TimestampMixin, Base):
     """GitHub-authenticated learner."""
 
     __tablename__ = "users"
-    __table_args__ = (
-        Column("first_name", String(255), nullable=True),
-        Column("last_name", String(255), nullable=True),
-        Index("ix_users_github_username", "github_username"),
-    )
-    # Retain migration metadata without requiring legacy columns at runtime.
-    __mapper_args__ = {"exclude_properties": ["first_name", "last_name"]}
+    __table_args__ = (Index("ix_users_github_username", "github_username"),)
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=False)
     display_name: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/packages/learn-to-cloud-shared/tests/repositories/test_user_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_user_repository.py
@@ -4,7 +4,7 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from sqlalchemy import event, select, text
+from sqlalchemy import event, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
@@ -85,12 +85,6 @@ class TestUpsert:
             github_username="original",
             display_name="Original",
             avatar_url="avatar",
-        )
-        await db_session.execute(
-            text(
-                "UPDATE users SET first_name = 'Stale', last_name = 'Legacy' "
-                "WHERE id = 99999"
-            )
         )
         assert await repo.upsert(99999, github_username="original") is user
         assert user.display_name is None


### PR DESCRIPTION
## What changes and why

Removes first_name and last_name after the combined display-name release is serving. Canonical display names and unrelated account/progress data stay unchanged; the migration does not repeat the backfill. Removes the matching legacy model metadata and temporary mapping exclusions.

The migration has a 5-second lock timeout and a 2-minute per-statement timeout.

## Rollout

This is the second and final release, directly based on #838. The former separate application PR #839 has been folded into #838. Completes #836.

Do not merge both releases together. Before a separately authorized cleanup merge, confirm the complete #838 deployment succeeded, the new API and Functions are deployed, all old API instances requiring legacy columns have retired, authenticated profile/dashboard and verification checks passed, and no rollback is outstanding. After #838 merges, restack onto main and require normal successful GitHub CI and renewed review.

After cleanup, require the full Application Deploy workflow, the expected API image and Functions artifact, and authenticated profile/dashboard and public community checks. Publication does not authorize a merge or production mutation.

## Recovery limits

Downgrade restores two empty nullable columns, not discarded names. display_name remains intact. A later downgrade of the addition loses canonical names too. Do not split names to reconstruct lost data.

After cleanup, do not deploy old code requiring legacy columns without restoring its schema first. Prefer a forward fix. The profile runtime can use the cleaned-up table, but its older migration tooling does not recognize the cleanup revision. Recovery must use schema-aware tooling and separate authorization; rerunning an old deployment workflow is not a safe rollback.

## Validation

The full uv run poe check passed after restacking. Existing coverage includes populated cleanup, downgrade and re-upgrade, old/new runtime compatibility, schema agreement, migration naming, and offline SQL lint. CI configuration is unchanged; normal GitHub CI is required after retargeting to main. No production changes were made.