### PR TITLE
Make login sessions expire and revoke them on logout

### DIFF
--- a/.github/agents/dog-food.agent.md
+++ b/.github/agents/dog-food.agent.md
@@ -138,9 +138,11 @@ confirm you are signed in.
 If session generation or authentication fails, record it as a defect with the
 script's error output, and continue against public pages only.
 
-The session needs both `user_id` and `github_username`; use the helper rather
-than minting an ID-only cookie. Do not paste cookie values or identity data into
-logs or reports. Session data is signed, not encrypted.
+The helper commits an opaque session for an existing local account. It requires
+development settings and a loopback database; it refuses production targets and
+does not invent a fallback user. Signed identity cookies cannot authenticate.
+Treat the returned cookie as a credential: consume it directly in the browser
+context, never paste it or identity data into logs, issues, or reports.
 
 Expected login navigation and repeatable logout behavior are described in
 [the authentication response contract](dog-food/reference.md#authentication-response-contract).

--- a/.github/agents/dog-food/reference.md
+++ b/.github/agents/dog-food/reference.md
@@ -43,17 +43,22 @@ HTTP request was rejected.
 | Anonymous API request | 401 without a login redirect |
 | HTMX action with a missing or expired session | 401; the existing browser handler navigates to login |
 | HTMX endpoint called without the HTMX header | Still 401, not a login redirect |
-| Logout with a valid, missing, or rejected cookie | Session/cookie cleared, 303 to `/`; safe to repeat |
+| Logout with a valid, missing, or rejected cookie | Current session revoked and cookies cleared, 303 to `/`; safe to repeat |
+| Sign out everywhere from Account | All current account sessions revoked, including this browser; 303 to `/` |
 | Public page without a session | Remains available |
 
 A fresh, valid local session unexpectedly rejected by a protected route is a
 defect. Normal expired-session navigation is not; report friction if it is
 confusing or leaves the learner stuck.
 
-Logout clears this browser's cookie, not every copy of an issued signed cookie.
-Do not report missing global revocation as a new regression; it is tracked in
-[#828](https://github.com/learntocloud/learn-to-cloud-app/issues/828). Do report
-new behavior that differs from the documented response contract.
+Replay the exact saved cookie in a fresh browser context after logout: it must
+be rejected, while an independently issued session remains valid. Sign out
+everywhere must reject both sessions and requires the Account form's CSRF token.
+Database failure is a real failure, not successful revocation or anonymous
+fallback. Sessions expire after seven inactive days or thirty days total.
+Deleting an account invalidates all its sessions; recreating it cannot revive
+old cookies. These are application sessions, not GitHub sessions, and revocation
+does not cancel already-authorized work.
 
 See [Authentication and sessions](../../../docs/contributing.md#authentication-and-sessions)
 for the underlying design. Record sanitized routes, statuses, and visible

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,8 @@ Keep docstrings short and useful. One line is enough for most functions.
 
 ## Authentication
 
-- Use `CurrentUser` for protected routes and `OptionalCurrentUser` for public routes. Both supply `AuthenticatedUser`; use its `.user_id` or `.github_username` rather than adding ID-only dependencies.
+- Use `CurrentUser` / `OptionalCurrentUser` when a route needs only `AuthenticatedUser` identity (`.user_id`, `.github_username`). Use `CurrentAccount` / `OptionalCurrentAccount` when it needs the loaded `User` account (`.id`, profile fields), including account-aware pages and rendering. Required aliases protect routes; optional aliases allow anonymous requests.
+- All four aliases share the cached account resolver and one session lookup/touch per request. Treat the account as a read-only loaded snapshot after the auth transaction closes: no lazy loading or writes through it. Pass accounts explicitly to helpers/templates, never retrieve them from `request.state`; do not add ID-only dependencies or duplicate account queries.
 - Keep identity loading separate from navigation. Page routers use `LoginRedirectRoute`; API and HTMX endpoints retain 401 responses. Do not infer this policy from URL prefixes or `Accept`.
 - Authentication uses opaque PostgreSQL-backed sessions, not identity fields in the OAuth cookie. Logout revokes the current session; Sign out everywhere revokes all current account sessions. Commit before clearing cookies or reporting success.
 - Keep expected auth responses in request telemetry, without logging identities, cookies, or tokens.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ Keep docstrings short and useful. One line is enough for most functions.
 
 - Use `CurrentUser` for protected routes and `OptionalCurrentUser` for public routes. Both supply `AuthenticatedUser`; use its `.user_id` or `.github_username` rather than adding ID-only dependencies.
 - Keep identity loading separate from navigation. Page routers use `LoginRedirectRoute`; API and HTMX endpoints retain 401 responses. Do not infer this policy from URL prefixes or `Accept`.
-- Logout clears the local cookie but does not revoke copied signed cookies. Do not claim server-side revocation exists.
+- Authentication uses opaque PostgreSQL-backed sessions, not identity fields in the OAuth cookie. Logout revokes the current session; Sign out everywhere revokes all current account sessions. Commit before clearing cookies or reporting success.
 - Keep expected auth responses in request telemetry, without logging identities, cookies, or tokens.
 - Follow [Authentication and sessions](../docs/contributing.md#authentication-and-sessions) for the complete contract and test boundaries.
 

--- a/.github/prompts/new-route.prompt.md
+++ b/.github/prompts/new-route.prompt.md
@@ -13,7 +13,7 @@ when adding or changing protected routes.
 1. **Feature name** and a brief description of what it does.
 2. Whether it needs **database access** (new model/table, or existing model).
 3. Whether it's a **page route** (TemplateResponse), **HTMX route** (HTMLResponse fragment), or **API route** (JSON).
-4. Whether it requires **authentication** (`CurrentUser` or `OptionalCurrentUser`).
+4. Whether it requires **authentication**, and whether it needs only identity or the loaded account.
 
 ## What to generate
 
@@ -21,7 +21,8 @@ when adding or changing protected routes.
 - Add to an existing route file or create a new one with `APIRouter(prefix="...", tags=[...])`.
 - Use `async def` for all handlers.
 - Use `DbSession` or `DbSessionReadOnly` from `core.database` for database access.
-- Use `CurrentUser` or `OptionalCurrentUser` from `core.auth`; access `.user_id` or `.github_username` on the identity.
+- Use `CurrentUser` or `OptionalCurrentUser` from `core.auth` for identity-only consumers (`.user_id`, `.github_username`). Use `CurrentAccount` or `OptionalCurrentAccount` for account/profile consumers (`.id`, loaded fields), including account-aware pages.
+- These aliases share one cached account resolver. Treat its loaded account as read-only after the auth transaction closes: no lazy loading, writes, or duplicate account reads for rendering. Pass accounts explicitly to helpers and templates rather than reading `request.state`.
 - Page routers use `route_class=LoginRedirectRoute` from `core.routing` for login navigation. API and HTMX routers retain 401 responses.
 - Keep routes thin - delegate business logic to the service layer.
 - Add a module-level docstring explaining the routes.

--- a/.github/skills/ship-it/SKILL.md
+++ b/.github/skills/ship-it/SKILL.md
@@ -12,8 +12,12 @@ Deliver the current task without absorbing unrelated worktree changes.
 2. Stage only files belonging to the task, then run `uv run poe check`. Run any
    additional CI-equivalent checks required by the changed surfaces (Terraform,
    migrations, curriculum artifacts, or workflow commands).
-3. Review the staged diff and commit with a conventional message plus required
-   repository trailers.
+3. Review the staged diff, following the `validate` skill's unused-argument and
+   unnecessary-async guidance. Trace changed signatures through callers and
+   mocks; preserve dependency side effects and required callback interfaces.
+   Ruff enforces `ARG001` and `RUF029` in API rendering helpers, so manually
+   review these concerns outside that scope. Commit with a conventional message
+   plus required repository trailers.
 4. Push without force. If histories diverge, stop rather than rebasing or
    rewriting history automatically.
 5. Open a PR to `main` and watch its checks.

--- a/.github/skills/validate/SKILL.md
+++ b/.github/skills/validate/SKILL.md
@@ -27,7 +27,10 @@ Do not kill unrelated listeners. Report startup logs if any endpoint fails.
 
 For authentication or route-policy changes, preserve the real-route coverage in
 `api/tests/routes/test_auth_http.py`: API/HTMX 401s, page 303s, redirect methods,
-signed-session success, and repeatable logout. Do not bypass authentication
+persisted-session success, and repeatable logout. Preserve the real PostgreSQL
+lifecycle coverage in `api/tests/routes/test_session_lifecycle.py`, including
+copied-cookie replay, independent browsers, expiry, and deletion/recreation.
+Do not bypass authentication
 with dependency overrides when testing authentication itself. The same file
 checks exported request spans; `api/tests/core/test_middleware.py` covers nested
 router templates. These tests already run in `uv run poe check`.

--- a/.github/skills/validate/SKILL.md
+++ b/.github/skills/validate/SKILL.md
@@ -15,6 +15,17 @@ It runs static checks, package installation smoke testing, and all test suites.
 New files must be staged before `prek --all-files` can inspect them; stage only
 files belonging to the current task.
 
+Before changing a function signature or removing `async`, trace its callers,
+dependency declarations, callback contracts, and test mocks. Ruff's `ARG001`
+(unused function arguments) and preview `RUF029` (unneeded `async`) are enforced
+for API rendering helpers; elsewhere, include these checks in the diff review.
+Remove genuinely unused parameters and unnecessary `async`, updating callers
+and mocks together. Preserve authentication dependencies, required callback
+parameters, async interfaces, and fixtures that execute for their side effects.
+Do not add dummy awaits, rename parameters just to hide findings, or suppress
+rules to pass the gate. If an interface requires an apparent violation, explain
+the contract and get agreement on an appropriate rule scope before changing it.
+
 After Python application changes, start a fresh API process on
 `127.0.0.1:8000` and request:
 

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -118,6 +118,7 @@ jobs:
       migration_identity_client_id: ${{ steps.outputs.outputs.migration_identity_client_id }}
       migration_identity_id: ${{ steps.outputs.outputs.migration_identity_id }}
       migration_postgres_role: ${{ steps.outputs.outputs.migration_postgres_role }}
+      api_postgres_role: ${{ steps.outputs.outputs.api_postgres_role }}
       verification_functions_postgres_role: ${{ steps.outputs.outputs.verification_functions_postgres_role }}
       api_url: ${{ steps.outputs.outputs.api_url }}
       smoke_auth_scope: ${{ steps.outputs.outputs.smoke_auth_scope }}
@@ -182,6 +183,7 @@ jobs:
           publish_output migration_identity_client_id migration_identity_client_id
           publish_output migration_identity_id migration_identity_id
           publish_output migration_postgres_role migration_postgres_role
+          publish_output api_postgres_role api_postgres_role
           publish_output verification_functions_postgres_role verification_functions_postgres_role
           publish_output api_url api_url
           publish_output smoke_auth_scope smoke_auth_scope
@@ -346,6 +348,7 @@ jobs:
           DATABASE_NAME: ${{ needs.deployment_context.outputs.database_name }}
           DATABASE_HOST: ${{ needs.deployment_context.outputs.database_host }}
           DATABASE_USER: ${{ needs.deployment_context.outputs.migration_postgres_role }}
+          POSTGRES_API_RUNTIME_ROLE: ${{ needs.deployment_context.outputs.api_postgres_role }}
           POSTGRES_VERIFICATION_FUNCTIONS_ROLE: ${{ needs.deployment_context.outputs.verification_functions_postgres_role }}
           RESOURCE_GROUP: ${{ needs.deployment_context.outputs.resource_group_name }}
           IMAGE: ${{ needs.deployment_context.outputs.container_registry_endpoint }}/migrations:${{ github.sha }}
@@ -366,6 +369,7 @@ jobs:
                 DATABASE__USER="$DATABASE_USER" \
                 DATABASE__NAME="$DATABASE_NAME" \
                 AZURE_CLIENT_ID="$MIGRATION_CLIENT_ID" \
+                POSTGRES_API_RUNTIME_ROLE="$POSTGRES_API_RUNTIME_ROLE" \
                 POSTGRES_VERIFICATION_FUNCTIONS_ROLE="$POSTGRES_VERIFICATION_FUNCTIONS_ROLE" \
               --registry-identity "$MIGRATION_IDENTITY_ID" \
               --query name \

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ A web application for tracking your progress through the [Learn to Cloud](https:
 | **Infra** | Azure Container Apps, Azure Functions, Azure PostgreSQL, Terraform |
 | **CI/CD** | GitHub Actions |
 
-GitHub login establishes signed-cookie sessions. See
+GitHub login establishes revocable, PostgreSQL-backed sessions. See
 [Authentication and sessions](docs/contributing.md#authentication-and-sessions)
-for route dependencies, login redirects, and logout limitations.
+for route dependencies, login redirects, expiry, and logout guarantees.
 
 ## Quick Start
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -15,8 +15,13 @@ WEB_SECURITY__REQUIRE_HTTPS=false
 # OAUTH__CLIENT_ID=your_github_client_id
 # OAUTH__CLIENT_SECRET=your_github_client_secret
 
-# Session cookie signing key (generate: python -c "import secrets; print(secrets.token_hex(32))")
+# OAuth-state cookie signing key and session-bound form protection
+# (generate: python -c "import secrets; print(secrets.token_hex(32))")
 # SESSION__SECRET_KEY=change-me-in-production
+# Signed OAuth handshake state is separate from the opaque authentication cookie.
+# SESSION__OAUTH_STATE_MAX_AGE_SECONDS=600
+# SESSION__IDLE_TIMEOUT_SECONDS=604800
+# SESSION__ABSOLUTE_TIMEOUT_SECONDS=2592000
 
 # GitHub API token (optional, for higher rate limits on verification)
 # GITHUB__TOKEN=ghp_xxx

--- a/api/alembic/versions/0060_add_auth_sessions.py
+++ b/api/alembic/versions/0060_add_auth_sessions.py
@@ -1,0 +1,50 @@
+"""Add revocable sessions and optional explicit API runtime DML grants.
+
+The migration owner's default ACLs apply normally. POSTGRES_API_RUNTIME_ROLE
+can explicitly grant API DML when the deployment does not use default ACLs.
+Downgrade discards all sessions without changing users or learning records.
+"""
+
+import os
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0060_add_auth_sessions"
+down_revision: str | None = "0059_drop_user_legacy_names"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create and stamp storage atomically before the separate index builds."""
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+    op.create_table(
+        "auth_sessions",
+        sa.Column("token_digest", sa.LargeBinary(), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "octet_length(token_digest) = 32", name="ck_auth_sessions_digest_length"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("token_digest"),
+    )
+    role = os.environ.get("POSTGRES_API_RUNTIME_ROLE")
+    if role:
+        if not role.replace("_", "").isalnum() or len(role) > 63:
+            raise ValueError("POSTGRES_API_RUNTIME_ROLE must be a valid identifier.")
+        op.execute(f'GRANT SELECT, INSERT, UPDATE, DELETE ON auth_sessions TO "{role}"')
+
+
+def downgrade() -> None:
+    """Discard sessions only after all session-aware application processes stop."""
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '2min'")
+    op.drop_table("auth_sessions")

--- a/api/alembic/versions/0061_auth_sessions_concurrent_indexes.py
+++ b/api/alembic/versions/0061_auth_sessions_concurrent_indexes.py
@@ -1,0 +1,50 @@
+"""Build session indexes separately from the atomic storage migration.
+
+Drop partial or invalid builds before retrying, rather than skipping their names.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0061_auth_sessions_concurrent_indexes"
+down_revision: str | None = "0060_add_auth_sessions"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_COLUMNS = ("user_id", "expires_at", "last_seen_at")
+
+
+def upgrade() -> None:
+    """Rebuild each index concurrently with bounded session-level timeouts."""
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '10min'")
+    with op.get_context().autocommit_block():
+        op.execute("SET lock_timeout = '5s'")
+        op.execute("SET statement_timeout = '10min'")
+        try:
+            for column in _COLUMNS:
+                name = f"ix_auth_sessions_{column}"
+                op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+                op.execute(
+                    f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} "
+                    f"ON auth_sessions ({column})"
+                )
+        finally:
+            op.execute("RESET statement_timeout")
+            op.execute("RESET lock_timeout")
+
+
+def downgrade() -> None:
+    """Drop secondary indexes before the table migration is reversed."""
+    with op.get_context().autocommit_block():
+        op.execute("SET lock_timeout = '5s'")
+        op.execute("SET statement_timeout = '10min'")
+        try:
+            for column in reversed(_COLUMNS):
+                op.execute(
+                    f"DROP INDEX CONCURRENTLY IF EXISTS ix_auth_sessions_{column}"
+                )
+        finally:
+            op.execute("RESET statement_timeout")
+            op.execute("RESET lock_timeout")

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -72,9 +72,13 @@ line-length = 88
 target-version = "py313"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "PLC0415"]
+select = ["E", "F", "I", "UP", "PLC0415", "ARG001", "RUF029"]
+preview = true
+explicit-preview-rules = true
 
 [tool.ruff.lint.per-file-ignores]
+# Enforce cleanup rules in rendering helpers first; wider adoption needs interface review.
+"!src/learn_to_cloud/rendering/**" = ["ARG001", "RUF029"]
 "tests/**" = ["PLC0415"]
 "alembic/**" = ["PLC0415"]
 "src/learn_to_cloud/core/observability.py" = ["PLC0415"]

--- a/api/src/learn_to_cloud/core/auth.py
+++ b/api/src/learn_to_cloud/core/auth.py
@@ -9,26 +9,38 @@ from typing import Annotated
 
 from authlib.integrations.starlette_client import OAuth
 from fastapi import Depends, HTTPException, Request
-from learn_to_cloud_shared.core.config import OAuthConfig
+from learn_to_cloud_shared.core.config import OAuthConfig, get_web_settings
+from learn_to_cloud_shared.models import User
+from learn_to_cloud_shared.repositories.auth_session_repository import (
+    AuthSessionRepository,
+    ResolvedSession,
+    SessionRejection,
+)
+
+from learn_to_cloud.core.session_cookies import (
+    AUTH_COOKIE_NAME,
+    token_digest,
+)
+from learn_to_cloud.core.session_cookies import (
+    SESSION_COOKIE_NAME as SESSION_COOKIE_NAME,
+)
 
 logger = logging.getLogger(__name__)
 
 oauth = OAuth()
-SESSION_COOKIE_NAME = "session"
 MAX_GITHUB_USER_ID = 2**63 - 1
 MAX_USERNAME_LENGTH = 255
 
 
 @dataclass(frozen=True, slots=True)
 class AuthenticatedUser:
-    """Authenticated identity stored in the session cookie."""
+    """Authenticated identity resolved from the database."""
 
     user_id: int
     github_username: str
 
 
 class IdentityRejectionReason(StrEnum):
-    INCOMPLETE_IDENTITY = "incomplete_identity"
     INVALID_USER_ID = "invalid_user_id"
     INVALID_GITHUB_USERNAME = "invalid_github_username"
     INVALID_RESPONSE_FORMAT = "invalid_response_format"
@@ -85,38 +97,74 @@ def init_oauth(settings: OAuthConfig) -> None:
     )
 
 
-def get_authenticated_user_from_session(request: Request) -> AuthenticatedUser | None:
-    """Return the session user, removing invalid identity fields."""
+@dataclass(frozen=True, repr=False)
+class RequestAuthentication:
+    identity: AuthenticatedUser
+    account: User
+
+
+def get_request_user(request: Request) -> User | None:
+    context = getattr(request.state, "authentication", None)
+    return context.account if isinstance(context, RequestAuthentication) else None
+
+
+async def get_authenticated_user_from_session(
+    request: Request,
+) -> AuthenticatedUser | None:
+    """Resolve and touch once, releasing the transaction before route work."""
+    if getattr(request.state, "auth_resolved", False):
+        context = getattr(request.state, "authentication", None)
+        return context.identity if isinstance(context, RequestAuthentication) else None
+    request.state.authentication = None
     session = request.session
-    if "user_id" not in session and "github_username" not in session:
+    if "user_id" in session or "github_username" in session:
+        session.pop("user_id", None)
+        session.pop("github_username", None)
+        logger.info("auth.session.rejected", extra={"auth.session.reason": "legacy"})
+    cookie = request.cookies.get(AUTH_COOKIE_NAME)
+    if cookie is None:
+        request.state.auth_resolved = True
         return None
-    identity = (
-        IdentityRejectionReason.INCOMPLETE_IDENTITY
-        if "user_id" not in session or "github_username" not in session
-        else validate_identity(session["user_id"], session["github_username"])
-    )
-    if isinstance(identity, AuthenticatedUser):
-        return identity
-    session.pop("user_id", None)
-    session.pop("github_username", None)
-    logger.warning(
-        "auth.session.identity_rejected",
-        extra={"auth.identity.reason": identity.value},
-    )
-    return None
+    digest = token_digest(cookie)
+    if digest is None:
+        request.state.auth_resolved = True
+        request.state.clear_auth_cookie = True
+        logger.warning(
+            "auth.session.rejected", extra={"auth.session.reason": "malformed"}
+        )
+        return None
+    async with request.app.state.session_maker() as db:
+        async with db.begin():
+            resolved = await AuthSessionRepository(
+                db, get_web_settings().session
+            ).resolve_and_touch(digest)
+    request.state.auth_resolved = True
+    if not isinstance(resolved, ResolvedSession):
+        request.state.clear_auth_cookie = True
+        logger.log(
+            logging.WARNING
+            if resolved == SessionRejection.ACCOUNT_MISSING
+            else logging.INFO,
+            "auth.session.rejected",
+            extra={"auth.session.reason": resolved.value},
+        )
+        return None
+    identity = AuthenticatedUser(resolved.user.id, resolved.user.github_username)
+    request.state.authentication = RequestAuthentication(identity, resolved.user)
+    return identity
 
 
-def require_authenticated_user(request: Request) -> AuthenticatedUser:
+async def require_authenticated_user(request: Request) -> AuthenticatedUser:
     """Return the session user or raise a 401 authentication error."""
-    authenticated_user = optional_authenticated_user(request)
+    authenticated_user = await optional_authenticated_user(request)
     if authenticated_user is None:
         raise AuthenticationRequired()
     return authenticated_user
 
 
-def optional_authenticated_user(request: Request) -> AuthenticatedUser | None:
+async def optional_authenticated_user(request: Request) -> AuthenticatedUser | None:
     """Return the session user and populate request state when authenticated."""
-    authenticated_user = get_authenticated_user_from_session(request)
+    authenticated_user = await get_authenticated_user_from_session(request)
     if authenticated_user is not None:
         request.state.user_id = authenticated_user.user_id
         request.state.github_username = authenticated_user.github_username

--- a/api/src/learn_to_cloud/core/auth.py
+++ b/api/src/learn_to_cloud/core/auth.py
@@ -97,25 +97,12 @@ def init_oauth(settings: OAuthConfig) -> None:
     )
 
 
-@dataclass(frozen=True, repr=False)
-class RequestAuthentication:
-    identity: AuthenticatedUser
-    account: User
-
-
-def get_request_user(request: Request) -> User | None:
-    context = getattr(request.state, "authentication", None)
-    return context.account if isinstance(context, RequestAuthentication) else None
-
-
-async def get_authenticated_user_from_session(
-    request: Request,
-) -> AuthenticatedUser | None:
+async def optional_authenticated_account(request: Request) -> User | None:
     """Resolve and touch once, releasing the transaction before route work."""
     if getattr(request.state, "auth_resolved", False):
-        context = getattr(request.state, "authentication", None)
-        return context.identity if isinstance(context, RequestAuthentication) else None
-    request.state.authentication = None
+        account = request.state.auth_account
+        return account
+    request.state.auth_account = None
     session = request.session
     if "user_id" in session or "github_username" in session:
         session.pop("user_id", None)
@@ -149,26 +136,38 @@ async def get_authenticated_user_from_session(
             extra={"auth.session.reason": resolved.value},
         )
         return None
-    identity = AuthenticatedUser(resolved.user.id, resolved.user.github_username)
-    request.state.authentication = RequestAuthentication(identity, resolved.user)
-    return identity
+    account = resolved.user
+    request.state.auth_account = account
+    request.state.user_id = account.id
+    request.state.github_username = account.github_username
+    return account
 
 
-async def require_authenticated_user(request: Request) -> AuthenticatedUser:
-    """Return the session user or raise a 401 authentication error."""
-    authenticated_user = await optional_authenticated_user(request)
-    if authenticated_user is None:
+OptionalCurrentAccount = Annotated[User | None, Depends(optional_authenticated_account)]
+
+
+def require_authenticated_account(account: OptionalCurrentAccount) -> User:
+    """Return the loaded account or raise a 401 authentication error."""
+    if account is None:
         raise AuthenticationRequired()
-    return authenticated_user
+    return account
 
 
-async def optional_authenticated_user(request: Request) -> AuthenticatedUser | None:
-    """Return the session user and populate request state when authenticated."""
-    authenticated_user = await get_authenticated_user_from_session(request)
-    if authenticated_user is not None:
-        request.state.user_id = authenticated_user.user_id
-        request.state.github_username = authenticated_user.github_username
-    return authenticated_user
+CurrentAccount = Annotated[User, Depends(require_authenticated_account)]
+
+
+def require_authenticated_user(account: CurrentAccount) -> AuthenticatedUser:
+    """Return the identity of the required account."""
+    return AuthenticatedUser(account.id, account.github_username)
+
+
+def optional_authenticated_user(
+    account: OptionalCurrentAccount,
+) -> AuthenticatedUser | None:
+    """Return the identity of the optional account."""
+    if account is None:
+        return None
+    return AuthenticatedUser(account.id, account.github_username)
 
 
 CurrentUser = Annotated[AuthenticatedUser, Depends(require_authenticated_user)]

--- a/api/src/learn_to_cloud/core/session_cookies.py
+++ b/api/src/learn_to_cloud/core/session_cookies.py
@@ -1,0 +1,92 @@
+"""Separate browser authentication credentials from signed OAuth state."""
+
+import base64
+import hashlib
+import re
+from datetime import UTC, datetime
+
+from fastapi import Request, Response
+from learn_to_cloud_shared.core.config import get_web_settings
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+AUTH_COOKIE_NAME = "ltc_session"
+SESSION_COOKIE_NAME = "session"
+_TOKEN = re.compile(r"[A-Za-z0-9_-]{43}", re.ASCII)
+
+
+def token_digest(value: str | None) -> bytes | None:
+    """Reject noncanonical credentials before contacting the database."""
+    if value is None or _TOKEN.fullmatch(value) is None:
+        return None
+    raw = base64.urlsafe_b64decode(value + "=")
+    if base64.urlsafe_b64encode(raw).rstrip(b"=").decode() != value:
+        return None
+    return hashlib.sha256(raw).digest()
+
+
+def clear_cookies(request: Request) -> None:
+    request.session.clear()
+    request.state.clear_auth_cookie = True
+    request.state.clear_oauth_cookie = True
+
+
+def issue_cookie(
+    request: Request, response: Response, token: str, expires_at: datetime
+) -> None:
+    response.set_cookie(
+        AUTH_COOKIE_NAME,
+        token,
+        max_age=max(0, int((expires_at - datetime.now(UTC)).total_seconds())),
+        expires=expires_at,
+        path="/",
+        secure=get_web_settings().web_security.require_https,
+        httponly=True,
+        samesite="lax",
+    )
+    request.state.auth_cookie_issued = True
+
+
+class SessionResponseMiddleware:
+    """Apply lifecycle headers even to handled authentication failures."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_response(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                state = scope.get("state", {})
+                headers = MutableHeaders(scope=message)
+                auth_route = scope["path"].startswith("/auth/")
+                if state.get("auth_resolved") or auth_route:
+                    vary = headers.get("vary", "")
+                    if "cookie" not in {v.strip().lower() for v in vary.split(",")}:
+                        headers["vary"] = f"{vary}, Cookie" if vary else "Cookie"
+                    headers["cache-control"] = "private, no-store"
+                cleanup = Response()
+                names = []
+                if state.get("clear_auth_cookie") and not state.get(
+                    "auth_cookie_issued"
+                ):
+                    names.append(AUTH_COOKIE_NAME)
+                if state.get("clear_oauth_cookie"):
+                    names.append(SESSION_COOKIE_NAME)
+                for name in names:
+                    cleanup.delete_cookie(
+                        name,
+                        path="/",
+                        secure=get_web_settings().web_security.require_https,
+                        httponly=True,
+                        samesite="lax",
+                    )
+                for key, value in cleanup.raw_headers:
+                    if key == b"set-cookie":
+                        headers.append("set-cookie", value.decode("latin-1"))
+            await send(message)
+
+        await self.app(scope, receive, send_response)

--- a/api/src/learn_to_cloud/core/templates.py
+++ b/api/src/learn_to_cloud/core/templates.py
@@ -16,6 +16,7 @@ from fastapi.templating import Jinja2Templates
 from learn_to_cloud_shared.core.config import get_web_settings
 
 from learn_to_cloud.rendering.markdown import render_md
+from learn_to_cloud.services.sessions_service import csrf_token
 
 _templates_dir = Path(__file__).resolve().parent.parent / "templates"
 _static_dir = Path(__file__).resolve().parent.parent / "static"
@@ -48,7 +49,7 @@ def static_url(path: str) -> str:
 
 def _static_url_context(request: Request) -> dict[str, object]:
     """Context processor that injects ``static_url`` into every template."""
-    return {"static_url": static_url}
+    return {"static_url": static_url, "logout_all_csrf": csrf_token(request)}
 
 
 def _frontend_telemetry_context(request: Request) -> dict[str, object]:

--- a/api/src/learn_to_cloud/main.py
+++ b/api/src/learn_to_cloud/main.py
@@ -32,6 +32,7 @@ from learn_to_cloud.core.middleware import (
     SecurityHeadersMiddleware,
     TelemetrySanitizationMiddleware,
 )
+from learn_to_cloud.core.session_cookies import SessionResponseMiddleware
 from learn_to_cloud.core.templates import templates
 from learn_to_cloud.routes import (
     auth_router,
@@ -175,11 +176,12 @@ async def global_exception_handler(_request: Request, exc: Exception) -> JSONRes
 
 
 app.add_middleware(TelemetrySanitizationMiddleware)
+app.add_middleware(SessionResponseMiddleware)
 app.add_middleware(
     SessionMiddleware,
     secret_key=_settings.session.secret_key,
     session_cookie=SESSION_COOKIE_NAME,
-    max_age=60 * 60 * 24 * 30,
+    max_age=_settings.session.oauth_state_max_age_seconds,
     same_site="lax",
     https_only=_settings.web_security.require_https,
 )

--- a/api/src/learn_to_cloud/rendering/htmx_responses.py
+++ b/api/src/learn_to_cloud/rendering/htmx_responses.py
@@ -9,7 +9,7 @@ from fastapi.responses import HTMLResponse
 from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.schemas import HandsOnRequirement, Topic
 
-from learn_to_cloud.core.auth import AuthenticatedUser
+from learn_to_cloud.core.auth import AuthenticatedUser, get_request_user
 from learn_to_cloud.core.templates import templates
 from learn_to_cloud.rendering.context import (
     RequirementCardContext,
@@ -18,7 +18,6 @@ from learn_to_cloud.rendering.context import (
     build_progress_dict,
     build_unavailable_requirement_card_context,
 )
-from learn_to_cloud.services.users_service import get_user_by_id
 
 
 def reload_page_response() -> HTMLResponse:
@@ -107,7 +106,7 @@ async def render_step_toggle(
     completed_step_uuids: set[UUID],
     db: DbSession,
 ) -> HTMLResponse:
-    user = await get_user_by_id(db, user_id)
+    user = get_request_user(request)
     progress = build_progress_dict(
         len(completed_step_uuids),
         len(topic.learning_steps),

--- a/api/src/learn_to_cloud/rendering/htmx_responses.py
+++ b/api/src/learn_to_cloud/rendering/htmx_responses.py
@@ -6,9 +6,10 @@ from uuid import UUID
 
 from fastapi import Request
 from fastapi.responses import HTMLResponse
+from learn_to_cloud_shared.models import User
 from learn_to_cloud_shared.schemas import HandsOnRequirement, Topic
 
-from learn_to_cloud.core.auth import AuthenticatedUser, get_request_user
+from learn_to_cloud.core.auth import AuthenticatedUser
 from learn_to_cloud.core.templates import templates
 from learn_to_cloud.rendering.context import (
     RequirementCardContext,
@@ -99,11 +100,11 @@ def render_unavailable(
 
 def render_step_toggle(
     request: Request,
+    account: User,
     topic: Topic,
     step,
     completed_step_uuids: set[UUID],
 ) -> HTMLResponse:
-    user = get_request_user(request)
     progress = build_progress_dict(
         len(completed_step_uuids),
         len(topic.learning_steps),
@@ -112,7 +113,7 @@ def render_step_toggle(
         request=request,
         step=step,
         completed_steps=completed_step_uuids,
-        user=user,
+        user=account,
     )
     progress_html = templates.get_template("partials/topic_progress.html").render(
         progress=progress

--- a/api/src/learn_to_cloud/rendering/htmx_responses.py
+++ b/api/src/learn_to_cloud/rendering/htmx_responses.py
@@ -6,7 +6,6 @@ from uuid import UUID
 
 from fastapi import Request
 from fastapi.responses import HTMLResponse
-from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.schemas import HandsOnRequirement, Topic
 
 from learn_to_cloud.core.auth import AuthenticatedUser, get_request_user
@@ -98,13 +97,11 @@ def render_unavailable(
     )
 
 
-async def render_step_toggle(
+def render_step_toggle(
     request: Request,
-    user_id: int,
     topic: Topic,
     step,
     completed_step_uuids: set[UUID],
-    db: DbSession,
 ) -> HTMLResponse:
     user = get_request_user(request)
     progress = build_progress_dict(

--- a/api/src/learn_to_cloud/routes/auth_routes.py
+++ b/api/src/learn_to_cloud/routes/auth_routes.py
@@ -1,21 +1,31 @@
 """GitHub OAuth login, callback, and logout routes."""
 
+import hmac
 import logging
 from json import JSONDecodeError
+from time import time
 
 import httpx2
 from authlib.integrations.starlette_client import OAuthError
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Form, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from learn_to_cloud_shared.core.config import get_web_settings
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from learn_to_cloud.core.auth import (
-    SESSION_COOKIE_NAME,
     AuthenticatedUser,
+    CurrentUser,
     IdentityRejectionReason,
     oauth,
     validate_identity,
+)
+from learn_to_cloud.core.session_cookies import AUTH_COOKIE_NAME, issue_cookie
+from learn_to_cloud.services.sessions_service import (
+    csrf_token,
+    issue_session,
+    log_pruned,
+    mutate_account,
+    revoke_current,
 )
 from learn_to_cloud.services.users_service import (
     get_or_create_user_from_github,
@@ -25,6 +35,21 @@ from learn_to_cloud.services.users_service import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def _prepare_oauth_state(request: Request) -> dict:
+    """Discard obsolete identities and expired handshakes, retaining live tabs."""
+    request.session.pop("user_id", None)
+    request.session.pop("github_username", None)
+    now = time()
+    for key, value in list(request.session.items()):
+        if key.startswith("_state_github_") and (
+            not isinstance(value, dict)
+            or not isinstance(value.get("exp"), (int, float))
+            or value["exp"] <= now
+        ):
+            request.session.pop(key)
+    return dict(request.session)
 
 
 def _reject_identity(reason: IdentityRejectionReason) -> RedirectResponse:
@@ -47,6 +72,8 @@ async def login(request: Request) -> RedirectResponse:
         logger.error("auth.login.github_not_configured")
         return RedirectResponse(url="/", status_code=302)
 
+    previous_states = _prepare_oauth_state(request)
+    github.framework.expires_in = get_web_settings().session.oauth_state_max_age_seconds
     redirect_uri = str(request.url_for("auth_callback"))
     # Azure Container Apps terminates TLS at the load balancer; ensure
     # the redirect URI uses https so it matches the GitHub OAuth config.
@@ -54,7 +81,10 @@ async def login(request: Request) -> RedirectResponse:
         "http://"
     ):
         redirect_uri = redirect_uri.replace("http://", "https://", 1)
-    return await github.authorize_redirect(request, redirect_uri)
+    response = await github.authorize_redirect(request, redirect_uri)
+    for key, value in previous_states.items():
+        request.session.setdefault(key, value)
+    return response
 
 
 @router.get(
@@ -70,6 +100,7 @@ async def callback(request: Request) -> RedirectResponse:
         logger.error("auth.callback.github_not_configured")
         return RedirectResponse(url="/", status_code=302)
 
+    _prepare_oauth_state(request)
     try:
         token = await github.authorize_access_token(request)
     except (OAuthError, httpx2.HTTPError) as exc:
@@ -124,13 +155,22 @@ async def callback(request: Request) -> RedirectResponse:
             raise RuntimeError(
                 "Persisted OAuth identity does not match validated identity"
             )
+        issued = await issue_session(
+            db,
+            get_web_settings().session,
+            user.id,
+            request.cookies.get(AUTH_COOKIE_NAME),
+        )
         await db.commit()
 
-    request.session["user_id"] = persisted_identity.user_id
-    request.session["github_username"] = persisted_identity.github_username
+    request.session.pop("user_id", None)
+    request.session.pop("github_username", None)
+    response = RedirectResponse(url="/dashboard", status_code=302)
+    issue_cookie(request, response, issued.token, issued.expires_at)
     logger.info("auth.login.success")
+    log_pruned(issued)
 
-    return RedirectResponse(url="/dashboard", status_code=302)
+    return response
 
 
 @router.post(
@@ -139,15 +179,18 @@ async def callback(request: Request) -> RedirectResponse:
     include_in_schema=False,
 )
 async def logout(request: Request) -> RedirectResponse:
-    """Clear the session cookie and redirect to home."""
-    request.session.clear()
-    response = RedirectResponse(url="/", status_code=303)
-    # Rejected cookies look like empty sessions to SessionMiddleware.
-    response.delete_cookie(
-        SESSION_COOKIE_NAME,
-        path="/",
-        secure=get_web_settings().web_security.require_https,
-        httponly=True,
-        samesite="lax",
-    )
-    return response
+    """Revoke this browser's credential before clearing its cookies."""
+    await revoke_current(request)
+    return RedirectResponse(url="/", status_code=303)
+
+
+@router.post("/logout-all", include_in_schema=False)
+async def logout_all(
+    request: Request, current_user: CurrentUser, csrf: str = Form("")
+) -> RedirectResponse:
+    """Revoke every current session, including this browser."""
+    expected = csrf_token(request)
+    if not expected or not hmac.compare_digest(expected.encode(), csrf.encode()):
+        raise HTTPException(status_code=403, detail="Invalid confirmation token")
+    await mutate_account(request, current_user.user_id, delete_account=False)
+    return RedirectResponse(url="/", status_code=303)

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -45,6 +45,7 @@ from learn_to_cloud.services.durable_verification_client import (
     DurableVerificationConfigError,
     DurableVerificationStatusError,
 )
+from learn_to_cloud.services.sessions_service import mutate_account
 from learn_to_cloud.services.steps_service import (
     StepValidationError,
     complete_step,
@@ -55,10 +56,6 @@ from learn_to_cloud.services.submissions_service import (
     InvalidSubmittedValueError,
     PriorPhaseNotCompleteError,
     RequirementNotFoundError,
-)
-from learn_to_cloud.services.users_service import (
-    UserNotFoundError,
-    delete_user_account,
 )
 from learn_to_cloud.services.verification_attempt_service import (
     INITIAL_VERIFICATION_STATUS_DELAY_SECONDS,
@@ -451,19 +448,10 @@ async def htmx_verification_attempt_status(
 @router.delete("/account", response_class=HTMLResponse)
 async def htmx_delete_account(
     request: Request,
-    db: DbSession,
     current_user: CurrentUser,
 ) -> HTMLResponse:
     """Delete the current user's account and redirect to home via HTMX."""
-    try:
-        await delete_user_account(db, current_user.user_id)
-    except UserNotFoundError:
-        return HTMLResponse(
-            '<p class="text-sm text-red-600">Account not found.</p>',
-            status_code=404,
-        )
-
-    request.session.clear()
+    await mutate_account(request, current_user.user_id, delete_account=True)
     response = HTMLResponse("")
     response.headers["HX-Redirect"] = "/"
     return response

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -31,7 +31,7 @@ from learn_to_cloud_shared.submission_values import (
 )
 from pydantic import BaseModel, ValidationError
 
-from learn_to_cloud.core.auth import AuthenticatedUser, CurrentUser
+from learn_to_cloud.core.auth import AuthenticatedUser, CurrentAccount, CurrentUser
 from learn_to_cloud.rendering.htmx_responses import (
     reload_page_response,
     render_input_error,
@@ -98,12 +98,12 @@ router = APIRouter(prefix="/htmx", tags=["htmx"], include_in_schema=False)
 async def htmx_complete_step(
     request: Request,
     db: DbSession,
-    current_user: CurrentUser,
+    account: CurrentAccount,
     step_uuid: Annotated[UUID, Form()],
 ) -> HTMLResponse:
     """Complete a step and return the updated step partial."""
     try:
-        _, topic, completed = await complete_step(db, current_user.user_id, step_uuid)
+        _, topic, completed = await complete_step(db, account.id, step_uuid)
     except StepValidationError:
         # Step UUID doesn't exist in current content (stale cached page).
         # Force a full page reload so the user gets the current steps.
@@ -112,7 +112,7 @@ async def htmx_complete_step(
         return response
 
     step = next(s for s in topic.learning_steps if s.uuid == step_uuid)
-    return render_step_toggle(request, topic, step, completed)
+    return render_step_toggle(request, account, topic, step, completed)
 
 
 @router.delete("/steps/{step_uuid}", response_class=HTMLResponse)
@@ -120,19 +120,17 @@ async def htmx_uncomplete_step(
     request: Request,
     step_uuid: UUID,
     db: DbSession,
-    current_user: CurrentUser,
+    account: CurrentAccount,
 ) -> HTMLResponse:
     """Uncomplete a step and return the updated step partial."""
     try:
-        _, topic, step, completed = await uncomplete_step(
-            db, current_user.user_id, step_uuid
-        )
+        _, topic, step, completed = await uncomplete_step(db, account.id, step_uuid)
     except StepValidationError:
         response = HTMLResponse("")
         response.headers["HX-Refresh"] = "true"
         return response
 
-    return render_step_toggle(request, topic, step, completed)
+    return render_step_toggle(request, account, topic, step, completed)
 
 
 async def _parse_verification_form[FormModel: BaseModel](

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -112,9 +112,7 @@ async def htmx_complete_step(
         return response
 
     step = next(s for s in topic.learning_steps if s.uuid == step_uuid)
-    return await render_step_toggle(
-        request, current_user.user_id, topic, step, completed, db
-    )
+    return render_step_toggle(request, topic, step, completed)
 
 
 @router.delete("/steps/{step_uuid}", response_class=HTMLResponse)
@@ -134,9 +132,7 @@ async def htmx_uncomplete_step(
         response.headers["HX-Refresh"] = "true"
         return response
 
-    return await render_step_toggle(
-        request, current_user.user_id, topic, step, completed, db
-    )
+    return render_step_toggle(request, topic, step, completed)
 
 
 async def _parse_verification_form[FormModel: BaseModel](

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -62,7 +62,6 @@ def _template_context(
 @router.get("/", response_class=HTMLResponse, summary="Home page")
 async def home_page(
     request: Request,
-    db: DbSession,
     current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Home page with phase overview."""
@@ -79,7 +78,6 @@ async def home_page(
 @router.get("/curriculum", response_class=HTMLResponse, summary="Curriculum overview")
 async def curriculum_page(
     request: Request,
-    db: DbSession,
     current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Full curriculum overview with all phases and topics."""
@@ -306,7 +304,6 @@ async def dashboard_page(
 @router.get("/account", response_class=HTMLResponse, summary="Account settings")
 async def account_page(
     request: Request,
-    db: DbSession,
     current_user: CurrentUser,
 ) -> HTMLResponse:
     """Account settings page."""
@@ -357,7 +354,6 @@ async def stats_page_redirect() -> RedirectResponse:
 @router.get("/faq", response_class=HTMLResponse, summary="FAQ")
 async def faq_page(
     request: Request,
-    db: DbSession,
     current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """FAQ page."""
@@ -373,7 +369,6 @@ async def faq_page(
 @router.get("/privacy", response_class=HTMLResponse, summary="Privacy policy")
 async def privacy_page(
     request: Request,
-    db: DbSession,
     current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Privacy policy page."""
@@ -389,7 +384,6 @@ async def privacy_page(
 @router.get("/terms", response_class=HTMLResponse, summary="Terms of service")
 async def terms_page(
     request: Request,
-    db: DbSession,
     current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Terms of service page."""

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -18,9 +18,8 @@ from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.models import User
 
 from learn_to_cloud.core.auth import (
-    CurrentUser,
-    OptionalCurrentUser,
-    get_request_user,
+    CurrentAccount,
+    OptionalCurrentAccount,
 )
 from learn_to_cloud.core.routing import LoginRedirectRoute
 from learn_to_cloud.core.templates import templates
@@ -48,9 +47,7 @@ router = APIRouter(
 )
 
 
-def _template_context(
-    request: Request, user: User | None = None, **kwargs: object
-) -> dict:
+def _template_context(user: User | None = None, **kwargs: object) -> dict:
     """Build common template context."""
     return {
         "user": user,
@@ -62,32 +59,30 @@ def _template_context(
 @router.get("/", response_class=HTMLResponse, summary="Home page")
 async def home_page(
     request: Request,
-    current_user: OptionalCurrentUser,
+    account: OptionalCurrentAccount,
 ) -> HTMLResponse:
     """Home page with phase overview."""
-    user = get_request_user(request)
     phases = get_curriculum_overview()
 
     return templates.TemplateResponse(
         request,
         "pages/home.html",
-        _template_context(request, user=user, phases=phases),
+        _template_context(user=account, phases=phases),
     )
 
 
 @router.get("/curriculum", response_class=HTMLResponse, summary="Curriculum overview")
 async def curriculum_page(
     request: Request,
-    current_user: OptionalCurrentUser,
+    account: OptionalCurrentAccount,
 ) -> HTMLResponse:
     """Full curriculum overview with all phases and topics."""
-    user = get_request_user(request)
     phases = get_curriculum_overview()
 
     return templates.TemplateResponse(
         request,
         "pages/curriculum.html",
-        _template_context(request, user=user, phases=phases),
+        _template_context(user=account, phases=phases),
     )
 
 
@@ -100,20 +95,19 @@ async def phase_page(
     request: Request,
     phase_id: int,
     db: DbSession,
-    current_user: CurrentUser,
+    account: CurrentAccount,
 ) -> HTMLResponse:
     """Single phase learning detail (requires auth)."""
-    user = get_request_user(request)
     phase = get_phase_by_slug(f"phase{phase_id}")
     if phase is None:
         return templates.TemplateResponse(
             request,
             "pages/404.html",
-            _template_context(request, user=user),
+            _template_context(user=account),
             status_code=404,
         )
 
-    detail = await fetch_phase_progress(db, current_user.user_id, phase)
+    detail = await fetch_phase_progress(db, account.id, phase)
     topics = build_phase_topics(phase, detail)
     has_verification = bool(
         phase.hands_on_verification and phase.hands_on_verification.requirements
@@ -123,8 +117,7 @@ async def phase_page(
         request,
         "pages/phase.html",
         _template_context(
-            request,
-            user=user,
+            user=account,
             phase=phase,
             topics=topics,
             phase_progress=detail,
@@ -141,23 +134,14 @@ async def phase_page(
 async def verifications_page(
     request: Request,
     db: DbSession,
-    current_user: CurrentUser,
+    account: CurrentAccount,
 ) -> HTMLResponse:
     """Verification progress and phase navigation (requires auth)."""
-    user = get_request_user(request)
-    if user is None:
-        return templates.TemplateResponse(
-            request,
-            "pages/404.html",
-            _template_context(request),
-            status_code=404,
-        )
-
-    overview = await get_verifications_overview(db, current_user.user_id)
+    overview = await get_verifications_overview(db, account.id)
     return templates.TemplateResponse(
         request,
         "pages/verifications.html",
-        _template_context(request, user=user, overview=overview),
+        _template_context(user=account, overview=overview),
     )
 
 
@@ -170,33 +154,31 @@ async def phase_verification_page(
     request: Request,
     phase_id: int,
     db: DbSession,
-    current_user: CurrentUser,
+    account: CurrentAccount,
     history_page: Annotated[int, Query(ge=1)] = 1,
 ) -> HTMLResponse:
     """One phase's verification requirements and feedback (requires auth)."""
-    user = get_request_user(request)
     phase = get_phase_by_slug(f"phase{phase_id}")
-    if user is None or phase is None:
+    if phase is None:
         return templates.TemplateResponse(
             request,
             "pages/404.html",
-            _template_context(request, user=user),
+            _template_context(user=account),
             status_code=404,
         )
 
     workspace = await get_phase_verification_workspace(
         db,
-        current_user.user_id,
+        account.id,
         phase,
-        user.github_username,
+        account.github_username,
         history_page=history_page,
     )
     return templates.TemplateResponse(
         request,
         "pages/verification_phase.html",
         _template_context(
-            request,
-            user=user,
+            user=account,
             phase=workspace.phase,
             phase_progress=workspace.phase_progress,
             requirements=workspace.requirements,
@@ -218,10 +200,9 @@ async def topic_page(
     phase_id: int,
     topic_slug: str,
     db: DbSession,
-    current_user: CurrentUser,
+    account: CurrentAccount,
 ) -> HTMLResponse:
     """Single topic with learning steps (requires auth)."""
-    user = get_request_user(request)
     phase_slug = f"phase{phase_id}"
     phase = get_phase_by_slug(phase_slug)
     topic = None
@@ -232,13 +213,11 @@ async def topic_page(
         return templates.TemplateResponse(
             request,
             "pages/404.html",
-            _template_context(request, user=user),
+            _template_context(user=account),
             status_code=404,
         )
 
-    completed_step_uuids = await get_valid_completed_steps(
-        db, current_user.user_id, topic
-    )
+    completed_step_uuids = await get_valid_completed_steps(db, account.id, topic)
 
     all_topics = phase.topics
     prev_topic, next_topic = build_topic_nav(
@@ -256,8 +235,7 @@ async def topic_page(
         request,
         "pages/topic.html",
         _template_context(
-            request,
-            user=user,
+            user=account,
             topic=topic,
             steps=topic.learning_steps,
             phase_slug=phase_slug,
@@ -275,26 +253,16 @@ async def topic_page(
 async def dashboard_page(
     request: Request,
     db: DbSession,
-    current_user: CurrentUser,
+    account: CurrentAccount,
 ) -> HTMLResponse:
     """Authenticated dashboard with progress."""
-    user = get_request_user(request)
-    if user is None:
-        return templates.TemplateResponse(
-            request,
-            "pages/404.html",
-            _template_context(request),
-            status_code=404,
-        )
-
-    dashboard = await get_dashboard_data(db, current_user.user_id)
+    dashboard = await get_dashboard_data(db, account.id)
 
     return templates.TemplateResponse(
         request,
         "pages/dashboard.html",
         _template_context(
-            request,
-            user=user,
+            user=account,
             dashboard=dashboard,
             help_links=HELP_LINKS,
         ),
@@ -304,22 +272,13 @@ async def dashboard_page(
 @router.get("/account", response_class=HTMLResponse, summary="Account settings")
 async def account_page(
     request: Request,
-    current_user: CurrentUser,
+    account: CurrentAccount,
 ) -> HTMLResponse:
     """Account settings page."""
-    user = get_request_user(request)
-    if user is None:
-        return templates.TemplateResponse(
-            request,
-            "pages/404.html",
-            _template_context(request),
-            status_code=404,
-        )
-
     return templates.TemplateResponse(
         request,
         "pages/account.html",
-        _template_context(request, user=user),
+        _template_context(user=account),
     )
 
 
@@ -327,18 +286,16 @@ async def account_page(
 async def community_page(
     request: Request,
     db: DbSession,
-    current_user: OptionalCurrentUser,
+    account: OptionalCurrentAccount,
 ) -> HTMLResponse:
     """Public community progress, graduates, and curriculum updates."""
-    user = get_request_user(request)
     community = await get_community_page_data(db)
 
     return templates.TemplateResponse(
         request,
         "pages/community.html",
         _template_context(
-            request,
-            user=user,
+            user=account,
             community=community,
             community_links=COMMUNITY_LINKS,
         ),
@@ -354,43 +311,37 @@ async def stats_page_redirect() -> RedirectResponse:
 @router.get("/faq", response_class=HTMLResponse, summary="FAQ")
 async def faq_page(
     request: Request,
-    current_user: OptionalCurrentUser,
+    account: OptionalCurrentAccount,
 ) -> HTMLResponse:
     """FAQ page."""
-    user = get_request_user(request)
-
     return templates.TemplateResponse(
         request,
         "pages/faq.html",
-        _template_context(request, user=user, faqs=FAQS),
+        _template_context(user=account, faqs=FAQS),
     )
 
 
 @router.get("/privacy", response_class=HTMLResponse, summary="Privacy policy")
 async def privacy_page(
     request: Request,
-    current_user: OptionalCurrentUser,
+    account: OptionalCurrentAccount,
 ) -> HTMLResponse:
     """Privacy policy page."""
-    user = get_request_user(request)
-
     return templates.TemplateResponse(
         request,
         "pages/privacy.html",
-        _template_context(request, user=user),
+        _template_context(user=account),
     )
 
 
 @router.get("/terms", response_class=HTMLResponse, summary="Terms of service")
 async def terms_page(
     request: Request,
-    current_user: OptionalCurrentUser,
+    account: OptionalCurrentAccount,
 ) -> HTMLResponse:
     """Terms of service page."""
-    user = get_request_user(request)
-
     return templates.TemplateResponse(
         request,
         "pages/terms.html",
-        _template_context(request, user=user),
+        _template_context(user=account),
     )

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -18,9 +18,9 @@ from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.models import User
 
 from learn_to_cloud.core.auth import (
-    AuthenticatedUser,
     CurrentUser,
     OptionalCurrentUser,
+    get_request_user,
 )
 from learn_to_cloud.core.routing import LoginRedirectRoute
 from learn_to_cloud.core.templates import templates
@@ -36,7 +36,6 @@ from learn_to_cloud.services.community_service import get_community_page_data
 from learn_to_cloud.services.dashboard_service import get_dashboard_data
 from learn_to_cloud.services.progress_service import fetch_phase_progress
 from learn_to_cloud.services.steps_service import get_valid_completed_steps
-from learn_to_cloud.services.users_service import get_user_by_id
 from learn_to_cloud.services.verification_page_service import (
     get_phase_verification_workspace,
     get_verifications_overview,
@@ -47,15 +46,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(
     tags=["pages"], include_in_schema=False, route_class=LoginRedirectRoute
 )
-
-
-async def _get_user_or_none(
-    db: DbSession, current_user: AuthenticatedUser | None
-) -> User | None:
-    """Get user from DB if authenticated, else None."""
-    if current_user is None:
-        return None
-    return await get_user_by_id(db, current_user.user_id)
 
 
 def _template_context(
@@ -76,7 +66,7 @@ async def home_page(
     current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Home page with phase overview."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
     phases = get_curriculum_overview()
 
     return templates.TemplateResponse(
@@ -93,7 +83,7 @@ async def curriculum_page(
     current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Full curriculum overview with all phases and topics."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
     phases = get_curriculum_overview()
 
     return templates.TemplateResponse(
@@ -115,7 +105,7 @@ async def phase_page(
     current_user: CurrentUser,
 ) -> HTMLResponse:
     """Single phase learning detail (requires auth)."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
     phase = get_phase_by_slug(f"phase{phase_id}")
     if phase is None:
         return templates.TemplateResponse(
@@ -156,7 +146,7 @@ async def verifications_page(
     current_user: CurrentUser,
 ) -> HTMLResponse:
     """Verification progress and phase navigation (requires auth)."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
     if user is None:
         return templates.TemplateResponse(
             request,
@@ -186,7 +176,7 @@ async def phase_verification_page(
     history_page: Annotated[int, Query(ge=1)] = 1,
 ) -> HTMLResponse:
     """One phase's verification requirements and feedback (requires auth)."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
     phase = get_phase_by_slug(f"phase{phase_id}")
     if user is None or phase is None:
         return templates.TemplateResponse(
@@ -233,7 +223,7 @@ async def topic_page(
     current_user: CurrentUser,
 ) -> HTMLResponse:
     """Single topic with learning steps (requires auth)."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
     phase_slug = f"phase{phase_id}"
     phase = get_phase_by_slug(phase_slug)
     topic = None
@@ -290,7 +280,7 @@ async def dashboard_page(
     current_user: CurrentUser,
 ) -> HTMLResponse:
     """Authenticated dashboard with progress."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
     if user is None:
         return templates.TemplateResponse(
             request,
@@ -320,7 +310,7 @@ async def account_page(
     current_user: CurrentUser,
 ) -> HTMLResponse:
     """Account settings page."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
     if user is None:
         return templates.TemplateResponse(
             request,
@@ -343,7 +333,7 @@ async def community_page(
     current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Public community progress, graduates, and curriculum updates."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
     community = await get_community_page_data(db)
 
     return templates.TemplateResponse(
@@ -371,7 +361,7 @@ async def faq_page(
     current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """FAQ page."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
 
     return templates.TemplateResponse(
         request,
@@ -387,7 +377,7 @@ async def privacy_page(
     current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Privacy policy page."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
 
     return templates.TemplateResponse(
         request,
@@ -403,7 +393,7 @@ async def terms_page(
     current_user: OptionalCurrentUser,
 ) -> HTMLResponse:
     """Terms of service page."""
-    user = await _get_user_or_none(db, current_user)
+    user = get_request_user(request)
 
     return templates.TemplateResponse(
         request,

--- a/api/src/learn_to_cloud/routes/users_routes.py
+++ b/api/src/learn_to_cloud/routes/users_routes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Request
 from learn_to_cloud_shared.schemas import UserResponse
 
-from learn_to_cloud.core.auth import CurrentUser, get_request_user
+from learn_to_cloud.core.auth import CurrentAccount, CurrentUser
 from learn_to_cloud.services.sessions_service import mutate_account
 
 __all__ = ["router"]
@@ -16,10 +16,9 @@ router = APIRouter(prefix="/api/user", tags=["users"])
     summary="Get current user",
     responses={401: {"description": "Not authenticated"}},
 )
-async def get_current_user(request: Request, current_user: CurrentUser) -> UserResponse:
+async def get_current_user(account: CurrentAccount) -> UserResponse:
     """Get current user info."""
-    user = get_request_user(request)
-    return UserResponse.model_validate(user)
+    return UserResponse.model_validate(account)
 
 
 @router.delete(

--- a/api/src/learn_to_cloud/routes/users_routes.py
+++ b/api/src/learn_to_cloud/routes/users_routes.py
@@ -1,15 +1,10 @@
 """User-related endpoints."""
 
-from fastapi import APIRouter, HTTPException, Request
-from learn_to_cloud_shared.core.database import DbSession
+from fastapi import APIRouter, Request
 from learn_to_cloud_shared.schemas import UserResponse
 
-from learn_to_cloud.core.auth import CurrentUser
-from learn_to_cloud.services.users_service import (
-    UserNotFoundError,
-    delete_user_account,
-    get_user_by_id,
-)
+from learn_to_cloud.core.auth import CurrentUser, get_request_user
+from learn_to_cloud.services.sessions_service import mutate_account
 
 __all__ = ["router"]
 
@@ -21,13 +16,9 @@ router = APIRouter(prefix="/api/user", tags=["users"])
     summary="Get current user",
     responses={401: {"description": "Not authenticated"}},
 )
-async def get_current_user(
-    request: Request, current_user: CurrentUser, db: DbSession
-) -> UserResponse:
+async def get_current_user(request: Request, current_user: CurrentUser) -> UserResponse:
     """Get current user info."""
-    user = await get_user_by_id(db, current_user.user_id)
-    if user is None:
-        raise HTTPException(status_code=404, detail="User not found")
+    user = get_request_user(request)
     return UserResponse.model_validate(user)
 
 
@@ -38,16 +29,8 @@ async def get_current_user(
     responses={
         204: {"description": "Account deleted"},
         401: {"description": "Not authenticated"},
-        404: {"description": "User not found"},
     },
 )
-async def delete_current_user(
-    request: Request, current_user: CurrentUser, db: DbSession
-) -> None:
+async def delete_current_user(request: Request, current_user: CurrentUser) -> None:
     """Permanently delete the authenticated user's account and all associated data."""
-    try:
-        await delete_user_account(db, current_user.user_id)
-    except UserNotFoundError as exc:
-        raise HTTPException(status_code=404, detail="User not found") from exc
-
-    request.session.clear()
+    await mutate_account(request, current_user.user_id, delete_account=True)

--- a/api/src/learn_to_cloud/services/sessions_service.py
+++ b/api/src/learn_to_cloud/services/sessions_service.py
@@ -1,0 +1,120 @@
+"""Short, committed authentication lifecycle transactions."""
+
+import base64
+import hashlib
+import hmac
+import logging
+import secrets
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from fastapi import Request
+from learn_to_cloud_shared.core.config import SessionConfig, get_web_settings
+from learn_to_cloud_shared.repositories.auth_session_repository import (
+    AuthSessionRepository,
+    ResolvedSession,
+)
+from learn_to_cloud_shared.repositories.user_repository import UserRepository
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud.core.auth import AuthenticationRequired
+from learn_to_cloud.core.session_cookies import (
+    AUTH_COOKIE_NAME,
+    clear_cookies,
+    token_digest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, repr=False)
+class IssuedSession:
+    token: str = field(repr=False)
+    expires_at: datetime
+    pruned_count: int
+
+
+async def issue_session(
+    db: AsyncSession, config: SessionConfig, user_id: int, previous: str | None = None
+) -> IssuedSession:
+    """Issue inside the caller's transaction; never publish before commit."""
+    raw = secrets.token_bytes(32)
+    repository = AuthSessionRepository(db, config)
+    record = await repository.create(user_id, hashlib.sha256(raw).digest())
+    if record is None:
+        raise RuntimeError("Cannot issue a session for an absent account")
+    previous_digest = token_digest(previous)
+    if previous_digest is not None:
+        await repository.delete(previous_digest)
+    count = await repository.prune_expired()
+    return IssuedSession(
+        base64.urlsafe_b64encode(raw).rstrip(b"=").decode(), record.expires_at, count
+    )
+
+
+def log_pruned(issued: IssuedSession) -> None:
+    if issued.pruned_count:
+        logger.info(
+            "auth.session.pruned", extra={"auth.session.count": issued.pruned_count}
+        )
+
+
+def csrf_token(request: Request) -> str:
+    digest = token_digest(request.cookies.get(AUTH_COOKIE_NAME))
+    if digest is None:
+        return ""
+    return hmac.new(
+        get_web_settings().session.secret_key.encode(),
+        b"ltc:logout-all:v1:" + digest,
+        hashlib.sha256,
+    ).hexdigest()
+
+
+async def revoke_current(request: Request) -> None:
+    digest = token_digest(request.cookies.get(AUTH_COOKIE_NAME))
+    count = 0
+    if digest is not None:
+        async with request.app.state.session_maker() as db:
+            async with db.begin():
+                count = await AuthSessionRepository(
+                    db, get_web_settings().session
+                ).delete(digest)
+    clear_cookies(request)
+    logger.info(
+        "auth.session.revoked",
+        extra={"auth.session.scope": "current", "auth.session.count": count},
+    )
+
+
+async def mutate_account(
+    request: Request, user_id: int, *, delete_account: bool
+) -> None:
+    """Lock account before rechecking session, then revoke or delete atomically."""
+    digest = token_digest(request.cookies.get(AUTH_COOKIE_NAME))
+    if digest is None:
+        request.state.clear_auth_cookie = True
+        raise AuthenticationRequired()
+    async with request.app.state.session_maker() as db:
+        async with db.begin():
+            repository = AuthSessionRepository(db, get_web_settings().session)
+            account = await repository.lock_user(user_id)
+            if account is None:
+                request.state.clear_auth_cookie = True
+                raise AuthenticationRequired()
+            resolved = await repository.resolve_and_touch(digest)
+            if not isinstance(resolved, ResolvedSession) or resolved.user.id != user_id:
+                request.state.clear_auth_cookie = True
+                raise AuthenticationRequired()
+            if delete_account:
+                await UserRepository(db).delete(user_id)
+                count = 0
+            else:
+                count = await repository.delete_all(user_id)
+    clear_cookies(request)
+    if delete_account:
+        logger.info("user.account_deleted")
+    else:
+        logger.info(
+            "auth.session.revoked",
+            extra={"auth.session.scope": "all", "auth.session.count": count},
+        )

--- a/api/src/learn_to_cloud/services/users_service.py
+++ b/api/src/learn_to_cloud/services/users_service.py
@@ -32,12 +32,6 @@ def normalize_display_name(name: object) -> str | None:
     return None
 
 
-async def get_user_by_id(db: AsyncSession, user_id: int) -> User | None:
-    """Get a user by ID, or None if not found."""
-    user_repo = UserRepository(db)
-    return await user_repo.get_by_id(user_id)
-
-
 async def get_or_create_user_from_github(
     db: AsyncSession,
     *,
@@ -64,28 +58,3 @@ async def get_or_create_user_from_github(
         github_username=normalized_username,
     )
     return user
-
-
-class UserNotFoundError(Exception):
-    """Raised when a user is not found in the database."""
-
-    def __init__(self, user_id: int) -> None:
-        self.user_id = user_id
-        super().__init__(f"User not found: {user_id}")
-
-
-async def delete_user_account(db: AsyncSession, user_id: int) -> None:
-    """Permanently delete a user and all associated data.
-
-    Cascades to verification attempts and learning-step completions.
-
-    Raises:
-        UserNotFoundError: If the user does not exist.
-    """
-    user_repo = UserRepository(db)
-    user = await user_repo.get_by_id(user_id)
-    if user is None:
-        raise UserNotFoundError(user_id)
-
-    await user_repo.delete(user_id)
-    logger.info("user.account_deleted")

--- a/api/src/learn_to_cloud/templates/pages/account.html
+++ b/api/src/learn_to_cloud/templates/pages/account.html
@@ -6,6 +6,22 @@
 {% endblock %}
 
 {% block page_body %}
+<section class="mb-8">
+    <h2 class="section-title mb-3">Sign out everywhere</h2>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        Sign out of Learn to Cloud in every browser, including this one. This does not sign you out of GitHub
+        or cancel work already authorized. If your GitHub account is compromised, secure it at GitHub first.
+        Sessions expire after 7 days without activity or 30 days after sign-in.
+    </p>
+    <form action="/auth/logout-all" method="post" hx-boost="false">
+        <input type="hidden" name="csrf" value="{{ logout_all_csrf }}">
+        <label class="block mb-4">
+            <input type="checkbox" required>
+            I confirm I want to sign out of all browsers, including this one.
+        </label>
+        <button type="submit" class="button-secondary">Sign out everywhere</button>
+    </form>
+</section>
 <div x-data="{ confirmDelete: false }">
     <h2 class="section-title mb-3">Delete Account</h2>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">

--- a/api/src/learn_to_cloud/templates/pages/privacy.html
+++ b/api/src/learn_to_cloud/templates/pages/privacy.html
@@ -31,7 +31,7 @@
         </ul>
         <p>
             We do <strong>not</strong> collect your email address, password, private repositories, or any other personal
-            information beyond what is listed above.
+            profile information beyond what is listed above.
         </p>
         <p>
             We collect basic browser telemetry, such as page views, performance timings, and client-side errors, to
@@ -90,8 +90,11 @@
     <section>
         <h2>Cookies</h2>
         <p>
-            We use a single session cookie to keep you signed in. This cookie is signed, HTTP-only, and contains only
-            your user ID. We do not use tracking cookies, analytics cookies, or any third-party cookies. Browser
+            We use two HTTP-only cookies for different purposes. A short-lived signed cookie preserves GitHub
+            sign-in state for up to 10 minutes. A separate authentication cookie contains an opaque random
+            credential, not your profile or user ID. On the server, we store only its digest, account link,
+            creation and activity times, and absolute expiry. We do not store IP addresses or device details
+            with sessions. We do not use tracking cookies, analytics cookies, or any third-party cookies. Browser
             telemetry is configured without cookies or browser storage.
         </p>
     </section>
@@ -103,6 +106,13 @@
             associated data (progress and submissions) at any time from your
             <a href="/account">Account page</a>.
             Deletion is immediate and irreversible.
+        </p>
+        <p>
+            Sessions stop working after 7 days without authenticated activity or 30 days after sign-in.
+            Signing out deletes that browser's session; Sign out everywhere deletes all current sessions.
+            Account deletion also deletes all sessions. Expired records are removed in small batches during
+            later successful sign-ins, so physical removal has no guaranteed deadline. Expired records
+            cannot authenticate while waiting for cleanup.
         </p>
         <p>
             Account deletion does not remove existing diagnostic logs. Those logs follow the telemetry

--- a/api/tests/core/test_auth.py
+++ b/api/tests/core/test_auth.py
@@ -1,17 +1,21 @@
 """Tests for session identities, authentication policies, and OAuth registration."""
 
+import logging
 from importlib import import_module, util
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import Request
 from learn_to_cloud_shared.core.config import OAuthConfig
+from learn_to_cloud_shared.models import User
+from learn_to_cloud_shared.repositories.auth_session_repository import SessionRejection
 from starlette.datastructures import State
 
 from learn_to_cloud.core.auth import (
     AuthenticatedUser,
     AuthenticationRequired,
     IdentityRejectionReason,
+    RequestAuthentication,
     get_authenticated_user_from_session,
     init_oauth,
     oauth,
@@ -19,6 +23,7 @@ from learn_to_cloud.core.auth import (
     require_authenticated_user,
     validate_identity,
 )
+from learn_to_cloud.core.session_cookies import AUTH_COOKIE_NAME
 
 
 def test_authlib_uses_supported_http_client() -> None:
@@ -40,6 +45,7 @@ def _make_request(session: dict | None = None, headers: dict | None = None) -> R
     request.session = session if session is not None else {}
     request.headers = headers or {}
     request.state = State()
+    request.cookies = {}
     return request
 
 
@@ -47,23 +53,51 @@ def _make_request(session: dict | None = None, headers: dict | None = None) -> R
 class TestGetAuthenticatedUserFromSession:
     """Test session identity extraction."""
 
+    @pytest.mark.parametrize("reason", list(SessionRejection))
+    async def test_store_rejection_severity_and_request_cache(self, reason, caplog):
+        request = _make_request()
+        request.cookies[AUTH_COOKIE_NAME] = "A" * 43
+        db = AsyncMock()
+        db.begin = MagicMock(return_value=AsyncMock())
+        request.app.state.session_maker.return_value.__aenter__ = AsyncMock(
+            return_value=db
+        )
+        caplog.set_level(logging.INFO)
+        with patch(
+            "learn_to_cloud.core.auth.AuthSessionRepository", autospec=True
+        ) as repository:
+            repository.return_value.resolve_and_touch.return_value = reason
+            assert await optional_authenticated_user(request) is None
+            assert await optional_authenticated_user(request) is None
+            repository.return_value.resolve_and_touch.assert_awaited_once()
+        (record,) = caplog.records
+        assert record.getMessage() == "auth.session.rejected"
+        assert record.__dict__["auth.session.reason"] == reason.value
+        assert record.levelno == (
+            logging.WARNING
+            if reason == SessionRejection.ACCOUNT_MISSING
+            else logging.INFO
+        )
+        assert request.state.clear_auth_cookie is True
+
     @pytest.mark.parametrize("user_id", [1, 42, 2**63 - 1])
-    def test_returns_identity_with_integer_id(self, user_id):
+    async def test_legacy_identity_never_authenticates(self, user_id):
         request = _make_request(
             session={"user_id": user_id, "github_username": "testuser"}
         )
-        result = get_authenticated_user_from_session(request)
-        assert result == AuthenticatedUser(user_id=user_id, github_username="testuser")
+        result = await get_authenticated_user_from_session(request)
+        assert result is None
+        assert request.session == {}
 
-    def test_returns_none_without_username(self):
+    async def test_returns_none_without_username(self):
         request = _make_request(session={"user_id": 42})
-        result = get_authenticated_user_from_session(request)
+        result = await get_authenticated_user_from_session(request)
         assert result is None
 
     @pytest.mark.parametrize("username", [None, "", 42, []])
-    def test_returns_none_for_invalid_username(self, username):
+    async def test_returns_none_for_invalid_username(self, username):
         request = _make_request(session={"user_id": 42, "github_username": username})
-        assert get_authenticated_user_from_session(request) is None
+        assert await get_authenticated_user_from_session(request) is None
 
     @pytest.mark.parametrize(
         "session",
@@ -73,9 +107,9 @@ class TestGetAuthenticatedUserFromSession:
             {"user_id": None, "github_username": "testuser"},
         ],
     )
-    def test_returns_none_when_user_id_missing(self, session):
+    async def test_returns_none_when_user_id_missing(self, session):
         request = _make_request(session=session)
-        result = get_authenticated_user_from_session(request)
+        result = await get_authenticated_user_from_session(request)
         assert result is None
 
 
@@ -147,21 +181,22 @@ class TestSessionIdentityCleanup:
             ({"user_id": 42, "github_username": "\ud800"}, "invalid_github_username"),
         ],
     )
-    def test_cleans_in_place_preserves_oauth_and_logs_once(
+    async def test_cleans_in_place_preserves_oauth_and_logs_once(
         self, caplog, identity, reason
     ):
+        caplog.set_level(logging.INFO)
         unrelated = {"_state_github_probe": {"data": {"state": "private-state"}}}
         session = {**unrelated, **identity}
         request = _make_request(session)
-        assert optional_authenticated_user(request) is None
+        assert await optional_authenticated_user(request) is None
         assert request.session is session
         assert session == unrelated
         assert not hasattr(request.state, "user_id")
         assert not hasattr(request.state, "github_username")
-        assert optional_authenticated_user(request) is None
+        assert await optional_authenticated_user(request) is None
         (record,) = caplog.records
-        assert record.getMessage() == "auth.session.identity_rejected"
-        assert record.__dict__["auth.identity.reason"] == reason
+        assert record.getMessage() == "auth.session.rejected"
+        assert record.__dict__["auth.session.reason"] == "legacy"
         assert record.args == ()
         assert record.exc_info is None
         assert (
@@ -172,41 +207,41 @@ class TestSessionIdentityCleanup:
     @pytest.mark.parametrize(
         "session", [{}, {"_state_github_probe": {"data": {"state": "private-state"}}}]
     )
-    def test_absent_identity_does_not_mutate_or_log(self, caplog, session):
+    async def test_absent_identity_does_not_mutate_or_log(self, caplog, session):
         original = session.copy()
-        assert optional_authenticated_user(_make_request(session)) is None
+        assert await optional_authenticated_user(_make_request(session)) is None
         assert session == original
         assert caplog.records == []
 
-    def test_valid_identity_does_not_mutate_or_log(self, caplog):
+    async def test_complete_legacy_identity_is_removed(self, caplog):
         session = {"user_id": 42, "github_username": "MiXeD", "other": "private-state"}
-        original = session.copy()
-        assert get_authenticated_user_from_session(_make_request(session)) == (
-            AuthenticatedUser(42, "MiXeD")
-        )
-        assert session == original
-        assert caplog.records == []
+        assert await get_authenticated_user_from_session(_make_request(session)) is None
+        assert session == {"other": "private-state"}
 
 
 @pytest.mark.unit
 class TestRequireAuthenticatedUser:
     """Test require_authenticated_user dependency."""
 
-    def test_returns_identity_and_sets_state(self):
-        request = _make_request(session={"user_id": 42, "github_username": "testuser"})
-        result = require_authenticated_user(request)
+    async def test_returns_identity_and_sets_state(self):
+        request = _make_request()
+        request.state.auth_resolved = True
+        request.state.authentication = RequestAuthentication(
+            AuthenticatedUser(42, "testuser"), User(id=42, github_username="testuser")
+        )
+        result = await require_authenticated_user(request)
         assert result == AuthenticatedUser(user_id=42, github_username="testuser")
         assert request.state.user_id == 42
         assert request.state.github_username == "testuser"
 
     @pytest.mark.parametrize("session", [{}, {"user_id": 42}])
     @pytest.mark.parametrize("htmx", [False, True])
-    def test_raises_401_when_unauthenticated(self, session, htmx):
+    async def test_raises_401_when_unauthenticated(self, session, htmx):
         request = _make_request(
             session=session, headers={"hx-request": "true"} if htmx else {}
         )
         with pytest.raises(AuthenticationRequired) as exc_info:
-            require_authenticated_user(request)
+            await require_authenticated_user(request)
         assert exc_info.value.status_code == 401
         assert exc_info.value.headers is None
 
@@ -215,16 +250,20 @@ class TestRequireAuthenticatedUser:
 class TestOptionalAuthenticatedUser:
     """Test optional_authenticated_user dependency."""
 
-    def test_returns_identity_and_sets_state(self):
-        request = _make_request(session={"user_id": 99, "github_username": "user"})
-        result = optional_authenticated_user(request)
+    async def test_returns_identity_and_sets_state(self):
+        request = _make_request()
+        request.state.auth_resolved = True
+        request.state.authentication = RequestAuthentication(
+            AuthenticatedUser(99, "user"), User(id=99, github_username="user")
+        )
+        result = await optional_authenticated_user(request)
         assert result == AuthenticatedUser(user_id=99, github_username="user")
         assert request.state.user_id == 99
         assert request.state.github_username == "user"
 
-    def test_returns_none_when_not_authenticated(self):
+    async def test_returns_none_when_not_authenticated(self):
         request = _make_request(session={})
-        result = optional_authenticated_user(request)
+        result = await optional_authenticated_user(request)
         assert result is None
 
 

--- a/api/tests/core/test_auth.py
+++ b/api/tests/core/test_auth.py
@@ -8,18 +8,21 @@ import pytest
 from fastapi import Request
 from learn_to_cloud_shared.core.config import OAuthConfig
 from learn_to_cloud_shared.models import User
-from learn_to_cloud_shared.repositories.auth_session_repository import SessionRejection
+from learn_to_cloud_shared.repositories.auth_session_repository import (
+    ResolvedSession,
+    SessionRejection,
+)
 from starlette.datastructures import State
 
 from learn_to_cloud.core.auth import (
     AuthenticatedUser,
     AuthenticationRequired,
     IdentityRejectionReason,
-    RequestAuthentication,
-    get_authenticated_user_from_session,
     init_oauth,
     oauth,
+    optional_authenticated_account,
     optional_authenticated_user,
+    require_authenticated_account,
     require_authenticated_user,
     validate_identity,
 )
@@ -50,8 +53,65 @@ def _make_request(session: dict | None = None, headers: dict | None = None) -> R
 
 
 @pytest.mark.unit
-class TestGetAuthenticatedUserFromSession:
-    """Test session identity extraction."""
+class TestOptionalAuthenticatedAccount:
+    """Test session account resolution."""
+
+    async def test_loaded_account_is_cached_and_populates_telemetry(self):
+        request = _make_request()
+        request.cookies[AUTH_COOKIE_NAME] = "A" * 43
+        account = User(id=42, github_username="current-name")
+        db = AsyncMock()
+        transaction = AsyncMock()
+        db.begin = MagicMock(return_value=transaction)
+        request.app.state.session_maker.return_value.__aenter__ = AsyncMock(
+            return_value=db
+        )
+        with patch(
+            "learn_to_cloud.core.auth.AuthSessionRepository", autospec=True
+        ) as repository:
+            repository.return_value.resolve_and_touch.return_value = ResolvedSession(
+                session=MagicMock(), user=account
+            )
+            assert await optional_authenticated_account(request) is account
+            transaction.__aexit__.assert_awaited_once_with(None, None, None)
+            request.app.state.session_maker.return_value.__aexit__.assert_awaited_once()
+            assert await optional_authenticated_account(request) is account
+            assert require_authenticated_account(account) is account
+            assert (
+                require_authenticated_user(account)
+                == optional_authenticated_user(account)
+                == AuthenticatedUser(42, "current-name")
+            )
+            repository.return_value.resolve_and_touch.assert_awaited_once()
+        assert request.state.user_id == 42
+        assert request.state.github_username == "current-name"
+
+    @pytest.mark.parametrize("failure", ["lookup", "commit"])
+    async def test_store_failure_is_not_cached_as_anonymous(self, failure):
+        request = _make_request()
+        request.cookies[AUTH_COOKIE_NAME] = "A" * 43
+        db = AsyncMock()
+        transaction = AsyncMock()
+        db.begin = MagicMock(return_value=transaction)
+        request.app.state.session_maker.return_value.__aenter__ = AsyncMock(
+            return_value=db
+        )
+        with patch(
+            "learn_to_cloud.core.auth.AuthSessionRepository", autospec=True
+        ) as repository:
+            operation = (
+                repository.return_value.resolve_and_touch
+                if failure == "lookup"
+                else transaction.__aexit__
+            )
+            operation.side_effect = RuntimeError("store unavailable")
+            for _ in range(2):
+                with pytest.raises(RuntimeError, match="store unavailable"):
+                    await optional_authenticated_account(request)
+                assert not getattr(request.state, "auth_resolved", False)
+                assert not hasattr(request.state, "user_id")
+                assert not hasattr(request.state, "clear_auth_cookie")
+            assert repository.return_value.resolve_and_touch.await_count == 2
 
     @pytest.mark.parametrize("reason", list(SessionRejection))
     async def test_store_rejection_severity_and_request_cache(self, reason, caplog):
@@ -67,8 +127,8 @@ class TestGetAuthenticatedUserFromSession:
             "learn_to_cloud.core.auth.AuthSessionRepository", autospec=True
         ) as repository:
             repository.return_value.resolve_and_touch.return_value = reason
-            assert await optional_authenticated_user(request) is None
-            assert await optional_authenticated_user(request) is None
+            assert await optional_authenticated_account(request) is None
+            assert await optional_authenticated_account(request) is None
             repository.return_value.resolve_and_touch.assert_awaited_once()
         (record,) = caplog.records
         assert record.getMessage() == "auth.session.rejected"
@@ -85,19 +145,19 @@ class TestGetAuthenticatedUserFromSession:
         request = _make_request(
             session={"user_id": user_id, "github_username": "testuser"}
         )
-        result = await get_authenticated_user_from_session(request)
+        result = await optional_authenticated_account(request)
         assert result is None
         assert request.session == {}
 
     async def test_returns_none_without_username(self):
         request = _make_request(session={"user_id": 42})
-        result = await get_authenticated_user_from_session(request)
+        result = await optional_authenticated_account(request)
         assert result is None
 
     @pytest.mark.parametrize("username", [None, "", 42, []])
     async def test_returns_none_for_invalid_username(self, username):
         request = _make_request(session={"user_id": 42, "github_username": username})
-        assert await get_authenticated_user_from_session(request) is None
+        assert await optional_authenticated_account(request) is None
 
     @pytest.mark.parametrize(
         "session",
@@ -109,7 +169,7 @@ class TestGetAuthenticatedUserFromSession:
     )
     async def test_returns_none_when_user_id_missing(self, session):
         request = _make_request(session=session)
-        result = await get_authenticated_user_from_session(request)
+        result = await optional_authenticated_account(request)
         assert result is None
 
 
@@ -188,12 +248,12 @@ class TestSessionIdentityCleanup:
         unrelated = {"_state_github_probe": {"data": {"state": "private-state"}}}
         session = {**unrelated, **identity}
         request = _make_request(session)
-        assert await optional_authenticated_user(request) is None
+        assert await optional_authenticated_account(request) is None
         assert request.session is session
         assert session == unrelated
         assert not hasattr(request.state, "user_id")
         assert not hasattr(request.state, "github_username")
-        assert await optional_authenticated_user(request) is None
+        assert await optional_authenticated_account(request) is None
         (record,) = caplog.records
         assert record.getMessage() == "auth.session.rejected"
         assert record.__dict__["auth.session.reason"] == "legacy"
@@ -209,13 +269,13 @@ class TestSessionIdentityCleanup:
     )
     async def test_absent_identity_does_not_mutate_or_log(self, caplog, session):
         original = session.copy()
-        assert await optional_authenticated_user(_make_request(session)) is None
+        assert await optional_authenticated_account(_make_request(session)) is None
         assert session == original
         assert caplog.records == []
 
     async def test_complete_legacy_identity_is_removed(self, caplog):
         session = {"user_id": 42, "github_username": "MiXeD", "other": "private-state"}
-        assert await get_authenticated_user_from_session(_make_request(session)) is None
+        assert await optional_authenticated_account(_make_request(session)) is None
         assert session == {"other": "private-state"}
 
 
@@ -223,16 +283,11 @@ class TestSessionIdentityCleanup:
 class TestRequireAuthenticatedUser:
     """Test require_authenticated_user dependency."""
 
-    async def test_returns_identity_and_sets_state(self):
-        request = _make_request()
-        request.state.auth_resolved = True
-        request.state.authentication = RequestAuthentication(
-            AuthenticatedUser(42, "testuser"), User(id=42, github_username="testuser")
-        )
-        result = await require_authenticated_user(request)
+    def test_returns_identity(self):
+        account = User(id=42, github_username="testuser")
+        assert require_authenticated_account(account) is account
+        result = require_authenticated_user(account)
         assert result == AuthenticatedUser(user_id=42, github_username="testuser")
-        assert request.state.user_id == 42
-        assert request.state.github_username == "testuser"
 
     @pytest.mark.parametrize("session", [{}, {"user_id": 42}])
     @pytest.mark.parametrize("htmx", [False, True])
@@ -241,7 +296,7 @@ class TestRequireAuthenticatedUser:
             session=session, headers={"hx-request": "true"} if htmx else {}
         )
         with pytest.raises(AuthenticationRequired) as exc_info:
-            await require_authenticated_user(request)
+            require_authenticated_account(await optional_authenticated_account(request))
         assert exc_info.value.status_code == 401
         assert exc_info.value.headers is None
 
@@ -250,21 +305,12 @@ class TestRequireAuthenticatedUser:
 class TestOptionalAuthenticatedUser:
     """Test optional_authenticated_user dependency."""
 
-    async def test_returns_identity_and_sets_state(self):
-        request = _make_request()
-        request.state.auth_resolved = True
-        request.state.authentication = RequestAuthentication(
-            AuthenticatedUser(99, "user"), User(id=99, github_username="user")
-        )
-        result = await optional_authenticated_user(request)
+    def test_returns_identity(self):
+        result = optional_authenticated_user(User(id=99, github_username="user"))
         assert result == AuthenticatedUser(user_id=99, github_username="user")
-        assert request.state.user_id == 99
-        assert request.state.github_username == "user"
 
-    async def test_returns_none_when_not_authenticated(self):
-        request = _make_request(session={})
-        result = await optional_authenticated_user(request)
-        assert result is None
+    def test_returns_none_when_not_authenticated(self):
+        assert optional_authenticated_user(None) is None
 
 
 @pytest.mark.unit

--- a/api/tests/core/test_session_cookies.py
+++ b/api/tests/core/test_session_cookies.py
@@ -1,0 +1,78 @@
+"""Cookie cleanup on handled responses without clobbering a replacement."""
+
+from datetime import UTC, datetime, timedelta
+from http.cookies import SimpleCookie
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import Response
+from httpx import ASGITransport, AsyncClient
+
+from learn_to_cloud.core.session_cookies import (
+    AUTH_COOKIE_NAME,
+    SessionResponseMiddleware,
+    issue_cookie,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("secure", [False, True])
+@pytest.mark.parametrize("status", [200, 401, 303])
+async def test_handled_cleanup_flags_and_vary(test_settings, secure, status):
+    settings = test_settings.model_copy(
+        update={
+            "web_security": test_settings.web_security.model_copy(
+                update={"require_https": secure}
+            )
+        }
+    )
+    app = FastAPI()
+    app.add_middleware(SessionResponseMiddleware)
+
+    @app.get("/")
+    async def page(request: Request):
+        request.state.auth_resolved = True
+        request.state.clear_auth_cookie = True
+        raise HTTPException(status, headers={"Vary": "Accept-Encoding"})
+
+    with patch(
+        "learn_to_cloud.core.session_cookies.get_web_settings", return_value=settings
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            response = await client.get("/")
+    assert response.status_code == status
+    assert response.headers["vary"] == "Accept-Encoding, Cookie"
+    assert response.headers["cache-control"] == "private, no-store"
+    cookie = SimpleCookie(response.headers["set-cookie"])[AUTH_COOKIE_NAME]
+    assert cookie["max-age"] == "0"
+    assert cookie["path"] == "/"
+    assert not cookie["domain"]
+    assert bool(cookie["secure"]) is secure
+    assert cookie["httponly"] and cookie["samesite"] == "lax"
+
+
+async def test_fresh_cookie_wins_over_requested_cleanup():
+    app = FastAPI()
+    app.add_middleware(SessionResponseMiddleware)
+
+    @app.get("/auth/callback")
+    async def page(request: Request):
+        request.state.clear_auth_cookie = True
+        response = Response(headers={"Vary": "cookie, Accept-Encoding"})
+        issue_cookie(
+            request, response, "new-credential", datetime.now(UTC) + timedelta(days=30)
+        )
+        return response
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://testserver"
+    ) as client:
+        response = await client.get("/auth/callback")
+    headers = response.headers.get_list("set-cookie")
+    assert len(headers) == 1
+    assert SimpleCookie(headers[0])[AUTH_COOKIE_NAME].value == "new-credential"
+    assert response.headers["vary"] == "cookie, Accept-Encoding"

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -3,9 +3,13 @@
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import PropertyMock, patch
 from uuid import uuid4
 
 import pytest
+from fastapi import Request
+from learn_to_cloud_shared.content_yaml_loader import get_all_phases_from_yaml
+from learn_to_cloud_shared.models import User
 from learn_to_cloud_shared.schemas import SubmissionData
 
 from learn_to_cloud.core.templates import templates
@@ -15,8 +19,41 @@ from learn_to_cloud.rendering.context import (
     build_requirement_card_context,
     feedback_tasks_and_passed,
 )
+from learn_to_cloud.rendering.htmx_responses import render_step_toggle
 
 _ENV = templates.env
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("completed", [False, True])
+def test_step_toggle_uses_explicit_account_without_request_state(completed):
+    topic = next(
+        topic
+        for phase in get_all_phases_from_yaml()
+        for topic in phase.topics
+        if topic.learning_steps
+    )
+    step = topic.learning_steps[0]
+    request = Request({"type": "http", "path": "/"})
+    account = User(id=42, github_username="current-user")
+    with patch.object(
+        Request,
+        "state",
+        new_callable=PropertyMock,
+        side_effect=AssertionError("Rendering must not read request state"),
+    ):
+        response = render_step_toggle(
+            request, account, topic, step, {step.uuid} if completed else set()
+        )
+    html = bytes(response.body).decode()
+    assert 'type="checkbox"' in html
+    if completed:
+        assert f'hx-delete="/htmx/steps/{step.uuid}"' in html
+        assert "checked" in html
+    else:
+        assert 'hx-post="/htmx/steps/complete"' in html
+    assert 'id="topic-progress" hx-swap-oob="true"' in html
+    assert f"{int(completed)}/{len(topic.learning_steps)} steps checked" in html
 
 
 def _base_ctx(**overrides: object) -> dict[str, object]:

--- a/api/tests/routes/test_auth_http.py
+++ b/api/tests/routes/test_auth_http.py
@@ -16,6 +16,7 @@ from httpx import ASGITransport, AsyncClient
 from itsdangerous import TimestampSigner
 from learn_to_cloud_shared.core.database import get_db
 from learn_to_cloud_shared.models import User
+from learn_to_cloud_shared.schemas import UserResponse
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.logging.handler import LoggingHandler
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
@@ -28,24 +29,26 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind, StatusCode
-from sqlalchemy import text
+from sqlalchemy import inspect, text, update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from starlette.middleware.sessions import SessionMiddleware
 
-from learn_to_cloud.core.auth import SESSION_COOKIE_NAME, CurrentUser, get_request_user
+from learn_to_cloud.core.auth import SESSION_COOKIE_NAME, CurrentUser
 from learn_to_cloud.core.middleware import TelemetrySanitizationMiddleware
 from learn_to_cloud.core.routing import LoginRedirectRoute
 from learn_to_cloud.core.session_cookies import (
     AUTH_COOKIE_NAME,
     SessionResponseMiddleware,
 )
+from learn_to_cloud.core.templates import templates
 from learn_to_cloud.routes import (
     auth_router,
     htmx_router,
     pages_router,
     users_router,
 )
+from learn_to_cloud.routes.pages_routes import _template_context
 from learn_to_cloud.services.sessions_service import issue_session, mutate_account
 
 pytestmark = pytest.mark.integration
@@ -115,12 +118,12 @@ def user():
 
 
 @pytest.fixture
-def api_services(user):
+def api_services():
     with (
         patch(
-            "learn_to_cloud.routes.users_routes.get_request_user",
+            "learn_to_cloud.routes.users_routes.UserResponse.model_validate",
             autospec=True,
-            side_effect=get_request_user,
+            side_effect=UserResponse.model_validate,
         ) as get_user,
         patch(
             "learn_to_cloud.routes.users_routes.mutate_account",
@@ -197,16 +200,16 @@ async def app(test_settings, test_engine, user, api_services, github):
             return_value=test_settings,
         ),
         patch(
-            "learn_to_cloud.routes.pages_routes.get_request_user",
+            "learn_to_cloud.routes.pages_routes._template_context",
             autospec=True,
-            side_effect=get_request_user,
-        ) as page_user,
+            side_effect=_template_context,
+        ) as page_context,
         patch(
             "learn_to_cloud.routes.pages_routes.get_curriculum_overview",
             return_value=(),
         ),
     ):
-        app.state.page_user = page_user
+        app.state.page_context = page_context
         yield app
 
 
@@ -425,7 +428,7 @@ async def test_logout_expires_cookie_and_is_repeatable(client, github, cookie_ki
     "path", ["/", "/curriculum", "/account", "/faq", "/privacy", "/terms"]
 )
 @pytest.mark.parametrize("session_state", ["anonymous", "valid", "revoked"])
-async def test_pages_resolve_identity_without_route_database(
+async def test_pages_inject_account_without_route_database(
     app, client, auth_cookie, path, session_state
 ):
     def unexpected_database():
@@ -447,12 +450,11 @@ async def test_pages_resolve_identity_without_route_database(
     if path == "/account" and session_state != "valid":
         assert response.status_code == 303
         assert response.headers["location"] == "/auth/login"
-        app.state.page_user.assert_not_called()
+        app.state.page_context.assert_not_called()
     else:
         assert response.status_code == 200
-        app.state.page_user.assert_called_once()
-        request = app.state.page_user.call_args.args[0]
-        user = get_request_user(request)
+        app.state.page_context.assert_called_once()
+        user = app.state.page_context.call_args.kwargs["user"]
         if session_state == "valid":
             assert user is not None
             assert user.id == 42
@@ -475,6 +477,42 @@ async def test_persisted_session_authenticates_real_routes(client, auth_cookie, 
         assert response.json()["id"] == 42
     else:
         assert "testuser" in response.text
+
+
+@pytest.mark.parametrize("path", ["/", "/account", "/api/user/me"])
+async def test_account_routes_use_current_loaded_profile(
+    app, client, auth_cookie, api_services, path
+):
+    async with app.state.session_maker() as db, db.begin():
+        await db.execute(
+            update(User)
+            .where(User.id == 42)
+            .values(github_username="renamed-user", display_name="Current Profile")
+        )
+    client.cookies.set(
+        AUTH_COOKIE_NAME, auth_cookie, domain="testserver.local", path="/"
+    )
+    with patch.object(
+        templates, "TemplateResponse", side_effect=templates.TemplateResponse
+    ) as render:
+        response = await client.get(path)
+    assert response.status_code == 200
+    if path == "/api/user/me":
+        account = api_services[0].call_args.args[0]
+        assert response.json()["github_username"] == "renamed-user"
+        assert response.json()["display_name"] == "Current Profile"
+    else:
+        account = app.state.page_context.call_args.kwargs["user"]
+        request, _, context = render.call_args.args
+        assert context["user"] is account
+        assert request.state.user_id == account.id
+        assert request.state.github_username == account.github_username
+        assert "renamed-user" in response.text
+    assert account.id == 42
+    assert account.github_username == "renamed-user"
+    assert account.display_name == "Current Profile"
+    assert inspect(account).detached
+    assert not inspect(account).unloaded
 
 
 async def test_authenticated_api_delete_keeps_204_contract(

--- a/api/tests/routes/test_auth_http.py
+++ b/api/tests/routes/test_auth_http.py
@@ -421,6 +421,45 @@ async def test_logout_expires_cookie_and_is_repeatable(client, github, cookie_ki
     github.authorize_redirect.assert_not_awaited()
 
 
+@pytest.mark.parametrize(
+    "path", ["/", "/curriculum", "/account", "/faq", "/privacy", "/terms"]
+)
+@pytest.mark.parametrize("session_state", ["anonymous", "valid", "revoked"])
+async def test_pages_resolve_identity_without_route_database(
+    app, client, auth_cookie, path, session_state
+):
+    def unexpected_database():
+        raise AssertionError("This page should not request a route database session")
+
+    app.dependency_overrides[get_db] = unexpected_database
+    if session_state != "anonymous":
+        client.cookies.set(
+            AUTH_COOKIE_NAME, auth_cookie, domain="testserver.local", path="/"
+        )
+        if session_state == "revoked":
+            logout = await client.post("/auth/logout")
+            assert logout.status_code == 303
+            client.cookies.set(
+                AUTH_COOKIE_NAME, auth_cookie, domain="testserver.local", path="/"
+            )
+
+    response = await client.get(path)
+    if path == "/account" and session_state != "valid":
+        assert response.status_code == 303
+        assert response.headers["location"] == "/auth/login"
+        app.state.page_user.assert_not_called()
+    else:
+        assert response.status_code == 200
+        app.state.page_user.assert_called_once()
+        request = app.state.page_user.call_args.args[0]
+        user = get_request_user(request)
+        if session_state == "valid":
+            assert user is not None
+            assert user.id == 42
+        else:
+            assert user is None
+
+
 @pytest.mark.parametrize("path", ["/api/user/me", "/account"])
 async def test_persisted_session_authenticates_real_routes(client, auth_cookie, path):
     client.cookies.set(

--- a/api/tests/routes/test_auth_http.py
+++ b/api/tests/routes/test_auth_http.py
@@ -181,6 +181,18 @@ async def app(test_settings, test_engine, user, api_services, github):
     app.dependency_overrides[get_db] = database
     with (
         patch(
+            "learn_to_cloud.core.auth.get_web_settings",
+            return_value=test_settings,
+        ),
+        patch(
+            "learn_to_cloud.core.session_cookies.get_web_settings",
+            return_value=test_settings,
+        ),
+        patch(
+            "learn_to_cloud.services.sessions_service.get_web_settings",
+            return_value=test_settings,
+        ),
+        patch(
             "learn_to_cloud.routes.auth_routes.get_web_settings",
             return_value=test_settings,
         ),

--- a/api/tests/routes/test_auth_http.py
+++ b/api/tests/routes/test_auth_http.py
@@ -6,7 +6,7 @@ from base64 import b64decode, b64encode
 from datetime import UTC, datetime
 from http.cookies import SimpleCookie
 from time import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import httpx2
 import pytest
@@ -30,19 +30,25 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import SpanKind, StatusCode
 from sqlalchemy import text
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import async_sessionmaker
 from starlette.middleware.sessions import SessionMiddleware
 
-from learn_to_cloud.core.auth import SESSION_COOKIE_NAME, CurrentUser
+from learn_to_cloud.core.auth import SESSION_COOKIE_NAME, CurrentUser, get_request_user
 from learn_to_cloud.core.middleware import TelemetrySanitizationMiddleware
 from learn_to_cloud.core.routing import LoginRedirectRoute
+from learn_to_cloud.core.session_cookies import (
+    AUTH_COOKIE_NAME,
+    SessionResponseMiddleware,
+)
 from learn_to_cloud.routes import (
     auth_router,
     htmx_router,
     pages_router,
     users_router,
 )
+from learn_to_cloud.services.sessions_service import issue_session, mutate_account
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.integration
 
 _SECRET = "auth-http-test-only-secret"
 _PAGE_PATHS = [
@@ -79,6 +85,10 @@ _INVALID_IDENTITIES = (
         )
     ]
     + [
+        pytest.param(
+            {"user_id": 42, "github_username": "testuser"},
+            id="complete-legacy-identity",
+        ),
         pytest.param({"user_id": 42}, id="missing-name"),
         pytest.param({"github_username": "private-name"}, id="missing-id"),
     ]
@@ -108,13 +118,14 @@ def user():
 def api_services(user):
     with (
         patch(
-            "learn_to_cloud.routes.users_routes.get_user_by_id",
+            "learn_to_cloud.routes.users_routes.get_request_user",
             autospec=True,
-            return_value=user,
+            side_effect=get_request_user,
         ) as get_user,
         patch(
-            "learn_to_cloud.routes.users_routes.delete_user_account",
+            "learn_to_cloud.routes.users_routes.mutate_account",
             autospec=True,
+            side_effect=mutate_account,
         ) as delete_user,
     ):
         yield get_user, delete_user
@@ -131,9 +142,13 @@ def github():
 
 
 @pytest.fixture
-def app(test_settings, user, api_services, github):
+async def app(test_settings, test_engine, user, api_services, github):
     app = FastAPI()
+    app.state.session_maker = async_sessionmaker(test_engine, expire_on_commit=False)
+    async with app.state.session_maker() as db, db.begin():
+        db.add(user)
     app.add_middleware(TelemetrySanitizationMiddleware)
+    app.add_middleware(SessionResponseMiddleware)
     app.add_middleware(
         SessionMiddleware,
         secret_key=_SECRET,
@@ -170,9 +185,9 @@ def app(test_settings, user, api_services, github):
             return_value=test_settings,
         ),
         patch(
-            "learn_to_cloud.routes.pages_routes.get_user_by_id",
+            "learn_to_cloud.routes.pages_routes.get_request_user",
             autospec=True,
-            return_value=user,
+            side_effect=get_request_user,
         ) as page_user,
         patch(
             "learn_to_cloud.routes.pages_routes.get_curriculum_overview",
@@ -181,6 +196,13 @@ def app(test_settings, user, api_services, github):
     ):
         app.state.page_user = page_user
         yield app
+
+
+@pytest.fixture
+async def auth_cookie(app, test_settings):
+    async with app.state.session_maker() as db, db.begin():
+        issued = await issue_session(db, test_settings.session, 42)
+    return issued.token
 
 
 @pytest.fixture
@@ -249,7 +271,7 @@ async def test_api_auth_failure(client, api_services, method, accept, htmx):
     assert "location" not in response.headers
     assert response.history == []
     for service in api_services:
-        service.assert_not_awaited()
+        service.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -374,7 +396,8 @@ async def test_logout_expires_cookie_and_is_repeatable(client, github, cookie_ki
         cookies = logout.headers.get_list("set-cookie")
         assert cookies
         for header in cookies:
-            expired = SimpleCookie(header)[SESSION_COOKIE_NAME]
+            parsed = SimpleCookie(header)
+            expired = next(iter(parsed.values()))
             assert expired["path"] == "/"
             assert expired["httponly"]
             assert expired["samesite"] == "lax"
@@ -387,10 +410,10 @@ async def test_logout_expires_cookie_and_is_repeatable(client, github, cookie_ki
 
 
 @pytest.mark.parametrize("path", ["/api/user/me", "/account"])
-async def test_signed_session_authenticates_real_routes(client, path):
+async def test_persisted_session_authenticates_real_routes(client, auth_cookie, path):
     client.cookies.set(
-        SESSION_COOKIE_NAME,
-        _session_cookie({"user_id": 42, "github_username": "testuser"}),
+        AUTH_COOKIE_NAME,
+        auth_cookie,
         domain="testserver.local",
         path="/",
     )
@@ -403,10 +426,12 @@ async def test_signed_session_authenticates_real_routes(client, path):
         assert "testuser" in response.text
 
 
-async def test_authenticated_api_delete_keeps_204_contract(client, api_services):
+async def test_authenticated_api_delete_keeps_204_contract(
+    client, api_services, auth_cookie
+):
     client.cookies.set(
-        SESSION_COOKIE_NAME,
-        _session_cookie({"user_id": 42, "github_username": "testuser"}),
+        AUTH_COOKIE_NAME,
+        auth_cookie,
         domain="testserver.local",
         path="/",
     )
@@ -435,6 +460,7 @@ async def test_authenticated_api_delete_keeps_204_contract(client, api_services)
 async def test_malformed_identity_is_cleaned_over_http(
     client, app, api_services, caplog, identity, preserve_oauth, path, htmx, status
 ):
+    caplog.set_level(logging.INFO)
     unrelated = (
         {"_state_github_probe": {"data": {"state": "private-oauth-state"}}}
         if preserve_oauth
@@ -464,18 +490,17 @@ async def test_malformed_identity_is_cleaned_over_http(
         expired = SimpleCookie(response.headers["set-cookie"])[SESSION_COOKIE_NAME]
         assert "1970" in expired["expires"]
     for service in api_services:
-        service.assert_not_awaited()
-    app.state.page_user.assert_not_awaited()
+        service.assert_not_called()
 
     again = await client.get(path, headers=headers)
     assert again.status_code == status
     assert "set-cookie" not in again.headers
     (record,) = [r for r in caplog.records if r.name == "learn_to_cloud.core.auth"]
-    assert record.getMessage() == "auth.session.identity_rejected"
+    assert record.getMessage() == "auth.session.rejected"
     assert record.args == ()
     assert record.exc_info is None
     assert set(key for key in record.__dict__ if key.startswith("auth.")) == {
-        "auth.identity.reason"
+        "auth.session.reason"
     }
 
 
@@ -483,7 +508,9 @@ async def test_malformed_identity_is_cleaned_over_http(
     "kind", ["missing", "valid", "expired", "tampered", "oauth-only"]
 )
 @pytest.mark.parametrize("path", ["/", "/curriculum", "/api/user/me", "/account"])
-async def test_session_cookie_lifecycle_on_real_routes(client, caplog, kind, path):
+async def test_session_cookie_lifecycle_on_real_routes(
+    client, caplog, auth_cookie, kind, path
+):
     if kind != "missing":
         session = (
             {"_state_github_probe": {"data": {"state": "private-state"}}}
@@ -497,6 +524,11 @@ async def test_session_cookie_lifecycle_on_real_routes(client, caplog, kind, pat
         client.cookies.set(
             SESSION_COOKIE_NAME, cookie, domain="testserver.local", path="/"
         )
+        if kind == "valid":
+            client.cookies.clear()
+            client.cookies.set(
+                AUTH_COOKIE_NAME, auth_cookie, domain="testserver.local", path="/"
+            )
     response = await client.get(path)
     status = 200
     if kind != "valid" and path == "/api/user/me":
@@ -509,12 +541,11 @@ async def test_session_cookie_lifecycle_on_real_routes(client, caplog, kind, pat
 
 
 @pytest.fixture
-def oauth_callback(app, github, user):
-    database = AsyncMock()
-    context = AsyncMock()
-    context.__aenter__.return_value = database
-    context.__aexit__.return_value = False
-    app.state.session_maker = MagicMock(return_value=context)
+async def oauth_callback(app, github, user):
+    maker = app.state.session_maker
+    database = maker()
+    database.commit = AsyncMock(wraps=database.commit)
+    app.state.session_maker = lambda: database
     github.authorize_access_token = AsyncMock(
         return_value={"access_token": "private-oauth-token"}
     )
@@ -531,11 +562,18 @@ def oauth_callback(app, github, user):
         return_value=user,
     ) as upsert:
         yield database, upsert
+    app.state.session_maker = maker
+    await database.close()
 
 
 async def test_oauth_issued_cookie_authenticates_next_request(client, oauth_callback):
     database, upsert = oauth_callback
-    unrelated = {"_state_github_other": {"data": {"state": "private-other-state"}}}
+    unrelated = {
+        "_state_github_other": {
+            "data": {"state": "private-other-state"},
+            "exp": time() + 600,
+        }
+    }
     client.cookies.set(
         SESSION_COOKIE_NAME,
         _session_cookie(unrelated),
@@ -547,10 +585,11 @@ async def test_oauth_issued_cookie_authenticates_next_request(client, oauth_call
     assert response.headers["location"] == "/dashboard"
     cookie = client.cookies.get(SESSION_COOKIE_NAME)
     identity = json.loads(b64decode(TimestampSigner(_SECRET).unsign(cookie)))
-    assert identity == {**unrelated, "user_id": 42, "github_username": "testuser"}
+    assert identity == unrelated
+    assert len(client.cookies.get(AUTH_COOKIE_NAME)) == 43
     database.commit.assert_awaited_once()
-    assert upsert.call_args.kwargs["github_id"] == identity["user_id"]
-    assert upsert.call_args.kwargs["github_username"] == identity["github_username"]
+    assert upsert.call_args.kwargs["github_id"] == 42
+    assert upsert.call_args.kwargs["github_username"] == "testuser"
     authenticated = await client.get("/api/user/me")
     assert authenticated.status_code == 200
     assert authenticated.json()["id"] == 42
@@ -607,11 +646,15 @@ async def test_callback_profile_and_session_contract(
     app.add_exception_handler(Exception, global_exception_handler)
     _, exporter = telemetry_client
     caplog.set_level(logging.INFO)
-    database = AsyncMock()
-    context = AsyncMock()
-    context.__aenter__.return_value = database
-    context.__aexit__.return_value = False
-    app.state.session_maker = MagicMock(return_value=context)
+    maker = app.state.session_maker
+    async with maker() as setup, setup.begin():
+        await setup.execute(
+            text("UPDATE users SET display_name = :name WHERE id = 42"),
+            {"name": expected},
+        )
+    database = maker()
+    database.commit = AsyncMock(wraps=database.commit)
+    app.state.session_maker = lambda: database
     github.authorize_access_token = AsyncMock(
         return_value={"access_token": "private-token"}
     )
@@ -658,11 +701,10 @@ async def test_callback_profile_and_session_contract(
                 assert response.status_code == 302
                 assert response.headers["location"] == "/dashboard"
                 database.commit.assert_awaited_once()
-                cookie = client.cookies.get(SESSION_COOKIE_NAME)
+                cookie = client.cookies.get(AUTH_COOKIE_NAME)
                 assert cookie is not None
-                payload = json.loads(b64decode(TimestampSigner(_SECRET).unsign(cookie)))
-                assert payload == {"user_id": 42, "github_username": "testuser"}
-                assert "Profile-Sentinel" not in repr(payload)
+                assert len(cookie) == 43
+                assert "Profile-Sentinel" not in cookie
                 me = await client.get("/api/user/me")
                 assert me.status_code == 200
                 assert me.json() == {
@@ -817,7 +859,7 @@ async def test_callback_postgres_failure_rolls_back_without_issuing_session(
                 for span in spans
                 if span.kind == SpanKind.CLIENT and span.name.startswith("INSERT")
             ]
-            assert len(writes) == 1
+            assert len(writes) == (1 if failure == "upsert" else 2)
             assert writes[0].status.status_code == (
                 StatusCode.ERROR if failure == "upsert" else StatusCode.UNSET
             )
@@ -868,6 +910,7 @@ async def test_profile_openapi_has_only_new_name_field(client):
 async def test_malformed_identity_telemetry_has_no_private_values(
     telemetry_client, caplog, path, htmx, status
 ):
+    caplog.set_level(logging.INFO)
     client, exporter = telemetry_client
     cookie = _session_cookie(
         {"user_id": "private-user-id", "github_username": "private-username"}
@@ -933,13 +976,13 @@ async def test_malformed_identity_telemetry_has_no_private_values(
     ],
 )
 async def test_auth_request_telemetry_is_bounded_and_has_no_exception_events(
-    telemetry_client, method, path, htmx, authenticated, status, route
+    telemetry_client, auth_cookie, method, path, htmx, authenticated, status, route
 ):
     client, exporter = telemetry_client
-    cookie = _session_cookie({"user_id": 42, "github_username": "testuser"})
+    cookie = auth_cookie
     if authenticated:
         client.cookies.set(
-            SESSION_COOKIE_NAME, cookie, domain="testserver.local", path="/"
+            AUTH_COOKIE_NAME, cookie, domain="testserver.local", path="/"
         )
 
     response = await client.request(

--- a/api/tests/routes/test_auth_routes.py
+++ b/api/tests/routes/test_auth_routes.py
@@ -14,7 +14,8 @@ These are unit tests: no HTTP client, no real OAuth, no database.
 """
 
 import json
-from http.cookies import SimpleCookie
+from datetime import UTC, datetime, timedelta
+from time import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,14 +24,16 @@ import pytest
 from authlib.integrations.starlette_client import OAuthError
 from fastapi.responses import RedirectResponse
 
-from learn_to_cloud.core.auth import SESSION_COOKIE_NAME
+from learn_to_cloud.core.session_cookies import AUTH_COOKIE_NAME
 from learn_to_cloud.routes.auth_routes import callback, login, logout
+from learn_to_cloud.services.sessions_service import IssuedSession
 
 
 def _mock_request(*, session: dict | None = None) -> MagicMock:
     """Build a minimal mock Request with session support."""
     request = MagicMock()
     request.session = session if session is not None else {}
+    request.cookies = {}
     request.url_for.return_value = "http://testserver/auth/callback"
 
     # session_maker context manager used by callback() for scoped DB access
@@ -43,6 +46,16 @@ def _mock_request(*, session: dict | None = None) -> MagicMock:
     request._mock_db_session = mock_session  # exposed for test assertions
 
     return request
+
+
+@pytest.fixture(autouse=True)
+def session_issuance():
+    with patch(
+        "learn_to_cloud.routes.auth_routes.issue_session",
+        autospec=True,
+        return_value=IssuedSession("a" * 43, datetime.now(UTC) + timedelta(days=30), 0),
+    ) as issue:
+        yield issue
 
 
 @pytest.mark.unit
@@ -160,9 +173,8 @@ class TestCallbackRoute:
 
             result = await callback(request)
 
-        # Session should be populated
-        assert request.session["user_id"] == 12345
-        assert request.session["github_username"] == "testuser"
+        assert request.session == {}
+        assert AUTH_COOKIE_NAME in result.headers["set-cookie"]
 
         # Should redirect to /dashboard
         assert isinstance(result, RedirectResponse)
@@ -319,9 +331,10 @@ class TestCallbackRoute:
 def callback_context():
     request = _mock_request(
         session={
-            "user_id": 99,
-            "github_username": "existing-user",
-            "_state_github_other": {"data": {"state": "private-state"}},
+            "_state_github_other": {
+                "data": {"state": "private-state"},
+                "exp": time() + 600,
+            },
         }
     )
     github = MagicMock()
@@ -492,11 +505,8 @@ class TestCallbackIdentityContract:
         with caplog.at_level("INFO", logger="learn_to_cloud.routes.auth_routes"):
             response = await callback(request)
         assert response.status_code == 302
-        assert request.session == {
-            **original,
-            "user_id": 42,
-            "github_username": "testuser",
-        }
+        assert request.session == original
+        assert AUTH_COOKIE_NAME in response.headers["set-cookie"]
         request._mock_db_session.commit.assert_awaited_once()
         assert [r.getMessage() for r in caplog.records] == ["auth.login.success"]
 
@@ -523,9 +533,5 @@ class TestLogoutRoute:
         assert result.status_code == 303
         assert result.headers["location"] == "/"
         assert request.session == {}
-        cookie = SimpleCookie(result.headers["set-cookie"])[SESSION_COOKIE_NAME]
-        assert cookie["max-age"] == "0"
-        assert cookie["path"] == "/"
-        assert cookie["httponly"]
-        assert cookie["samesite"] == "lax"
-        assert bool(cookie["secure"]) is secure
+        assert request.state.clear_auth_cookie is True
+        assert request.state.clear_oauth_cookie is True

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -109,9 +109,9 @@ class TestHtmxCompleteStep:
             ) as mock_complete,
             patch(
                 "learn_to_cloud.routes.htmx_routes.render_step_toggle",
-                new_callable=AsyncMock,
+                autospec=True,
                 return_value=HTMLResponse("<html>mock</html>"),
-            ),
+            ) as mock_render,
         ):
             result = await htmx_complete_step(
                 request,
@@ -121,6 +121,7 @@ class TestHtmxCompleteStep:
             )
 
         mock_complete.assert_awaited_once_with(mock_db, 1, step_uuid)
+        mock_render.assert_called_once_with(request, mock_topic, mock_step, {step_uuid})
         assert isinstance(result, HTMLResponse)
 
     async def test_complete_step_returns_hx_refresh_on_validation_error(self):
@@ -167,9 +168,9 @@ class TestHtmxUncompleteStep:
             ) as mock_uncomplete,
             patch(
                 "learn_to_cloud.routes.htmx_routes.render_step_toggle",
-                new_callable=AsyncMock,
+                autospec=True,
                 return_value=HTMLResponse("<html>mock</html>"),
-            ),
+            ) as mock_render,
         ):
             result = await htmx_uncomplete_step(
                 request,
@@ -179,6 +180,7 @@ class TestHtmxUncompleteStep:
             )
 
         mock_uncomplete.assert_awaited_once_with(mock_db, 1, step_uuid)
+        mock_render.assert_called_once_with(request, mock_topic, mock_step, set())
         assert isinstance(result, HTMLResponse)
 
     async def test_uncomplete_step_returns_hx_refresh_on_validation_error(self):

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi.responses import HTMLResponse
+from learn_to_cloud_shared.models import User
 from learn_to_cloud_shared.submission_values import (
     GitHubUrlValue,
     TextValue,
@@ -100,6 +101,7 @@ class TestHtmxCompleteStep:
         mock_step.uuid = step_uuid
         mock_step.slug = "step-1"
         mock_topic.learning_steps = [mock_step]
+        account = User(id=1, github_username="user")
 
         with (
             patch(
@@ -116,12 +118,14 @@ class TestHtmxCompleteStep:
             result = await htmx_complete_step(
                 request,
                 mock_db,
-                current_user=AuthenticatedUser(user_id=1, github_username="user"),
+                account=account,
                 step_uuid=step_uuid,
             )
 
         mock_complete.assert_awaited_once_with(mock_db, 1, step_uuid)
-        mock_render.assert_called_once_with(request, mock_topic, mock_step, {step_uuid})
+        mock_render.assert_called_once_with(
+            request, account, mock_topic, mock_step, {step_uuid}
+        )
         assert isinstance(result, HTMLResponse)
 
     async def test_complete_step_returns_hx_refresh_on_validation_error(self):
@@ -138,7 +142,7 @@ class TestHtmxCompleteStep:
             result = await htmx_complete_step(
                 request,
                 mock_db,
-                current_user=AuthenticatedUser(user_id=1, github_username="user"),
+                account=User(id=1, github_username="user"),
                 step_uuid=step_uuid,
             )
 
@@ -159,6 +163,7 @@ class TestHtmxUncompleteStep:
         mock_step.uuid = step_uuid
         mock_step.slug = "step-1"
         mock_topic.learning_steps = [mock_step]
+        account = User(id=1, github_username="user")
 
         with (
             patch(
@@ -176,11 +181,13 @@ class TestHtmxUncompleteStep:
                 request,
                 step_uuid,
                 mock_db,
-                current_user=AuthenticatedUser(user_id=1, github_username="user"),
+                account=account,
             )
 
         mock_uncomplete.assert_awaited_once_with(mock_db, 1, step_uuid)
-        mock_render.assert_called_once_with(request, mock_topic, mock_step, set())
+        mock_render.assert_called_once_with(
+            request, account, mock_topic, mock_step, set()
+        )
         assert isinstance(result, HTMLResponse)
 
     async def test_uncomplete_step_returns_hx_refresh_on_validation_error(self):
@@ -198,7 +205,7 @@ class TestHtmxUncompleteStep:
                 request,
                 step_uuid,
                 mock_db,
-                current_user=AuthenticatedUser(user_id=1, github_username="user"),
+                account=User(id=1, github_username="user"),
             )
 
         assert result.headers.get("HX-Refresh") == "true"

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -27,7 +27,7 @@ from learn_to_cloud_shared.submission_values import (
 from sqlalchemy.exc import SQLAlchemyError
 from starlette.datastructures import FormData, UploadFile
 
-from learn_to_cloud.core.auth import AuthenticatedUser
+from learn_to_cloud.core.auth import AuthenticatedUser, AuthenticationRequired
 from learn_to_cloud.rendering.context import UnavailableCardContext
 from learn_to_cloud.routes.htmx_routes import (
     _submit_canonical_verification,
@@ -49,7 +49,6 @@ from learn_to_cloud.services.steps_service import StepValidationError
 from learn_to_cloud.services.submissions_service import (
     VerificationAttemptSubmission,
 )
-from learn_to_cloud.services.users_service import UserNotFoundError
 from learn_to_cloud.services.verification_status_tokens import VerificationStatusToken
 from learn_to_cloud.verification_forms import combine_reflection_answers
 
@@ -1234,33 +1233,31 @@ class TestHtmxDeleteAccount:
     async def test_delete_account_clears_session_and_redirects(self):
         """Successful deletion clears session and sets HX-Redirect."""
         request = _mock_request(session={"user_id": 42, "github_username": "testuser"})
-        mock_db = AsyncMock()
-
         with patch(
-            "learn_to_cloud.routes.htmx_routes.delete_user_account", autospec=True
-        ):
+            "learn_to_cloud.routes.htmx_routes.mutate_account", autospec=True
+        ) as mutate:
             result = await htmx_delete_account(
-                request, mock_db, current_user=AuthenticatedUser(42, "testuser")
+                request, current_user=AuthenticatedUser(42, "testuser")
             )
 
         assert result.headers.get("HX-Redirect") == "/"
-        assert request.session == {}
+        mutate.assert_awaited_once_with(request, 42, delete_account=True)
 
-    async def test_delete_account_returns_404_for_missing_user(self):
-        """UserNotFoundError returns 404 HTML."""
+    async def test_delete_account_rechecks_authorization(self):
+        """Deletion recheck failures stay unauthorized."""
         request = _mock_request(session={"user_id": 999})
-        mock_db = AsyncMock()
 
-        with patch(
-            "learn_to_cloud.routes.htmx_routes.delete_user_account",
-            autospec=True,
-            side_effect=UserNotFoundError(999),
+        with (
+            patch(
+                "learn_to_cloud.routes.htmx_routes.mutate_account",
+                autospec=True,
+                side_effect=AuthenticationRequired(),
+            ),
+            pytest.raises(AuthenticationRequired),
         ):
-            result = await htmx_delete_account(
-                request, mock_db, current_user=AuthenticatedUser(999, "testuser")
+            await htmx_delete_account(
+                request, current_user=AuthenticatedUser(999, "testuser")
             )
-
-        assert result.status_code == 404
 
 
 class TestCombineReflectionAnswers:

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -86,7 +86,6 @@ class TestHomePage:
     async def test_home_renders_for_anonymous_user(self, _patch_templates):
         """Anonymous users see the home page with phases."""
         request, template = _mock_request(_patch_templates)
-        mock_db = AsyncMock()
         phases = [_fake_phase(order=i) for i in range(1, 6)]
 
         with (
@@ -100,7 +99,7 @@ class TestHomePage:
                 return_value=None,
             ),
         ):
-            await home_page(request, mock_db, current_user=None)
+            await home_page(request, current_user=None)
 
         template.assert_called_once()
         ctx = template.call_args[0][2]
@@ -112,7 +111,6 @@ class TestHomePage:
     async def test_home_renders_for_authenticated_user(self, _patch_templates):
         """Authenticated users see their user object in context."""
         request, template = _mock_request(_patch_templates)
-        mock_db = AsyncMock()
         mock_user = MagicMock()
         phases = [_fake_phase()]
 
@@ -127,9 +125,7 @@ class TestHomePage:
                 return_value=mock_user,
             ),
         ):
-            await home_page(
-                request, mock_db, current_user=AuthenticatedUser(42, "testuser")
-            )
+            await home_page(request, current_user=AuthenticatedUser(42, "testuser"))
 
         ctx = template.call_args[0][2]
         assert ctx["user"] is mock_user
@@ -142,7 +138,6 @@ class TestCurriculumPage:
     async def test_curriculum_renders_with_phases(self, _patch_templates):
         """Curriculum page passes all phases to template."""
         request, template = _mock_request(_patch_templates)
-        mock_db = AsyncMock()
         phases = [_fake_phase(order=i) for i in range(1, 6)]
 
         with (
@@ -156,7 +151,7 @@ class TestCurriculumPage:
                 return_value=None,
             ),
         ):
-            await curriculum_page(request, mock_db, current_user=None)
+            await curriculum_page(request, current_user=None)
 
         assert template.call_args[0][1] == "pages/curriculum.html"
         ctx = template.call_args[0][2]
@@ -519,7 +514,6 @@ class TestAccountPage:
     async def test_account_renders_for_user(self, _patch_templates):
         """Account page renders with user context."""
         request, template = _mock_request(_patch_templates)
-        mock_db = AsyncMock()
         mock_user = MagicMock()
 
         with patch(
@@ -527,9 +521,7 @@ class TestAccountPage:
             autospec=True,
             return_value=mock_user,
         ):
-            await account_page(
-                request, mock_db, current_user=AuthenticatedUser(42, "testuser")
-            )
+            await account_page(request, current_user=AuthenticatedUser(42, "testuser"))
 
         assert template.call_args[0][1] == "pages/account.html"
         ctx = template.call_args[0][2]
@@ -538,16 +530,13 @@ class TestAccountPage:
     async def test_account_returns_404_when_user_not_found(self, _patch_templates):
         """Account returns 404 if user doesn't exist."""
         request, template = _mock_request(_patch_templates)
-        mock_db = AsyncMock()
 
         with patch(
             "learn_to_cloud.routes.pages_routes.get_request_user",
             autospec=True,
             return_value=None,
         ):
-            await account_page(
-                request, mock_db, current_user=AuthenticatedUser(999, "testuser")
-            )
+            await account_page(request, current_user=AuthenticatedUser(999, "testuser"))
 
         assert template.call_args[0][1] == "pages/404.html"
 
@@ -567,14 +556,13 @@ class TestPublicPages:
     )
     async def test_public_page_renders(self, _patch_templates, handler, template_name):
         request, template = _mock_request(_patch_templates)
-        mock_db = AsyncMock()
 
         with patch(
             "learn_to_cloud.routes.pages_routes.get_request_user",
             autospec=True,
             return_value=None,
         ):
-            await handler(request, mock_db, current_user=None)
+            await handler(request, current_user=None)
 
         assert template.call_args[0][1] == template_name
 

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -95,7 +95,7 @@ class TestHomePage:
                 return_value=phases,
             ),
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=None,
             ),
@@ -122,7 +122,7 @@ class TestHomePage:
                 return_value=phases,
             ),
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=mock_user,
             ),
@@ -151,7 +151,7 @@ class TestCurriculumPage:
                 return_value=phases,
             ),
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=None,
             ),
@@ -178,7 +178,7 @@ class TestPhasePage:
                 return_value=None,
             ),
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=None,
             ),
@@ -208,7 +208,7 @@ class TestPhasePage:
                 return_value=phase,
             ),
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=mock_user,
             ),
@@ -248,7 +248,7 @@ class TestVerificationsPage:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=mock_user,
             ),
@@ -271,7 +271,7 @@ class TestVerificationsPage:
         request, template = _mock_request(_patch_templates)
 
         with patch(
-            "learn_to_cloud.routes.pages_routes.get_user_by_id",
+            "learn_to_cloud.routes.pages_routes.get_request_user",
             autospec=True,
             return_value=None,
         ):
@@ -291,7 +291,7 @@ class TestPhaseVerificationPage:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=MagicMock(),
             ),
@@ -326,7 +326,7 @@ class TestPhaseVerificationPage:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=mock_user,
             ),
@@ -377,7 +377,7 @@ class TestTopicPage:
                 return_value=None,
             ),
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=None,
             ),
@@ -405,7 +405,7 @@ class TestTopicPage:
                 return_value=phase,
             ),
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=None,
             ),
@@ -434,7 +434,7 @@ class TestTopicPage:
                 return_value=phase,
             ),
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=MagicMock(),
             ),
@@ -474,7 +474,7 @@ class TestDashboardPage:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=mock_user,
             ),
@@ -499,7 +499,7 @@ class TestDashboardPage:
         mock_db = AsyncMock()
 
         with patch(
-            "learn_to_cloud.routes.pages_routes.get_user_by_id",
+            "learn_to_cloud.routes.pages_routes.get_request_user",
             autospec=True,
             return_value=None,
         ):
@@ -523,7 +523,7 @@ class TestAccountPage:
         mock_user = MagicMock()
 
         with patch(
-            "learn_to_cloud.routes.pages_routes.get_user_by_id",
+            "learn_to_cloud.routes.pages_routes.get_request_user",
             autospec=True,
             return_value=mock_user,
         ):
@@ -541,7 +541,7 @@ class TestAccountPage:
         mock_db = AsyncMock()
 
         with patch(
-            "learn_to_cloud.routes.pages_routes.get_user_by_id",
+            "learn_to_cloud.routes.pages_routes.get_request_user",
             autospec=True,
             return_value=None,
         ):
@@ -570,7 +570,7 @@ class TestPublicPages:
         mock_db = AsyncMock()
 
         with patch(
-            "learn_to_cloud.routes.pages_routes.get_user_by_id",
+            "learn_to_cloud.routes.pages_routes.get_request_user",
             autospec=True,
             return_value=None,
         ):
@@ -590,7 +590,7 @@ class TestCommunityPage:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 autospec=True,
                 return_value=None,
             ),

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -25,8 +25,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from learn_to_cloud_shared.models import User
 
-from learn_to_cloud.core.auth import AuthenticatedUser
 from learn_to_cloud.routes.pages_routes import (
     account_page,
     community_page,
@@ -93,13 +93,8 @@ class TestHomePage:
                 "learn_to_cloud.routes.pages_routes.get_curriculum_overview",
                 return_value=phases,
             ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=None,
-            ),
         ):
-            await home_page(request, current_user=None)
+            await home_page(request, account=None)
 
         template.assert_called_once()
         ctx = template.call_args[0][2]
@@ -111,7 +106,7 @@ class TestHomePage:
     async def test_home_renders_for_authenticated_user(self, _patch_templates):
         """Authenticated users see their user object in context."""
         request, template = _mock_request(_patch_templates)
-        mock_user = MagicMock()
+        mock_user = User(id=42, github_username="testuser")
         phases = [_fake_phase()]
 
         with (
@@ -119,13 +114,8 @@ class TestHomePage:
                 "learn_to_cloud.routes.pages_routes.get_curriculum_overview",
                 return_value=phases,
             ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=mock_user,
-            ),
         ):
-            await home_page(request, current_user=AuthenticatedUser(42, "testuser"))
+            await home_page(request, account=mock_user)
 
         ctx = template.call_args[0][2]
         assert ctx["user"] is mock_user
@@ -145,13 +135,8 @@ class TestCurriculumPage:
                 "learn_to_cloud.routes.pages_routes.get_curriculum_overview",
                 return_value=phases,
             ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=None,
-            ),
         ):
-            await curriculum_page(request, current_user=None)
+            await curriculum_page(request, account=None)
 
         assert template.call_args[0][1] == "pages/curriculum.html"
         ctx = template.call_args[0][2]
@@ -172,17 +157,12 @@ class TestPhasePage:
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
                 return_value=None,
             ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=None,
-            ),
         ):
             await phase_page(
                 request,
                 phase_id=999,
                 db=mock_db,
-                current_user=AuthenticatedUser(1, "testuser"),
+                account=User(id=1, github_username="testuser"),
             )
 
         assert template.call_args[0][1] == "pages/404.html"
@@ -195,17 +175,12 @@ class TestPhasePage:
         request, template = _mock_request(_patch_templates)
         mock_db = AsyncMock()
         phase = _fake_phase()
-        mock_user = MagicMock()
+        mock_user = User(id=42, github_username="testuser")
 
         with (
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
                 return_value=phase,
-            ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=mock_user,
             ),
             patch(
                 "learn_to_cloud.routes.pages_routes.fetch_phase_progress",
@@ -221,7 +196,7 @@ class TestPhasePage:
                 request,
                 phase_id=1,
                 db=mock_db,
-                current_user=AuthenticatedUser(42, "testuser"),
+                account=mock_user,
             )
 
         assert template.call_args[0][1] == "pages/phase.html"
@@ -238,43 +213,22 @@ class TestVerificationsPage:
     async def test_verifications_renders_overview(self, _patch_templates):
         request, template = _mock_request(_patch_templates)
         mock_db = AsyncMock()
-        mock_user = MagicMock()
+        mock_user = User(id=42, github_username="testuser")
         mock_overview = MagicMock()
 
         with (
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=mock_user,
-            ),
             patch(
                 "learn_to_cloud.routes.pages_routes.get_verifications_overview",
                 autospec=True,
                 return_value=mock_overview,
             ),
         ):
-            await verifications_page(
-                request, mock_db, current_user=AuthenticatedUser(42, "testuser")
-            )
+            await verifications_page(request, mock_db, account=mock_user)
 
         assert template.call_args[0][1] == "pages/verifications.html"
         ctx = template.call_args[0][2]
         assert ctx["user"] is mock_user
         assert ctx["overview"] is mock_overview
-
-    async def test_verifications_returns_404_when_user_missing(self, _patch_templates):
-        request, template = _mock_request(_patch_templates)
-
-        with patch(
-            "learn_to_cloud.routes.pages_routes.get_request_user",
-            autospec=True,
-            return_value=None,
-        ):
-            await verifications_page(
-                request, AsyncMock(), current_user=AuthenticatedUser(999, "testuser")
-            )
-
-        assert template.call_args[0][1] == "pages/404.html"
 
 
 @pytest.mark.unit
@@ -286,11 +240,6 @@ class TestPhaseVerificationPage:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=MagicMock(),
-            ),
-            patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
                 return_value=None,
             ),
@@ -299,7 +248,7 @@ class TestPhaseVerificationPage:
                 request,
                 phase_id=999,
                 db=AsyncMock(),
-                current_user=AuthenticatedUser(42, "testuser"),
+                account=User(id=42, github_username="testuser"),
             )
 
         assert template.call_args[0][1] == "pages/404.html"
@@ -307,7 +256,7 @@ class TestPhaseVerificationPage:
     async def test_phase_verification_renders_workspace(self, _patch_templates):
         request, template = _mock_request(_patch_templates)
         mock_db = AsyncMock()
-        mock_user = MagicMock(github_username="learner")
+        mock_user = User(id=42, github_username="learner")
         phase = _fake_phase(order=4)
         workspace = MagicMock(
             phase=phase,
@@ -320,11 +269,6 @@ class TestPhaseVerificationPage:
         )
 
         with (
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=mock_user,
-            ),
             patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
                 return_value=phase,
@@ -339,7 +283,7 @@ class TestPhaseVerificationPage:
                 request,
                 phase_id=4,
                 db=mock_db,
-                current_user=AuthenticatedUser(42, "testuser"),
+                account=mock_user,
             )
 
         get_workspace.assert_awaited_once_with(
@@ -371,18 +315,13 @@ class TestTopicPage:
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
                 return_value=None,
             ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=None,
-            ),
         ):
             await topic_page(
                 request,
                 phase_id=1,
                 topic_slug="bad-topic",
                 db=mock_db,
-                current_user=AuthenticatedUser(1, "testuser"),
+                account=User(id=1, github_username="testuser"),
             )
 
         assert template.call_args[0][1] == "pages/404.html"
@@ -399,18 +338,13 @@ class TestTopicPage:
                 "learn_to_cloud.routes.pages_routes.get_phase_by_slug",
                 return_value=phase,
             ),
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=None,
-            ),
         ):
             await topic_page(
                 request,
                 phase_id=1,
                 topic_slug="bad-topic",
                 db=mock_db,
-                current_user=AuthenticatedUser(1, "testuser"),
+                account=User(id=1, github_username="testuser"),
             )
 
         assert template.call_args[0][1] == "pages/404.html"
@@ -429,11 +363,6 @@ class TestTopicPage:
                 return_value=phase,
             ),
             patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=MagicMock(),
-            ),
-            patch(
                 "learn_to_cloud.routes.pages_routes.get_valid_completed_steps",
                 autospec=True,
                 return_value=[],
@@ -448,7 +377,7 @@ class TestTopicPage:
                 phase_id=1,
                 topic_slug="linux-basics",
                 db=mock_db,
-                current_user=AuthenticatedUser(1, "testuser"),
+                account=User(id=1, github_username="testuser"),
             )
 
         assert template.call_args[0][1] == "pages/topic.html"
@@ -464,47 +393,22 @@ class TestDashboardPage:
         """Dashboard renders with user and dashboard data."""
         request, template = _mock_request(_patch_templates)
         mock_db = AsyncMock()
-        mock_user = MagicMock()
+        mock_user = User(id=42, github_username="testuser")
         mock_dashboard = MagicMock()
 
         with (
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=mock_user,
-            ),
             patch(
                 "learn_to_cloud.routes.pages_routes.get_dashboard_data",
                 autospec=True,
                 return_value=mock_dashboard,
             ),
         ):
-            await dashboard_page(
-                request, mock_db, current_user=AuthenticatedUser(42, "testuser")
-            )
+            await dashboard_page(request, mock_db, account=mock_user)
 
         assert template.call_args[0][1] == "pages/dashboard.html"
         ctx = template.call_args[0][2]
         assert ctx["user"] is mock_user
         assert ctx["dashboard"] is mock_dashboard
-
-    async def test_dashboard_returns_404_when_user_not_found(self, _patch_templates):
-        """Dashboard returns 404 if user_id doesn't match a DB user."""
-        request, template = _mock_request(_patch_templates)
-        mock_db = AsyncMock()
-
-        with patch(
-            "learn_to_cloud.routes.pages_routes.get_request_user",
-            autospec=True,
-            return_value=None,
-        ):
-            await dashboard_page(
-                request, mock_db, current_user=AuthenticatedUser(999, "testuser")
-            )
-
-        assert template.call_args[0][1] == "pages/404.html"
-        call_kwargs = template.call_args[1] if template.call_args[1] else {}
-        assert call_kwargs.get("status_code") == 404
 
 
 @pytest.mark.unit
@@ -514,31 +418,12 @@ class TestAccountPage:
     async def test_account_renders_for_user(self, _patch_templates):
         """Account page renders with user context."""
         request, template = _mock_request(_patch_templates)
-        mock_user = MagicMock()
-
-        with patch(
-            "learn_to_cloud.routes.pages_routes.get_request_user",
-            autospec=True,
-            return_value=mock_user,
-        ):
-            await account_page(request, current_user=AuthenticatedUser(42, "testuser"))
+        mock_user = User(id=42, github_username="testuser")
+        await account_page(request, account=mock_user)
 
         assert template.call_args[0][1] == "pages/account.html"
         ctx = template.call_args[0][2]
         assert ctx["user"] is mock_user
-
-    async def test_account_returns_404_when_user_not_found(self, _patch_templates):
-        """Account returns 404 if user doesn't exist."""
-        request, template = _mock_request(_patch_templates)
-
-        with patch(
-            "learn_to_cloud.routes.pages_routes.get_request_user",
-            autospec=True,
-            return_value=None,
-        ):
-            await account_page(request, current_user=AuthenticatedUser(999, "testuser"))
-
-        assert template.call_args[0][1] == "pages/404.html"
 
 
 @pytest.mark.unit
@@ -557,12 +442,7 @@ class TestPublicPages:
     async def test_public_page_renders(self, _patch_templates, handler, template_name):
         request, template = _mock_request(_patch_templates)
 
-        with patch(
-            "learn_to_cloud.routes.pages_routes.get_request_user",
-            autospec=True,
-            return_value=None,
-        ):
-            await handler(request, current_user=None)
+        await handler(request, account=None)
 
         assert template.call_args[0][1] == template_name
 
@@ -578,17 +458,12 @@ class TestCommunityPage:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                autospec=True,
-                return_value=None,
-            ),
-            patch(
                 "learn_to_cloud.routes.pages_routes.get_community_page_data",
                 autospec=True,
                 return_value=mock_community,
             ),
         ):
-            await community_page(request, mock_db, current_user=None)
+            await community_page(request, mock_db, account=None)
 
         assert template.call_args[0][1] == "pages/community.html"
         ctx = template.call_args[0][2]

--- a/api/tests/routes/test_session_failures.py
+++ b/api/tests/routes/test_session_failures.py
@@ -1,0 +1,168 @@
+"""Exported PostgreSQL failure telemetry and committed-cookie boundaries."""
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import httpx2
+import pytest
+from learn_to_cloud_shared.core.logger import _json_formatter
+from learn_to_cloud_shared.models import AuthSession, User
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.logging.handler import LoggingHandler
+from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import (
+    InMemoryLogRecordExporter,
+    SimpleLogRecordProcessor,
+)
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, StatusCode
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from learn_to_cloud.core.session_cookies import AUTH_COOKIE_NAME, token_digest
+from tests.routes.test_session_lifecycle import browser, build_app, csrf, mint
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.parametrize(
+    "operation", ["lookup", "create", "commit", "logout", "global", "delete"]
+)
+async def test_postgres_failure_telemetry_has_no_session_credentials(
+    test_engine,
+    test_settings,
+    caplog,
+    operation,
+):
+    engine = create_async_engine(test_settings.database.url, hide_parameters=True)
+    app = build_app(engine, test_settings)
+    async with app.state.session_maker() as db, db.begin():
+        db.add(User(id=42, github_username="private-session-username"))
+    token = await mint(app, test_settings)
+    digest = token_digest(token)
+    assert digest is not None
+    span_exporter = InMemorySpanExporter()
+    trace_provider = TracerProvider()
+    trace_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    log_exporter = InMemoryLogRecordExporter()
+    log_provider = LoggerProvider()
+    log_provider.add_log_record_processor(SimpleLogRecordProcessor(log_exporter))
+    handler = LoggingHandler(logger_provider=log_provider)
+    root = logging.getLogger()
+    root.addHandler(handler)
+    instrumentor = SQLAlchemyInstrumentor()
+    instrumentor.instrument(engine=engine.sync_engine, tracer_provider=trace_provider)
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=trace_provider)
+    caplog.set_level(logging.INFO)
+    github = AsyncMock()
+    github.authorize_access_token.return_value = {"access_token": "private-oauth-token"}
+    github.get.return_value = httpx2.Response(
+        200,
+        json={"id": 42, "login": "private-session-username"},
+        request=httpx2.Request("GET", "https://api.github.com/user"),
+    )
+    try:
+        async with browser(app, token, raise_errors=False) as client:
+            confirmation = await csrf(client)
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "CREATE FUNCTION reject_session_test() RETURNS trigger "
+                        "LANGUAGE plpgsql AS $$ BEGIN "
+                        "RAISE EXCEPTION 'Session store unavailable' "
+                        "USING ERRCODE = 'P0001'; "
+                        "END $$"
+                    )
+                )
+                if operation == "commit":
+                    trigger = (
+                        "CREATE CONSTRAINT TRIGGER reject_session_test "
+                        "AFTER INSERT ON auth_sessions DEFERRABLE INITIALLY DEFERRED "
+                        "FOR EACH ROW EXECUTE FUNCTION reject_session_test()"
+                    )
+                else:
+                    action = (
+                        "UPDATE"
+                        if operation == "lookup"
+                        else ("INSERT" if operation == "create" else "DELETE")
+                    )
+                    trigger = (
+                        f"CREATE TRIGGER reject_session_test BEFORE {action} "
+                        "ON auth_sessions "
+                        "FOR EACH ROW EXECUTE FUNCTION reject_session_test()"
+                    )
+                await conn.execute(text(trigger))
+            span_exporter.clear()
+            log_exporter.clear()
+            caplog.clear()
+            with patch("learn_to_cloud.routes.auth_routes.oauth") as oauth:
+                oauth.create_client.return_value = github
+                if operation == "lookup":
+                    response = await client.get("/api/user/me")
+                elif operation in ("create", "commit"):
+                    response = await client.get("/auth/callback")
+                elif operation == "logout":
+                    response = await client.post("/auth/logout")
+                elif operation == "global":
+                    response = await client.post(
+                        "/auth/logout-all", data={"csrf": confirmation}
+                    )
+                else:
+                    response = await client.delete("/api/user/me")
+            assert response.status_code == 500
+            assert "set-cookie" not in response.headers
+            assert "location" not in response.headers
+            assert client.cookies.get(AUTH_COOKIE_NAME) == token
+            assert not {
+                "auth.login.success",
+                "auth.session.revoked",
+                "user.account_deleted",
+            } & {r.getMessage() for r in caplog.records}
+            spans = span_exporter.get_finished_spans()
+            assert any(
+                span.kind == SpanKind.SERVER
+                and span.status.status_code == StatusCode.ERROR
+                for span in spans
+            )
+            assert any(span.kind == SpanKind.CLIENT for span in spans)
+            telemetry = "\n".join(
+                [span.to_json() for span in spans]
+                + [record.to_json() for record in log_exporter.get_finished_logs()]
+                + [_json_formatter().format(record) for record in caplog.records]
+            )
+            assert "unhandled.exception" in telemetry
+            for prohibited in (
+                token,
+                digest.hex(),
+                repr(digest),
+                confirmation,
+                "private-oauth-token",
+                "private-session-username",
+                test_settings.session.secret_key,
+            ):
+                assert prohibited not in telemetry
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text("DROP TRIGGER reject_session_test ON auth_sessions")
+                )
+                await conn.execute(text("DROP FUNCTION reject_session_test()"))
+            assert (await client.get("/api/user/me")).status_code == 200
+            async with app.state.session_maker() as db:
+                assert await db.get(AuthSession, digest) is not None
+                assert await db.get(User, 42) is not None
+    finally:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("DROP TRIGGER IF EXISTS reject_session_test ON auth_sessions")
+            )
+            await conn.execute(text("DROP FUNCTION IF EXISTS reject_session_test()"))
+        FastAPIInstrumentor.uninstrument_app(app)
+        instrumentor.uninstrument()
+        root.removeHandler(handler)
+        handler.close()
+        log_provider.shutdown()
+        trace_provider.shutdown()
+        await engine.dispose()

--- a/api/tests/routes/test_session_lifecycle.py
+++ b/api/tests/routes/test_session_lifecycle.py
@@ -27,12 +27,18 @@ from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     VerificationAttemptRepository,
 )
 from learn_to_cloud_shared.submission_values import GitHubUrlValue
-from sqlalchemy import event, func, select, update
+from sqlalchemy import event, func, inspect, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker
 from starlette.middleware.sessions import SessionMiddleware
 
-from learn_to_cloud.core.auth import CurrentUser, get_authenticated_user_from_session
+from learn_to_cloud.core.auth import (
+    CurrentAccount,
+    CurrentUser,
+    OptionalCurrentAccount,
+    OptionalCurrentUser,
+    optional_authenticated_account,
+)
 from learn_to_cloud.core.middleware import TelemetrySanitizationMiddleware
 from learn_to_cloud.core.session_cookies import (
     AUTH_COOKIE_NAME,
@@ -68,10 +74,62 @@ def build_app(engine, settings):
         return {"ok": True}
 
     @app.get("/reuse")
-    async def reuse(request: Request, current_user: CurrentUser):
-        again = await get_authenticated_user_from_session(request)
-        assert again is current_user
-        return {"id": again.user_id}
+    async def reuse(
+        request: Request,
+        optional_account: OptionalCurrentAccount,
+        current_user: CurrentUser,
+        account: CurrentAccount,
+        optional_user: OptionalCurrentUser,
+    ):
+        again = await optional_authenticated_account(request)
+        assert again is account is optional_account
+        assert inspect(account).detached
+        assert not inspect(account).expired_attributes
+        assert not inspect(account).unloaded
+        assert optional_user == current_user
+        assert account.id == current_user.user_id == request.state.user_id
+        assert (
+            account.github_username
+            == current_user.github_username
+            == request.state.github_username
+        )
+        return {"id": account.id}
+
+    @app.get("/required-first")
+    def required_first(
+        request: Request,
+        account: CurrentAccount,
+        current_user: CurrentUser,
+        optional_account: OptionalCurrentAccount,
+        optional_user: OptionalCurrentUser,
+    ):
+        assert account is optional_account
+        assert current_user == optional_user
+        assert account.id == current_user.user_id == request.state.user_id
+        assert account.github_username == request.state.github_username
+        return {"id": account.id}
+
+    @app.get("/account-only")
+    def account_only(request: Request, account: CurrentAccount):
+        assert account.id == request.state.user_id
+        assert account.github_username == request.state.github_username
+        assert inspect(account).detached
+        return {"id": account.id}
+
+    @app.get("/optional-reuse")
+    def optional_reuse(
+        request: Request,
+        current_user: OptionalCurrentUser,
+        account: OptionalCurrentAccount,
+    ):
+        if account is None:
+            assert current_user is None
+            assert not hasattr(request.state, "user_id")
+            return {"id": None}
+        assert current_user is not None
+        assert account.id == current_user.user_id == request.state.user_id
+        assert account.github_username == request.state.github_username
+        return {"id": account.id}
 
     return app
 
@@ -278,6 +336,9 @@ async def test_touch_once_reuses_account_and_skips_static_health(
                 "/api/user/me",
                 "/account",
                 "/reuse",
+                "/required-first",
+                "/account-only",
+                "/optional-reuse",
                 "/",
                 "/curriculum",
                 "/phase/1",
@@ -297,6 +358,7 @@ async def test_touch_once_reuses_account_and_skips_static_health(
                     400 if path.startswith("/htmx/verification/attempts/") else 200
                 )
                 assert sum("UPDATE auth_sessions" in q for q in queries) == 1
+                assert sum(q.startswith("SELECT auth_sessions.") for q in queries) == 1
                 assert not any(q.startswith("SELECT users.") for q in queries)
                 assert "Cookie" in response.headers["vary"]
             topic = next(topic for topic in phase.topics if topic.learning_steps)
@@ -309,6 +371,7 @@ async def test_touch_once_reuses_account_and_skips_static_health(
                 response = await client.request(method, path, data=data)
                 assert response.status_code == 200
                 assert sum("UPDATE auth_sessions" in q for q in queries) == 1
+                assert sum(q.startswith("SELECT auth_sessions.") for q in queries) == 1
                 assert not any(q.startswith("SELECT users.") for q in queries)
     finally:
         event.remove(test_engine.sync_engine, "before_cursor_execute", record)
@@ -317,6 +380,37 @@ async def test_touch_once_reuses_account_and_skips_static_health(
         assert after.last_seen_at > before.last_seen_at
         assert after.expires_at == before.expires_at
         assert after.created_at == before.created_at
+
+
+@pytest.mark.parametrize("path", ["/reuse", "/required-first", "/optional-reuse"])
+@pytest.mark.parametrize(
+    "state", ["valid", "missing", "revoked", "malformed", "unknown"]
+)
+async def test_account_identity_graph_resolves_consistently(
+    session_apps, test_settings, path, state
+):
+    first, second = session_apps
+    token = await mint(first, test_settings)
+    if state == "revoked":
+        async with browser(first, token) as client:
+            assert (await client.post("/auth/logout")).status_code == 303
+    elif state == "missing":
+        token = None
+    elif state == "malformed":
+        token = "malformed"
+    elif state == "unknown":
+        token = "A" * 43
+    async with browser(second, token) as client:
+        response = await client.get(path)
+    if state == "valid":
+        assert response.status_code == 200
+        assert response.json() == {"id": 42}
+    elif path == "/optional-reuse":
+        assert response.status_code == 200
+        assert response.json() == {"id": None}
+    else:
+        assert response.status_code == 401
+        assert response.json() == {"detail": "Unauthorized"}
 
 
 @pytest.mark.parametrize(
@@ -363,8 +457,10 @@ async def test_no_connection_held_during_route_or_provider_work(
         active -= 1
 
     @first.get("/remote")
-    async def remote(current_user: CurrentUser):
+    async def remote(account: CurrentAccount, current_user: CurrentUser):
         assert active == 0
+        assert inspect(account).detached
+        assert account.id == current_user.user_id
         await asyncio.sleep(0)
         assert active == 0
         return {"id": current_user.user_id}
@@ -448,7 +544,18 @@ async def test_oauth_issues_rotates_preserves_states_and_releases_connections(
         assert (await replay.get("/api/user/me")).status_code == 401
 
 
-@pytest.mark.parametrize("operation", ["lookup", "logout", "global", "delete"])
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "lookup",
+        "required-account",
+        "required-identity",
+        "optional-identity",
+        "logout",
+        "global",
+        "delete",
+    ],
+)
 async def test_store_failure_is_500_not_anonymous_or_success(
     session_apps, test_settings, caplog, operation
 ):
@@ -462,6 +569,12 @@ async def test_store_failure_is_500_not_anonymous_or_success(
         ):
             if operation == "lookup":
                 response = await client.get("/")
+            elif operation == "required-account":
+                response = await client.get("/account")
+            elif operation == "required-identity":
+                response = await client.get("/reuse")
+            elif operation == "optional-identity":
+                response = await client.get("/optional-reuse")
             elif operation == "logout":
                 response = await client.post("/auth/logout")
             elif operation == "global":

--- a/api/tests/routes/test_session_lifecycle.py
+++ b/api/tests/routes/test_session_lifecycle.py
@@ -1,0 +1,661 @@
+"""Committed PostgreSQL credentials through independent HTTP applications."""
+
+import asyncio
+import json
+import logging
+import re
+from base64 import b64decode, b64encode
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from time import time
+from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlsplit
+from uuid import uuid4
+
+import httpx2
+import pytest
+from authlib.integrations.starlette_client import OAuth
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+from itsdangerous import TimestampSigner
+from learn_to_cloud_shared.content_service import get_phase_by_slug
+from learn_to_cloud_shared.models import AuthSession, User, VerificationAttempt
+from learn_to_cloud_shared.repositories.auth_session_repository import (
+    AuthSessionRepository,
+)
+from learn_to_cloud_shared.repositories.verification_attempt_repository import (
+    VerificationAttemptRepository,
+)
+from learn_to_cloud_shared.submission_values import GitHubUrlValue
+from sqlalchemy import event, func, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker
+from starlette.middleware.sessions import SessionMiddleware
+
+from learn_to_cloud.core.auth import CurrentUser, get_authenticated_user_from_session
+from learn_to_cloud.core.middleware import TelemetrySanitizationMiddleware
+from learn_to_cloud.core.session_cookies import (
+    AUTH_COOKIE_NAME,
+    SESSION_COOKIE_NAME,
+    SessionResponseMiddleware,
+    token_digest,
+)
+from learn_to_cloud.main import global_exception_handler
+from learn_to_cloud.routes import auth_router, htmx_router, pages_router, users_router
+from learn_to_cloud.services.sessions_service import issue_session
+
+pytestmark = pytest.mark.integration
+
+
+def build_app(engine, settings):
+    app = FastAPI()
+    app.state.session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    app.add_exception_handler(Exception, global_exception_handler)
+    app.add_middleware(TelemetrySanitizationMiddleware)
+    app.add_middleware(SessionResponseMiddleware)
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=settings.session.secret_key,
+        session_cookie=SESSION_COOKIE_NAME,
+        max_age=settings.session.oauth_state_max_age_seconds,
+    )
+    for router in (auth_router, users_router, htmx_router, pages_router):
+        app.include_router(router)
+
+    @app.get("/health")
+    @app.get("/static/probe")
+    async def untouched():
+        return {"ok": True}
+
+    @app.get("/reuse")
+    async def reuse(request: Request, current_user: CurrentUser):
+        again = await get_authenticated_user_from_session(request)
+        assert again is current_user
+        return {"id": again.user_id}
+
+    return app
+
+
+@pytest.fixture
+async def session_apps(test_engine, test_settings):
+    apps = (
+        build_app(test_engine, test_settings),
+        build_app(test_engine, test_settings),
+    )
+    async with apps[0].state.session_maker() as db, db.begin():
+        db.add_all(
+            [
+                User(id=42, github_username="testuser"),
+                User(id=43, github_username="unrelated"),
+            ]
+        )
+    with (
+        patch("learn_to_cloud.core.auth.get_web_settings", return_value=test_settings),
+        patch(
+            "learn_to_cloud.core.session_cookies.get_web_settings",
+            return_value=test_settings,
+        ),
+        patch(
+            "learn_to_cloud.services.sessions_service.get_web_settings",
+            return_value=test_settings,
+        ),
+        patch(
+            "learn_to_cloud.routes.auth_routes.get_web_settings",
+            return_value=test_settings,
+        ),
+        patch(
+            "learn_to_cloud.services.community_service.get_latest_curriculum_commits",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        yield apps
+
+
+async def mint(app, settings, user_id=42):
+    async with app.state.session_maker() as db, db.begin():
+        issued = await issue_session(db, settings.session, user_id)
+    return issued.token
+
+
+@asynccontextmanager
+async def browser(app, token=None, *, raise_errors=True):
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=raise_errors),
+        base_url="http://testserver",
+    ) as client:
+        if token is not None:
+            client.cookies.set(
+                AUTH_COOKIE_NAME, token, domain="testserver.local", path="/"
+            )
+        yield client
+
+
+async def csrf(client):
+    response = await client.get("/account")
+    assert response.status_code == 200
+    assert 'hx-boost="false"' in response.text
+    assert "including this one" in response.text
+    match = re.search(r'name="csrf" value="([^"]+)"', response.text)
+    assert match is not None
+    return match[1]
+
+
+async def test_current_logout_replay_cross_app_and_independent_browser(
+    session_apps, test_settings
+):
+    first, second = session_apps
+    original = await mint(first, test_settings)
+    independent = await mint(second, test_settings)
+    async with browser(first, original) as client:
+        assert (await client.get("/api/user/me")).status_code == 200
+        response = await client.post("/auth/logout")
+        assert response.status_code == 303
+        assert response.headers["cache-control"] == "private, no-store"
+        assert AUTH_COOKIE_NAME not in client.cookies
+        assert (await client.post("/auth/logout")).status_code == 303
+    for app in session_apps:
+        async with browser(app, original) as replay:
+            response = await replay.get("/api/user/me")
+            assert response.status_code == 401
+            assert AUTH_COOKIE_NAME not in replay.cookies
+    async with browser(second, independent) as client:
+        assert (await client.get("/api/user/me")).status_code == 200
+
+
+async def test_global_logout_csrf_all_browsers_and_later_login(
+    session_apps, test_settings
+):
+    first, second = session_apps
+    tokens = [await mint(app, test_settings) for app in session_apps]
+    other = await mint(second, test_settings, 43)
+    async with browser(first, tokens[0]) as client:
+        confirmation = await csrf(client)
+        for value in ("", "wrong", "é", tokens[0]):
+            response = await client.post("/auth/logout-all", data={"csrf": value})
+            assert response.status_code == 403
+        async with browser(second, tokens[1]) as other_browser:
+            assert (
+                await other_browser.post(
+                    "/auth/logout-all", data={"csrf": confirmation}
+                )
+            ).status_code == 403
+        response = await client.post("/auth/logout-all", data={"csrf": confirmation})
+        assert response.status_code == 303
+        assert response.headers["location"] == "/"
+    for token in tokens:
+        async with browser(second, token) as replay:
+            assert (await replay.get("/api/user/me")).status_code == 401
+    for token in (other, await mint(first, test_settings)):
+        async with browser(second, token) as client:
+            assert (await client.get("/api/user/me")).status_code == 200
+
+
+@pytest.mark.parametrize(
+    "endpoint, status", [("/api/user/me", 204), ("/htmx/account", 200)]
+)
+async def test_delete_cascade_public_anonymous_and_recreation(
+    session_apps, test_settings, endpoint, status
+):
+    first, second = session_apps
+    tokens = [await mint(app, test_settings) for app in session_apps]
+    async with browser(first, tokens[0]) as client:
+        response = await client.delete(endpoint)
+        assert response.status_code == status
+        assert response.content == b""
+        if endpoint == "/htmx/account":
+            assert response.headers["HX-Redirect"] == "/"
+        assert AUTH_COOKIE_NAME not in client.cookies
+    async with browser(second, tokens[1]) as client:
+        response = await client.get("/")
+        assert response.status_code == 200
+        assert AUTH_COOKIE_NAME not in client.cookies
+    async with first.state.session_maker() as db, db.begin():
+        assert await db.get(User, 42) is None
+        assert await db.get(User, 43) is not None
+        db.add(User(id=42, github_username="recreated"))
+    for token in tokens:
+        async with browser(second, token) as replay:
+            assert (await replay.get("/api/user/me")).status_code == 401
+    async with browser(second, await mint(first, test_settings)) as client:
+        assert (await client.get("/api/user/me")).json()[
+            "github_username"
+        ] == "recreated"
+
+
+@pytest.mark.parametrize("expiry", ["idle", "absolute"])
+async def test_server_expiry_overrides_browser_extension(
+    session_apps, test_settings, expiry
+):
+    first, second = session_apps
+    token = await mint(first, test_settings)
+    values = (
+        {
+            "last_seen_at": func.statement_timestamp()
+            - timedelta(seconds=test_settings.session.idle_timeout_seconds)
+        }
+        if expiry == "idle"
+        else {"expires_at": func.statement_timestamp()}
+    )
+    async with first.state.session_maker() as db, db.begin():
+        await db.execute(
+            update(AuthSession)
+            .where(AuthSession.token_digest == token_digest(token))
+            .values(**values)
+        )
+    async with browser(second, token) as client:
+        response = await client.get("/account")
+        assert response.status_code == 303
+        assert AUTH_COOKIE_NAME not in client.cookies
+
+
+async def test_touch_once_reuses_account_and_skips_static_health(
+    session_apps, test_settings, test_engine
+):
+    first, _ = session_apps
+    token = await mint(first, test_settings)
+    async with first.state.session_maker() as db, db.begin():
+        await db.execute(
+            update(AuthSession).values(
+                last_seen_at=func.statement_timestamp() - timedelta(hours=1)
+            )
+        )
+    async with first.state.session_maker() as db:
+        before = await db.get(AuthSession, token_digest(token))
+    queries = []
+
+    def record(_conn, _cursor, statement, _params, _context, _many):
+        queries.append(statement)
+
+    event.listen(test_engine.sync_engine, "before_cursor_execute", record)
+    try:
+        async with browser(first, token) as client:
+            for path in ("/static/probe", "/health"):
+                assert (await client.get(path)).status_code == 200
+            assert queries == []
+            phase = get_phase_by_slug("phase1")
+            assert phase is not None
+            for path in (
+                "/api/user/me",
+                "/account",
+                "/reuse",
+                "/",
+                "/curriculum",
+                "/phase/1",
+                f"/phase/1/{phase.topics[0].slug}",
+                "/verifications",
+                "/verifications/phase/1",
+                "/dashboard",
+                "/community",
+                "/htmx/verification/attempts/status?token=invalid",
+                "/faq",
+                "/privacy",
+                "/terms",
+            ):
+                queries.clear()
+                response = await client.get(path)
+                assert response.status_code == (
+                    400 if path.startswith("/htmx/verification/attempts/") else 200
+                )
+                assert sum("UPDATE auth_sessions" in q for q in queries) == 1
+                assert not any(q.startswith("SELECT users.") for q in queries)
+                assert "Cookie" in response.headers["vary"]
+            topic = next(topic for topic in phase.topics if topic.learning_steps)
+            step = topic.learning_steps[0]
+            for method, path, data in (
+                ("POST", "/htmx/steps/complete", {"step_uuid": str(step.uuid)}),
+                ("DELETE", f"/htmx/steps/{step.uuid}", None),
+            ):
+                queries.clear()
+                response = await client.request(method, path, data=data)
+                assert response.status_code == 200
+                assert sum("UPDATE auth_sessions" in q for q in queries) == 1
+                assert not any(q.startswith("SELECT users.") for q in queries)
+    finally:
+        event.remove(test_engine.sync_engine, "before_cursor_execute", record)
+    async with first.state.session_maker() as db:
+        after = await db.get(AuthSession, token_digest(token))
+        assert after.last_seen_at > before.last_seen_at
+        assert after.expires_at == before.expires_at
+        assert after.created_at == before.created_at
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("GET", "/api/user/me"),
+        ("DELETE", "/api/user/me"),
+        ("POST", "/htmx/steps/complete"),
+        ("DELETE", "/htmx/steps/00000000-0000-0000-0000-000000000001"),
+        ("POST", "/htmx/verifications/test/submit/derived"),
+        ("POST", "/htmx/verifications/test/submit/value"),
+        ("POST", "/htmx/verifications/test/submit/reflection"),
+        ("POST", "/htmx/github/submit"),
+        ("GET", "/htmx/verification/attempts/status?token=private-token"),
+        ("DELETE", "/htmx/account"),
+    ],
+)
+async def test_revoked_cookie_cannot_reach_protected_work(
+    session_apps, test_settings, method, path
+):
+    first, second = session_apps
+    token = await mint(first, test_settings)
+    async with browser(first, token) as client:
+        assert (await client.post("/auth/logout")).status_code == 303
+    async with browser(second, token) as client:
+        response = await client.request(method, path)
+        assert response.status_code == 401
+        assert AUTH_COOKIE_NAME not in client.cookies
+
+
+async def test_no_connection_held_during_route_or_provider_work(
+    session_apps, test_settings, test_engine
+):
+    first, _ = session_apps
+    token = await mint(first, test_settings)
+    active = 0
+
+    def checked_out(*_args):
+        nonlocal active
+        active += 1
+
+    def checked_in(*_args):
+        nonlocal active
+        active -= 1
+
+    @first.get("/remote")
+    async def remote(current_user: CurrentUser):
+        assert active == 0
+        await asyncio.sleep(0)
+        assert active == 0
+        return {"id": current_user.user_id}
+
+    async def profile(*_args, **_kwargs):
+        assert active == 0
+        return httpx2.Response(
+            200,
+            json={"id": 42, "login": "testuser"},
+            request=httpx2.Request("GET", "https://api.github.com/user"),
+        )
+
+    github = AsyncMock()
+    github.get.side_effect = profile
+    github.authorize_access_token.return_value = {"access_token": "private-token"}
+    event.listen(test_engine.sync_engine, "checkout", checked_out)
+    event.listen(test_engine.sync_engine, "checkin", checked_in)
+    try:
+        with patch("learn_to_cloud.routes.auth_routes.oauth") as oauth:
+            oauth.create_client.return_value = github
+            async with browser(first, token) as client:
+                assert (await client.get("/remote")).status_code == 200
+                assert (await client.get("/auth/callback")).status_code == 302
+        assert active == 0
+    finally:
+        event.remove(test_engine.sync_engine, "checkout", checked_out)
+        event.remove(test_engine.sync_engine, "checkin", checked_in)
+
+
+@pytest.mark.parametrize("cookie", ["", "short", "x" * 5000, "é", "a" * 43])
+async def test_malformed_cookie_has_no_database_lookup(session_apps, cookie):
+    first, _ = session_apps
+    # A noncanonical final base64 character must not be accepted.
+    if cookie == "a" * 43:
+        assert token_digest(cookie) is None
+    with patch.object(
+        first.state, "session_maker", side_effect=AssertionError("database called")
+    ):
+        async with browser(first) as client:
+            response = await client.get(
+                "/api/user/me",
+                headers={b"cookie": f"{AUTH_COOKIE_NAME}={cookie}".encode("latin-1")},
+            )
+            assert response.status_code == 401
+
+
+async def test_oauth_issues_rotates_preserves_states_and_releases_connections(
+    session_apps, test_settings
+):
+    first, second = session_apps
+    old = await mint(first, test_settings)
+    states = {"_state_github_other": {"data": {"state": "other"}, "exp": time() + 600}}
+    signed = (
+        TimestampSigner(test_settings.session.secret_key)
+        .sign(b64encode(json.dumps(states).encode()))
+        .decode()
+    )
+    github = AsyncMock()
+    github.authorize_access_token.return_value = {
+        "access_token": "private-provider-token"
+    }
+    github.get.return_value = httpx2.Response(
+        200,
+        json={"id": 42, "login": "TestUser"},
+        request=httpx2.Request("GET", "https://api.github.com/user"),
+    )
+    with patch("learn_to_cloud.routes.auth_routes.oauth") as oauth:
+        oauth.create_client.return_value = github
+        async with browser(first, old) as client:
+            client.cookies.set(
+                SESSION_COOKIE_NAME, signed, domain="testserver.local", path="/"
+            )
+            response = await client.get("/auth/callback")
+            assert response.status_code == 302
+            new = client.cookies.get(AUTH_COOKIE_NAME)
+            assert len(new) == 43 and new != old
+            assert client.cookies.get(SESSION_COOKIE_NAME) == signed
+            assert "user_id" not in response.headers["set-cookie"]
+            assert (await client.get("/api/user/me")).status_code == 200
+    async with browser(second, old) as replay:
+        assert (await replay.get("/api/user/me")).status_code == 401
+
+
+@pytest.mark.parametrize("operation", ["lookup", "logout", "global", "delete"])
+async def test_store_failure_is_500_not_anonymous_or_success(
+    session_apps, test_settings, caplog, operation
+):
+    first, _ = session_apps
+    token = await mint(first, test_settings)
+    caplog.set_level(logging.INFO)
+    async with browser(first, token, raise_errors=False) as client:
+        confirmation = await csrf(client)
+        with patch.object(
+            first.state, "session_maker", side_effect=RuntimeError("store unavailable")
+        ):
+            if operation == "lookup":
+                response = await client.get("/")
+            elif operation == "logout":
+                response = await client.post("/auth/logout")
+            elif operation == "global":
+                response = await client.post(
+                    "/auth/logout-all", data={"csrf": confirmation}
+                )
+            else:
+                response = await client.delete("/api/user/me")
+        assert response.status_code == 500
+        assert "location" not in response.headers
+        assert "set-cookie" not in response.headers
+        assert client.cookies.get(AUTH_COOKIE_NAME) == token
+        assert (await client.get("/api/user/me")).status_code == 200
+    assert "auth.session.revoked" not in caplog.text
+    assert "user.account_deleted" not in caplog.text
+    assert token not in caplog.text
+    digest = token_digest(token)
+    assert digest is not None
+    assert digest.hex() not in caplog.text
+
+
+async def test_concurrent_touch_logout_never_resurrects(session_apps, test_settings):
+    first, second = session_apps
+    token = await mint(first, test_settings)
+    async with browser(first, token) as reader, browser(second, token) as logout:
+        responses = await asyncio.gather(
+            reader.get("/api/user/me"), logout.post("/auth/logout")
+        )
+        assert responses[0].status_code in (200, 401)
+        assert responses[1].status_code == 303
+    async with browser(first, token) as replay:
+        assert (await replay.get("/api/user/me")).status_code == 401
+    async with first.state.session_maker() as db:
+        assert await db.get(AuthSession, token_digest(token)) is None
+
+
+async def test_login_waits_for_account_global_revocation_order(
+    session_apps, test_settings
+):
+    first, second = session_apps
+    old = await mint(first, test_settings)
+    acquired = asyncio.Event()
+    release = asyncio.Event()
+
+    async def revoke():
+        async with first.state.session_maker() as db, db.begin():
+            repo = AuthSessionRepository(db, test_settings.session)
+            await repo.lock_user(42)
+            acquired.set()
+            await release.wait()
+            await repo.delete_all(42)
+
+    revocation = asyncio.create_task(revoke())
+    await acquired.wait()
+    issuance = asyncio.create_task(mint(second, test_settings))
+    await asyncio.sleep(0.03)
+    assert not issuance.done()
+    release.set()
+    await revocation
+    new = await issuance
+    async with browser(second, old) as client:
+        assert (await client.get("/api/user/me")).status_code == 401
+    async with browser(first, new) as client:
+        assert (await client.get("/api/user/me")).status_code == 200
+
+
+async def test_real_authlib_parallel_states_and_expired_wrong_callbacks(
+    session_apps, test_settings
+):
+    app, _ = session_apps
+    oauth = OAuth()
+    github = oauth.register(
+        "github",
+        client_id="local-test",
+        client_secret="local-test",
+        authorize_url="https://github.com/login/oauth/authorize",
+        access_token_url="https://github.com/login/oauth/access_token",
+        api_base_url="https://api.github.com/",
+    )
+    old = await mint(app, test_settings)
+    with (
+        patch("learn_to_cloud.routes.auth_routes.oauth", oauth),
+        patch.object(
+            github,
+            "fetch_access_token",
+            new=AsyncMock(return_value={"access_token": "private-token"}),
+        ) as exchange,
+        patch.object(
+            github,
+            "get",
+            new=AsyncMock(
+                return_value=httpx2.Response(
+                    200,
+                    json={"id": 42, "login": "testuser"},
+                    request=httpx2.Request("GET", "https://api.github.com/user"),
+                )
+            ),
+        ),
+    ):
+        async with browser(app, old) as client:
+            states = []
+            for _ in range(2):
+                response = await client.get("/auth/login")
+                states.append(
+                    parse_qs(urlsplit(response.headers["location"]).query)["state"][0]
+                )
+                assert "Max-Age=600" in response.headers["set-cookie"]
+                assert AUTH_COOKIE_NAME not in response.headers["set-cookie"]
+            assert github.framework.expires_in == 600
+            signer = TimestampSigner(test_settings.session.secret_key)
+            payload = json.loads(
+                b64decode(signer.unsign(client.cookies.get(SESSION_COOKIE_NAME)))
+            )
+            assert all(f"_state_github_{state}" in payload for state in states)
+            response = await client.get(
+                "/auth/callback", params={"state": "wrong", "code": "test"}
+            )
+            assert response.headers["location"] == "/"
+            assert client.cookies.get(AUTH_COOKIE_NAME) == old
+            exchange.assert_not_awaited()
+            payload[f"_state_github_{states[0]}"]["exp"] = time() - 1
+            signed = signer.sign(b64encode(json.dumps(payload).encode())).decode()
+            client.cookies.set(
+                SESSION_COOKIE_NAME, signed, domain="testserver.local", path="/"
+            )
+            response = await client.get(
+                "/auth/callback", params={"state": states[0], "code": "test"}
+            )
+            assert response.headers["location"] == "/"
+            exchange.assert_not_awaited()
+            response = await client.get(
+                "/auth/callback", params={"state": states[1], "code": "test"}
+            )
+            assert response.headers["location"] == "/dashboard"
+            assert client.cookies.get(AUTH_COOKIE_NAME) != old
+            exchange.assert_awaited_once()
+
+
+async def test_account_deletion_serializes_with_submission_and_preserves_foreign_key(
+    session_apps, test_settings
+):
+    first, second = session_apps
+    token = await mint(first, test_settings)
+    inserted = asyncio.Event()
+    release = asyncio.Event()
+    requirement_uuid = uuid4()
+
+    async def submit():
+        async with first.state.session_maker() as db, db.begin():
+            await VerificationAttemptRepository(db).create_or_get_active(
+                id=uuid4(),
+                user_id=42,
+                requirement_uuid=requirement_uuid,
+                artifact_schema_version=1,
+                curriculum_version=1,
+                content_hash="a" * 64,
+                requirement_snapshot={},
+                requirement_snapshot_hash="b" * 64,
+                payload_version=1,
+                github_username_snapshot="testuser",
+                submitted_value=GitHubUrlValue("https://github.com/testuser/repo"),
+                cloud_provider=None,
+            )
+            inserted.set()
+            await release.wait()
+
+    submission = asyncio.create_task(submit())
+    await asyncio.wait_for(inserted.wait(), timeout=5)
+    async with browser(second, token) as client:
+        deletion = asyncio.create_task(client.delete("/api/user/me"))
+        await asyncio.sleep(0.03)
+        assert not deletion.done()
+        release.set()
+        await submission
+        assert (await deletion).status_code == 204
+    async with first.state.session_maker() as db:
+        assert await db.get(User, 42) is None
+        assert (
+            await db.scalar(select(func.count()).select_from(VerificationAttempt)) == 0
+        )
+    # A request authorized before deletion cannot insert an orphan afterwards.
+    with pytest.raises(IntegrityError):
+        async with first.state.session_maker() as db, db.begin():
+            await VerificationAttemptRepository(db).create_or_get_active(
+                id=uuid4(),
+                user_id=42,
+                requirement_uuid=requirement_uuid,
+                artifact_schema_version=1,
+                curriculum_version=1,
+                content_hash="a" * 64,
+                requirement_snapshot={},
+                requirement_snapshot_hash="b" * 64,
+                payload_version=1,
+                github_username_snapshot="testuser",
+                submitted_value=GitHubUrlValue("https://github.com/testuser/repo"),
+                cloud_provider=None,
+            )

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -38,11 +38,7 @@ from learn_to_cloud_shared.schemas import (
     VerificationProgress,
 )
 
-from learn_to_cloud.core.auth import (
-    AuthenticatedUser,
-    optional_authenticated_user,
-    require_authenticated_user,
-)
+from learn_to_cloud.core.auth import optional_authenticated_account
 
 # =============================================================================
 # Fixtures
@@ -155,7 +151,7 @@ async def anon_client(_patched_content):
 
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_db_readonly] = _override_get_db_readonly
-    app.dependency_overrides[optional_authenticated_user] = _override_optional_user
+    app.dependency_overrides[optional_authenticated_account] = _override_optional_user
 
     # Mark app as initialized so /ready doesn't 503
     app.state.init_done = True
@@ -173,7 +169,7 @@ async def anon_client(_patched_content):
 async def auth_client(_patched_content):
     """HTTP client for authenticated requests.
 
-    Overrides auth to return an identity, mocks DB and user service.
+    Overrides the account resolver and mocks route database work.
     """
     from learn_to_cloud.main import app
 
@@ -186,12 +182,11 @@ async def auth_client(_patched_content):
         yield mock_db
 
     def _override_current_user():
-        return AuthenticatedUser(user_id=1, github_username="testuser")
+        return _fake_user()
 
     app.dependency_overrides[get_db] = _override_get_db
     app.dependency_overrides[get_db_readonly] = _override_get_db_readonly
-    app.dependency_overrides[optional_authenticated_user] = _override_current_user
-    app.dependency_overrides[require_authenticated_user] = _override_current_user
+    app.dependency_overrides[optional_authenticated_account] = _override_current_user
 
     app.state.init_done = True
     app.state.init_error = None
@@ -271,10 +266,6 @@ class TestAuthPageSmoke:
         """GET /dashboard renders the dashboard template."""
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                return_value=_fake_user(),
-            ),
-            patch(
                 "learn_to_cloud.routes.pages_routes.get_dashboard_data",
                 return_value=_fake_dashboard(),
             ),
@@ -284,11 +275,7 @@ class TestAuthPageSmoke:
 
     async def test_account_renders(self, auth_client: AsyncClient):
         """GET /account renders the account settings template."""
-        with patch(
-            "learn_to_cloud.routes.pages_routes.get_request_user",
-            return_value=_fake_user(),
-        ):
-            response = await auth_client.get("/account")
+        response = await auth_client.get("/account")
         assert response.status_code == 200
 
     async def test_typed_verification_submission_routes_bind_forms(
@@ -364,10 +351,6 @@ class TestAuthPageSmoke:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                return_value=_fake_user(),
-            ),
-            patch(
                 "learn_to_cloud.routes.pages_routes.fetch_phase_progress",
                 return_value=detail,
             ),
@@ -397,10 +380,6 @@ class TestAuthPageSmoke:
         )
 
         with (
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                return_value=_fake_user(),
-            ),
             patch(
                 "learn_to_cloud.routes.pages_routes.get_verifications_overview",
                 return_value=overview,
@@ -491,10 +470,6 @@ class TestAuthPageSmoke:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                return_value=_fake_user(),
-            ),
-            patch(
                 "learn_to_cloud.routes.pages_routes.get_phase_verification_workspace",
                 return_value=workspace,
             ),
@@ -520,10 +495,6 @@ class TestAuthPageSmoke:
         topic_slug = phase.topics[0].slug
 
         with (
-            patch(
-                "learn_to_cloud.routes.pages_routes.get_request_user",
-                return_value=_fake_user(),
-            ),
             patch(
                 "learn_to_cloud.routes.pages_routes.get_valid_completed_steps",
                 return_value=[],

--- a/api/tests/routes/test_smoke.py
+++ b/api/tests/routes/test_smoke.py
@@ -271,7 +271,7 @@ class TestAuthPageSmoke:
         """GET /dashboard renders the dashboard template."""
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 return_value=_fake_user(),
             ),
             patch(
@@ -285,7 +285,7 @@ class TestAuthPageSmoke:
     async def test_account_renders(self, auth_client: AsyncClient):
         """GET /account renders the account settings template."""
         with patch(
-            "learn_to_cloud.routes.pages_routes.get_user_by_id",
+            "learn_to_cloud.routes.pages_routes.get_request_user",
             return_value=_fake_user(),
         ):
             response = await auth_client.get("/account")
@@ -364,7 +364,7 @@ class TestAuthPageSmoke:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 return_value=_fake_user(),
             ),
             patch(
@@ -398,7 +398,7 @@ class TestAuthPageSmoke:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 return_value=_fake_user(),
             ),
             patch(
@@ -491,7 +491,7 @@ class TestAuthPageSmoke:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 return_value=_fake_user(),
             ),
             patch(
@@ -521,7 +521,7 @@ class TestAuthPageSmoke:
 
         with (
             patch(
-                "learn_to_cloud.routes.pages_routes.get_user_by_id",
+                "learn_to_cloud.routes.pages_routes.get_request_user",
                 return_value=_fake_user(),
             ),
             patch(

--- a/api/tests/routes/test_users_routes.py
+++ b/api/tests/routes/test_users_routes.py
@@ -5,12 +5,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from learn_to_cloud_shared.models import User
-from starlette.datastructures import State
 
 from learn_to_cloud.core.auth import (
     AuthenticatedUser,
     AuthenticationRequired,
-    RequestAuthentication,
 )
 from learn_to_cloud.routes.users_routes import delete_current_user, get_current_user
 
@@ -26,10 +24,7 @@ async def test_current_user_reuses_loaded_account():
         is_admin=False,
         created_at=datetime(2024, 1, 1, tzinfo=UTC),
     )
-    identity = AuthenticatedUser(1, "testuser")
-    request = MagicMock()
-    request.state = State({"authentication": RequestAuthentication(identity, user)})
-    result = await get_current_user(request, identity)
+    result = await get_current_user(user)
     assert result.id == 1
     assert result.github_username == "testuser"
     assert result.display_name == "Test User"

--- a/api/tests/routes/test_users_routes.py
+++ b/api/tests/routes/test_users_routes.py
@@ -1,122 +1,67 @@
-"""Unit tests for user routes."""
+"""User routes reuse resolved accounts and committed lifecycle operations."""
 
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
 from learn_to_cloud_shared.models import User
+from starlette.datastructures import State
 
-from learn_to_cloud.core.auth import AuthenticatedUser
-from learn_to_cloud.routes.users_routes import (
-    delete_current_user,
-    get_current_user,
+from learn_to_cloud.core.auth import (
+    AuthenticatedUser,
+    AuthenticationRequired,
+    RequestAuthentication,
 )
-from learn_to_cloud.services.users_service import UserNotFoundError
+from learn_to_cloud.routes.users_routes import delete_current_user, get_current_user
+
+pytestmark = pytest.mark.unit
 
 
-def _fake_user() -> User:
-    """Build a minimal User model for testing."""
-    user = User()
-    user.id = 1
-    user.display_name = "Test User"
-    user.avatar_url = "https://example.com/avatar.png"
-    user.github_username = "testuser"
-    user.is_admin = False
-    user.created_at = datetime(2024, 1, 1, tzinfo=UTC)
-    return user
+async def test_current_user_reuses_loaded_account():
+    user = User(
+        id=1,
+        github_username="testuser",
+        display_name="Test User",
+        avatar_url=None,
+        is_admin=False,
+        created_at=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    identity = AuthenticatedUser(1, "testuser")
+    request = MagicMock()
+    request.state = State({"authentication": RequestAuthentication(identity, user)})
+    result = await get_current_user(request, identity)
+    assert result.id == 1
+    assert result.github_username == "testuser"
+    assert result.display_name == "Test User"
+    assert set(result.model_dump()) == {
+        "id",
+        "github_username",
+        "display_name",
+        "avatar_url",
+        "is_admin",
+        "created_at",
+    }
 
 
-@pytest.mark.unit
-class TestGetCurrentUser:
-    """Tests for GET /api/user/me."""
+async def test_delete_uses_committed_lifecycle():
+    request = MagicMock()
+    with patch(
+        "learn_to_cloud.routes.users_routes.mutate_account", autospec=True
+    ) as mutate:
+        assert (
+            await delete_current_user(request, AuthenticatedUser(42, "testuser"))
+            is None
+        )
+    mutate.assert_awaited_once_with(request, 42, delete_account=True)
 
-    async def test_returns_user_response(self):
-        """Returns UserResponse from get_user_by_id."""
-        mock_db = AsyncMock()
-        mock_request = MagicMock()
-        user = _fake_user()
 
-        with patch(
-            "learn_to_cloud.routes.users_routes.get_user_by_id",
+async def test_deletion_recheck_failure_stays_unauthorized():
+    with (
+        patch(
+            "learn_to_cloud.routes.users_routes.mutate_account",
             autospec=True,
-            return_value=user,
-        ) as mock_service:
-            result = await get_current_user(
-                mock_request, current_user=AuthenticatedUser(1, "testuser"), db=mock_db
-            )
-
-        mock_service.assert_awaited_once_with(mock_db, 1)
-        assert result.id == 1
-        assert result.github_username == "testuser"
-        assert result.display_name == "Test User"
-        assert set(result.model_dump()) == {
-            "id",
-            "github_username",
-            "display_name",
-            "avatar_url",
-            "is_admin",
-            "created_at",
-        }
-
-    async def test_user_not_found_raises_404(self):
-        """Returns 404 when user not found."""
-        mock_db = AsyncMock()
-        mock_request = MagicMock()
-
-        with (
-            patch(
-                "learn_to_cloud.routes.users_routes.get_user_by_id",
-                autospec=True,
-                return_value=None,
-            ),
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            await get_current_user(
-                mock_request,
-                current_user=AuthenticatedUser(999, "testuser"),
-                db=mock_db,
-            )
-
-        assert exc_info.value.status_code == 404
-
-
-@pytest.mark.unit
-class TestDeleteCurrentUser:
-    """Tests for DELETE /api/user/me."""
-
-    async def test_delete_returns_none(self):
-        """Successful deletion returns None (204 via route decorator)."""
-        mock_db = AsyncMock()
-        mock_request = MagicMock()
-
-        with patch(
-            "learn_to_cloud.routes.users_routes.delete_user_account",
-            autospec=True,
-        ) as mock_service:
-            result = await delete_current_user(
-                mock_request, current_user=AuthenticatedUser(42, "testuser"), db=mock_db
-            )
-
-        assert result is None
-        mock_service.assert_awaited_once_with(mock_db, 42)
-        mock_request.session.clear.assert_called_once()
-
-    async def test_delete_user_not_found_raises_404(self):
-        """UserNotFoundError from service becomes 404."""
-        mock_db = AsyncMock()
-        mock_request = MagicMock()
-
-        with (
-            patch(
-                "learn_to_cloud.routes.users_routes.delete_user_account",
-                autospec=True,
-                side_effect=UserNotFoundError(42),
-            ),
-            pytest.raises(HTTPException) as exc_info,
-        ):
-            await delete_current_user(
-                mock_request, current_user=AuthenticatedUser(42, "testuser"), db=mock_db
-            )
-
-        assert exc_info.value.status_code == 404
+            side_effect=AuthenticationRequired(),
+        ),
+        pytest.raises(AuthenticationRequired),
+    ):
+        await delete_current_user(MagicMock(), AuthenticatedUser(42, "testuser"))

--- a/api/tests/services/test_sessions_service.py
+++ b/api/tests/services/test_sessions_service.py
@@ -1,0 +1,80 @@
+"""Session issuance transaction ownership, rollback, and credential privacy."""
+
+import hashlib
+from base64 import urlsafe_b64decode
+from unittest.mock import patch
+
+import pytest
+from learn_to_cloud_shared.models import AuthSession, User
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from learn_to_cloud.core.session_cookies import token_digest
+from learn_to_cloud.services.sessions_service import issue_session
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def maker(test_engine):
+    maker = async_sessionmaker(test_engine, expire_on_commit=False)
+    async with maker() as db, db.begin():
+        db.add(User(id=42, github_username="testuser"))
+    return maker
+
+
+async def test_random_opaque_digest_only_and_no_implicit_commit(maker, test_settings):
+    async with maker() as db:
+        issued = await issue_session(db, test_settings.session, 42)
+        assert issued.token not in repr(issued)
+        raw = urlsafe_b64decode(issued.token + "=")
+        assert len(raw) == 32
+        digest = hashlib.sha256(raw).digest()
+        assert digest == token_digest(issued.token)
+        row = await db.get(AuthSession, digest)
+        assert row.user_id == 42
+        assert (
+            row.expires_at - row.created_at
+        ).total_seconds() == test_settings.session.absolute_timeout_seconds
+        async with maker() as other:
+            assert await other.get(AuthSession, digest) is None
+        await db.commit()
+    async with maker() as other:
+        assert await other.get(AuthSession, digest) is not None
+
+
+async def test_failed_issuance_rolls_back_rotation_and_pruning(maker, test_settings):
+    async with maker() as db, db.begin():
+        old = await issue_session(db, test_settings.session, 42)
+    with patch(
+        "learn_to_cloud.services.sessions_service.AuthSessionRepository.prune_expired",
+        side_effect=RuntimeError("pruning failed"),
+    ):
+        with pytest.raises(RuntimeError, match="pruning failed"):
+            async with maker() as db, db.begin():
+                await issue_session(db, test_settings.session, 42, old.token)
+    async with maker() as db:
+        assert await db.get(AuthSession, token_digest(old.token)) is not None
+        assert await db.scalar(select(func.count()).select_from(AuthSession)) == 1
+
+
+async def test_absent_user_does_not_issue(maker, test_settings):
+    with pytest.raises(RuntimeError, match="absent account"):
+        async with maker() as db, db.begin():
+            await issue_session(db, test_settings.session, 999)
+    async with maker() as db:
+        assert await db.scalar(select(func.count()).select_from(AuthSession)) == 0
+
+
+async def test_later_successful_login_prunes_expired_rows(maker, test_settings):
+    async with maker() as db, db.begin():
+        expired = await issue_session(db, test_settings.session, 42)
+        await db.execute(
+            update(AuthSession).values(expires_at=func.statement_timestamp())
+        )
+    async with maker() as db, db.begin():
+        active = await issue_session(db, test_settings.session, 42)
+        assert active.pruned_count == 1
+    async with maker() as db:
+        assert await db.get(AuthSession, token_digest(expired.token)) is None
+        assert await db.get(AuthSession, token_digest(active.token)) is not None

--- a/api/tests/services/test_users_service.py
+++ b/api/tests/services/test_users_service.py
@@ -3,9 +3,7 @@
 Tests cover:
 - normalize_github_username lowercasing and edge cases
 - normalize_display_name preservation and malformed provider data
-- get_user_by_id cache hit/miss and not found
 - get_or_create_user_from_github upsert and username conflict
-- delete_user_account success and not found
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -15,85 +13,10 @@ from learn_to_cloud_shared.schemas import UserResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from learn_to_cloud.services.users_service import (
-    UserNotFoundError,
-    delete_user_account,
     get_or_create_user_from_github,
-    get_user_by_id,
     normalize_display_name,
     normalize_github_username,
 )
-
-
-@pytest.mark.unit
-class TestDeleteUserAccount:
-    """Tests for delete_user_account service function."""
-
-    @pytest.mark.asyncio
-    async def test_delete_existing_user(self):
-        """Deleting an existing user calls repo.delete (caller commits)."""
-        mock_db = AsyncMock()
-        mock_user = MagicMock()
-        mock_user.github_username = "testuser"
-
-        with patch(
-            "learn_to_cloud.services.users_service.UserRepository", autospec=True
-        ) as mock_repo_class:
-            mock_repo = mock_repo_class.return_value
-            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
-            mock_repo.delete = AsyncMock()
-
-            await delete_user_account(mock_db, user_id=12345)
-
-            mock_repo.get_by_id.assert_awaited_once_with(12345)
-            mock_repo.delete.assert_awaited_once_with(12345)
-            # Service does NOT commit — caller (route) owns the transaction
-            mock_db.commit.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_delete_nonexistent_user_raises(self):
-        """Deleting a user that doesn't exist raises UserNotFoundError."""
-        mock_db = AsyncMock()
-
-        with patch(
-            "learn_to_cloud.services.users_service.UserRepository", autospec=True
-        ) as mock_repo_class:
-            mock_repo = mock_repo_class.return_value
-            mock_repo.get_by_id = AsyncMock(return_value=None)
-
-            with pytest.raises(UserNotFoundError) as exc_info:
-                await delete_user_account(mock_db, user_id=99999)
-
-            assert exc_info.value.user_id == 99999
-            mock_db.commit.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_delete_calls_repo(self):
-        """Account deletion calls repository delete."""
-        mock_db = AsyncMock()
-        mock_user = MagicMock()
-        mock_user.github_username = "loguser"
-
-        with patch(
-            "learn_to_cloud.services.users_service.UserRepository", autospec=True
-        ) as mock_repo_class:
-            mock_repo = mock_repo_class.return_value
-            mock_repo.get_by_id = AsyncMock(return_value=mock_user)
-            mock_repo.delete = AsyncMock()
-
-            await delete_user_account(mock_db, user_id=12345)
-
-            mock_repo.delete.assert_awaited_once()
-
-
-@pytest.mark.integration
-class TestDeleteUserAccountIntegration:
-    """Integration tests for account deletion.
-
-    Cascade behavior (submissions, step_progress) is enforced
-    by SQLAlchemy model definitions (cascade="all, delete-orphan") and
-    PostgreSQL ON DELETE CASCADE foreign keys.
-    """
-
 
 # ---------------------------------------------------------------------------
 # normalize_github_username
@@ -154,33 +77,6 @@ class TestNormalizeDisplayName:
         assert record.getMessage() == "auth.callback.display_name_ignored"
         assert record.args == ()
         assert record.exc_info is None
-
-
-# ---------------------------------------------------------------------------
-# get_user_by_id
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestGetUserById:
-    @pytest.mark.asyncio
-    async def test_returns_user_from_db(self):
-        mock_user = MagicMock()
-        with patch(
-            "learn_to_cloud.services.users_service.UserRepository", autospec=True
-        ) as MockRepo:
-            MockRepo.return_value.get_by_id = AsyncMock(return_value=mock_user)
-            result = await get_user_by_id(AsyncMock(), user_id=1)
-        assert result is mock_user
-
-    @pytest.mark.asyncio
-    async def test_not_found_returns_none(self):
-        with patch(
-            "learn_to_cloud.services.users_service.UserRepository", autospec=True
-        ) as MockRepo:
-            MockRepo.return_value.get_by_id = AsyncMock(return_value=None)
-            result = await get_user_by_id(AsyncMock(), user_id=999)
-        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_auth_sessions_migration.py
+++ b/api/tests/test_auth_sessions_migration.py
@@ -1,0 +1,237 @@
+"""Populated session migration, retry, downgrade, and nonowner privilege tests."""
+
+from io import StringIO
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from alembic.config import Config
+from learn_to_cloud_shared.models import AuthSession, LearnerStepCompletion, User
+from sqlalchemy import delete, func, insert, inspect, select, text
+from sqlalchemy.exc import IntegrityError
+
+from alembic import command, op
+from tests.test_migration_chain import alembic_config as alembic_config
+from tests.test_migration_chain import alembic_engine as alembic_engine
+
+BASE = "0059_drop_user_legacy_names"
+TABLE = "0060_add_auth_sessions"
+HEAD = "0061_auth_sessions_concurrent_indexes"
+
+
+def seed_account(conn):
+    conn.execute(insert(User).values(id=1, github_username="preserved"))
+    conn.execute(insert(LearnerStepCompletion).values(user_id=1, step_uuid=UUID(int=1)))
+
+
+def insert_session(conn, digest=b"a" * 32):
+    now = func.statement_timestamp()
+    conn.execute(
+        insert(AuthSession).values(
+            token_digest=digest,
+            user_id=1,
+            created_at=now,
+            updated_at=now,
+            last_seen_at=now,
+            expires_at=now + text("interval '30 days'"),
+        )
+    )
+
+
+def test_populated_upgrade_downgrade_and_reupgrade(alembic_runner, alembic_engine):
+    alembic_runner.migrate_up_to(BASE)
+    with alembic_engine.begin() as conn:
+        seed_account(conn)
+        users = conn.execute(select(User.__table__)).all()
+        progress = conn.execute(select(LearnerStepCompletion.__table__)).all()
+    alembic_runner.migrate_up_to(HEAD)
+    with alembic_engine.begin() as conn:
+        assert conn.execute(select(User.__table__)).all() == users
+        assert conn.execute(select(LearnerStepCompletion.__table__)).all() == progress
+        assert conn.execute(select(func.count()).select_from(AuthSession)).scalar() == 0
+        indexes = {i["name"]: i for i in inspect(conn).get_indexes("auth_sessions")}
+        assert set(indexes) == {
+            "ix_auth_sessions_user_id",
+            "ix_auth_sessions_expires_at",
+            "ix_auth_sessions_last_seen_at",
+        }
+        fk = inspect(conn).get_foreign_keys("auth_sessions")
+        assert len(fk) == 1
+        assert fk[0]["referred_table"] == "users"
+        assert fk[0]["options"]["ondelete"] == "CASCADE"
+        insert_session(conn)
+    alembic_runner.migrate_down_to(BASE)
+    with alembic_engine.connect() as conn:
+        assert "auth_sessions" not in inspect(conn).get_table_names()
+        assert conn.execute(select(User.__table__)).all() == users
+        assert conn.execute(select(LearnerStepCompletion.__table__)).all() == progress
+    alembic_runner.migrate_up_to(HEAD)
+    with alembic_engine.begin() as conn:
+        assert conn.execute(select(func.count()).select_from(AuthSession)).scalar() == 0
+        insert_session(conn)
+        conn.execute(delete(User).where(User.id == 1))
+        assert conn.execute(select(func.count()).select_from(AuthSession)).scalar() == 0
+
+
+def test_concurrent_index_failure_retry_rebuilds_invalid_indexes(
+    alembic_runner, alembic_engine, monkeypatch
+):
+    alembic_runner.migrate_up_to(TABLE)
+    with alembic_engine.begin() as conn:
+        seed_account(conn)
+        insert_session(conn)
+        insert_session(conn, b"b" * 32)
+    with alembic_engine.connect().execution_options(
+        isolation_level="AUTOCOMMIT"
+    ) as conn:
+        with pytest.raises(IntegrityError):
+            conn.execute(
+                text(
+                    "CREATE UNIQUE INDEX CONCURRENTLY ix_auth_sessions_user_id "
+                    "ON auth_sessions (user_id)"
+                )
+            )
+        assert (
+            conn.execute(
+                text(
+                    "SELECT indisvalid FROM pg_index "
+                    "WHERE indexrelid = 'ix_auth_sessions_user_id'::regclass"
+                )
+            ).scalar_one()
+            is False
+        )
+
+    original = op.execute
+
+    def fail_second_index(statement, *args, **kwargs):
+        if str(statement).startswith(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_auth_sessions_expires_at"
+        ):
+            raise RuntimeError("Simulated interrupted index build")
+        return original(statement, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(op, "execute", fail_second_index)
+        with pytest.raises(RuntimeError, match="Simulated"):
+            alembic_runner.migrate_up_to(HEAD)
+    with alembic_engine.connect() as conn:
+        assert (
+            conn.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
+            == TABLE
+        )
+        assert conn.execute(select(func.count()).select_from(AuthSession)).scalar() == 2
+    alembic_runner.migrate_up_to(HEAD)
+    with alembic_engine.connect() as conn:
+        validity = conn.execute(
+            text(
+                "SELECT indisvalid, indisready, indisunique FROM pg_index "
+                "JOIN pg_class ON pg_class.oid = indexrelid "
+                "WHERE relname LIKE 'ix_auth_sessions_%'"
+            )
+        ).all()
+        assert validity == [(True, True, False)] * 3
+
+
+@pytest.mark.parametrize("grant_mode", ["default_acl", "explicit"])
+def test_api_runtime_dml_without_ownership_or_functions_access(
+    alembic_runner, alembic_engine, monkeypatch, grant_mode
+):
+    runtime = f"session_api_{uuid4().hex[:12]}"
+    functions = f"session_fn_{uuid4().hex[:12]}"
+    if grant_mode == "explicit":
+        monkeypatch.setenv("POSTGRES_API_RUNTIME_ROLE", runtime)
+    else:
+        monkeypatch.delenv("POSTGRES_API_RUNTIME_ROLE", raising=False)
+    monkeypatch.setenv("POSTGRES_VERIFICATION_FUNCTIONS_ROLE", functions)
+    try:
+        with alembic_engine.begin() as conn:
+            conn.execute(text(f'CREATE ROLE "{runtime}"'))
+            if grant_mode == "default_acl":
+                conn.execute(
+                    text(
+                        "ALTER DEFAULT PRIVILEGES IN SCHEMA public "
+                        f'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "{runtime}"'
+                    )
+                )
+        alembic_runner.migrate_up_to(BASE)
+        with alembic_engine.begin() as conn:
+            conn.execute(text(f'CREATE ROLE "{functions}"'))
+            seed_account(conn)
+            conn.execute(text(f'GRANT USAGE ON SCHEMA public TO "{runtime}"'))
+            conn.execute(text(f'GRANT SELECT, UPDATE ON users TO "{runtime}"'))
+        alembic_runner.migrate_up_to(HEAD)
+        with alembic_engine.begin() as conn:
+            privileges = set(
+                conn.execute(
+                    text(
+                        "SELECT privilege_type "
+                        "FROM information_schema.table_privileges "
+                        "WHERE table_name = 'auth_sessions' AND grantee = :role"
+                    ),
+                    {"role": runtime},
+                ).scalars()
+            )
+            assert privileges == {"SELECT", "INSERT", "UPDATE", "DELETE"}
+            assert (
+                conn.execute(
+                    text(
+                        "SELECT has_table_privilege(:role, 'auth_sessions', "
+                        "'SELECT,INSERT,UPDATE,DELETE')"
+                    ),
+                    {"role": functions},
+                ).scalar_one()
+                is False
+            )
+            assert (
+                conn.execute(
+                    text(
+                        "SELECT pg_get_userbyid(relowner) FROM pg_class "
+                        "WHERE oid = 'auth_sessions'::regclass"
+                    )
+                ).scalar_one()
+                != runtime
+            )
+            conn.execute(text(f'SET LOCAL ROLE "{runtime}"'))
+            conn.execute(text("SELECT id FROM users WHERE id = 1 FOR UPDATE"))
+            insert_session(conn)
+            assert conn.execute(select(AuthSession.user_id)).scalar_one() == 1
+            conn.execute(
+                text("UPDATE auth_sessions SET last_seen_at = statement_timestamp()")
+            )
+            conn.execute(text("DELETE FROM auth_sessions"))
+            assert (
+                conn.execute(select(func.count()).select_from(AuthSession)).scalar()
+                == 0
+            )
+    finally:
+        with alembic_engine.begin() as conn:
+            for role in (runtime, functions):
+                conn.execute(text(f'DROP OWNED BY "{role}"'))
+                conn.execute(text(f'DROP ROLE "{role}"'))
+
+
+def test_offline_session_ddl_has_atomic_stamp_and_bounded_concurrent_indexes():
+    config = Config(str(Path(__file__).parent.parent / "alembic.ini"))
+    config.set_main_option(
+        "script_location", str(Path(__file__).parent.parent / "alembic")
+    )
+    output = StringIO()
+    config.output_buffer = output
+    command.upgrade(config, f"{BASE}:{HEAD}", sql=True)
+    sql = output.getvalue()
+    table = sql.index("CREATE TABLE auth_sessions")
+    stamp = sql.index(f"SET version_num='{TABLE}'")
+    commit = sql.index("COMMIT;", stamp)
+    index = sql.index("CREATE INDEX CONCURRENTLY")
+    assert table < stamp < commit < index
+    assert "SET LOCAL lock_timeout = '5s';" in sql
+    assert "SET LOCAL statement_timeout = '2min';" in sql
+    assert "SET statement_timeout = '10min';" in sql
+    assert "RESET statement_timeout;" in sql
+    assert sql.count("DROP INDEX CONCURRENTLY IF EXISTS ix_auth_sessions_") == 3
+    assert sql.count("CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_auth_sessions_") == 3
+    output = StringIO()
+    config.output_buffer = output
+    command.downgrade(config, f"{HEAD}:{BASE}", sql=True)
+    sql = output.getvalue()
+    assert sql.rindex("DROP INDEX CONCURRENTLY") < sql.index("DROP TABLE auth_sessions")

--- a/api/tests/test_dogfood_session.py
+++ b/api/tests/test_dogfood_session.py
@@ -1,0 +1,95 @@
+"""The browser-cookie generator must use the local committed session service."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from learn_to_cloud_shared.core.config import DatabaseConfig, Environment
+from learn_to_cloud_shared.models import AuthSession, User
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from learn_to_cloud.core.session_cookies import AUTH_COOKIE_NAME, token_digest
+
+_PATH = Path(__file__).resolve().parents[2] / "scripts" / "dogfood_session.py"
+_SPEC = importlib.util.spec_from_file_location("dogfood_session", _PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+dogfood = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(dogfood)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("host", ["localhost", "127.0.0.1", "127.1.2.3", "[::1]"])
+def test_accepts_loopback(test_settings, host):
+    settings = test_settings.model_copy(
+        update={
+            "database": DatabaseConfig(
+                url=f"postgresql+asyncpg://local:local@{host}:55432/test_learn_to_cloud"
+            )
+        }
+    )
+    dogfood.validate_local_target(settings)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "target",
+    [
+        "postgresql+asyncpg://u:p@db:5432/local",
+        "postgresql+asyncpg://u:p@localhost.example.com/local",
+        "postgresql+asyncpg://u:p@192.168.1.1/local",
+        "postgresql+asyncpg://u:p@[::ffff:192.168.1.1]/local",
+        "postgresql+asyncpg://u:p@localhost/local?host=remote",
+        "postgresql+asyncpg://u:p@localhost/local?hostaddr=10.0.0.1",
+        "postgresql+asyncpg://u:p@/local",
+        "postgresql://u:p@localhost/local",
+    ],
+)
+def test_refuses_remote_or_ambiguous_database(test_settings, target):
+    settings = test_settings.model_copy(update={"database": DatabaseConfig(url=target)})
+    with pytest.raises(ValueError, match="local|loopback"):
+        dogfood.validate_local_target(settings)
+
+
+@pytest.mark.unit
+def test_refuses_production(test_settings):
+    settings = test_settings.model_copy(update={"environment": Environment.PRODUCTION})
+    with pytest.raises(ValueError, match="development"):
+        dogfood.validate_local_target(settings)
+
+
+@pytest.mark.integration
+async def test_generator_persists_real_cookie_and_existing_user(
+    test_engine, test_settings
+):
+    maker = async_sessionmaker(test_engine, expire_on_commit=False)
+    async with maker() as db, db.begin():
+        db.add(User(id=42, github_username="madebygps"))
+    result = await dogfood.generate_cookie(settings=test_settings)
+    assert result["cookie_name"] == AUTH_COOKIE_NAME
+    assert result["user_id"] == 42
+    assert result["domain"] == "localhost"
+    assert result["path"] == "/"
+    async with maker() as db:
+        row = await db.get(AuthSession, token_digest(result["cookie_value"]))
+        assert row is not None
+        assert row.user_id == 42
+
+
+@pytest.mark.integration
+async def test_missing_user_has_no_synthetic_fallback(test_engine, test_settings):
+    with pytest.raises(ValueError, match="existing local account"):
+        await dogfood.generate_cookie(999, settings=test_settings)
+
+
+@pytest.mark.unit
+async def test_database_failure_is_not_silenced(test_settings):
+    with (
+        patch.object(
+            dogfood,
+            "create_async_engine",
+            side_effect=RuntimeError("database unavailable"),
+        ),
+        pytest.raises(RuntimeError, match="database unavailable"),
+    ):
+        await dogfood.generate_cookie(42, settings=test_settings)

--- a/api/tests/test_migration_chain.py
+++ b/api/tests/test_migration_chain.py
@@ -235,13 +235,17 @@ _WHITESPACE_CODEPOINTS = (
 )
 
 
-def _expanded_metadata() -> MetaData:
+def _expanded_metadata(*, contracted: bool = False) -> MetaData:
     """Reconstruct transitional metadata without restoring runtime dependencies."""
     metadata = MetaData()
     for table in Base.metadata.sorted_tables:
-        table.to_metadata(metadata)
-    for name in ("first_name", "last_name"):
-        metadata.tables["users"].append_column(Column(name, String(255), nullable=True))
+        if table.name != "auth_sessions":
+            table.to_metadata(metadata)
+    if not contracted:
+        for name in ("first_name", "last_name"):
+            metadata.tables["users"].append_column(
+                Column(name, String(255), nullable=True)
+            )
     return metadata
 
 
@@ -431,7 +435,7 @@ def test_display_name_contract_preserves_populated_data_and_downgrade_is_empty(
             context = MigrationContext.configure(
                 conn, opts={"compare_type": True, "compare_server_default": True}
             )
-            metadata = Base.metadata if contracted else _expanded_metadata()
+            metadata = _expanded_metadata(contracted=contracted)
             assert compare_metadata(context, metadata) == []
 
 

--- a/api/tests/test_telemetry_contracts.py
+++ b/api/tests/test_telemetry_contracts.py
@@ -20,6 +20,9 @@ _PYTHON_TELEMETRY_ROOTS = (
 _ALLOWED_APPLICATION_ATTRIBUTES = {
     "auth.configuration.reason",
     "auth.identity.reason",
+    "auth.session.reason",
+    "auth.session.scope",
+    "auth.session.count",
     "content.artifact.hash",
     "content.artifact_schema.version",
     "content.curriculum.version",
@@ -64,6 +67,10 @@ _ALLOWED_APPLICATION_ATTRIBUTES = {
 }
 
 _PROHIBITED_APPLICATION_ATTRIBUTES = {
+    "session.id",
+    "session.token",
+    "session.digest",
+    "csrf",
     "attempt_age_seconds",
     "attempt_created",
     "attempt_id",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -412,19 +412,38 @@ These are positive durations, and inactivity cannot exceed absolute lifetime.
 Seven inactive days is a convenience tradeoff, not a claim of high-assurance
 session timeout policy.
 
-The API uses one identity type:
+Choose the dependency for the data the route actually consumes:
 
 | Name | Purpose |
 |------|---------|
 | `AuthenticatedUser` | Plain identity data: numeric user ID and GitHub username. Use it in helpers receiving an existing identity. |
 | `CurrentUser` | An `Annotated` alias that tells FastAPI to call `require_authenticated_user` and supply that identity to a protected route. |
 | `OptionalCurrentUser` | Supplies the same identity or `None` to a public route. |
+| `CurrentAccount` | Supplies the loaded `User` account to a protected route that needs profile fields or renders account-aware templates. |
+| `OptionalCurrentAccount` | Supplies that loaded account or `None` to a public route. |
 
-Import these from `learn_to_cloud.core.auth`. Routes access
-`current_user.user_id` or `current_user.github_username`; do not introduce
-ID-only dependencies or a separate browser-user type.
-`require_authenticated_user` raises `AuthenticationRequired` when no live
-session and current account resolve. It does not choose a browser redirect.
+Import these from `learn_to_cloud.core.auth`. Identity consumers access
+`current_user.user_id` or `current_user.github_username`; account consumers access
+`account.id`, `account.github_username`, and loaded profile fields. Do not introduce
+ID-only dependencies or a separate browser-user type. Pass accounts explicitly
+to templates and rendering helpers; do not look them up through `request.state`.
+
+All four aliases share `optional_authenticated_account`, which resolves the
+session and loads the account in one short, committed transaction before route
+work. FastAPI caches this shared subdependency per request; a request-local cache
+also prevents repeat resolution and touches when the resolver is called directly.
+The resolver populates telemetry identity state for both account and identity
+consumers. Database failures propagate rather than becoming anonymous requests.
+`require_authenticated_account` raises `AuthenticationRequired` when no live
+session and current account resolve; the required identity dependency derives
+from it. Neither chooses a browser redirect.
+
+The injected account is a read-only, loaded ORM snapshot, not a transaction.
+Session makers use `expire_on_commit=False` so loaded scalar fields remain
+available after the authentication session closes. Do not lazy-load relationships,
+attach the snapshot for writes, or mutate it. Use an explicit service and database
+session for additional reads or writes; do not query the account again just to
+render it.
 
 Browser navigation is a route policy, separate from identity loading.
 Page routers select `LoginRedirectRoute` from `learn_to_cloud.core.routing`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -225,7 +225,7 @@ or invoke the agent directly with `@dog-food`. The agent will:
 2. **Install Chromium** if needed (headless, `--no-sandbox`)
 3. **Test all public pages** — Home, Curriculum, FAQ, Privacy, Terms, Status
 4. **Toggle dark mode** and verify it works
-5. **Authenticate** via a signed session cookie (no real GitHub OAuth needed)
+5. **Authenticate** via a persisted local session (no real GitHub OAuth needed)
 6. **Test authenticated pages** — Dashboard, Account, Phase, Topic
 7. **Toggle a learning step** checkbox and verify it persists
 8. **Report results** as a structured summary with pass/fail for each page
@@ -241,7 +241,11 @@ playwright-mcp install-browser chromium --with-deps
 
 The MCP server is configured in `.mcp.json` for the Copilot CLI and
 `.vscode/mcp.json` for VS Code. The database must contain at least one user;
-`scripts/dogfood_session.py` creates the local authenticated session.
+`scripts/dogfood_session.py` commits an authenticated session for an existing
+local account. It requires development settings and a loopback database and
+refuses production targets. Missing accounts and database errors are failures,
+not reasons to invent a user. Its cookie JSON is a local credential: pass it
+directly to browser automation, never into logs, issue reports, or commits.
 
 ### Cross-architecture support
 
@@ -302,13 +306,22 @@ Routes (HTTP) → Services (Business Logic) → Repositories (Database)
 
 ### Authentication and sessions
 
-GitHub OAuth establishes a signed client-side session cookie containing
-`user_id` and `github_username`. Session middleware verifies its signature and
-age on subsequent requests; those requests do not contact GitHub again.
-The cookie is signed, not encrypted, so do not store secrets in its payload.
+GitHub OAuth establishes an opaque login cookie, `ltc_session`, backed by
+PostgreSQL. The cookie is a random credential, not an encoded identity. The
+`auth_sessions` table stores only its SHA-256 digest, account ID, and creation,
+update, last-activity, and absolute-expiry timestamps. It stores no IP address,
+User-Agent, device label, profile snapshot, or OAuth token. Normal authenticated
+requests resolve the current account from this store; they do not contact GitHub.
 
-OAuth issuance and session reads share `validate_identity` from
-`learn_to_cloud.core.auth`. It requires:
+The separate signed `session` cookie is only for Authlib's temporary OAuth
+handshake state, with a ten-minute browser lifetime. Its contents are signed,
+not encrypted. Unrelated in-flight OAuth state survives callback failures;
+OAuth responses cannot replace the separate authentication cookie.
+Both cookies use HttpOnly, SameSite=Lax, Path=/, no Domain, and Secure in
+production. Browser expiry is not the authority for session validity.
+
+OAuth issuance uses `validate_identity` from `learn_to_cloud.core.auth`.
+It requires:
 
 - An integer GitHub ID from 1 through `2**63 - 1`. Booleans, floats, numeric
   strings, zero, negative values, and larger integers are rejected, not converted.
@@ -318,11 +331,11 @@ OAuth issuance and session reads share `validate_identity` from
 
 GitHub's authenticated profile response establishes account identity. We do not
 duplicate signup rules, check reserved names, or requery GitHub on each request.
-Session reads preserve accepted values without trimming or changing case.
 OAuth retains lowercase normalization and validates the normalized value before
 database access, since lowercasing can increase a Unicode string's length.
 The returned database identity must match that validated identity, and the
-transaction must commit before a new cookie identity is written. A mismatch
+account upsert and session-creation transaction must commit before a new cookie
+or successful-login event is issued. A mismatch
 is an internal error, not an ordinary rejected login.
 
 #### Profile names
@@ -367,19 +380,37 @@ an existing user's profile unchanged.
 
 #### Session reads
 
-Missing both identity fields is normal anonymous access, including a session
-containing only OAuth state. Partial or malformed identity is also treated as
-anonymous, but both identity fields are removed from the existing session object.
-Unrelated entries, including OAuth state, are preserved. Middleware persists the
-cleaned cookie or expires it if nothing remains.
+Missing authentication cookies and OAuth-state-only cookies are anonymous
+without a session/account query. Legacy identity fields are never trusted and
+are removed while preserving unrelated OAuth state. The cutover requires
+everyone to sign in again; there is no legacy fallback or session backfill.
+The signing key does not need rotation.
 
-Rejecting numeric-string IDs is an intentional change from the previous
-coercing reader. Valid sessions remain valid; rejected sessions require login
-again. Local tools such as `scripts/dogfood_session.py` must also supply valid
-identity values. No migration, backfill, or cookie-key rotation is needed.
-Malformed cookie encoding, JSON, or top-level session shapes are a separate
-middleware concern tracked in
-[#834](https://github.com/learntocloud/learn-to-cloud-app/issues/834).
+Resolution is asynchronous and cached for this request only, including
+anonymous results. A valid session is conditionally touched using the database
+clock and returned with its current account in a short committed transaction.
+Pages, `/api/user/me`, and HTMX step rendering reuse that account rather than
+select it again. No session lock or database connection remains held during
+template rendering, provider calls, or verification work.
+
+Unknown, revoked, deleted-account, and expired credentials cannot authenticate
+or recreate rows. Supplied invalid credentials are cleared on handled responses,
+including 401s and redirects. A database failure is a real service failure,
+not anonymous access or permission to trust a cookie. Responses affected by
+identity vary on Cookie; authenticated and account/auth responses are private
+and non-cacheable. Static asset caching is unchanged.
+
+| Session limit | Behavior |
+| --- | --- |
+| Inactivity | Reject at seven days since the last authenticated request. Pages, APIs, and verification polling count; static assets, health probes, and simply keeping a page open do not. |
+| Absolute lifetime | Reject at thirty days after creation, even with continual activity. A new GitHub login starts a new lifetime. |
+| Expired-row retention | A successful login prunes at most 100 idle- or absolute-expired rows. No worker or wall-clock removal deadline is promised; pending cleanup never makes expired rows valid. |
+
+`SessionConfig` exposes `idle_timeout_seconds` (604800),
+`absolute_timeout_seconds` (2592000), and `oauth_state_max_age_seconds` (600).
+These are positive durations, and inactivity cannot exceed absolute lifetime.
+Seven inactive days is a convenience tradeoff, not a claim of high-assurance
+session timeout policy.
 
 The API uses one identity type:
 
@@ -392,10 +423,8 @@ The API uses one identity type:
 Import these from `learn_to_cloud.core.auth`. Routes access
 `current_user.user_id` or `current_user.github_username`; do not introduce
 ID-only dependencies or a separate browser-user type.
-`require_authenticated_user` raises `AuthenticationRequired` when the session
-has no complete identity. It does not choose a browser redirect or check
-whether the application account still exists. Account-validity work is tracked
-in [#829](https://github.com/learntocloud/learn-to-cloud-app/issues/829).
+`require_authenticated_user` raises `AuthenticationRequired` when no live
+session and current account resolve. It does not choose a browser redirect.
 
 Browser navigation is a route policy, separate from identity loading.
 Page routers select `LoginRedirectRoute` from `learn_to_cloud.core.routing`
@@ -414,22 +443,44 @@ A browser mutation that intentionally redirects uses 303 so the next request
 is GET, not a replay of POST or DELETE. Do not infer auth response policy from
 URL prefixes or `Accept` headers.
 
-POST `/auth/logout` needs no authenticated dependency. It clears the session,
-explicitly expires the browser cookie, and returns 303 to `/`, including when
-the cookie is missing, rejected, or already cleared. Explicit cookie deletion
-also handles rejected cookies that middleware presents as an empty session.
-The signed session lifetime is currently 30 days. Logout removes this browser's
-cookie but does not revoke a previously copied valid cookie; session-revocation
-and expiry guarantees are tracked in
-[#828](https://github.com/learntocloud/learn-to-cloud-app/issues/828).
+POST `/auth/logout` needs no authenticated dependency. It deletes this browser's
+session, commits, clears its cookies, and returns 303 to `/`. Replaying an exact
+copy of that cookie fails across all app processes; independent browser sessions
+stay valid. Missing, malformed, unknown, expired, and already-revoked cookies
+retain repeatable cleanup behavior. If the database cannot confirm revocation,
+the route fails instead of claiming success.
+
+The Account page's Sign out everywhere form posts to `/auth/logout-all`. It
+requires a live session and a session-bound, non-bearer CSRF token. Missing or
+incorrect tokens return 403 without deletion. The form asks for confirmation,
+includes this browser, and disables HTMX boost so its 303 navigates normally.
+The server locks the account before rechecking the requesting session and
+deleting all current sessions. Login issuance uses the same account-first lock
+order; a genuinely later GitHub login can create a new session.
+
+Both account-deletion endpoints commit account deletion and foreign-key
+cascades before reporting success, emitting `user.account_deleted`, or clearing
+cookies. All sessions, progress, and submissions are removed atomically.
+Other browsers become anonymous on their next request. A new login can recreate
+the same numeric GitHub account ID, but never revives an old session.
+
+Revocation takes effect when its transaction commits. Already-authorized work
+may finish, and running verification work is not cancelled. An expired open
+page is rejected on its next server interaction; there is no background logout
+timer. Sign out everywhere revokes this app's sessions, not GitHub sessions or
+GitHub authorization. After cookie theft, sign in on a trusted browser and use
+that action. A compromised GitHub account must also be secured at GitHub.
 
 Auth behavior is covered through real routes, session middleware, and HTTP
-redirects in `api/tests/routes/test_auth_http.py`. Auth overrides are useful
+redirects in `api/tests/routes/test_auth_http.py`, with persisted multi-browser
+lifecycle coverage in `api/tests/routes/test_session_lifecycle.py`.
+Auth overrides are useful
 for unrelated rendering tests, but must not replace authentication in tests
 of the auth contract itself. Request telemetry records handled 401/303 outcomes;
 it must not add usernames, user IDs, cookie values, or session identifiers.
-Handled identity rejection emits a bounded warning without exception details;
-ordinary anonymous access does not. Failed OAuth attempts do not clear an
+Session rejections use bounded reasons without exception details; expected
+expiry, unknown-session, and cutover outcomes are informational, not automatic
+compromise warnings. Ordinary anonymous access emits no event. Failed OAuth attempts do not clear an
 existing valid login or unrelated authorization state.
 See the [telemetry schema](observability/telemetry-schema.html).
 

--- a/docs/curriculum.md
+++ b/docs/curriculum.md
@@ -31,6 +31,7 @@ PostgreSQL stores only durable learner state:
 | Table | Purpose |
 |---|---|
 | `users` | GitHub-authenticated learner accounts |
+| `auth_sessions` | Revocable login-session digests, account ownership, and expiry timestamps |
 | `learner_step_completions` | Checked learning steps, keyed by catalog UUID |
 | `verification_attempts` | Submitted verification attempts and outcomes |
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -46,6 +46,47 @@ in failure messages and swallowed real `UniqueViolation`s as "already
 applied by another process." Production stayed pinned to an older
 revision for eight days while CI reported green deploys.
 
+## Revocable-session cutover (#828, #829)
+
+This is a hard cutover, with downtime acceptable. Deploy the schema and
+application together in one release; there is no legacy-cookie fallback,
+session backfill, dual-write period, or rolling-version support. Everyone
+must sign in again. Old in-flight OAuth handshakes may also need restarting.
+
+`0060_add_auth_sessions` creates digest-only session storage with an account
+foreign key using `ON DELETE CASCADE`. Existing accounts and learning data are
+unchanged. The migration uses local five-second lock and two-minute statement
+timeouts. It grants the configured API runtime role only SELECT, INSERT,
+UPDATE, and DELETE on this table; it does not grant ownership or Functions
+access. The migration job and deployment workflow pass
+`POSTGRES_API_RUNTIME_ROLE` from Terraform's effective `api_postgres_role`.
+This explicit grant avoids relying on unverified production default ACLs.
+Local owner-backed migrations can omit it; nonowner migration tests exercise
+both explicit grants and default ACLs.
+
+`0061_auth_sessions_concurrent_indexes` creates the account, absolute-expiry,
+and last-activity indexes concurrently. Separating it ensures the table and
+its revision stamp commit together before index work leaves a transaction.
+The index migration uses bounded five-second lock and ten-minute statement
+timeouts. An interrupted build can be retried: it drops and rebuilds its named
+indexes, including invalid indexes, without discarding sessions or accounts.
+Do not stamp a failed migration manually or suppress index errors.
+
+For an authorized deployment, stop old API processes from serving requests,
+apply both migrations, and start only the session-aware application. Downtime
+is preferable to serving old identity-cookie authentication. The automated
+pipeline runs migrations before the image update; retiring old processes is
+an explicit cutover boundary, not a claim made by database readiness or Single
+revision mode. Confirm new GitHub login, copied-cookie rejection after logout,
+and independent-browser behavior before considering the cutover complete.
+
+Prefer a forward fix or a session-aware known-good revision. Restoring old
+identity-cookie code would undo revocation guarantees and is not a routine
+rollback. Do not downgrade while session-aware processes run. Downgrade removes
+the indexes before the table and loses every login session, but preserves
+accounts and learning data. Re-upgrade starts with no sessions; it cannot
+recover discarded sessions or make revoked cookies valid.
+
 ## Display-name rollout (#836)
 
 Ship the schema addition and application cutover together, then remove legacy

--- a/docs/observability/telemetry-schema.md
+++ b/docs/observability/telemetry-schema.md
@@ -175,13 +175,19 @@ alert notifications, and must not be added to general request spans.
 | `repo` | `github.repository` | Identify a failed curriculum repository lookup | Fixed public repository set | Operational | Rename; only approved curriculum repositories |
 | `status_code` on auth events | `http.response.status_code` | GitHub OAuth response status | Bounded integer | Operational | Rename |
 | `reason` on auth events | `auth.configuration.reason` | Explain disabled OAuth | Fixed enum | Operational | Rename |
-| `auth.identity.reason` | `auth.identity.reason` | Explain rejected session or provider identity | Fixed enum below | Operational | Keep |
+| `auth.identity.reason` | `auth.identity.reason` | Explain rejected provider identity | Fixed enum below | Operational | Keep |
+| `auth.session.reason` | `auth.session.reason` | Explain rejected app session | Fixed enum below | Operational | Keep |
+| `auth.session.scope` | `auth.session.scope` | Distinguish current-session and account-wide revocation | `current`, `all` | Operational | Keep |
+| `auth.session.count` | `auth.session.count` | Count committed revocations or expired-row pruning | Nonnegative aggregate integer | Operational | Keep |
 
 Authentication events do not deliberately include GitHub usernames, GitHub IDs,
 internal user IDs, or profile names. Public profile values may occur in unexpected
 database error diagnostics under the error policy above. Do not add them as
 metric labels, span attributes, or browser identity context. OAuth tokens,
-session cookies, claims, and session secrets remain prohibited.
+session cookies, token digests, session identifiers, CSRF values, OAuth state,
+claims, and session secrets remain prohibited. Raw session credentials are
+never sent to PostgreSQL. Keep SQL parameter hiding; normal profile diagnostics
+are not permission to expose authentication credentials.
 
 `auth.callback.display_name_ignored` is a constant warning with no application
 attributes or exception details. It means an optional profile name was a
@@ -190,13 +196,12 @@ The name becomes `NULL` and normal login continues. Missing/null/blank names
 are ordinary profile data and emit no warning. Do not use this warning as an
 identity-rejection or failed-login signal, and never attach the discarded value.
 
-`auth.session.identity_rejected` and `auth.callback.identity_rejected` are
-warning-level logs for handled identity rejection. Their only application
+`auth.callback.identity_rejected` is a warning for handled provider identity
+rejection. Its only application
 attribute is `auth.identity.reason`:
 
 | Value | Meaning |
 | --- | --- |
-| `incomplete_identity` | A session contains only one application identity field. |
 | `invalid_user_id` | The ID fails the strict positive signed-64-bit integer contract. |
 | `invalid_github_username` | The username fails the type, nonblank, length, or storage-encoding contract, including after OAuth normalization. |
 | `invalid_response_format` | The provider response has invalid JSON/character encoding or is not a JSON object. |
@@ -205,11 +210,35 @@ These events replace the callback's former `auth.callback.missing_github_id`
 and `auth.callback.missing_github_login` events. Existing provider transport
 failures retain `auth.callback.profile_fetch_failed` and bounded `error.type`.
 
-Rejection does not attach exception details or identity values. Empty sessions,
-OAuth-state-only sessions, and cookies rejected by middleware do not produce
-identity warnings. Cleaning an invalid session prevents another warning when
-that cleaned session is read again; this is not cross-request deduplication if
-a client keeps replaying the original cookie.
+`auth.session.rejected` replaces `auth.session.identity_rejected`. Its sole
+application attribute is `auth.session.reason`:
+
+| Value | Meaning |
+| --- | --- |
+| `malformed` | Supplied opaque credential has an invalid shape. |
+| `unknown` | No matching session exists, including a previously revoked session. |
+| `idle_expired` | The inactivity deadline has been reached. |
+| `absolute_expired` | The immutable absolute deadline has been reached. |
+| `account_missing` | A session has no current account; an invariant problem under the cascade FK. |
+| `legacy` | Obsolete identity fields were found in the signed OAuth cookie and removed. |
+
+Ordinary expiry, unknown, and legacy cutover outcomes use info; malformed input
+and account-invariant failures use warning. No event is emitted for missing
+authentication cookies, OAuth-only state, or successful reads/touches. Cleaning
+a cookie is not cross-request deduplication if a client replays the original.
+Rejection attaches no exception details or identity values.
+
+`auth.session.revoked` is an info event emitted only after committed revocation,
+with `auth.session.scope` (`current` or `all`) and `auth.session.count`.
+`auth.session.pruned` is informational and emitted only after committed removal
+of expired rows, with the aggregate count alone. `user.account_deleted` likewise
+means committed deletion and has no identity attribute. None is emitted as a
+success when the store transaction fails.
+
+Store errors retain ordinary request/dependency failure and
+`unhandled.exception` telemetry; they must not become expiry or anonymous
+outcomes. These signals describe app sessions, not GitHub logout or cancellation
+of already-authorized work.
 
 Handled rejection keeps the normal public-page 200, protected API/HTMX 401, and
 browser 303 request telemetry. An invalid or mismatched persisted OAuth identity
@@ -266,7 +295,7 @@ names are bounded code constants and never contain learner values.
 
 The following event families are retained:
 
-- `auth.*`: OAuth configuration, bounded callback outcomes, and identity rejection.
+- `auth.*`: OAuth configuration, bounded callback outcomes, and session lifecycle.
 - `content.*`: failures loading bundled curriculum artifacts.
 - `db.*`: database lifecycle and rollback failures.
 - `health.*`: readiness and schema drift signals.

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -72,33 +72,63 @@ revision, path, exception type, and first/last timestamps.
 
 ### Safe recovery
 
-Prefer rolling back the affected API revision when the failures began directly
-after a deployment. Do not suppress the exception or disable the alert. If a
+Use only a compatible rollback when failures began directly after a deployment.
+For the session cutover, prefer a forward fix or a session-aware known-good
+revision: old identity-cookie code would undo revocation. Do not suppress the
+exception or disable the alert. If a
 dependency is transiently unavailable, restore that dependency and confirm the
 exact exception alert returns to a healthy state.
 
-## Rejected session or OAuth identity
+## Session lifecycle and rejected OAuth identity
 
-`auth.session.identity_rejected` and `auth.callback.identity_rejected` are
-handled warnings, not unhandled-exception alerts. Inspect their bounded
-`auth.identity.reason` and the associated request outcome; do not request or
-copy the cookie, user identity, OAuth state, or provider response body.
+`auth.session.rejected` records bounded `auth.session.reason` values. Expiry,
+unknown sessions, and legacy-cookie cutover are expected info events, not
+automatic compromise alerts. Malformed credentials and account-invariant
+problems are warnings. `auth.callback.identity_rejected` remains a handled
+provider warning with `auth.identity.reason`. Inspect the reason and request
+outcome; never request or copy cookies, digests, CSRF tokens, user identity,
+OAuth state, or provider bodies.
 
-Session rejection removes only the application identity. Public pages remain
-available, protected API/HTMX routes return 401, and browser page navigation
-redirects to login. OAuth rejection redirects home without replacing an existing
-valid login. Ordinary anonymous requests do not emit these warnings.
+Public pages stay available, protected API/HTMX routes return 401, and browser
+page navigation redirects to login. Rejected credentials are cleared; unrelated
+OAuth state survives. Provider rejection redirects home without replacing a
+valid existing login. Ordinary anonymous access emits no rejection event.
 
-Compare an increase with the deployed revision and recent authentication
-changes. An old malformed signed cookie, a faulty session-producing tool, or
-unexpected provider data can explain a rejection; the warning alone does not
-prove cookie forgery or account compromise. Reauthentication can replace a
-malformed identity. Do not disable validation or restore numeric-ID coercion.
+Expect a one-time rise in login traffic at the hard cutover: all old identity
+cookies require a fresh GitHub login. Compare subsequent changes with the
+revision, auth request statuses, and `auth.login.success`. Do not restore
+legacy-cookie trust, numeric-ID coercion, or a cache-based bypass.
+
+Every authenticated request now uses PostgreSQL. For unexpected 5xxs or slow
+login/navigation, correlate database dependency latency, connection/pool errors,
+lock waits, migration completion, and API runtime table grants. Check
+`auth_sessions` schema readiness and the configured API role's DML privileges,
+not just database connectivity. A store outage must remain a real failure:
+neither successful logout nor anonymous fallback is safe.
+
+Cookie cleanup alone is not revocation. `auth.session.revoked` means the
+transaction committed, with scope `current` or `all` and aggregate count only.
+Current logout invalidates copies of that session; other browsers stay signed
+in. Sign out everywhere invalidates all current app sessions. It does not
+revoke GitHub sessions or authorization, prevent genuinely later logins, or
+cancel already-authorized requests and running verification work.
+
+After cookie theft, use a trusted browser to sign in and choose Sign out
+everywhere on Account. Secure a compromised GitHub account at GitHub as well.
+Deleting an app account cascades all sessions; recreating it never revives
+old cookies. Use real replay and independent-browser behavior to diagnose a
+revocation defect, without copying credentials into telemetry or reports.
+
+Successful logins opportunistically prune at most 100 expired rows.
+`auth.session.pruned` reports committed aggregate counts. To investigate
+retention backlog, use aggregate idle/absolute-expired counts only, never
+session records or identifiers. No scheduler or fixed removal deadline exists;
+expired rows cannot authenticate while awaiting cleanup. Sustained backlog
+requires a separately scoped retention decision, not an assumed timer.
 
 A persisted OAuth identity that differs from the validated provider identity is
 an application invariant failure. It should not commit or issue a new session;
-investigate it through the existing unhandled-exception guide above. Malformed
-cookie decoding occurs earlier in middleware and is tracked separately in #834.
+investigate it through the existing unhandled-exception guide above.
 See the [telemetry schema](../observability/telemetry-schema.html) for reason values.
 
 ## Ignored optional profile names and staged schema rollout

--- a/infra/migrations.tf
+++ b/infra/migrations.tf
@@ -69,6 +69,10 @@ resource "azapi_resource" "migrations" {
                 value = azurerm_user_assigned_identity.migrations.client_id
               },
               {
+                name  = "POSTGRES_API_RUNTIME_ROLE"
+                value = local.api_postgres_role
+              },
+              {
                 name  = "POSTGRES_VERIFICATION_FUNCTIONS_ROLE"
                 value = local.verification_functions_postgres_role
               },

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -105,6 +105,11 @@ output "migration_postgres_role" {
   value       = local.migration_postgres_role
 }
 
+output "api_postgres_role" {
+  description = "PostgreSQL runtime role receiving application table DML grants"
+  value       = local.api_postgres_role
+}
+
 output "verification_functions_name" {
   description = "Azure Functions app name used for Durable verification jobs"
   value       = azapi_resource.verification_functions.name

--- a/infra/tests/secretless_planning.tftest.hcl
+++ b/infra/tests/secretless_planning.tftest.hcl
@@ -18,6 +18,26 @@ mock_provider "azurerm" {
 mock_provider "azapi" {}
 mock_provider "random" {}
 
+run "session_migration_runtime_grant" {
+  command = plan
+
+  variables {
+    postgres_api_runtime_role = "custom_api_runtime"
+  }
+
+  plan_options {
+    target = [azapi_resource.migrations]
+  }
+
+  assert {
+    condition = one([
+      for setting in azapi_resource.migrations.body.properties.template.containers[0].env :
+      setting.value if setting.name == "POSTGRES_API_RUNTIME_ROLE"
+    ]) == "custom_api_runtime"
+    error_message = "Session migrations must grant DML to the configured API runtime role."
+  }
+}
+
 variables {
   subscription_id                     = "00000000-0000-0000-0000-000000000001"
   postgres_entra_admin_object_id      = "00000000-0000-0000-0000-000000000002"

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/config.py
@@ -142,9 +142,18 @@ class OAuthConfig(FrozenConfig):
 
 
 class SessionConfig(FrozenConfig):
-    """Session cookie config."""
+    """OAuth cookie signing and server-enforced authentication lifetimes."""
 
     secret_key: str = _DEV_SESSION_SECRET
+    oauth_state_max_age_seconds: int = Field(default=600, gt=0, le=600)
+    idle_timeout_seconds: int = Field(default=604800, gt=0, le=604800)
+    absolute_timeout_seconds: int = Field(default=2592000, gt=0, le=2592000)
+
+    @model_validator(mode="after")
+    def _validate_lifetimes(self) -> Self:
+        if self.idle_timeout_seconds > self.absolute_timeout_seconds:
+            raise ValueError("Session idle timeout must not exceed absolute timeout.")
+        return self
 
 
 class SmokeTestConfig(FrozenConfig):

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/models.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Index,
+    LargeBinary,
     String,
     Text,
     Uuid,
@@ -50,6 +51,29 @@ class User(TimestampMixin, Base):
     avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     github_username: Mapped[str] = mapped_column(String(255), nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
+
+
+class AuthSession(Base):
+    """Revocable authentication credential digest; never a bearer token."""
+
+    __tablename__ = "auth_sessions"
+    __table_args__ = (
+        CheckConstraint(
+            "octet_length(token_digest) = 32", name="ck_auth_sessions_digest_length"
+        ),
+        Index("ix_auth_sessions_user_id", "user_id"),
+        Index("ix_auth_sessions_expires_at", "expires_at"),
+        Index("ix_auth_sessions_last_seen_at", "last_seen_at"),
+    )
+
+    token_digest: Mapped[bytes] = mapped_column(LargeBinary, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
 
 class SubmissionType(StrEnum):

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/auth_session_repository.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/repositories/auth_session_repository.py
@@ -1,0 +1,172 @@
+"""Digest-only session persistence; callers own transaction completion."""
+
+from dataclasses import dataclass, field
+from datetime import timedelta
+from enum import StrEnum
+
+from sqlalchemy import case, delete, func, or_, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from learn_to_cloud_shared.core.config import SessionConfig
+from learn_to_cloud_shared.models import AuthSession, User
+
+PRUNE_BATCH_SIZE = 100
+
+
+class SessionRejection(StrEnum):
+    """Bounded store rejection reasons, without credential or identity values."""
+
+    UNKNOWN = "unknown"
+    IDLE_EXPIRED = "idle_expired"
+    ABSOLUTE_EXPIRED = "absolute_expired"
+    ACCOUNT_MISSING = "account_missing"
+
+
+class SessionDigestCollision(ValueError):
+    """The generated digest already exists; retry with a fresh credential."""
+
+
+@dataclass(frozen=True)
+class ResolvedSession:
+    session: AuthSession = field(repr=False)
+    user: User = field(repr=False)
+
+
+def _validate_digest(token_digest: bytes) -> None:
+    if not isinstance(token_digest, bytes) or len(token_digest) != 32:
+        raise ValueError("Session digest must contain exactly 32 bytes.")
+
+
+class AuthSessionRepository:
+    """Use account-before-session locking for issuance and global mutations."""
+
+    def __init__(self, db: AsyncSession, config: SessionConfig) -> None:
+        self.db = db
+        self.config = config
+
+    async def lock_user(self, user_id: int) -> User | None:
+        """Hold the account lock until caller commit, before locking sessions."""
+        return await self.db.scalar(
+            select(User)
+            .where(User.id == user_id)
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+
+    async def create(self, user_id: int, token_digest: bytes) -> AuthSession | None:
+        """Lock the account and insert safely; None means the account is absent."""
+        _validate_digest(token_digest)
+        # Prevent FK diagnostics and serialize against account-wide revocation.
+        if await self.lock_user(user_id) is None:
+            return None
+        now = func.statement_timestamp()
+        result = await self.db.scalar(
+            pg_insert(AuthSession)
+            .values(
+                token_digest=token_digest,
+                user_id=user_id,
+                created_at=now,
+                updated_at=now,
+                last_seen_at=now,
+                expires_at=now
+                + timedelta(seconds=self.config.absolute_timeout_seconds),
+            )
+            .on_conflict_do_nothing(index_elements=["token_digest"])
+            .returning(AuthSession)
+        )
+        if result is None:
+            # ON CONFLICT avoids driver DETAIL containing the credential digest.
+            raise SessionDigestCollision("Generated session digest already exists.")
+        return result
+
+    async def resolve_and_touch(
+        self, token_digest: bytes
+    ) -> ResolvedSession | SessionRejection:
+        """Lock, then conditionally touch using a fresh database statement clock."""
+        _validate_digest(token_digest)
+        locked = await self.db.scalar(
+            select(AuthSession.token_digest)
+            .where(AuthSession.token_digest == token_digest)
+            .with_for_update()
+        )
+        if locked is None:
+            return SessionRejection.UNKNOWN
+        # A separate statement samples time AFTER waiting for an existing lock.
+        now = func.statement_timestamp()
+        idle_cutoff = now - timedelta(seconds=self.config.idle_timeout_seconds)
+        row = (
+            await self.db.execute(
+                update(AuthSession)
+                .where(
+                    AuthSession.token_digest == token_digest,
+                    AuthSession.user_id == User.id,
+                    AuthSession.expires_at > now,
+                    AuthSession.last_seen_at > idle_cutoff,
+                )
+                .values(
+                    last_seen_at=func.greatest(AuthSession.last_seen_at, now),
+                    updated_at=func.greatest(AuthSession.updated_at, now),
+                )
+                .returning(AuthSession, User)
+                .execution_options(synchronize_session=False, populate_existing=True)
+            )
+        ).one_or_none()
+        if row is not None:
+            return ResolvedSession(session=row[0], user=row[1])
+        reason = await self.db.scalar(
+            select(
+                case(
+                    (User.id.is_(None), SessionRejection.ACCOUNT_MISSING.value),
+                    (
+                        AuthSession.expires_at <= now,
+                        SessionRejection.ABSOLUTE_EXPIRED.value,
+                    ),
+                    else_=SessionRejection.IDLE_EXPIRED.value,
+                )
+            )
+            .select_from(AuthSession)
+            .outerjoin(User, User.id == AuthSession.user_id)
+            .where(AuthSession.token_digest == token_digest)
+        )
+        return SessionRejection(reason) if reason else SessionRejection.UNKNOWN
+
+    async def delete(self, token_digest: bytes) -> int:
+        """Delete one credential, including an expired credential."""
+        _validate_digest(token_digest)
+        result = await self.db.execute(
+            delete(AuthSession)
+            .where(AuthSession.token_digest == token_digest)
+            .returning(AuthSession.token_digest)
+        )
+        return len(result.all())
+
+    async def delete_all(self, user_id: int) -> int:
+        """Lock the account, then revoke all its sessions in this transaction."""
+        if await self.lock_user(user_id) is None:
+            return 0
+        result = await self.db.execute(
+            delete(AuthSession)
+            .where(AuthSession.user_id == user_id)
+            .returning(AuthSession.token_digest)
+        )
+        return len(result.all())
+
+    async def prune_expired(self) -> int:
+        """Delete at most 100 expired rows, skipping concurrent session work."""
+        now = func.statement_timestamp()
+        expired = select(AuthSession.token_digest).where(
+            or_(
+                AuthSession.expires_at <= now,
+                AuthSession.last_seen_at
+                <= now - timedelta(seconds=self.config.idle_timeout_seconds),
+            )
+        )
+        candidates = expired.limit(PRUNE_BATCH_SIZE).with_for_update(skip_locked=True)
+        result = await self.db.execute(
+            delete(AuthSession)
+            .where(AuthSession.token_digest.in_(candidates))
+            .returning(AuthSession.token_digest)
+            .execution_options(synchronize_session=False)
+        )
+        return len(result.all())

--- a/packages/learn-to-cloud-shared/tests/core/test_config.py
+++ b/packages/learn-to-cloud-shared/tests/core/test_config.py
@@ -49,6 +49,56 @@ class TestDatabaseConfig:
 
 
 @pytest.mark.unit
+class TestSessionConfig:
+    def test_defaults(self):
+        config = SessionConfig()
+        assert config.oauth_state_max_age_seconds == 600
+        assert config.idle_timeout_seconds == 7 * 24 * 3600
+        assert config.absolute_timeout_seconds == 30 * 24 * 3600
+
+    @pytest.mark.parametrize(
+        "field,maximum",
+        [
+            ("oauth_state_max_age_seconds", 600),
+            ("idle_timeout_seconds", 604800),
+            ("absolute_timeout_seconds", 2592000),
+        ],
+    )
+    @pytest.mark.parametrize("invalid", [0, -1, 1.5, "bad", None])
+    def test_invalid_durations(self, field, maximum, invalid):
+        with pytest.raises(ValidationError):
+            SessionConfig(**{field: invalid})
+
+    @pytest.mark.parametrize(
+        "field,maximum",
+        [
+            ("oauth_state_max_age_seconds", 600),
+            ("idle_timeout_seconds", 604800),
+            ("absolute_timeout_seconds", 2592000),
+        ],
+    )
+    def test_lifetimes_cannot_exceed_policy(self, field, maximum):
+        with pytest.raises(ValidationError):
+            SessionConfig(**{field: maximum + 1})
+
+    def test_idle_cannot_exceed_absolute(self):
+        with pytest.raises(ValidationError, match="must not exceed"):
+            SessionConfig(idle_timeout_seconds=20, absolute_timeout_seconds=10)
+
+    def test_environment_overrides(self, monkeypatch):
+        monkeypatch.setenv("SESSION__IDLE_TIMEOUT_SECONDS", "60")
+        monkeypatch.setenv("SESSION__ABSOLUTE_TIMEOUT_SECONDS", "120")
+        monkeypatch.setenv("SESSION__OAUTH_STATE_MAX_AGE_SECONDS", "90")
+        settings = WebSettings(
+            database=DatabaseConfig(url="postgresql+asyncpg://localhost/test"),
+            environment=Environment.DEVELOPMENT,
+        )
+        assert settings.session.idle_timeout_seconds == 60
+        assert settings.session.absolute_timeout_seconds == 120
+        assert settings.session.oauth_state_max_age_seconds == 90
+
+
+@pytest.mark.unit
 class TestWorkerSettings:
     def test_accepts_worker_sections(self):
         s = WorkerSettings(

--- a/packages/learn-to-cloud-shared/tests/repositories/test_auth_session_repository.py
+++ b/packages/learn-to-cloud-shared/tests/repositories/test_auth_session_repository.py
@@ -1,0 +1,348 @@
+"""Real PostgreSQL lifetime, transaction, and concurrent revocation coverage."""
+
+import asyncio
+import traceback
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import delete, func, literal, select, text, update
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from learn_to_cloud_shared.core.config import SessionConfig
+from learn_to_cloud_shared.models import AuthSession, User
+from learn_to_cloud_shared.repositories import auth_session_repository as module
+from learn_to_cloud_shared.repositories.auth_session_repository import (
+    AuthSessionRepository,
+    ResolvedSession,
+    SessionDigestCollision,
+    SessionRejection,
+)
+
+pytestmark = pytest.mark.integration
+CONFIG = SessionConfig()
+DIGEST = bytes(range(32))
+
+
+async def seed(db, count=1):
+    db.add(User(id=1, github_username="learner"))
+    await db.flush()
+    repo = AuthSessionRepository(db, CONFIG)
+    sessions = [
+        await repo.create(1, i.to_bytes(32, "big")) for i in range(1, count + 1)
+    ]
+    return repo, sessions
+
+
+async def test_create_clock_collision_missing_account_and_rollback(db_session):
+    repo, sessions = await seed(db_session)
+    session = sessions[0]
+    assert session is not None
+    assert session.created_at == session.updated_at == session.last_seen_at
+    assert session.expires_at - session.created_at == timedelta(days=30)
+    assert session.created_at <= await db_session.scalar(select(func.clock_timestamp()))
+    with pytest.raises(SessionDigestCollision) as caught:
+        await repo.create(1, session.token_digest)
+    formatted = "".join(traceback.format_exception(caught.value))
+    assert session.token_digest.hex() not in formatted
+    assert caught.value.__cause__ is None
+    assert await repo.create(9999, DIGEST) is None
+    assert await db_session.scalar(select(func.count()).select_from(AuthSession)) == 1
+
+
+@pytest.mark.parametrize("digest", [b"", b"short", b"x" * 33, "not-bytes"])
+async def test_invalid_digest_rejected_before_sql(db_session, digest):
+    repo = AuthSessionRepository(db_session, CONFIG)
+    for operation in (repo.resolve_and_touch, repo.delete):
+        with pytest.raises(ValueError, match="exactly 32 bytes"):
+            await operation(digest)
+    with pytest.raises(ValueError, match="exactly 32 bytes"):
+        await repo.create(1, digest)
+
+
+@pytest.mark.parametrize("kind", ["idle", "absolute"])
+@pytest.mark.parametrize("offset", [-1, 0, 1])
+async def test_exact_database_expiry_boundaries(db_session, monkeypatch, kind, offset):
+    repo, sessions = await seed(db_session)
+    session = sessions[0]
+    now = await db_session.scalar(select(func.statement_timestamp()))
+    # Freeze only this repository's SQL clock at a database-produced timestamp.
+    monkeypatch.setattr(
+        module,
+        "func",
+        SimpleNamespace(
+            statement_timestamp=lambda: literal(now), greatest=func.greatest
+        ),
+    )
+    values = (
+        {"last_seen_at": now - timedelta(days=7) + timedelta(microseconds=offset)}
+        if kind == "idle"
+        else {"expires_at": now + timedelta(microseconds=offset)}
+    )
+    await db_session.execute(
+        update(AuthSession)
+        .values(**values)
+        .execution_options(synchronize_session=False)
+    )
+    result = await repo.resolve_and_touch(session.token_digest)
+    if offset > 0:
+        assert isinstance(result, ResolvedSession)
+    else:
+        assert result == (
+            SessionRejection.IDLE_EXPIRED
+            if kind == "idle"
+            else SessionRejection.ABSOLUTE_EXPIRED
+        )
+        stored = (await db_session.execute(select(AuthSession.__table__))).one()
+        for key, value in values.items():
+            assert stored._mapping[key] == value
+
+
+async def test_touch_current_user_monotonic_and_absolute_unchanged(db_session):
+    repo, sessions = await seed(db_session)
+    session = sessions[0]
+    created, expires = session.created_at, session.expires_at
+    future = created + timedelta(hours=1)
+    await db_session.execute(
+        update(AuthSession).values(last_seen_at=future, updated_at=future)
+    )
+    stale_user = await db_session.get(User, 1)
+    await db_session.execute(
+        update(User)
+        .values(github_username="renamed")
+        .execution_options(synchronize_session=False)
+    )
+    assert stale_user.github_username == "learner"
+    result = await repo.resolve_and_touch(session.token_digest)
+    assert isinstance(result, ResolvedSession)
+    assert result.user.github_username == "renamed"
+    assert result.session.last_seen_at == result.session.updated_at == future
+    assert (result.session.created_at, result.session.expires_at) == (created, expires)
+    assert "renamed" not in repr(result)
+    assert session.token_digest.hex() not in repr(result)
+
+
+async def test_transaction_clock_does_not_freeze_session_activity(db_session):
+    repo, sessions = await seed(db_session)
+    before = sessions[0].last_seen_at
+    await db_session.execute(text("SELECT pg_sleep(0.02)"))
+    result = await repo.resolve_and_touch(sessions[0].token_digest)
+    assert isinstance(result, ResolvedSession)
+    assert result.session.last_seen_at > before
+
+
+async def test_delete_independent_session_and_account_cascade_recreation(db_session):
+    repo, sessions = await seed(db_session, 2)
+    first, second = [s.token_digest for s in sessions]
+    assert await repo.delete(first) == 1
+    assert await repo.delete(first) == 0
+    assert await repo.resolve_and_touch(first) == SessionRejection.UNKNOWN
+    assert isinstance(await repo.resolve_and_touch(second), ResolvedSession)
+    await db_session.execute(delete(User).where(User.id == 1))
+    db_session.expunge_all()
+    db_session.add(User(id=1, github_username="recreated"))
+    await db_session.flush()
+    assert await repo.resolve_and_touch(second) == SessionRejection.UNKNOWN
+    assert await repo.create(1, DIGEST) is not None
+    assert await repo.delete_all(1) == 1
+    assert await repo.delete_all(9999) == 0
+
+
+async def test_prune_bounded_both_expiries_and_rollback(db_session):
+    repo, sessions = await seed(db_session, 205)
+    now = func.statement_timestamp()
+    await db_session.execute(
+        update(AuthSession)
+        .where(AuthSession.token_digest.in_([s.token_digest for s in sessions[:100]]))
+        .values(expires_at=now)
+    )
+    await db_session.execute(
+        update(AuthSession)
+        .where(
+            AuthSession.token_digest.in_([s.token_digest for s in sessions[100:203]])
+        )
+        .values(last_seen_at=now - timedelta(days=7))
+    )
+    async with db_session.begin_nested() as savepoint:
+        assert await repo.prune_expired() == 100
+        await savepoint.rollback()
+    assert await db_session.scalar(select(func.count()).select_from(AuthSession)) == 205
+    assert [await repo.prune_expired() for _ in range(4)] == [100, 100, 3, 0]
+    for session in sessions[203:]:
+        assert isinstance(
+            await repo.resolve_and_touch(session.token_digest), ResolvedSession
+        )
+
+
+async def committed_seed(test_engine, count=1):
+    maker = async_sessionmaker(test_engine, expire_on_commit=False)
+    async with maker.begin() as db:
+        _, sessions = await seed(db, count)
+        digests = [s.token_digest for s in sessions]
+    return maker, digests
+
+
+async def assert_waiting(task):
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(asyncio.shield(task), timeout=0.1)
+
+
+@pytest.mark.parametrize("delete_first", [False, True])
+async def test_concurrent_touch_and_logout_cannot_revive(test_engine, delete_first):
+    maker, (digest,) = await committed_seed(test_engine)
+    async with maker() as first:
+        repo = AuthSessionRepository(first, CONFIG)
+        if delete_first:
+            assert await repo.delete(digest) == 1
+        else:
+            assert isinstance(await repo.resolve_and_touch(digest), ResolvedSession)
+
+        async def other():
+            async with maker.begin() as db:
+                other_repo = AuthSessionRepository(db, CONFIG)
+                return (
+                    await other_repo.resolve_and_touch(digest)
+                    if delete_first
+                    else await other_repo.delete(digest)
+                )
+
+        task = asyncio.create_task(other())
+        try:
+            await assert_waiting(task)
+            await first.commit()
+            result = await asyncio.wait_for(task, 5)
+            assert result == (SessionRejection.UNKNOWN if delete_first else 1)
+        finally:
+            await first.rollback()
+            if not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+    async with maker.begin() as db:
+        assert (
+            await AuthSessionRepository(db, CONFIG).resolve_and_touch(digest)
+            == SessionRejection.UNKNOWN
+        )
+
+
+@pytest.mark.parametrize("issue_first", [False, True])
+async def test_account_lock_serializes_issuance_and_global_revoke(
+    test_engine, issue_first
+):
+    maker, _ = await committed_seed(test_engine)
+    async with maker() as first:
+        repo = AuthSessionRepository(first, CONFIG)
+        if issue_first:
+            assert await repo.create(1, DIGEST) is not None
+        else:
+            assert await repo.delete_all(1) == 1
+
+        async def other():
+            async with maker.begin() as db:
+                other_repo = AuthSessionRepository(db, CONFIG)
+                return (
+                    await other_repo.delete_all(1)
+                    if issue_first
+                    else await other_repo.create(1, DIGEST)
+                )
+
+        task = asyncio.create_task(other())
+        try:
+            await assert_waiting(task)
+            await first.commit()
+            result = await asyncio.wait_for(task, 5)
+            assert result == 2 if issue_first else isinstance(result, AuthSession)
+        finally:
+            await first.rollback()
+            if not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+    async with maker.begin() as db:
+        count = await db.scalar(select(func.count()).select_from(AuthSession))
+        assert count == (0 if issue_first else 1)
+
+
+async def test_pruners_skip_locked_batches_and_refresh(test_engine):
+    maker, digests = await committed_seed(test_engine, 205)
+    async with maker.begin() as db:
+        await db.execute(
+            update(AuthSession).values(
+                last_seen_at=func.statement_timestamp() - timedelta(days=7)
+            )
+        )
+    async with maker() as refresher, maker() as first, maker() as second:
+        # A concurrent request has made one previously expired row active.
+        await refresher.execute(
+            update(AuthSession)
+            .where(AuthSession.token_digest == digests[0])
+            .values(last_seen_at=func.statement_timestamp())
+        )
+        assert await AuthSessionRepository(first, CONFIG).prune_expired() == 100
+        assert await AuthSessionRepository(second, CONFIG).prune_expired() == 100
+        await refresher.commit()
+        await first.commit()
+        await second.commit()
+    async with maker.begin() as db:
+        repo = AuthSessionRepository(db, CONFIG)
+        assert await repo.prune_expired() == 4
+        assert isinstance(await repo.resolve_and_touch(digests[0]), ResolvedSession)
+
+
+async def test_creation_waits_for_account_deletion_without_fk_diagnostics(test_engine):
+    maker, _ = await committed_seed(test_engine)
+    async with maker() as deleting:
+        await deleting.execute(delete(User).where(User.id == 1))
+
+        async def issue():
+            async with maker.begin() as db:
+                return await AuthSessionRepository(db, CONFIG).create(1, DIGEST)
+
+        task = asyncio.create_task(issue())
+        try:
+            await assert_waiting(task)
+            await deleting.commit()
+            assert await asyncio.wait_for(task, 5) is None
+        finally:
+            await deleting.rollback()
+            if not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+
+
+async def test_create_and_revoke_are_not_committed_by_repository(test_engine):
+    maker, (digest,) = await committed_seed(test_engine)
+    async with maker() as db:
+        repo = AuthSessionRepository(db, CONFIG)
+        assert await repo.create(1, DIGEST) is not None
+        assert await repo.delete(digest) == 1
+        await db.rollback()
+    async with maker.begin() as db:
+        repo = AuthSessionRepository(db, CONFIG)
+        assert await repo.resolve_and_touch(DIGEST) == SessionRejection.UNKNOWN
+        assert isinstance(await repo.resolve_and_touch(digest), ResolvedSession)
+
+
+async def test_expiry_is_checked_after_waiting_for_an_unmodified_row(test_engine):
+    maker = async_sessionmaker(test_engine, expire_on_commit=False)
+    config = SessionConfig(idle_timeout_seconds=1, absolute_timeout_seconds=1)
+    async with maker.begin() as db:
+        db.add(User(id=1, github_username="learner"))
+        await db.flush()
+        await AuthSessionRepository(db, config).create(1, DIGEST)
+    async with maker() as locker:
+        await locker.execute(select(AuthSession).with_for_update())
+
+        async def resolve():
+            async with maker.begin() as db:
+                return await AuthSessionRepository(db, config).resolve_and_touch(DIGEST)
+
+        task = asyncio.create_task(resolve())
+        try:
+            await assert_waiting(task)
+            await locker.execute(text("SELECT pg_sleep(1.05)"))
+            await locker.commit()
+            assert await asyncio.wait_for(task, 5) == SessionRejection.ABSOLUTE_EXPIRED
+        finally:
+            await locker.rollback()
+            if not task.done():
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)

--- a/scripts/dogfood_session.py
+++ b/scripts/dogfood_session.py
@@ -1,137 +1,74 @@
-"""Generate a signed Starlette session cookie for local dogfooding.
-
-Outputs JSON with the cookie name, value, domain, and path so that
-browser automation or test scripts can inject the session without
-going through the GitHub OAuth flow.
-
-Usage:
-    cd api && uv run python ../scripts/dogfood_session.py
-    cd api && uv run python ../scripts/dogfood_session.py 6733686  # specific user ID
-
-Security:
-    Only works with the dev secret key ("dev-secret-key-change-in-production").
-    Production rejects this key at startup (see core/config.py validator).
-"""
+"""Issue a real local login session; stdout is a private browser-cookie JSON value."""
 
 from __future__ import annotations
 
+import asyncio
+import ipaddress
 import json
-import os
 import sys
-from base64 import b64encode
 
-import itsdangerous
-import sqlalchemy
-
-SECRET_KEY = "dev-secret-key-change-in-production"
-
-
-def _load_secret_key() -> str:
-    """Load the session secret key from the API's .env file."""
-    env_path = os.path.join(os.path.dirname(__file__), "..", "api", ".env")
-    if os.path.exists(env_path):
-        with open(env_path) as f:
-            for line in f:
-                line = line.strip()
-                if line.startswith("SESSION__SECRET_KEY"):
-                    _, _, value = line.partition("=")
-                    value = value.strip().strip("'\"")
-                    if value:
-                        return value
-    return SECRET_KEY
+from learn_to_cloud.core.session_cookies import AUTH_COOKIE_NAME
+from learn_to_cloud.services.sessions_service import issue_session
+from learn_to_cloud_shared.core.config import WebSettings, get_web_settings
+from learn_to_cloud_shared.models import User
+from sqlalchemy import select
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 
-def _get_user_from_db(user_id: int | None = None) -> dict[str, object] | None:
-    """Query the local DB for a user."""
+def validate_local_target(settings: WebSettings) -> None:
+    """Refuse nondevelopment and ambiguous/nonloopback database targets."""
+    if not settings.is_development:
+        raise ValueError("Session generation requires development configuration")
+    url = make_url(settings.database.url)
+    if url.drivername != "postgresql+asyncpg" or url.query or not url.database:
+        raise ValueError("Session generation requires an explicit local PostgreSQL URL")
+    host = url.host or ""
+    if host != "localhost":
+        try:
+            address = ipaddress.ip_address(host)
+        except ValueError:
+            raise ValueError(
+                "Session generation requires a loopback database"
+            ) from None
+        if not address.is_loopback or "%" in host:
+            raise ValueError("Session generation requires a loopback database")
+
+
+async def generate_cookie(
+    user_id: int | None = None, *, settings: WebSettings | None = None
+) -> dict[str, object]:
+    settings = settings or get_web_settings()
+    validate_local_target(settings)
+    engine = create_async_engine(settings.database.url, hide_parameters=True)
     try:
-        # Build a sync URL from the async one in .env
-        raw_url = os.environ.get("DATABASE__URL", "")
-        if not raw_url:
-            # Try loading from .env file in api/ directory
-            env_path = os.path.join(os.path.dirname(__file__), "..", "api", ".env")
-            if os.path.exists(env_path):
-                with open(env_path) as f:
-                    for line in f:
-                        if line.startswith("DATABASE__URL="):
-                            raw_url = line.split("=", 1)[1].strip()
-                            break
-
-        if not raw_url:
-            return None
-
-        # Convert async driver to sync for this one-off query
-        sync_url = raw_url.replace("postgresql+asyncpg://", "postgresql://")
-
-        engine = sqlalchemy.create_engine(sync_url)
-        with engine.connect() as conn:
-            if user_id is not None:
-                row = conn.execute(
-                    sqlalchemy.text(
-                        "SELECT id, github_username FROM users WHERE id = :id"
-                    ),
-                    {"id": user_id},
-                ).fetchone()
-            else:
-                row = conn.execute(
-                    sqlalchemy.text(
-                        "SELECT id, github_username FROM users "
-                        "WHERE github_username = 'madebygps' LIMIT 1"
-                    )
-                ).fetchone()
-
-            if row:
-                return {"id": row[0], "github_username": row[1] or "unknown"}
-        return None
-    except Exception:
-        return None
-
-
-def generate_cookie(user_id: int, github_username: str) -> dict[str, object]:
-    secret = _load_secret_key()
-    session_data = {
-        "user_id": user_id,
-        "github_username": github_username,
-    }
-    signer = itsdangerous.TimestampSigner(secret)
-    payload = b64encode(json.dumps(session_data).encode("utf-8"))
-    signed = signer.sign(payload).decode("utf-8")
-    return {
-        "cookie_name": "session",
-        "cookie_value": signed,
-        "user_id": user_id,
-        "domain": "localhost",
-        "path": "/",
-    }
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        async with maker() as db, db.begin():
+            query = select(User).where(
+                User.id == user_id
+                if user_id is not None
+                else User.github_username == "madebygps"
+            )
+            user = await db.scalar(query)
+            if user is None:
+                raise ValueError("An existing local account is required")
+            issued = await issue_session(db, settings.session, user.id)
+        return {
+            "cookie_name": AUTH_COOKIE_NAME,
+            "cookie_value": issued.token,
+            "user_id": user.id,
+            "domain": "localhost",
+            "path": "/",
+        }
+    finally:
+        await engine.dispose()
 
 
 def main() -> None:
-    # Accept optional user ID argument
     requested_id = int(sys.argv[1]) if len(sys.argv) > 1 else None
-
-    # Try to auto-detect from DB
-    user = _get_user_from_db(requested_id)
-
-    if user:
-        user_id = user["id"]
-        username = str(user["github_username"])
-    elif requested_id is not None:
-        # Use the requested ID even if DB lookup failed
-        user_id = requested_id
-        username = "unknown"
-    else:
-        # Fallback: no DB, no arg — use a synthetic user
-        user_id = 1
-        username = "dogfood-user"
-        print(
-            "Warning: User 'madebygps' not found in DB. Using synthetic user_id=1. "
-            "Seed the DB or pass a user ID as argument.",
-            file=sys.stderr,
-        )
-
-    result = generate_cookie(user_id, username)
+    result = asyncio.run(generate_cookie(requested_id))
     json.dump(result, sys.stdout)
     sys.stdout.write("\n")
-    sys.stdout.flush()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changes

Login now creates a random browser credential backed by PostgreSQL. Signing out invalidates copies of that browser session, while other browsers remain signed in. Account adds Sign out everywhere, protected by a session-bound form token, to revoke every current browser session.

Sessions expire after seven days without an authenticated request or thirty days after sign-in, whichever comes first. Both account-deletion endpoints delete all sessions before reporting success. Recreating the same GitHub account never revives old cookies. Current account data is resolved once per request and reused by pages and APIs.

## Explicit account dependencies: research and decision

Pages, `/api/user/me`, and step-completion handlers now receive their loaded account directly through `CurrentAccount` or `OptionalCurrentAccount`. Required dependencies reject invalid sessions; optional dependencies allow anonymous visitors. Rendering helpers receive the account as an explicit argument instead of retrieving it from request state.

Previously, a page could declare an apparently unused identity dependency to trigger authentication, then separately retrieve the account from request state. The page depended on an invisible ordering requirement. We replaced that pattern with dependency injection: the handler declares the account it needs, and FastAPI supplies it after authentication.

We considered returning a wrapper containing both identity and account, but chose the account directly because it already contains the ID and username. Identity-only routes retain `CurrentUser` and `OptionalCurrentUser`, which derive their lightweight identity from the same account resolver. All four aliases share one cached lookup and activity update per request. The request-local cache remains internal, including protection against repeated direct resolver calls; handlers no longer use it to discover their account.

This follows the current primary-source guidance researched through Context7:

- [FastAPI: Get Current User](https://fastapi.tiangolo.com/tutorial/security/get-current-user/) demonstrates returning a user from an authentication dependency and injecting that value into a handler.
- [FastAPI: Sub-dependencies](https://fastapi.tiangolo.com/tutorial/dependencies/sub-dependencies/) documents caching a shared dependency once per request, avoiding duplicate resolution across account and identity consumers.
- [FastAPI: Dependencies in decorators](https://fastapi.tiangolo.com/tutorial/dependencies/dependencies-in-path-operation-decorators/) supports checks whose return values are unused. That is valid for side-effect-only checks, but these pages actually need account data, so direct injection is the better fit here.
- [SQLAlchemy: AsyncSession guidance](https://docs.sqlalchemy.org/en/20/orm/extensions/asyncio.html#preventing-implicit-io-when-using-asyncsession) and [detached-object guidance](https://docs.sqlalchemy.org/en/20/errors.html#error-bhk3) explain loaded attribute access and the limitations of accessing unloaded data after a session closes. The injected account is a read-only snapshot with loaded scalar fields and `expire_on_commit=False`, not an open transaction. Additional reads and writes still use explicit database services.

The research supports the framework mechanisms; choosing direct account injection rather than a wrapper is our codebase-specific design decision. Cookie validation, expiry, revocation, telemetry identity setup, and page/API response policies are unchanged. Contributor instructions and the new-route prompt now explain when to use account versus identity dependencies.

## Rendering cleanup and prevention

The step-rendering helper is synchronous and takes the account explicitly, without unused database or user-ID parameters. Home, Curriculum, Account, FAQ, Privacy, and Terms no longer request a separate route database session. Pages that query progress or other data keep their database dependency.

Enabled Ruff ARG001 (unused function arguments) and RUF029 (unneeded async) for API rendering helpers through the existing prek gate. RUF029 uses preview mode with explicit preview-rule selection. Enforcement deliberately does not extend to other code yet: the initial repository-wide scan found 210 findings, some involving required authentication dependencies, callbacks, and fixtures rather than obsolete code.

Updated the validate and ship-it skills to require understanding callers, dependencies, callback contracts, and test mocks before applying cleanup. Required side effects and async interfaces must be preserved; dummy awaits and suppressions are not cleanup. Follow-up #846 tracks reviewing the remaining findings and widening enforcement safely.

## Hard cutover

Everyone must sign in again. There is no legacy-cookie fallback, backfill, or rolling-version support; downtime is acceptable. Stop old API processes from serving before considering the cutover complete. GitHub handshake state retains its separate, ten-minute signed cookie.

Migrations 0060 and 0061 add session storage and indexes without changing existing learner data. The migration job receives the effective API database role and grants only the required table operations; Functions receives no session-table access. Expired rows are removed in bounded batches during later successful logins, with no guaranteed physical-removal deadline.

Revocation does not sign out of GitHub or cancel work already authorized. A genuinely later GitHub login can issue a fresh session. Prefer a forward fix over restoring old identity-cookie code, which would undo these guarantees.

## Coverage

The repository quality gate passes. Real PostgreSQL and HTTP coverage exercises copied-cookie replay across independent apps, independent browsers, expiry boundaries, account deletion/recreation, concurrent operations, OAuth state coexistence, transaction failures, and exported telemetry privacy. Local session generation now requires an existing account, development settings, and a loopback database.

Additional coverage checks shared account/identity resolution in either dependency order, account-only telemetry identity setup, current profile data, no duplicate account queries, detached loaded accounts, database failure propagation, anonymous and revoked sessions, and explicit account rendering. No authentication overrides are used to test authentication itself.

Terraform validation and mocked plan tests passed using the pinned tool/provider versions in an isolated copy; platform hashes were added only to that copy, leaving the tracked lockfile unchanged. Azure-backed plan at commit 8ff1600: zero additions, one in-place update to the migration job to pass POSTGRES_API_RUNTIME_ROLE, and zero deletions or replacements. It also adds the api_postgres_role output; remaining job-body differences remove empty/null Azure defaults, and computed outputs refresh after the update. No identity, networking, or authentication configuration is changed. No production apply or deployment was performed.

Closes #828
Closes #829
