### PR TITLE
Keep upstream verification failures distinct from learner failures

### DIFF
--- a/api/src/learn_to_cloud/rendering/context.py
+++ b/api/src/learn_to_cloud/rendering/context.py
@@ -309,11 +309,17 @@ def build_phase_topics(phase: Phase, detail: PhaseProgress) -> list[dict[str, An
     return topics
 
 
-_PERSISTED_SERVICE_ERROR_MESSAGE = (
-    "The verification service couldn't finish checking this attempt because of "
-    "a problem on our side, not something you did. You can try again. If it keeps "
-    "failing, report the issue."
-)
+def incomplete_verification_message(cause: str | None) -> str:
+    """Explain an incomplete outcome alongside its saved learner-safe cause."""
+    explanation = (
+        "Verification stopped before it could finish. "
+        "Your work was not judged to have failed."
+    )
+    recovery = (
+        "You can try again. If this keeps happening, report the issue. "
+        "You do not need to change your work to fix a verification-service problem."
+    )
+    return " ".join(part for part in (explanation, cause, recovery) if part)
 
 
 @dataclass(frozen=True, slots=True)
@@ -692,7 +698,7 @@ def build_requirement_card_context(
         feedback_tasks=tasks,
         feedback_passed=passed,
         verification_form=verification_form,
-        message=_PERSISTED_SERVICE_ERROR_MESSAGE,
+        message=incomplete_verification_message(submission.validation_message),
     )
 
 
@@ -751,7 +757,7 @@ def build_unavailable_requirement_card_context(
             github_username,
             None,
         ),
-        message=message,
+        message=incomplete_verification_message(message),
     )
 
 

--- a/api/src/learn_to_cloud/services/verification_page_service.py
+++ b/api/src/learn_to_cloud/services/verification_page_service.py
@@ -30,6 +30,7 @@ from learn_to_cloud.rendering.context import (
     build_checking_requirement_card_context,
     build_requirement_card_context,
     feedback_tasks_and_passed,
+    incomplete_verification_message,
 )
 from learn_to_cloud.services.progress_service import (
     fetch_phase_progress,
@@ -51,7 +52,7 @@ VERIFICATION_HISTORY_PAGE_SIZE = 10
 _HISTORY_STATUS = {
     "succeeded": ("Verified", "success"),
     "failed": ("Needs work", "error"),
-    "server_error": ("Service unavailable", "warning"),
+    "server_error": ("Verification incomplete", "warning"),
     "cancelled": ("Cancelled", "warning"),
 }
 
@@ -124,6 +125,12 @@ class VerificationAttemptHistoryItem:
     @property
     def status_variant(self) -> str:
         return _HISTORY_STATUS.get(self.outcome, ("Completed", "info"))[1]
+
+    @property
+    def display_message(self) -> str | None:
+        if self.outcome == "server_error":
+            return incomplete_verification_message(self.validation_message)
+        return self.validation_message
 
 
 @dataclass(frozen=True, slots=True)

--- a/api/src/learn_to_cloud/templates/pages/verification_phase.html
+++ b/api/src/learn_to_cloud/templates/pages/verification_phase.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% set footer_margin = "mt-8" %}
 {% from "macros/badges.html" import status_pill %}
+{% from "macros/callouts.html" import banner %}
 {% block title %}Phase {{ phase.order }} Verification - Learn to Cloud{% endblock %}
 
 {% block content %}
@@ -140,9 +141,17 @@
                 {{ status_pill(item.status_label, item.status_variant) }}
             </div>
 
-            {% if item.validation_message %}
+            {% if item.outcome == 'server_error' %}
+            {{ banner(
+                item.display_message,
+                'warning',
+                report=true,
+                report_title='Verification error: ' ~ item.requirement.name,
+                report_context='requirement=' ~ item.requirement.slug
+            ) }}
+            {% elif item.display_message %}
             <p class="mt-3 text-sm leading-6 {% if item.outcome == 'failed' %}text-red-700 dark:text-red-300{% else %}text-gray-600 dark:text-gray-300{% endif %}">
-                {{ item.validation_message }}
+                {{ item.display_message }}
             </p>
             {% endif %}
 

--- a/api/src/learn_to_cloud/templates/partials/requirement_card.html
+++ b/api/src/learn_to_cloud/templates/partials/requirement_card.html
@@ -7,7 +7,7 @@
         {% if card.kind == 'passed' %}
         {{ status_pill("Verified", "success") }}
         {% elif card.kind == 'unavailable' %}
-        {{ status_pill("Service unavailable", "warning") }}
+        {{ status_pill("Verification incomplete", "warning") }}
         {% elif card.kind == 'failed' %}
         {{ status_pill("Needs work", "error") }}
         {% elif card.kind == 'checking' %}

--- a/api/tests/rendering/test_context.py
+++ b/api/tests/rendering/test_context.py
@@ -416,7 +416,8 @@ class TestBuildRequirementCardContextCardState:
         )
         assert isinstance(ctx, UnavailableCardContext)
         assert ctx.kind == "unavailable"
-        assert "problem on our side, not something you did" in ctx.message
+        assert "Verification stopped before it could finish." in ctx.message
+        assert "Your work was not judged to have failed." in ctx.message
         assert "You can try again" in ctx.message
         assert "report the issue" in ctx.message
 
@@ -429,4 +430,28 @@ class TestBuildRequirementCardContextCardState:
             message="Verification could not be started.",
         )
         assert ctx.kind == "unavailable"
-        assert ctx.message == "Verification could not be started."
+        assert "Verification could not be started." in ctx.message
+        assert "Your work was not judged to have failed." in ctx.message
+
+    @pytest.mark.parametrize(
+        "cause",
+        [
+            "GitHub API error (503). Try again later.",
+            "Network error connecting to GitHub. Try again later.",
+            "GitHub API error (401). Try again later.",
+            "Verification failed before recording a result.",
+        ],
+    )
+    def test_unavailable_preserves_saved_cause_without_guessing(self, cause):
+        req = _make_requirement(SubmissionType.CTF_TOKEN)
+        submission = _make_submission(is_validated=False, validation_message=cause)
+
+        ctx = build_requirement_card_context(
+            requirement=req, github_username="alice", submission=submission
+        )
+
+        assert isinstance(ctx, UnavailableCardContext)
+        assert cause in ctx.message
+        assert "Your work was not judged to have failed." in ctx.message
+        assert "report the issue" in ctx.message
+        assert "You do not need to change your work" in ctx.message

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -20,6 +20,9 @@ from learn_to_cloud.rendering.context import (
     feedback_tasks_and_passed,
 )
 from learn_to_cloud.rendering.htmx_responses import render_step_toggle
+from learn_to_cloud.services.verification_page_service import (
+    VerificationAttemptHistoryItem,
+)
 
 _ENV = templates.env
 
@@ -538,7 +541,7 @@ class TestPhaseVerificationCardStates:
         html = self._render_phase([req], {"ci-status": submission})
         assert "Needs work" in html
         assert "CI is not green yet." in html
-        assert "Service unavailable" not in html
+        assert "Verification incomplete" not in html
 
     def test_unavailable_shows_service_banner_not_learner_failure(self):
         """Regression: a persisted server_error/cancelled outcome must not
@@ -547,9 +550,10 @@ class TestPhaseVerificationCardStates:
         req = _requirement("ci-status", "CI Status")
         submission = _submission(is_validated=False, verification_completed=False)
         html = self._render_phase([req], {"ci-status": submission})
-        assert "Service unavailable" in html
+        assert "Verification incomplete" in html
         assert "Needs work" not in html
-        assert "a problem on our side, not something you did" in html
+        assert "Verification stopped before it could finish." in html
+        assert "Your work was not judged to have failed." in html
         assert "You can try again" in html
         assert "report the issue" in html
         assert "not counted against your rate limit" not in html
@@ -748,6 +752,7 @@ def test_phase_verification_renders_paginated_safe_attempt_history():
         status_label="Needs work",
         status_variant="error",
         validation_message="The required endpoint is missing.",
+        display_message="The required endpoint is missing.",
         feedback_tasks=[
             {
                 "name": "API shape",
@@ -791,6 +796,58 @@ def test_phase_verification_renders_paginated_safe_attempt_history():
     assert "submitted-token-value" not in html
     assert 'href="/verifications/phase/3?history_page=1"' in html
     assert 'href="/verifications/phase/3?history_page=3"' in html
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "cause",
+    [None, "GitHub API error (401). Try again later.", "<script>unsafe</script>"],
+)
+def test_incomplete_history_and_current_card_share_safe_explanation(cause):
+    requirement = _requirement("journal-api", "Journal API")
+    item = VerificationAttemptHistoryItem(
+        id=uuid4(),
+        requirement=requirement,
+        outcome="server_error",
+        validation_message=cause,
+        feedback_tasks=[],
+        feedback_passed=0,
+        completed_at=None,
+    )
+    card = build_requirement_card_context(
+        requirement=requirement,
+        github_username="alice",
+        submission=_submission(is_validated=False, validation_message=cause),
+    )
+    html = _render(
+        "pages/verification_phase.html",
+        phase=SimpleNamespace(name="Phase 3", description="", order=3),
+        phase_progress=SimpleNamespace(
+            verification=SimpleNamespace(
+                requirements_required=1,
+                requirements_verified=0,
+                percentage=0,
+                is_complete=False,
+            )
+        ),
+        requirements=[requirement],
+        card_contexts_by_req={requirement.slug: card},
+        verification_locked=False,
+        prerequisite_phase_id=None,
+        history=SimpleNamespace(
+            items=[item], page=1, has_previous=False, has_next=False
+        ),
+    )
+
+    assert html.count("Verification incomplete") == 2
+    assert html.count("Your work was not judged to have failed.") == 2
+    assert html.count("Report this issue") == 2
+    assert "Needs work" not in html
+    assert "<script>unsafe</script>" not in html
+    if cause == "<script>unsafe</script>":
+        assert html.count("&lt;script&gt;unsafe&lt;/script&gt;") == 2
+    elif cause:
+        assert html.count(cause) == 2
 
 
 @pytest.mark.unit

--- a/api/tests/services/test_verification_page_service.py
+++ b/api/tests/services/test_verification_page_service.py
@@ -26,9 +26,64 @@ from learn_to_cloud_shared.testing.requirement_factories import (
 
 from learn_to_cloud.rendering.context import CheckingCardContext
 from learn_to_cloud.services.verification_page_service import (
+    VerificationAttemptHistoryItem,
     get_phase_verification_workspace,
     get_verifications_overview,
 )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "cause",
+    [
+        None,
+        "Verification failed before recording a result.",
+        "GitHub API error (503). Try again later.",
+        "GitHub API error (401). Try again later.",
+        "Network error connecting to GitHub. Try again later.",
+    ],
+)
+def test_incomplete_history_explains_outcome_and_preserves_safe_cause(cause):
+    item = VerificationAttemptHistoryItem(
+        id=uuid4(),
+        requirement=repo_fork_requirement(),
+        outcome="server_error",
+        validation_message=cause,
+        feedback_tasks=[],
+        feedback_passed=0,
+        completed_at=None,
+    )
+
+    assert item.status_label == "Verification incomplete"
+    assert item.status_variant == "warning"
+    assert item.display_message is not None
+    assert "Your work was not judged to have failed." in item.display_message
+    assert "report the issue" in item.display_message
+    if cause:
+        assert cause in item.display_message
+    else:
+        assert "GitHub" not in item.display_message
+        assert "temporary" not in item.display_message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("outcome", "label"),
+    [("failed", "Needs work"), ("succeeded", "Verified"), ("cancelled", "Cancelled")],
+)
+def test_other_history_outcomes_keep_their_message(outcome, label):
+    item = VerificationAttemptHistoryItem(
+        id=uuid4(),
+        requirement=repo_fork_requirement(),
+        outcome=outcome,
+        validation_message="Saved outcome message.",
+        feedback_tasks=[],
+        feedback_passed=0,
+        completed_at=None,
+    )
+
+    assert item.status_label == label
+    assert item.display_message == "Saved outcome message."
 
 
 def _phase_overview(order: int) -> PhaseOverview:

--- a/apps/verification-functions/tests/test_attempt_orchestrations.py
+++ b/apps/verification-functions/tests/test_attempt_orchestrations.py
@@ -19,6 +19,7 @@ from learn_to_cloud_shared.models import VerificationAttemptOutcome
 from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     AttemptStatusRow,
 )
+from learn_to_cloud_shared.schemas import ValidationResult
 from learn_to_cloud_shared.submission_values import submitted_value_from_raw
 from learn_to_cloud_shared.testing.requirement_factories import (
     journal_api_verifier_requirement,
@@ -26,7 +27,9 @@ from learn_to_cloud_shared.testing.requirement_factories import (
 )
 from learn_to_cloud_shared.verification_attempt_reconciler import stale_cutoff
 from learn_to_cloud_shared.verification_workflow import (
+    GradingDisposition,
     PreparedVerificationAttempt,
+    VerificationRunResult,
 )
 
 import function_app
@@ -144,6 +147,47 @@ def _make_responder(
 
 
 class TestAttemptOrchestration:
+    def test_incomplete_evidence_run_finalizes_without_any_grading_activity(self):
+        prepared_payload = _prepared_payload(
+            journal_api_verifier_requirement(slug="journal"),
+            "https://github.com/alice/journal",
+        )
+        prepared = PreparedVerificationAttempt.from_payload(prepared_payload)
+        run_payload = VerificationRunResult(
+            attempt=prepared,
+            validation_result=ValidationResult(
+                is_valid=False,
+                message="GitHub API error (503). Try again later.",
+                verification_completed=False,
+            ),
+            grading_requests=[],
+            grading_disposition=GradingDisposition.SKIPPED_GATE_FAILED,
+        ).to_payload()
+        ctx = _FakeOrchestrationContext({"attempt_id": str(prepared.id)})
+        terminal = {"attempt_id": str(prepared.id), "outcome": "server_error"}
+
+        def responder(call):
+            if call.name == "prepare_verification_attempt":
+                return {"attempt": prepared_payload}
+            if call.name == "execute_requirement_verification":
+                return run_payload
+            if call.name == "finalize_verification_attempt":
+                assert call.payload is run_payload
+                restored = VerificationRunResult.from_payload(call.payload)
+                assert restored.validation_result.verification_completed is False
+                assert restored.grading_requests == []
+                return terminal
+            raise AssertionError(f"Unexpected grading or error activity: {call.name}")
+
+        calls, result = _drive(function_app._run_attempt_orchestration(ctx), responder)
+
+        assert _sequence(calls) == [
+            ("activity_with_retry", "prepare_verification_attempt"),
+            ("activity_with_retry", "execute_requirement_verification"),
+            ("activity_with_retry", "finalize_verification_attempt"),
+        ]
+        assert result == terminal
+
     def test_non_llm_sequence(self) -> None:
         payload = _prepared_payload(
             repo_fork_requirement(slug="fork", required_repo="owner/repo"),

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -325,6 +325,34 @@ before verification, not continuously; this does not provide an atomic GitHub
 snapshot or commit-consistent evidence. Direct checker helpers assume the
 shared engine has performed this preflight.
 
+### Verification errors and incomplete attempts
+
+`verification/errors.py` owns only shared retry primitives and the data-only
+`UpstreamResponseError` (safe message, response status, optional retry delay).
+GitHub response classification and telemetry belong to `github_errors.py`;
+deployed-API and GHCR errors stay in their respective integration modules.
+Native HTTPX request failures remain request failures, with no invented status.
+Each integration explicitly selects its retryable errors, never the common base.
+
+GitHub network and non-404 HTTP failures leave an attempt incomplete, not failed
+learner work. Failed evidence fetches stop collection and prevent all grading,
+including tasks collected earlier in the run. History and current cards retain
+the saved safe cause, explain that the work was not judged to have failed, and
+provide retry and issue-reporting guidance. Old rows without a cause use an
+outcome-based explanation rather than assuming an outage.
+
+A GitHub 404 keeps its existing missing/private-resource meaning. Optional
+missing files may still be skipped, and existing missing-work gates still apply.
+Evidence selection, file caps, truncation, and rubric missing-file rules are
+unchanged; this is not a general guarantee of complete repository evidence.
+
+GitHub API GET/HEAD and GHCR retain three attempts for their existing transient
+errors; raw-file reads make one attempt per file. Learner-API CRUD requests retain
+three attempts, while billable AI analysis makes exactly one request. Deployed-API
+failures keep their existing completed learner-failure behavior; transient GHCR
+failures remain incomplete. Response-status telemetry never includes provider
+bodies, headers, tokens, repository links, or learner endpoint URLs.
+
 ### Authentication and sessions
 
 GitHub OAuth establishes an opaque login cookie, `ltc_session`, backed by

--- a/docs/observability/telemetry-schema.md
+++ b/docs/observability/telemetry-schema.md
@@ -153,6 +153,35 @@ when GitHub cannot establish ownership. It is not an extra graded task.
 Neither event nor the span includes account IDs, names, repository URLs, or
 provider response bodies.
 
+GitHub failures mapped after the applicable retries use `error.type` consistently
+on warnings, span attributes, events, and the `github.api_error` counter:
+
+| Condition | `error.type` |
+| --- | --- |
+| HTTP 429, or HTTP 403 identified by rate-limit headers/message | `rate_limit` |
+| HTTP 5xx | `provider_unavailable` |
+| HTTP 401 | `authentication` |
+| Other HTTP 403 | `authorization` |
+| Other non-404 HTTP failures | `client_error` |
+| Native request/timeout failure | `network` |
+
+Response failures include `http.response.status_code`; transport failures do not.
+Ordinary 404s retain contextual missing-work events but produce no operational
+warning or counter increment. Expected upstream failures use
+`verification.step.result=unavailable` and persist the existing incomplete
+`server_error` outcome, not a learner-failed outcome.
+
+Evidence collection emits fixed events: `llm_rubric_review.repo_tree_error`,
+`llm_rubric_review.repo_file_error`, `security_scanning.repo_file_error`,
+`deployment_architecture.repo_tree_error`, and
+`deployment_architecture.repo_file_error`. Failed fetches prevent grading even
+when earlier steps already collected evidence. File paths are never dynamic
+event names or metric dimensions. Deployed-API and GHCR response failures retain
+their existing event names, categories, and completion behavior, adding only the
+actual `http.response.status_code` when available. Do not emit exception text,
+response bodies, headers, retry-header contents, tokens, identities, repository
+URLs, or learner endpoint URLs. Retry delays are not telemetry dimensions.
+
 ### Reconciler summary attributes
 
 | Current attribute | Canonical attribute | Purpose | Cardinality | Class | Decision |
@@ -260,7 +289,14 @@ make authentication telemetry look healthy.
 
 | Metric | Attribute | Purpose | Cardinality | Class | Decision |
 | --- | --- | --- | --- | --- | --- |
-| `github.api_error` | `error.type` | Count network, authentication, authorization, rate-limit, client, and provider failures | Fixed category set | Operational | Keep metric; replace mixed numeric/string `status` with bounded categories |
+| `github.api_error` | `error.type` | Count final mapped GitHub failures using the six categories above | Fixed category set | Operational | Keep; sole dimension is `error.type` |
+
+The meter is `learn_to_cloud`. Count once per final mapper invocation, after
+applicable retries, not once per request attempt. Coverage includes profile,
+fork, HEAD existence, and raw-file failures; raw-file reads still make only one
+attempt. Exhausted 429/5xx responses retain their HTTP category instead of
+appearing as `network`. Increased counts can reflect this expanded coverage and
+corrected classification rather than a new outage.
 
 Metrics must use low-cardinality dimensions. Attempt IDs, routes with concrete
 identifiers, repository names outside the approved curriculum set, exception

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -93,6 +93,35 @@ HTTP status/error categories and dependency failures. Do not bypass ownership
 to work around an outage or copy identity values, repository links, tokens, or
 provider response bodies into incident notes.
 
+## GitHub upstream verification failures
+
+An incomplete attempt means verification could not finish, not that the
+learner's work failed. Any attempted evidence fetch that fails with a network
+or non-404 GitHub error stops grading. Genuine missing/private resources retain
+their existing 404 feedback and do not increment `github.api_error`.
+
+Inspect the bounded `error.type` and, for responses, `http.response.status_code`:
+
+| Category | Investigation |
+| --- | --- |
+| `rate_limit` | Check GitHub quota and throttling; wait for recovery before retrying. |
+| `provider_unavailable` | Check GitHub service availability and dependency failures. |
+| `authentication` | Check the application's GitHub credential/configuration, not learner code. |
+| `authorization` | Check integration permissions and repository access; distinguish rate-limited 403s. |
+| `client_error` | Check the HTTP status and integration request contract. |
+| `network` | Check connectivity, DNS, and timeouts; there is no HTTP response status. |
+
+Exhausted 429/5xx responses now appear under `rate_limit`/`provider_unavailable`
+rather than `network`. Profile, HEAD, and raw-file failures now reach the shared
+mapper; increases in incomplete attempts or category counts can reflect corrected
+handling rather than a new outage. Count once per final mapping, not per retry.
+Raw-file reads still make one request per file.
+
+Retry after transient recovery and investigate persistent service trouble.
+Do not ask learners to change their work to fix application credentials, bypass
+ownership checks, or sign in again as a general outage fix. Historical attempts
+without a specific saved cause do not establish which dependency failed.
+
 ## Session lifecycle and rejected OAuth identity
 
 `auth.session.rejected` records bounded `auth.session.reason` values. Expiry,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ci_status.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ci_status.py
@@ -27,7 +27,7 @@ import httpx
 from opentelemetry import trace
 
 from learn_to_cloud_shared.schemas import ValidationResult
-from learn_to_cloud_shared.verification.errors import github_error_to_result
+from learn_to_cloud_shared.verification.github_errors import github_error_to_result
 from learn_to_cloud_shared.verification.github_http import (
     RETRIABLE_EXCEPTIONS,
 )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/codeql_status.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/codeql_status.py
@@ -35,7 +35,7 @@ import httpx
 from opentelemetry import trace
 
 from learn_to_cloud_shared.schemas import ValidationResult
-from learn_to_cloud_shared.verification.errors import github_error_to_result
+from learn_to_cloud_shared.verification.github_errors import github_error_to_result
 from learn_to_cloud_shared.verification.github_http import (
     RETRIABLE_EXCEPTIONS,
 )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
@@ -45,10 +45,67 @@ from learn_to_cloud_shared.core.config import get_worker_settings
 from learn_to_cloud_shared.core.http_client import PooledClient
 from learn_to_cloud_shared.schemas import ValidationResult
 from learn_to_cloud_shared.verification.errors import (
-    DeployedApiServerError,
-    deployed_api_error_to_result,
+    UpstreamResponseError,
     make_retriable,
 )
+
+
+class DeployedApiServerError(UpstreamResponseError):
+    """Raised when the learner's API returns a retriable 5xx response."""
+
+
+def deployed_api_error_to_result(exc: Exception, *, step: str = "") -> ValidationResult:
+    """Map deployed-API failures while retaining completed learner results."""
+    step_prefix = f"{step}: " if step else ""
+    span = trace.get_current_span()
+    if isinstance(exc, httpx.TimeoutException):
+        span.set_attribute("error.type", "timeout")
+        span.add_event(
+            "deployed_api.timeout",
+            {"error.type": "timeout", "verification.operation": step or "request"},
+        )
+        return ValidationResult(
+            is_valid=False,
+            message=(
+                f"{step_prefix}Request timed out. Ensure your API is accessible "
+                "and responding quickly."
+            ),
+        )
+    if isinstance(exc, DeployedApiServerError):
+        span.set_attribute("error.type", "server_error")
+        span.set_attribute("http.response.status_code", exc.status_code)
+        span.add_event(
+            "deployed_api.server_error",
+            {
+                "error.type": "server_error",
+                "verification.operation": step or "request",
+                "http.response.status_code": exc.status_code,
+            },
+        )
+        return ValidationResult(
+            is_valid=False,
+            message=(
+                f"{step_prefix}Your API returned a server error (5xx). "
+                "Please check your deployment."
+            ),
+        )
+    if isinstance(exc, httpx.RequestError):
+        span.set_attribute("error.type", "request_error")
+        span.add_event(
+            "deployed_api.request_error",
+            {
+                "error.type": "request_error",
+                "verification.operation": step or "request",
+            },
+        )
+        return ValidationResult(
+            is_valid=False,
+            message=(
+                f"{step_prefix}Could not connect to your API. "
+                f"Error: {type(exc).__name__}"
+            ),
+        )
+    raise exc
 
 
 def _build_deployed_api_client() -> httpx.AsyncClient:
@@ -383,7 +440,8 @@ async def _fetch_once(
     _check_response_ip(response)
     if response.status_code >= 500:
         raise DeployedApiServerError(
-            f"Server returned {response.status_code}: {response.text[:200]}"
+            f"Server returned {response.status_code}",
+            status_code=response.status_code,
         )
     return response
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployment_architecture.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployment_architecture.py
@@ -17,6 +17,10 @@ import httpx
 from learn_to_cloud_shared.github_repository_target import GitHubRepositoryTarget
 from learn_to_cloud_shared.schemas import HandsOnRequirement, ValidationResult
 from learn_to_cloud_shared.verification.evidence import truncate_to_bytes
+from learn_to_cloud_shared.verification.github_errors import (
+    GitHubServerError,
+    github_error_to_result,
+)
 from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
 from learn_to_cloud_shared.verification.tasks.base import (
     EvidenceBundle,
@@ -56,8 +60,7 @@ async def validate_deployment_architecture(
     Confirms the description meets the configured minimum length and that the
     deploy script exists in the learner's fork before handing the real
     judgement to the LLM rubric grader. Missing script or repo yields an
-    actionable failure; transient GitHub errors bubble up so the engine
-    records them as operational failures.
+    actionable failure; GitHub failures leave verification incomplete.
     """
     cfg = _deployment_architecture_config(requirement)
     if cfg is None or target is None:
@@ -87,8 +90,8 @@ async def validate_deployment_architecture(
     repo_files = repo_files or default_repo_files()
     try:
         file_paths = await repo_files.tree(target.owner, target.repo)
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 404:
+    except (GitHubServerError, httpx.HTTPStatusError, httpx.RequestError) as exc:
+        if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 404:
             return ValidationResult(
                 is_valid=False,
                 message=(
@@ -98,7 +101,9 @@ async def validate_deployment_architecture(
                 verification_completed=True,
                 repo_exists=False,
             )
-        raise
+        return github_error_to_result(
+            exc, event="deployment_architecture.repo_tree_error"
+        )
 
     if deploy_script_path not in file_paths:
         other_scripts = _top_level_shell_scripts(file_paths)

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/devops_analysis.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/devops_analysis.py
@@ -6,8 +6,8 @@ import httpx
 from opentelemetry import trace
 
 from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
-from learn_to_cloud_shared.verification.errors import github_error_to_result
 from learn_to_cloud_shared.verification.evidence import select_repo_paths
+from learn_to_cloud_shared.verification.github_errors import github_error_to_result
 from learn_to_cloud_shared.verification.github_http import RETRIABLE_EXCEPTIONS
 from learn_to_cloud_shared.verification.repo_files import RepoFiles, default_repo_files
 from learn_to_cloud_shared.verification.tasks.phase5 import (

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -50,13 +50,15 @@ from learn_to_cloud_shared.verification.deployment_architecture import (
 from learn_to_cloud_shared.verification.devops_analysis import (
     verify_required_devops_files,
 )
-from learn_to_cloud_shared.verification.errors import github_error_to_result
 from learn_to_cloud_shared.verification.evidence import (
     collect_repo_file_evidence,
-    collect_repo_pattern_evidence,
+    select_repo_paths,
 )
 from learn_to_cloud_shared.verification.ghcr import verify_public_ghcr_image
-from learn_to_cloud_shared.verification.github_http import RETRIABLE_EXCEPTIONS
+from learn_to_cloud_shared.verification.github_errors import (
+    GitHubServerError,
+    github_error_to_result,
+)
 from learn_to_cloud_shared.verification.github_profile import (
     validate_profile_readme,
     validate_repo_fork,
@@ -393,8 +395,8 @@ async def _check_llm_rubric_review(
 ) -> StepResult:
     """Fetch bounded repository evidence for a terminal LLM rubric review.
 
-    Never a gate: it gathers the bundle the LLM will grade and marks the task
-    for grading. The actual LLM call runs later in the separate durable
+    Stops on unavailable evidence; otherwise marks the task for grading.
+    The actual LLM call runs later in the separate durable
     ``run_llm_grading`` activity, so this step stays pure of any model call.
     """
     assert isinstance(params, LLMRubricReviewParams)
@@ -402,43 +404,40 @@ async def _check_llm_rubric_review(
     if target is None:
         return StepResult(passed=True, stop_on_fail=False)
     repo_files = context.repo_files or default_repo_files()
-    if params.discover_paths:
-        try:
-            bundle = await collect_repo_pattern_evidence(
-                repo_files,
-                target.owner,
-                target.repo,
-                params.task,
+    event = "llm_rubric_review.repo_file_error"
+    try:
+        paths = list(params.evidence_paths)
+        if params.discover_paths:
+            event = "llm_rubric_review.repo_tree_error"
+            all_files = await repo_files.tree(target.owner, target.repo)
+            paths = select_repo_paths(
+                all_files,
+                params.task.evidence.path_patterns,
+                max_files=params.task.evidence.max_files,
             )
-        except (httpx.HTTPStatusError, *RETRIABLE_EXCEPTIONS) as exc:
-            result = github_error_to_result(
-                exc,
-                event="llm_rubric_review.repo_tree_error",
-            )
-            return StepResult(
-                passed=False,
-                stop_on_fail=True,
-                validation_result=result,
-            )
-        if not bundle.items:
-            return StepResult(
-                passed=False,
-                stop_on_fail=True,
-                validation_result=ValidationResult(
-                    is_valid=False,
-                    message=(
-                        "Could not collect repository evidence for automated review."
-                    ),
-                    verification_completed=False,
-                ),
-            )
-    else:
+            event = "llm_rubric_review.repo_file_error"
         bundle = await collect_repo_file_evidence(
             repo_files,
             target.owner,
             target.repo,
-            list(params.evidence_paths),
+            paths,
             params.task,
+        )
+    except (GitHubServerError, httpx.HTTPStatusError, httpx.RequestError) as exc:
+        return StepResult(
+            passed=False,
+            stop_on_fail=True,
+            validation_result=github_error_to_result(exc, event=event),
+        )
+    if params.discover_paths and not bundle.items:
+        return StepResult(
+            passed=False,
+            stop_on_fail=True,
+            validation_result=ValidationResult(
+                is_valid=False,
+                message="Could not collect repository evidence for automated review.",
+                verification_completed=False,
+            ),
         )
     return StepResult(
         passed=True,
@@ -558,12 +557,21 @@ async def _check_security_scanning_review(
     if target is None:
         return StepResult(passed=True, stop_on_fail=False)
     repo_files = context.repo_files or default_repo_files()
-    bundle = await collect_security_scanning_evidence(
-        target.owner,
-        target.repo,
-        params.task,
-        repo_files=repo_files,
-    )
+    try:
+        bundle = await collect_security_scanning_evidence(
+            target.owner,
+            target.repo,
+            params.task,
+            repo_files=repo_files,
+        )
+    except (GitHubServerError, httpx.HTTPStatusError, httpx.RequestError) as exc:
+        return StepResult(
+            passed=False,
+            stop_on_fail=True,
+            validation_result=github_error_to_result(
+                exc, event="security_scanning.repo_file_error"
+            ),
+        )
     return StepResult(
         passed=True,
         stop_on_fail=False,
@@ -742,14 +750,23 @@ async def _check_deployment_architecture_review(
     submitted_value = context.submitted_value
     if not isinstance(submitted_value, TextValue):
         raise TypeError("Deployment architecture review requires a text value")
-    bundle = await collect_deployment_architecture_evidence(
-        target.owner,
-        target.repo,
-        submitted_value.text,
-        params.task,
-        deploy_script_path=deploy_script_path,
-        repo_files=context.repo_files or default_repo_files(),
-    )
+    try:
+        bundle = await collect_deployment_architecture_evidence(
+            target.owner,
+            target.repo,
+            submitted_value.text,
+            params.task,
+            deploy_script_path=deploy_script_path,
+            repo_files=context.repo_files or default_repo_files(),
+        )
+    except (GitHubServerError, httpx.HTTPStatusError, httpx.RequestError) as exc:
+        return StepResult(
+            passed=False,
+            stop_on_fail=True,
+            validation_result=github_error_to_result(
+                exc, event="deployment_architecture.repo_file_error"
+            ),
+        )
     return StepResult(
         passed=True,
         stop_on_fail=False,
@@ -1040,12 +1057,14 @@ def _grading_requests_for(
     """Turn steps that requested grading into recorded grading requests.
 
     Runs after aggregation so the prompt carries the final deterministic
-    result. Empty when a gate failed before the rubric step ran, which is how
-    a migrated profile signals "no grading needed" to the orchestrator.
+    result. Incomplete verification never produces grading requests, even
+    when an earlier step collected evidence before a later gate stopped the run.
 
     A task whose evidence source is ``submitted_text`` grades free text with no
     repository (Phase 7); every other task requires a repository target.
     """
+    if not deterministic_result.verification_completed:
+        return []
     requests: list[LLMGradingRequest] = []
     for result in step_results:
         task = result.grading_task

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/errors.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/errors.py
@@ -1,226 +1,30 @@
-"""Shared resilience primitives for verification services.
-
-Centralises retriable exception types, exception classes, and
-error-to-result mappers so every verification module draws from
-a single source of truth.
-"""
+"""Provider-independent response data and explicit retry primitives."""
 
 from __future__ import annotations
 
-import logging
-
 import httpx
-from opentelemetry import metrics, trace
 
-from learn_to_cloud_shared.schemas import ValidationResult
-
-logger = logging.getLogger(__name__)
-
-_meter = metrics.get_meter("learn_to_cloud")
-# Low-cardinality counter for alerting on upstream/auth failures.
-_GITHUB_API_ERROR_COUNTER = _meter.create_counter(
-    name="github.api_error",
-    description="GitHub API calls that failed with an auth, client, or server error",
-    unit="{error}",
-)
-
-
-def _github_error_type(response: httpx.Response) -> str:
-    status = response.status_code
-    if status == 429 or (
-        status == 403
-        and (
-            response.headers.get("x-ratelimit-remaining") == "0"
-            or "retry-after" in response.headers
-        )
-    ):
-        return "rate_limit"
-    if status == 403:
-        try:
-            body = response.json()
-        except ValueError:
-            body = None
-        if isinstance(body, dict):
-            message = body.get("message")
-            if isinstance(message, str) and (
-                "rate limit" in message.lower() or "abuse detection" in message.lower()
-            ):
-                return "rate_limit"
-    if status == 401:
-        return "authentication"
-    if status == 403:
-        return "authorization"
-    if status >= 500:
-        return "provider_unavailable"
-    return "client_error"
-
-
-# ---------------------------------------------------------------------------
-# Base retriable exceptions (httpx network / timeout errors)
-# ---------------------------------------------------------------------------
 BASE_RETRIABLE: tuple[type[Exception], ...] = (
     httpx.RequestError,
     httpx.TimeoutException,
 )
 
 
-def make_retriable(
-    *extra: type[Exception],
-) -> tuple[type[Exception], ...]:
-    """Build a RETRIABLE_EXCEPTIONS tuple by appending service-specific types."""
+def make_retriable(*extra: type[Exception]) -> tuple[type[Exception], ...]:
+    """Append integration-specific errors to the network retry types."""
     return BASE_RETRIABLE + extra
 
 
-# ---------------------------------------------------------------------------
-# Server error hierarchy
-# ---------------------------------------------------------------------------
-class VerificationError(Exception):
-    """Base exception for verification failures.
+class UpstreamResponseError(Exception):
+    """An upstream HTTP response's safe message and structured status."""
 
-    Attributes:
-        retriable: ``True`` when the caller should retry (transient error).
-    """
-
-    def __init__(self, message: str, retriable: bool = False):
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        retry_after: float | None = None,
+    ) -> None:
         super().__init__(message)
-        self.retriable = retriable
-
-
-class ServerError(Exception):
-    """Base for retriable server-side errors across all services.
-
-    Subclass per service so retry logic can
-    distinguish which upstream failed.
-    """
-
-    def __init__(self, message: str, retry_after: float | None = None):
-        super().__init__(message)
+        self.status_code = status_code
         self.retry_after = retry_after
-
-
-class GitHubServerError(ServerError):
-    """Raised when GitHub API returns a 5xx or 429 (retriable)."""
-
-
-class DeployedApiServerError(ServerError):
-    """Raised when deployed API returns a 5xx error (retriable)."""
-
-
-# ---------------------------------------------------------------------------
-# Error → ValidationResult mappers
-# ---------------------------------------------------------------------------
-def github_error_to_result(
-    e: Exception,
-    *,
-    event: str,
-) -> ValidationResult:
-    """Map GitHub API exceptions to a user-facing ValidationResult.
-
-    A 404 is a normal outcome (the learner pointed us at something that
-    isn't there), so it stays quiet: span/result only, no warning log or
-    metric. Auth/client errors (401/403), server errors (5xx), and transient
-    network failures are operational problems that operators need to find
-    across all users, so they emit a WARN log (severity, queryable) and bump
-    the ``github.api_error`` counter (alertable) in addition to the span
-    event.
-
-    Args:
-        e: The caught exception.
-        event: Structured log event name (e.g. ``"pr_verification.api_error"``).
-    """
-    if isinstance(e, httpx.HTTPStatusError):
-        status = e.response.status_code
-        if status == 404:
-            return ValidationResult(
-                is_valid=False,
-                message="Resource not found on GitHub. Check the URL and try again.",
-            )
-        span = trace.get_current_span()
-        span.set_attribute("http.response.status_code", status)
-        span.add_event(event, {"http.response.status_code": status})
-        logger.warning(event, extra={"http.response.status_code": status})
-        error_type = _github_error_type(e.response)
-        _GITHUB_API_ERROR_COUNTER.add(1, {"error.type": error_type})
-        return ValidationResult(
-            is_valid=False,
-            message=f"GitHub API error ({status}). Try again later.",
-            verification_completed=False,
-        )
-
-    # RETRIABLE_EXCEPTIONS (RequestError, TimeoutException, etc.)
-    error_type = type(e).__name__
-    span = trace.get_current_span()
-    span.set_attribute("error.type", error_type)
-    span.add_event(event, {"error.type": error_type})
-    logger.warning(event, extra={"error.type": error_type})
-    _GITHUB_API_ERROR_COUNTER.add(1, {"error.type": "network"})
-    return ValidationResult(
-        is_valid=False,
-        message="Could not reach GitHub. Please try again later.",
-        verification_completed=False,
-    )
-
-
-def deployed_api_error_to_result(
-    exc: Exception,
-    *,
-    step: str = "",
-) -> ValidationResult:
-    """Convert a deployed-API request exception into a ValidationResult.
-
-    Centralises error handling for timeout, connection,
-    and server errors that can occur during any HTTP call in the flow.
-    """
-    step_prefix = f"{step}: " if step else ""
-    span = trace.get_current_span()
-
-    if isinstance(exc, httpx.TimeoutException):
-        span.set_attribute("error.type", "timeout")
-        span.add_event(
-            "deployed_api.timeout",
-            {"error.type": "timeout", "verification.operation": step or "request"},
-        )
-        return ValidationResult(
-            is_valid=False,
-            message=(
-                f"{step_prefix}Request timed out. Ensure your API is accessible "
-                "and responding quickly."
-            ),
-        )
-
-    if isinstance(exc, DeployedApiServerError):
-        span.set_attribute("error.type", "server_error")
-        span.add_event(
-            "deployed_api.server_error",
-            {
-                "error.type": "server_error",
-                "verification.operation": step or "request",
-            },
-        )
-        return ValidationResult(
-            is_valid=False,
-            message=(
-                f"{step_prefix}Your API returned a server error (5xx). "
-                "Please check your deployment."
-            ),
-        )
-
-    if isinstance(exc, httpx.RequestError):
-        span.set_attribute("error.type", "request_error")
-        span.add_event(
-            "deployed_api.request_error",
-            {
-                "error.type": "request_error",
-                "verification.operation": step or "request",
-            },
-        )
-        return ValidationResult(
-            is_valid=False,
-            message=(
-                f"{step_prefix}Could not connect to your API. "
-                f"Error: {type(exc).__name__}"
-            ),
-        )
-
-    # Unexpected exception — re-raise so it's not silently swallowed
-    raise exc  # pragma: no cover

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ghcr.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/ghcr.py
@@ -16,7 +16,10 @@ from tenacity import (
 from learn_to_cloud_shared.core.config import get_worker_settings
 from learn_to_cloud_shared.core.http_client import PooledClient
 from learn_to_cloud_shared.schemas import TaskResult, ValidationResult
-from learn_to_cloud_shared.verification.errors import make_retriable
+from learn_to_cloud_shared.verification.errors import (
+    UpstreamResponseError,
+    make_retriable,
+)
 
 GHCR_BASE_URL = "https://ghcr.io"
 GHCR_IMAGE_NAME = "journal-api"
@@ -31,7 +34,7 @@ _MANIFEST_ACCEPT = ", ".join(
 _TASK_NAME = "Public GHCR Image"
 
 
-class _GhcrServerError(Exception):
+class _GhcrServerError(UpstreamResponseError):
     """Retriable GHCR server or rate-limit response."""
 
 
@@ -62,7 +65,9 @@ async def _get_client() -> httpx.AsyncClient:
 
 def _raise_for_transient_response(response: httpx.Response) -> None:
     if response.status_code == 429 or response.status_code >= 500:
-        raise _GhcrServerError(f"GHCR returned {response.status_code}")
+        raise _GhcrServerError(
+            f"GHCR returned {response.status_code}", status_code=response.status_code
+        )
 
 
 @retry(
@@ -89,6 +94,8 @@ async def _get_manifest_status(
         payload = token_response.json()
     except ValueError as exc:
         raise _GhcrProtocolError("GHCR token response was not valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise _GhcrProtocolError("GHCR token response was not an object")
     token = payload.get("token") or payload.get("access_token")
     if not isinstance(token, str) or not token:
         raise _GhcrProtocolError("GHCR token response did not include a token")
@@ -143,9 +150,13 @@ async def verify_public_ghcr_image(
     span = trace.get_current_span()
     try:
         status = await _get_manifest_status(normalized_owner, client)
-    except RETRIABLE_EXCEPTIONS:
+    except RETRIABLE_EXCEPTIONS as exc:
         span.set_attribute("error.type", "ghcr_unavailable")
-        span.add_event("ghcr.request_failed", {"error.type": "ghcr_unavailable"})
+        attributes: dict[str, str | int] = {"error.type": "ghcr_unavailable"}
+        if isinstance(exc, _GhcrServerError):
+            span.set_attribute("http.response.status_code", exc.status_code)
+            attributes["http.response.status_code"] = exc.status_code
+        span.add_event("ghcr.request_failed", attributes)
         return _result(
             passed=False,
             message="Could not reach GHCR to verify the container image.",
@@ -153,11 +164,15 @@ async def verify_public_ghcr_image(
             next_steps="Try submitting again later.",
             verification_completed=False,
         )
-    except (_GhcrProtocolError, httpx.HTTPStatusError):
+    except (_GhcrProtocolError, httpx.HTTPStatusError) as exc:
         span.set_attribute("error.type", "ghcr_response_error")
+        attributes = {"error.type": "ghcr_response_error"}
+        if isinstance(exc, httpx.HTTPStatusError):
+            span.set_attribute("http.response.status_code", exc.response.status_code)
+            attributes["http.response.status_code"] = exc.response.status_code
         span.add_event(
             "ghcr.request_failed",
-            {"error.type": "ghcr_response_error"},
+            attributes,
         )
         return _result(
             passed=False,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_errors.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_errors.py
@@ -1,0 +1,93 @@
+"""GitHub response errors, learner results, and bounded operational telemetry."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from opentelemetry import metrics, trace
+
+from learn_to_cloud_shared.schemas import ValidationResult
+from learn_to_cloud_shared.verification.errors import UpstreamResponseError
+
+logger = logging.getLogger(__name__)
+
+_meter = metrics.get_meter("learn_to_cloud")
+_GITHUB_API_ERROR_COUNTER = _meter.create_counter(
+    name="github.api_error",
+    description="GitHub API calls that failed with an auth, client, or server error",
+    unit="{error}",
+)
+
+
+class GitHubServerError(UpstreamResponseError):
+    """Raised when GitHub returns a retriable 5xx or 429 response."""
+
+
+def _github_error_type(status: int, response: httpx.Response | None = None) -> str:
+    if status == 429:
+        return "rate_limit"
+    if status == 403 and response is not None:
+        if (
+            response.headers.get("x-ratelimit-remaining") == "0"
+            or "retry-after" in response.headers
+        ):
+            return "rate_limit"
+        try:
+            body = response.json()
+        except ValueError:
+            body = None
+        if isinstance(body, dict):
+            message = body.get("message")
+            if isinstance(message, str) and (
+                "rate limit" in message.lower() or "abuse detection" in message.lower()
+            ):
+                return "rate_limit"
+    if status == 401:
+        return "authentication"
+    if status == 403:
+        return "authorization"
+    if status >= 500:
+        return "provider_unavailable"
+    return "client_error"
+
+
+def github_error_to_result(e: Exception, *, event: str) -> ValidationResult:
+    """Map supported GitHub failures once, keeping missing resources quiet."""
+    status: int | None = None
+    response: httpx.Response | None = None
+    if isinstance(e, GitHubServerError):
+        status = e.status_code
+    elif isinstance(e, httpx.HTTPStatusError):
+        response = e.response
+        status = response.status_code
+    elif not isinstance(e, httpx.RequestError):
+        raise e
+
+    if status == 404:
+        return ValidationResult(
+            is_valid=False,
+            message="Resource not found on GitHub. Check the URL and try again.",
+        )
+
+    error_type = (
+        _github_error_type(status, response) if status is not None else "network"
+    )
+    attributes: dict[str, str | int] = {"error.type": error_type}
+    if status is not None:
+        attributes["http.response.status_code"] = status
+    span = trace.get_current_span()
+    for key, value in attributes.items():
+        span.set_attribute(key, value)
+    span.add_event(event, attributes)
+    logger.warning(event, extra=attributes)
+    _GITHUB_API_ERROR_COUNTER.add(1, {"error.type": error_type})
+    return ValidationResult(
+        is_valid=False,
+        message=(
+            f"GitHub API error ({status}). Try again later."
+            if status is not None
+            else "Could not reach GitHub. Please try again later."
+        ),
+        verification_completed=False,
+    )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_http.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_http.py
@@ -27,7 +27,8 @@ from learn_to_cloud_shared.core.config import get_worker_settings
 from learn_to_cloud_shared.core.github_client import (
     get_github_client as _get_github_client,
 )
-from learn_to_cloud_shared.verification.errors import GitHubServerError, make_retriable
+from learn_to_cloud_shared.verification.errors import make_retriable
+from learn_to_cloud_shared.verification.github_errors import GitHubServerError
 
 # Exceptions that should trigger retry.
 RETRIABLE_EXCEPTIONS: tuple[type[Exception], ...] = make_retriable(GitHubServerError)
@@ -63,10 +64,14 @@ def get_github_headers() -> dict[str, str]:
 def raise_for_server_error(response: httpx.Response) -> None:
     """Map a 5xx or 429 response to the retriable :class:`GitHubServerError`."""
     if response.status_code >= 500:
-        raise GitHubServerError(f"GitHub returned {response.status_code}")
+        raise GitHubServerError(
+            f"GitHub returned {response.status_code}", status_code=response.status_code
+        )
     if response.status_code == 429:
         retry_after = _parse_retry_after(response.headers.get("Retry-After"))
-        raise GitHubServerError("GitHub rate limited (429)", retry_after=retry_after)
+        raise GitHubServerError(
+            "GitHub rate limited (429)", status_code=429, retry_after=retry_after
+        )
 
 
 @retry(
@@ -112,4 +117,6 @@ async def github_head_status(url: str) -> int:
     client = await _get_github_client()
     response = await client.head(url)
     raise_for_server_error(response)
+    if response.status_code != 404:
+        response.raise_for_status()
     return response.status_code

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_metadata.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_metadata.py
@@ -27,8 +27,9 @@ from learn_to_cloud_shared.verification.github_http import (
 class GitHubMetadata(Protocol):
     """Existence and metadata lookups against GitHub.
 
-    ``url_exists`` returns ``True`` for a 200 and ``False`` otherwise (for
-    example a 404). ``repo_metadata`` returns the repository JSON, or
+    ``url_exists`` returns ``True`` for a 200 and ``False`` for a 404 or
+    other successful status. Other HTTP failures propagate with their response.
+    ``repo_metadata`` returns the repository JSON, or
     ``None`` when the repository does not exist (404). Both raise the
     retriable :class:`GitHubServerError` on 5xx/429 and propagate
     ``httpx`` network errors; callers map those to an incomplete result.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/github_profile.py
@@ -17,7 +17,7 @@ from opentelemetry import trace
 
 from learn_to_cloud_shared.github_repository_target import GitHubRepositoryTarget
 from learn_to_cloud_shared.schemas import ValidationResult
-from learn_to_cloud_shared.verification.errors import github_error_to_result
+from learn_to_cloud_shared.verification.github_errors import github_error_to_result
 from learn_to_cloud_shared.verification.github_http import (
     RETRIABLE_EXCEPTIONS,
 )
@@ -57,14 +57,9 @@ async def check_github_url_exists(
             message="URL exists" if exists else "URL not found (404)",
         )
     except RETRIABLE_EXCEPTIONS as e:
-        span = trace.get_current_span()
-        span.set_attribute("error.type", type(e).__name__)
-        span.add_event("github.url_check.failed", {"error.type": type(e).__name__})
-        return ValidationResult(
-            is_valid=False,
-            message="Could not reach GitHub. Please try again later.",
-            verification_completed=False,
-        )
+        return github_error_to_result(e, event="github.url_check.failed")
+    except httpx.HTTPStatusError as e:
+        return github_error_to_result(e, event="github.url_check.failed")
     except Exception:
         span = trace.get_current_span()
         span.set_attribute("error.type", "unexpected_exception")
@@ -120,14 +115,7 @@ async def check_repo_is_fork_of(
             message=f"Forked from {parent_full_name}, not {original_repo}",
         )
     except RETRIABLE_EXCEPTIONS as e:
-        span = trace.get_current_span()
-        span.set_attribute("error.type", type(e).__name__)
-        span.add_event("github.fork_check.failed", {"error.type": type(e).__name__})
-        return ValidationResult(
-            is_valid=False,
-            message="Could not reach GitHub. Please try again later.",
-            verification_completed=False,
-        )
+        return github_error_to_result(e, event="github.fork_check.failed")
     except httpx.HTTPStatusError as e:
         return github_error_to_result(
             e,
@@ -157,6 +145,8 @@ async def validate_profile_readme(
     only checks that it resolves.
     """
     result = await check_github_url_exists(target.url, metadata)
+    if not result.verification_completed:
+        return result.model_copy(update={"username_match": True, "repo_exists": None})
     if not result.is_valid:
         return result.model_copy(
             update={
@@ -198,7 +188,7 @@ async def validate_repo_fork(
         return fork_result.model_copy(
             update={
                 "username_match": True,
-                "repo_exists": False,
+                "repo_exists": False if fork_result.verification_completed else None,
             }
         )
     return ValidationResult(

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_files.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repo_files.py
@@ -14,13 +14,13 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
-import httpx
 from opentelemetry import trace
 
 from learn_to_cloud_shared.core.github_client import get_github_client
 from learn_to_cloud_shared.verification.github_http import (
     get_github_headers,
     github_api_get,
+    raise_for_server_error,
 )
 
 
@@ -31,7 +31,8 @@ class RepoFiles(Protocol):
     ``tree`` raises ``httpx.HTTPStatusError`` (for example a 404 when the
     repository is missing or private) and the retriable GitHub server
     errors raised by the production adapter; callers already handle these.
-    ``file`` returns ``None`` when a file cannot be read.
+    ``file`` returns ``None`` only for a 404; other HTTP and request failures
+    propagate rather than producing incomplete evidence.
     """
 
     async def tree(self, owner: str, repo: str, branch: str = "main") -> list[str]: ...
@@ -58,17 +59,17 @@ class GitHubRepoFiles:
     async def file(
         self, owner: str, repo: str, path: str, branch: str = "main"
     ) -> str | None:
-        """Return a file's raw text, or ``None`` if it cannot be read."""
+        """Read a raw file once, returning ``None`` only for a 404."""
         client = await get_github_client()
         headers = get_github_headers()
         url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}"
-        try:
-            response = await client.get(url, headers=headers)
-            response.raise_for_status()
-        except httpx.HTTPStatusError:
+        response = await client.get(url, headers=headers)
+        if response.status_code == 404:
             span = trace.get_current_span()
             span.add_event("github.repo_file.fetch_failed")
             return None
+        raise_for_server_error(response)
+        response.raise_for_status()
         return response.text
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repository_ownership.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/repository_ownership.py
@@ -7,7 +7,7 @@ import httpx
 
 from learn_to_cloud_shared.github_repository_target import GitHubRepositoryTarget
 from learn_to_cloud_shared.schemas import ValidationResult
-from learn_to_cloud_shared.verification.errors import github_error_to_result
+from learn_to_cloud_shared.verification.github_errors import github_error_to_result
 from learn_to_cloud_shared.verification.github_http import RETRIABLE_EXCEPTIONS
 from learn_to_cloud_shared.verification.github_metadata import (
     GitHubApiMetadata,

--- a/packages/learn-to-cloud-shared/tests/services/test_ci_status_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_ci_status_verification_service.py
@@ -19,7 +19,7 @@ import httpx
 import pytest
 
 from learn_to_cloud_shared.verification.ci_status import verify_ci_status
-from learn_to_cloud_shared.verification.errors import GitHubServerError
+from learn_to_cloud_shared.verification.github_errors import GitHubServerError
 from learn_to_cloud_shared.verification.workflow_runs import InMemoryWorkflowRuns
 
 _TEST_OWNER = "testuser"
@@ -133,7 +133,9 @@ class TestCiStatusErrorHandling:
     """Tests for GitHub API error handling."""
 
     async def test_github_server_error(self):
-        runs = InMemoryWorkflowRuns(error=GitHubServerError("GitHub returned 500"))
+        runs = InMemoryWorkflowRuns(
+            error=GitHubServerError("GitHub returned 500", status_code=500)
+        )
         result = await verify_ci_status(_TEST_OWNER, _TEST_REPO, runs)
         assert not result.is_valid
         assert result.verification_completed is False

--- a/packages/learn-to-cloud-shared/tests/services/test_deployed_api_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_deployed_api_verification_service.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from learn_to_cloud_shared.verification import deployed_api
 from learn_to_cloud_shared.verification.deployed_api import (
     DeployedApiServerError,
     _check_response_ip,
@@ -541,7 +542,9 @@ class TestValidateDeployedApi:
             "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
             autospec=True,
         ) as mock_fetch:
-            mock_fetch.side_effect = DeployedApiServerError("Server returned 500")
+            mock_fetch.side_effect = DeployedApiServerError(
+                "Server returned 500", status_code=500
+            )
 
             result = await validate_deployed_api("https://api.example.com")
 
@@ -995,3 +998,154 @@ class TestCheckResponseIp:
 
         with pytest.raises(_SsrfError):
             _check_response_ip(response)
+
+
+@pytest.mark.parametrize("status", [500, 503])
+@pytest.mark.parametrize("method", ["GET", "POST", "DELETE"])
+async def test_crud_exhaustion_retains_safe_status_after_three_requests(status, method):
+    requests = []
+    span = MagicMock()
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(status, text="private learner response body")
+
+    operation = deployed_api._fetch_with_retry.retry_with(sleep=AsyncMock())
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with (
+            patch.object(deployed_api, "_get_client", AsyncMock(return_value=client)),
+            patch.object(deployed_api.trace, "get_current_span", return_value=span),
+        ):
+            with pytest.raises(DeployedApiServerError) as raised:
+                await operation("https://learner.example/entries", method=method)
+            error = raised.value
+            result = deployed_api.deployed_api_error_to_result(
+                error, step="GET /entries"
+            )
+    assert len(requests) == 3
+    assert [request.method for request in requests] == [method] * 3
+    assert error.status_code == status
+    assert error.retry_after is None
+    assert str(error) == f"Server returned {status}"
+    assert result.verification_completed
+    assert not result.is_valid
+    span.add_event.assert_called_once_with(
+        "deployed_api.server_error",
+        {
+            "error.type": "server_error",
+            "verification.operation": "GET /entries",
+            "http.response.status_code": status,
+        },
+    )
+    span.set_attribute.assert_any_call("http.response.status_code", status)
+    assert "private learner" not in str(span.mock_calls)
+    assert "learner.example" not in str(span.mock_calls)
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 429])
+async def test_crud_nonserver_responses_are_not_newly_retried(status):
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(status)
+
+    operation = deployed_api._fetch_with_retry.retry_with(sleep=AsyncMock())
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with patch.object(deployed_api, "_get_client", AsyncMock(return_value=client)):
+            response = await operation("https://learner.example/entries")
+    assert response.status_code == status
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize("error_type", [httpx.ConnectError, httpx.ReadTimeout])
+@pytest.mark.parametrize("retried", [False, True])
+async def test_fetch_preserves_native_request_exceptions(error_type, retried):
+    requests = []
+    error = error_type("private transport detail")
+
+    def handler(request):
+        requests.append(request)
+        raise error
+
+    operation = (
+        deployed_api._fetch_with_retry.retry_with(sleep=AsyncMock())
+        if retried
+        else deployed_api._fetch_once
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with (
+            patch.object(deployed_api, "_get_client", AsyncMock(return_value=client)),
+            pytest.raises(error_type) as raised,
+        ):
+            await operation("https://learner.example/entries")
+    assert raised.value is error
+    assert len(requests) == (3 if retried else 1)
+
+
+@pytest.mark.parametrize("failure", [500, 503, httpx.ReadTimeout, httpx.ConnectError])
+async def test_live_analysis_failure_sends_exactly_one_request(failure):
+    requests = []
+    span = MagicMock()
+
+    def handler(request):
+        requests.append(request)
+        if isinstance(failure, int):
+            return httpx.Response(failure, text="private analysis details")
+        raise failure("private analysis details")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with (
+            patch.object(deployed_api, "_get_client", AsyncMock(return_value=client)),
+            patch.object(deployed_api.trace, "get_current_span", return_value=span),
+        ):
+            result = await deployed_api._verify_analysis(
+                "https://learner.example", "challenge-id"
+            )
+    assert len(requests) == 1
+    assert requests[0].method == "POST"
+    assert requests[0].url.path == "/entries/challenge-id/analyze"
+    assert result.verification_completed
+    assert not result.is_valid
+    assert result.message.startswith("POST /entries/{id}/analyze:")
+    assert "private" not in result.message
+    assert "private" not in str(span.mock_calls)
+    assert "learner.example" not in str(span.mock_calls)
+
+
+@pytest.mark.parametrize(
+    ("error", "category", "message"),
+    [
+        (
+            httpx.ReadTimeout("private network detail"),
+            "timeout",
+            "Request timed out. Ensure your API is accessible and responding quickly.",
+        ),
+        (
+            httpx.ConnectError("private network detail"),
+            "request_error",
+            "Could not connect to your API. Error: ConnectError",
+        ),
+    ],
+)
+def test_deployed_request_mapper_preserves_messages_and_completion(
+    error, category, message
+):
+    span = MagicMock()
+    with patch.object(deployed_api.trace, "get_current_span", return_value=span):
+        result = deployed_api.deployed_api_error_to_result(error)
+    assert result.message == message
+    assert result.verification_completed
+    assert not result.is_valid
+    span.set_attribute.assert_called_once_with("error.type", category)
+    span.add_event.assert_called_once_with(
+        f"deployed_api.{category}",
+        {"error.type": category, "verification.operation": "request"},
+    )
+
+
+def test_deployed_mapper_rethrows_unsupported_exception():
+    error = ValueError("programming error")
+    with pytest.raises(ValueError) as raised:
+        deployed_api.deployed_api_error_to_result(error)
+    assert raised.value is error

--- a/packages/learn-to-cloud-shared/tests/services/test_ghcr_verification.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_ghcr_verification.py
@@ -1,10 +1,12 @@
 """Tests for anonymous GHCR manifest verification."""
 
 from collections.abc import Callable
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
+from learn_to_cloud_shared.verification import ghcr
 from learn_to_cloud_shared.verification.ghcr import verify_public_ghcr_image
 
 
@@ -97,3 +99,149 @@ async def test_transient_manifest_failure_is_retried():
 
     assert result.is_valid is True
     assert manifest_attempts == 2
+
+
+@pytest.mark.parametrize("phase", ["token", "manifest"])
+@pytest.mark.parametrize("status", [429, 500, 503])
+async def test_exhausted_response_errors_keep_status_and_operation_counts(
+    phase, status
+):
+    paths = []
+    span = MagicMock()
+
+    def handler(request):
+        paths.append(request.url.path)
+        if phase == "manifest" and request.url.path == "/token":
+            return _token_response(request)
+        return httpx.Response(status, text="private response body")
+
+    operation = ghcr._get_manifest_status.retry_with(sleep=AsyncMock())
+    with (
+        patch.object(ghcr, "_get_manifest_status", operation),
+        patch.object(ghcr.trace, "get_current_span", return_value=span),
+    ):
+        result = await _verify(handler)
+
+    assert paths.count("/token") == 3
+    assert len(paths) == (3 if phase == "token" else 6)
+    assert not result.is_valid
+    assert not result.verification_completed
+    assert result.message == "Could not reach GHCR to verify the container image."
+    span.set_attribute.assert_any_call("http.response.status_code", status)
+    span.add_event.assert_called_once_with(
+        "ghcr.request_failed",
+        {"error.type": "ghcr_unavailable", "http.response.status_code": status},
+    )
+    assert "private response body" not in str(span.mock_calls)
+    assert "public-token" not in str(span.mock_calls)
+    assert "private response body" not in result.model_dump_json()
+
+
+@pytest.mark.parametrize("phase", ["token", "manifest"])
+@pytest.mark.parametrize("error_type", [httpx.ConnectError, httpx.ReadTimeout])
+async def test_network_failures_are_incomplete_without_response_status(
+    phase, error_type
+):
+    paths = []
+    span = MagicMock()
+
+    def handler(request):
+        paths.append(request.url.path)
+        if phase == "manifest" and request.url.path == "/token":
+            return _token_response(request)
+        raise error_type("private network details")
+
+    operation = ghcr._get_manifest_status.retry_with(sleep=AsyncMock())
+    with (
+        patch.object(ghcr, "_get_manifest_status", operation),
+        patch.object(ghcr.trace, "get_current_span", return_value=span),
+    ):
+        result = await _verify(handler)
+    assert paths.count("/token") == 3
+    assert len(paths) == (3 if phase == "token" else 6)
+    assert not result.verification_completed
+    span.set_attribute.assert_called_once_with("error.type", "ghcr_unavailable")
+    span.add_event.assert_called_once_with(
+        "ghcr.request_failed", {"error.type": "ghcr_unavailable"}
+    )
+
+
+@pytest.mark.parametrize("body", ["not json", "[]", "null", "{}", '{"token":42}'])
+async def test_unusable_token_response_is_protocol_error_without_retries(body):
+    requests = []
+    span = MagicMock()
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(200, text=body)
+
+    with patch.object(ghcr.trace, "get_current_span", return_value=span):
+        result = await _verify(handler)
+    assert len(requests) == 1
+    assert not result.verification_completed
+    assert result.message == "GHCR returned an unexpected response."
+    span.add_event.assert_called_once_with(
+        "ghcr.request_failed", {"error.type": "ghcr_response_error"}
+    )
+
+
+async def test_unexpected_token_http_error_retains_status_without_retries():
+    requests = []
+    span = MagicMock()
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(422, text="private token details")
+
+    with patch.object(ghcr.trace, "get_current_span", return_value=span):
+        result = await _verify(handler)
+    assert len(requests) == 1
+    assert not result.verification_completed
+    span.add_event.assert_called_once_with(
+        "ghcr.request_failed",
+        {"error.type": "ghcr_response_error", "http.response.status_code": 422},
+    )
+    span.set_attribute.assert_any_call("http.response.status_code", 422)
+
+
+@pytest.mark.parametrize("phase", ["token", "manifest"])
+@pytest.mark.parametrize("status", [401, 403, 404])
+async def test_private_or_missing_image_stays_completed_without_retries(phase, status):
+    paths = []
+
+    def handler(request):
+        paths.append(request.url.path)
+        if phase == "manifest" and request.url.path == "/token":
+            return _token_response(request)
+        return httpx.Response(status)
+
+    result = await _verify(handler)
+    assert len(paths) == (1 if phase == "token" else 2)
+    assert result.verification_completed
+    assert not result.is_valid
+    assert ("not found" if status == 404 else "not publicly pullable") in result.message
+
+
+@pytest.mark.parametrize("phase", ["token", "manifest"])
+async def test_transient_phase_recovery_retries_complete_operation(phase):
+    paths = []
+    failing_attempts = 0
+
+    def handler(request):
+        nonlocal failing_attempts
+        paths.append(request.url.path)
+        if phase == "manifest" and request.url.path == "/token":
+            return _token_response(request)
+        if phase == "token" and request.url.path != "/token":
+            return httpx.Response(200)
+        failing_attempts += 1
+        if failing_attempts == 1:
+            return httpx.Response(429)
+        return _token_response(request) if phase == "token" else httpx.Response(200)
+
+    operation = ghcr._get_manifest_status.retry_with(sleep=AsyncMock())
+    with patch.object(ghcr, "_get_manifest_status", operation):
+        result = await _verify(handler)
+    assert result.is_valid
+    assert paths.count("/token") == 2
+    assert len(paths) == (3 if phase == "token" else 4)

--- a/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_github_hands_on_verification_service.py
@@ -11,13 +11,18 @@ instead of patching internals, so they exercise the real validator logic
 through the ``GitHubMetadata`` seam.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 from learn_to_cloud_shared.github_repository_target import GitHubRepositoryTarget
-from learn_to_cloud_shared.verification.errors import GitHubServerError
+from learn_to_cloud_shared.verification import (
+    github_errors,
+    github_http,
+    github_metadata,
+)
+from learn_to_cloud_shared.verification.github_errors import GitHubServerError
 from learn_to_cloud_shared.verification.github_http import (
     _parse_retry_after,
     get_github_headers,
@@ -176,13 +181,110 @@ class TestValidateRepoFork:
         result = await validate_repo_fork(_fork_target(), metadata)
         assert result.is_valid is False
         assert result.verification_completed is False
-        assert "Unexpected error" not in result.message
 
-    @pytest.mark.asyncio
-    async def test_server_error_propagated(self):
-        metadata = InMemoryGitHubMetadata(
-            repo_error=GitHubServerError("GitHub unavailable")
+
+async def test_server_error_propagated():
+    metadata = InMemoryGitHubMetadata(
+        repo_error=GitHubServerError("GitHub unavailable", status_code=503)
+    )
+    result = await validate_repo_fork(_fork_target(), metadata)
+    assert result.is_valid is False
+    assert result.verification_completed is False
+
+
+@pytest.mark.parametrize("kind", ["readme", "fork"])
+@pytest.mark.parametrize(
+    ("status", "headers", "category"),
+    [
+        (401, {}, "authentication"),
+        (403, {}, "authorization"),
+        (403, {"Retry-After": "30"}, "rate_limit"),
+        (404, {}, None),
+        (429, {"Retry-After": "30"}, "rate_limit"),
+        (503, {}, "provider_unavailable"),
+    ],
+)
+async def test_real_profile_requests_keep_missing_and_unavailable_distinct(
+    kind, status, headers, category
+):
+    calls = []
+    counter = MagicMock()
+    span = MagicMock()
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(status, headers=headers, text="private upstream detail")
+
+    get = github_http.github_api_get.retry_with(sleep=AsyncMock())
+    head = github_http.github_head_status.retry_with(sleep=AsyncMock())
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with (
+            patch.object(
+                github_http, "_get_github_client", AsyncMock(return_value=client)
+            ),
+            patch.object(github_http, "get_github_headers", return_value={}),
+            patch.object(github_metadata, "github_api_get", get),
+            patch.object(github_metadata, "github_head_status", head),
+            patch.object(github_errors, "_GITHUB_API_ERROR_COUNTER", counter),
+            patch.object(github_errors.trace, "get_current_span", return_value=span),
+        ):
+            result = (
+                await validate_profile_readme(
+                    GitHubRepositoryTarget(owner="testuser", repo="testuser")
+                )
+                if kind == "readme"
+                else await validate_repo_fork(_fork_target())
+            )
+    assert len(calls) == (3 if status in {429, 503} else 1)
+    assert calls[0].method == ("HEAD" if kind == "readme" else "GET")
+    assert not result.is_valid
+    assert result.username_match
+    assert "private" not in result.message
+    if status == 404:
+        assert result.verification_completed
+        assert result.repo_exists is False
+        assert "not found" in result.message
+        counter.add.assert_not_called()
+    else:
+        assert not result.verification_completed
+        assert result.repo_exists is None
+        assert result.message == f"GitHub API error ({status}). Try again later."
+        counter.add.assert_called_once_with(1, {"error.type": category})
+        event = (
+            "github.url_check.failed"
+            if kind == "readme"
+            else "github.fork_check.failed"
+            if status in {429, 503}
+            else "fork_check.api_error"
         )
-        result = await validate_repo_fork(_fork_target(), metadata)
-        assert result.is_valid is False
-        assert result.verification_completed is False
+        span.add_event.assert_called_once_with(
+            event, {"error.type": category, "http.response.status_code": status}
+        )
+
+
+@pytest.mark.parametrize("kind", ["readme", "fork"])
+@pytest.mark.parametrize(
+    "error_type", [httpx.ConnectError, httpx.ReadTimeout, ValueError]
+)
+async def test_incomplete_profile_does_not_claim_repository_absence(kind, error_type):
+    error = error_type("sensitive detail")
+    metadata = InMemoryGitHubMetadata(url_error=error, repo_error=error)
+    with patch.object(github_errors, "_GITHUB_API_ERROR_COUNTER") as counter:
+        result = (
+            await validate_profile_readme(
+                GitHubRepositoryTarget(owner="testuser", repo="testuser"), metadata
+            )
+            if kind == "readme"
+            else await validate_repo_fork(_fork_target(), metadata)
+        )
+    assert not result.verification_completed
+    assert result.repo_exists is None
+    assert result.username_match
+    assert "find your profile" not in result.message
+    assert "sensitive" not in result.message
+    if error_type is ValueError:
+        counter.add.assert_not_called()
+        assert result.message == "GitHub verification could not be completed."
+    else:
+        counter.add.assert_called_once_with(1, {"error.type": "network"})
+        assert "Unexpected error" not in result.message

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
@@ -1,8 +1,10 @@
 """Integration tests for verification-attempt execution."""
 
 import logging
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
+import httpx
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
@@ -13,6 +15,11 @@ from learn_to_cloud_shared.repositories.verification_attempt_repository import (
 )
 from learn_to_cloud_shared.schemas import CriterionResult, TaskResult, ValidationResult
 from learn_to_cloud_shared.submission_values import value_kind_for_submission_type
+from learn_to_cloud_shared.verification.github_errors import (
+    GitHubServerError,
+    github_error_to_result,
+)
+from learn_to_cloud_shared.verification.repo_files import GitHubRepoFiles
 from learn_to_cloud_shared.verification_attempt_executor import (
     AttemptNotRunnableError,
     finalize_verification_attempt,
@@ -24,7 +31,10 @@ from learn_to_cloud_shared.verification_attempt_snapshot import (
     build_requirement_snapshot,
     compute_snapshot_hash,
 )
-from learn_to_cloud_shared.verification_workflow import VerificationRunResult
+from learn_to_cloud_shared.verification_workflow import (
+    VERIFICATION_INCOMPLETE_ERROR_CODE,
+    VerificationRunResult,
+)
 
 pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
@@ -190,6 +200,60 @@ async def test_finalize_persists_structured_criterion_feedback(
     criterion = stored.feedback_json[0]["criterion_results"][0]
     assert criterion["criterion_id"] == "application-logging"
     assert criterion["evidence_refs"] == ["api/main.py"]
+
+
+async def test_failed_github_fetch_persists_incomplete_without_completion(
+    session_maker: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempt = await _create_attempt(session_maker)
+    preparation = await prepare_verification_attempt(
+        attempt.id, session_maker=session_maker
+    )
+    transport = httpx.MockTransport(
+        lambda _: httpx.Response(503, text="private upstream details")
+    )
+    async with httpx.AsyncClient(transport=transport) as client:
+        monkeypatch.setattr(
+            "learn_to_cloud_shared.verification.repo_files.get_github_client",
+            AsyncMock(return_value=client),
+        )
+        with pytest.raises(GitHubServerError) as raised:
+            await GitHubRepoFiles().file("octocat", "repo", "README.md")
+    validation = github_error_to_result(
+        raised.value, event="llm_rubric_review.repo_file_error"
+    )
+    run_result = VerificationRunResult(
+        attempt=preparation.attempt,
+        validation_result=validation,
+        grading_requests=[],
+    )
+    restored = VerificationRunResult.from_payload(run_result.to_payload())
+
+    finalized = await finalize_verification_attempt(
+        restored, session_maker=session_maker
+    )
+    repeated = await finalize_verification_attempt(
+        restored, session_maker=session_maker
+    )
+
+    assert finalized.won is True
+    assert repeated.won is False
+    assert finalized.state.outcome == "server_error"
+    assert finalized.state.error_code == VERIFICATION_INCOMPLETE_ERROR_CODE
+    assert finalized.state.validation_message == (
+        "GitHub API error (503). Try again later."
+    )
+    async with session_maker() as db:
+        stored = await db.get(VerificationAttempt, attempt.id)
+        completions = await VerificationAttemptRepository(db).list_phase_completions(
+            {1: 1}, {attempt.requirement_uuid: 1}
+        )
+    assert stored is not None
+    assert stored.outcome == "server_error"
+    assert stored.completed_at is not None
+    assert stored.feedback_json is None
+    assert (1, attempt.user_id) not in completions
 
 
 async def test_terminalize_records_cancelled_outcome(

--- a/packages/learn-to-cloud-shared/tests/verification/test_codeql_status.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_codeql_status.py
@@ -21,7 +21,7 @@ import httpx
 import pytest
 
 from learn_to_cloud_shared.verification.codeql_status import verify_codeql_status
-from learn_to_cloud_shared.verification.errors import GitHubServerError
+from learn_to_cloud_shared.verification.github_errors import GitHubServerError
 from learn_to_cloud_shared.verification.repo_ref import InMemoryRepoRef
 from learn_to_cloud_shared.verification.workflow_runs import InMemoryWorkflowRuns
 
@@ -132,7 +132,9 @@ class TestCodeQLStatusErrorHandling:
     """Tests for GitHub API error handling."""
 
     async def test_runs_server_error(self):
-        runs = InMemoryWorkflowRuns(error=GitHubServerError("GitHub returned 500"))
+        runs = InMemoryWorkflowRuns(
+            error=GitHubServerError("GitHub returned 500", status_code=500)
+        )
         result = await verify_codeql_status(
             _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(_HEAD)
         )

--- a/packages/learn-to-cloud-shared/tests/verification/test_deployment_architecture.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_deployment_architecture.py
@@ -1,5 +1,7 @@
 """Tests for the Phase 4 deployment-architecture deterministic gate and evidence."""
 
+from unittest.mock import AsyncMock
+
 import httpx
 import pytest
 
@@ -12,6 +14,7 @@ from learn_to_cloud_shared.verification.deployment_architecture import (
     collect_deployment_architecture_evidence,
     validate_deployment_architecture,
 )
+from learn_to_cloud_shared.verification.github_errors import GitHubServerError
 from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
 
 _TARGET = GitHubRepositoryTarget(owner="alice", repo="journal-starter")
@@ -99,11 +102,33 @@ class TestValidateDeploymentArchitecture:
         assert "not found" in result.message.lower()
 
     @pytest.mark.asyncio
-    async def test_transient_github_error_reraises(self):
+    @pytest.mark.parametrize(
+        "error",
+        [
+            _http_error(401),
+            _http_error(403),
+            _http_error(500),
+            GitHubServerError("Unavailable", status_code=503),
+            httpx.ConnectError("connection details"),
+        ],
+    )
+    async def test_github_error_is_incomplete(self, error):
         req = deployment_architecture_requirement(min_answer_length=100)
-        repo_files = InMemoryRepoFiles(tree_error=_http_error(500))
+        repo_files = InMemoryRepoFiles(tree_error=error)
 
-        with pytest.raises(httpx.HTTPStatusError):
+        result = await validate_deployment_architecture(
+            req, _LONG_DESCRIPTION, _TARGET, repo_files=repo_files
+        )
+
+        assert result.is_valid is False
+        assert result.verification_completed is False
+        assert result.repo_exists is None
+
+    @pytest.mark.asyncio
+    async def test_unexpected_tree_error_propagates(self):
+        req = deployment_architecture_requirement(min_answer_length=100)
+        repo_files = InMemoryRepoFiles(tree_error=RuntimeError("programming bug"))
+        with pytest.raises(RuntimeError, match="programming bug"):
             await validate_deployment_architecture(
                 req, _LONG_DESCRIPTION, _TARGET, repo_files=repo_files
             )
@@ -111,6 +136,32 @@ class TestValidateDeploymentArchitecture:
 
 @pytest.mark.unit
 class TestCollectDeploymentArchitectureEvidence:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error",
+        [
+            GitHubServerError("Unavailable", status_code=503),
+            httpx.ReadTimeout("connection details"),
+        ],
+    )
+    async def test_failed_script_read_does_not_return_description_only(
+        self, monkeypatch, error
+    ):
+        repo_files = InMemoryRepoFiles({"deploy.sh": _DEPLOY_SH})
+        read = AsyncMock(side_effect=error)
+        monkeypatch.setattr(repo_files, "file", read)
+
+        with pytest.raises(type(error)) as raised:
+            await collect_deployment_architecture_evidence(
+                "alice",
+                "journal-starter",
+                _LONG_DESCRIPTION,
+                repo_files=repo_files,
+            )
+
+        assert raised.value is error
+        read.assert_awaited_once_with("alice", "journal-starter", "deploy.sh")
+
     @pytest.mark.asyncio
     async def test_bundles_deploy_script_and_description(self):
         repo_files = InMemoryRepoFiles({"deploy.sh": _DEPLOY_SH})

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -1,7 +1,8 @@
 """Tests for the declarative verification engine."""
 
 import json
-from unittest.mock import AsyncMock
+from dataclasses import replace
+from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import httpx
@@ -16,6 +17,9 @@ from learn_to_cloud_shared.testing.requirement_factories import (
     repo_fork_requirement,
 )
 from learn_to_cloud_shared.verification import engine as engine_module
+from learn_to_cloud_shared.verification import github_errors
+from learn_to_cloud_shared.verification import repo_files as repo_files_module
+from learn_to_cloud_shared.verification.deployed_api import DeployedApiServerError
 from learn_to_cloud_shared.verification.engine import (
     CheckParams,
     CIStatusParams,
@@ -26,6 +30,10 @@ from learn_to_cloud_shared.verification.engine import (
     check_for,
     register_check,
     run_verification,
+)
+from learn_to_cloud_shared.verification.repo_files import (
+    GitHubRepoFiles,
+    InMemoryRepoFiles,
 )
 from learn_to_cloud_shared.verification.tasks.base import (
     EvidenceBundle,
@@ -986,6 +994,232 @@ async def test_security_profile_skips_grading_when_gate_fails(monkeypatch):
     assert result.validation_result.is_valid is False
     assert result.grading_requests == []
     assert result.evidence is None
+
+
+def _evidence_flow(flow, monkeypatch):
+    passing = ValidationResult(is_valid=True, message="Prerequisite passed.")
+    monkeypatch.setattr(
+        engine_module, "verify_ci_status", AsyncMock(return_value=passing)
+    )
+    monkeypatch.setattr(
+        engine_module, "verify_codeql_status", AsyncMock(return_value=passing)
+    )
+    monkeypatch.setattr(
+        engine_module, "verify_public_ghcr_image", AsyncMock(return_value=passing)
+    )
+    if flow == "exact":
+        from learn_to_cloud_shared.verification.tasks.phase3 import (
+            JOURNAL_API_IMPORTANT_PATHS,
+        )
+
+        return _journal_job(), list(JOURNAL_API_IMPORTANT_PATHS)
+    if flow == "discovered":
+        return _devops_job(), [
+            "Dockerfile",
+            "k8s/deployment.yaml",
+            "k8s/service.yaml",
+            ".github/workflows/deploy.yml",
+            "infra/main.tf",
+        ]
+    if flow == "security":
+        from learn_to_cloud_shared.verification.security_scanning import (
+            SECURITY_SCANNING_EVIDENCE_PATHS,
+        )
+
+        return _security_job(), SECURITY_SCANNING_EVIDENCE_PATHS
+    return _deployment_job("A detailed architecture description. " * 10), ["deploy.sh"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("flow", "event"),
+    [
+        ("exact", "llm_rubric_review.repo_file_error"),
+        ("discovered", "llm_rubric_review.repo_file_error"),
+        ("security", "security_scanning.repo_file_error"),
+        ("deployment", "deployment_architecture.repo_file_error"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("failure", "category"),
+    [
+        (401, "authentication"),
+        (403, "authorization"),
+        (429, "rate_limit"),
+        (503, "provider_unavailable"),
+        ("network", "network"),
+    ],
+)
+async def test_failed_evidence_read_stops_grading(
+    monkeypatch, flow, event, failure, category
+):
+    job, paths = _evidence_flow(flow, monkeypatch)
+    failed_path = paths[0] if flow == "deployment" else paths[1]
+    fetched = []
+    mapper = Mock(wraps=github_errors.github_error_to_result)
+    monkeypatch.setattr(engine_module, "github_error_to_result", mapper)
+    counter = Mock()
+    monkeypatch.setattr(github_errors, "_GITHUB_API_ERROR_COUNTER", counter)
+    tracer = _Tracer()
+    monkeypatch.setattr(engine_module, "_tracer", tracer)
+
+    def respond(request):
+        if request.url.host == "api.github.com":
+            return httpx.Response(
+                200, json={"tree": [{"type": "blob", "path": p} for p in paths]}
+            )
+        path = request.url.path.split("/main/", 1)[1]
+        fetched.append(path)
+        if path != failed_path:
+            return httpx.Response(200, text="Evidence content")
+        if failure == "network":
+            raise httpx.ReadTimeout("private connection details", request=request)
+        return httpx.Response(failure, text="private response details")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        monkeypatch.setattr(
+            repo_files_module, "get_github_client", AsyncMock(return_value=client)
+        )
+        monkeypatch.setattr(
+            "learn_to_cloud_shared.verification.github_http._get_github_client",
+            AsyncMock(return_value=client),
+        )
+        result = await run_verification(job, repo_files=GitHubRepoFiles())
+
+    assert fetched == paths[: 1 if flow == "deployment" else 2]
+    assert result.validation_result.is_valid is False
+    assert result.validation_result.verification_completed is False
+    assert "private" not in result.validation_result.message
+    assert result.evidence is None
+    assert result.grading_requests == []
+    assert result.grading_disposition is GradingDisposition.SKIPPED_GATE_FAILED
+    mapper.assert_called_once()
+    assert mapper.call_args.kwargs == {"event": event}
+    counter.add.assert_called_once_with(1, {"error.type": category})
+    assert tracer.spans[0][1].attributes["verification.step.result"] == "passed"
+    assert tracer.spans[-1][1].attributes["verification.step.result"] == "unavailable"
+    assert tracer.spans[-1][1].status.status_code is StatusCode.ERROR
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("flow", ["exact", "discovered", "security", "deployment"])
+@pytest.mark.parametrize(
+    "error",
+    [
+        RuntimeError("programming bug"),
+        DeployedApiServerError("another integration", status_code=503),
+    ],
+)
+async def test_evidence_boundaries_do_not_swallow_unsupported_errors(
+    monkeypatch, flow, error
+):
+    job, paths = _evidence_flow(flow, monkeypatch)
+    files = InMemoryRepoFiles(dict.fromkeys(paths, "evidence"))
+    monkeypatch.setattr(files, "file", AsyncMock(side_effect=error))
+    mapper = Mock(wraps=github_errors.github_error_to_result)
+    monkeypatch.setattr(engine_module, "github_error_to_result", mapper)
+
+    with pytest.raises(type(error)) as raised:
+        await run_verification(job, repo_files=files)
+
+    assert raised.value is error
+    mapper.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("flow", ["exact", "discovered", "security", "deployment"])
+async def test_missing_optional_evidence_preserves_existing_grading(monkeypatch, flow):
+    job, paths = _evidence_flow(flow, monkeypatch)
+    contents = dict.fromkeys(paths, "evidence")
+    missing_path = paths[0] if flow == "deployment" else paths[1]
+    del contents[missing_path]
+    files = InMemoryRepoFiles(contents, tree=paths)
+
+    result = await run_verification(job, repo_files=files)
+
+    assert result.validation_result.verification_completed is True
+    assert result.grading_disposition is GradingDisposition.REQUESTED
+    assert result.grading_requests
+    assert missing_path not in [item.path for item in result.evidence[0].items]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("flow", ["discovered", "deployment"])
+@pytest.mark.parametrize(
+    "error",
+    [
+        github_errors.GitHubServerError("Unavailable", status_code=503),
+        httpx.ConnectError("private connection details"),
+    ],
+)
+async def test_tree_failure_stops_grading_with_tree_event(monkeypatch, flow, error):
+    job, _ = _evidence_flow(flow, monkeypatch)
+    monkeypatch.setattr(
+        engine_module,
+        "verify_required_devops_files",
+        AsyncMock(return_value=ValidationResult(is_valid=True, message="Files found.")),
+    )
+    mapper = Mock(wraps=github_errors.github_error_to_result)
+    monkeypatch.setattr(engine_module, "github_error_to_result", mapper)
+    monkeypatch.setattr(
+        "learn_to_cloud_shared.verification.deployment_architecture.github_error_to_result",
+        mapper,
+    )
+    files = InMemoryRepoFiles(tree_error=error)
+    read = AsyncMock()
+    monkeypatch.setattr(files, "file", read)
+
+    result = await run_verification(job, repo_files=files)
+
+    assert result.validation_result.verification_completed is False
+    assert result.grading_requests == []
+    assert result.evidence is None
+    assert result.grading_disposition is GradingDisposition.SKIPPED_GATE_FAILED
+    event = (
+        "llm_rubric_review.repo_tree_error"
+        if flow == "discovered"
+        else "deployment_architecture.repo_tree_error"
+    )
+    mapper.assert_called_once_with(error, event=event)
+    read.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_later_incomplete_step_discards_previously_recorded_grading(monkeypatch):
+    job, paths = _evidence_flow("exact", monkeypatch)
+    profile = engine_module.profile_for(job.requirement.submission_type)
+    assert profile is not None
+    monkeypatch.setattr(
+        engine_module,
+        "profile_for",
+        lambda _: replace(
+            profile, steps=(*profile.steps, _step(CIStatusParams(), "later-gate"))
+        ),
+    )
+    incomplete = github_errors.github_error_to_result(
+        httpx.ConnectError("connection details"), event="test.upstream_error"
+    )
+    gate = AsyncMock(
+        side_effect=[
+            ValidationResult(is_valid=True, message="Initial gate passed."),
+            incomplete,
+        ]
+    )
+    monkeypatch.setattr(engine_module, "verify_ci_status", gate)
+    build_prompt = Mock()
+    monkeypatch.setattr(engine_module, "build_repo_rubric_message", build_prompt)
+
+    result = await run_verification(
+        job, repo_files=InMemoryRepoFiles(dict.fromkeys(paths, "evidence"))
+    )
+
+    assert gate.await_count == 2
+    assert result.evidence
+    assert result.validation_result.verification_completed is False
+    assert result.validation_result.message == incomplete.message
+    assert result.grading_requests == []
+    assert result.grading_disposition is GradingDisposition.SKIPPED_GATE_FAILED
+    build_prompt.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/packages/learn-to-cloud-shared/tests/verification/test_errors.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_errors.py
@@ -1,79 +1,56 @@
-"""Tests for bounded verification error telemetry."""
-
-from unittest.mock import MagicMock, patch
+"""Provider-independent error data does not imply retry policy."""
 
 import httpx
 import pytest
 
-from learn_to_cloud_shared.verification.errors import github_error_to_result
+from learn_to_cloud_shared.verification import deployed_api, ghcr, github_http
+from learn_to_cloud_shared.verification.errors import (
+    BASE_RETRIABLE,
+    UpstreamResponseError,
+    make_retriable,
+)
+from learn_to_cloud_shared.verification.github_errors import GitHubServerError
 
 
-def _status_error(
-    status: int,
-    *,
-    headers: dict[str, str] | None = None,
-) -> httpx.HTTPStatusError:
-    request = httpx.Request("GET", "https://api.github.com/resource")
-    response = httpx.Response(status, headers=headers, request=request)
-    return httpx.HTTPStatusError("failed", request=request, response=response)
+def test_response_error_retains_only_safe_response_data():
+    error = UpstreamResponseError("Unavailable", status_code=503, retry_after=2.5)
+    assert str(error) == "Unavailable"
+    assert vars(error) == {"status_code": 503, "retry_after": 2.5}
+    assert UpstreamResponseError("Unavailable", status_code=500).retry_after is None
+
+
+def test_response_status_is_required_and_keyword_only():
+    with pytest.raises(TypeError):
+        UpstreamResponseError("Unavailable")
+    with pytest.raises(TypeError):
+        UpstreamResponseError("Unavailable", 500)
+
+
+def test_make_retriable_preserves_explicit_network_types():
+    assert BASE_RETRIABLE == (httpx.RequestError, httpx.TimeoutException)
+    assert make_retriable() == BASE_RETRIABLE
+    assert make_retriable(GitHubServerError) == (*BASE_RETRIABLE, GitHubServerError)
 
 
 @pytest.mark.parametrize(
-    ("error", "expected"),
+    ("module", "own_error"),
     [
-        (_status_error(401), "authentication"),
-        (_status_error(403), "authorization"),
-        (_status_error(403, headers={"X-RateLimit-Remaining": "0"}), "rate_limit"),
-        (_status_error(403, headers={"Retry-After": "60"}), "rate_limit"),
-        (_status_error(429), "rate_limit"),
-        (_status_error(503), "provider_unavailable"),
-        (_status_error(422), "client_error"),
+        (github_http, GitHubServerError),
+        (deployed_api, deployed_api.DeployedApiServerError),
+        (ghcr, ghcr._GhcrServerError),
     ],
 )
-def test_github_http_error_metric_uses_bounded_category(error, expected):
-    counter = MagicMock()
-    with patch(
-        "learn_to_cloud_shared.verification.errors._GITHUB_API_ERROR_COUNTER",
-        counter,
-    ):
-        github_error_to_result(error, event="github.request.failed")
-
-    counter.add.assert_called_once_with(1, {"error.type": expected})
-
-
-def test_github_network_error_metric_uses_bounded_category():
-    counter = MagicMock()
-    request = httpx.Request("GET", "https://api.github.com/resource")
-    error = httpx.ConnectError("sensitive network detail", request=request)
-    with patch(
-        "learn_to_cloud_shared.verification.errors._GITHUB_API_ERROR_COUNTER",
-        counter,
-    ):
-        github_error_to_result(error, event="github.request.failed")
-
-    counter.add.assert_called_once_with(1, {"error.type": "network"})
-
-
-@pytest.mark.parametrize(
-    "message",
-    [
-        "You have exceeded a secondary rate limit.",
-        "You have triggered an abuse detection mechanism.",
-    ],
-)
-def test_github_403_body_can_identify_rate_limit(message):
-    request = httpx.Request("GET", "https://api.github.com/resource")
-    response = httpx.Response(
-        403,
-        json={"message": message},
-        request=request,
+def test_retry_policies_do_not_include_base_or_other_integrations(module, own_error):
+    assert own_error.__bases__ == (UpstreamResponseError,)
+    assert module.RETRIABLE_EXCEPTIONS == make_retriable(own_error)
+    assert not isinstance(
+        UpstreamResponseError("response", status_code=503), module.RETRIABLE_EXCEPTIONS
     )
-    error = httpx.HTTPStatusError("failed", request=request, response=response)
-    counter = MagicMock()
-    with patch(
-        "learn_to_cloud_shared.verification.errors._GITHUB_API_ERROR_COUNTER",
-        counter,
+    for other in (
+        GitHubServerError,
+        deployed_api.DeployedApiServerError,
+        ghcr._GhcrServerError,
     ):
-        github_error_to_result(error, event="github.request.failed")
-
-    counter.add.assert_called_once_with(1, {"error.type": "rate_limit"})
+        assert isinstance(
+            other("response", status_code=503), module.RETRIABLE_EXCEPTIONS
+        ) == (other is own_error)

--- a/packages/learn-to-cloud-shared/tests/verification/test_evidence.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_evidence.py
@@ -1,7 +1,11 @@
 """Tests for the evidence collector split (cap + per-source getters)."""
 
+from unittest.mock import AsyncMock
+
+import httpx
 import pytest
 
+from learn_to_cloud_shared.verification import repo_files as repo_files_module
 from learn_to_cloud_shared.verification.evidence import (
     apply_evidence_cap,
     collect_repo_file_evidence,
@@ -9,7 +13,11 @@ from learn_to_cloud_shared.verification.evidence import (
     collect_submitted_text_evidence,
     select_repo_paths,
 )
-from learn_to_cloud_shared.verification.repo_files import InMemoryRepoFiles
+from learn_to_cloud_shared.verification.github_errors import GitHubServerError
+from learn_to_cloud_shared.verification.repo_files import (
+    GitHubRepoFiles,
+    InMemoryRepoFiles,
+)
 from learn_to_cloud_shared.verification.tasks.base import (
     EvidencePolicy,
     FilePresenceGraderConfig,
@@ -139,3 +147,70 @@ async def test_collect_repo_pattern_evidence_preserves_paths_and_caps():
 
     assert [item.path for item in bundle.items] == ["Dockerfile", "infra/a.tf"]
     assert [item.content for item in bundle.items] == ["FROM python", "resource a"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("discovered", [False, True])
+@pytest.mark.parametrize("failure", [401, 403, 429, 503, "network"])
+async def test_failed_later_file_never_returns_partial_evidence(
+    monkeypatch, discovered, failure
+):
+    requested_paths = []
+
+    def respond(request):
+        if request.url.host == "api.github.com":
+            return httpx.Response(
+                200,
+                json={"tree": [{"type": "blob", "path": p} for p in ["a", "b", "c"]]},
+            )
+        requested_paths.append(request.url.path.rsplit("/", 1)[-1])
+        if len(requested_paths) == 1:
+            return httpx.Response(200, text="successfully fetched first file")
+        if failure == "network":
+            raise httpx.ReadTimeout("private connection details", request=request)
+        return httpx.Response(failure, text="private provider response")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        monkeypatch.setattr(
+            repo_files_module, "get_github_client", AsyncMock(return_value=client)
+        )
+        # Tree discovery uses the API helper's own client reference.
+        monkeypatch.setattr(
+            "learn_to_cloud_shared.verification.github_http._get_github_client",
+            AsyncMock(return_value=client),
+        )
+        expected = (
+            httpx.ReadTimeout
+            if failure == "network"
+            else GitHubServerError
+            if failure in (429, 503)
+            else httpx.HTTPStatusError
+        )
+        with pytest.raises(expected):
+            if discovered:
+                await collect_repo_pattern_evidence(
+                    GitHubRepoFiles(),
+                    "owner",
+                    "repo",
+                    _task(path_patterns=["a", "b", "c"]),
+                )
+            else:
+                await collect_repo_file_evidence(
+                    GitHubRepoFiles(), "owner", "repo", ["a", "b", "c"], _task()
+                )
+
+    assert requested_paths == ["a", "b"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("discovered", [False, True])
+async def test_missing_later_file_still_returns_available_evidence(discovered):
+    files = InMemoryRepoFiles({"a": "first", "c": "third"}, tree=["a", "b", "c"])
+    task = _task(path_patterns=["a", "b", "c"])
+    if discovered:
+        bundle = await collect_repo_pattern_evidence(files, "owner", "repo", task)
+    else:
+        bundle = await collect_repo_file_evidence(
+            files, "owner", "repo", ["a", "b", "c"], task
+        )
+    assert [item.path for item in bundle.items] == ["a", "c"]

--- a/packages/learn-to-cloud-shared/tests/verification/test_github_errors.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_github_errors.py
@@ -1,0 +1,188 @@
+"""Tests for bounded verification error telemetry."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from learn_to_cloud_shared.verification import github_errors
+from learn_to_cloud_shared.verification.deployed_api import DeployedApiServerError
+from learn_to_cloud_shared.verification.errors import UpstreamResponseError
+from learn_to_cloud_shared.verification.github_errors import (
+    GitHubServerError,
+    github_error_to_result,
+)
+
+
+def _status_error(
+    status: int,
+    *,
+    headers: dict[str, str] | None = None,
+) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://api.github.com/resource")
+    response = httpx.Response(status, headers=headers, request=request)
+    return httpx.HTTPStatusError("failed", request=request, response=response)
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (_status_error(401), "authentication"),
+        (_status_error(403), "authorization"),
+        (_status_error(403, headers={"X-RateLimit-Remaining": "0"}), "rate_limit"),
+        (_status_error(403, headers={"Retry-After": "60"}), "rate_limit"),
+        (_status_error(429), "rate_limit"),
+        (_status_error(503), "provider_unavailable"),
+        (_status_error(422), "client_error"),
+    ],
+)
+def test_github_http_error_metric_uses_bounded_category(error, expected):
+    counter = MagicMock()
+    with patch(
+        "learn_to_cloud_shared.verification.github_errors._GITHUB_API_ERROR_COUNTER",
+        counter,
+    ):
+        github_error_to_result(error, event="github.request.failed")
+
+    counter.add.assert_called_once_with(1, {"error.type": expected})
+
+
+def test_github_network_error_metric_uses_bounded_category():
+    counter = MagicMock()
+    request = httpx.Request("GET", "https://api.github.com/resource")
+    error = httpx.ConnectError("sensitive network detail", request=request)
+    with patch(
+        "learn_to_cloud_shared.verification.github_errors._GITHUB_API_ERROR_COUNTER",
+        counter,
+    ):
+        github_error_to_result(error, event="github.request.failed")
+
+    counter.add.assert_called_once_with(1, {"error.type": "network"})
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "You have exceeded a secondary rate limit.",
+        "You have triggered an abuse detection mechanism.",
+    ],
+)
+def test_github_403_body_can_identify_rate_limit(message):
+    request = httpx.Request("GET", "https://api.github.com/resource")
+    response = httpx.Response(
+        403,
+        json={"message": message},
+        request=request,
+    )
+    error = httpx.HTTPStatusError("failed", request=request, response=response)
+    counter = MagicMock()
+    with patch(
+        "learn_to_cloud_shared.verification.github_errors._GITHUB_API_ERROR_COUNTER",
+        counter,
+    ):
+        github_error_to_result(error, event="github.request.failed")
+
+    counter.add.assert_called_once_with(1, {"error.type": "rate_limit"})
+
+
+@pytest.mark.parametrize(
+    ("error", "category", "status"),
+    [
+        (_status_error(401), "authentication", 401),
+        (_status_error(403), "authorization", 403),
+        (_status_error(422), "client_error", 422),
+        (_status_error(500), "provider_unavailable", 500),
+        (GitHubServerError("private detail", status_code=429), "rate_limit", 429),
+        (
+            GitHubServerError("private detail", status_code=503),
+            "provider_unavailable",
+            503,
+        ),
+        (httpx.ConnectError("private detail"), "network", None),
+        (httpx.ReadTimeout("private detail"), "network", None),
+    ],
+)
+def test_all_telemetry_uses_same_safe_bounded_attributes(
+    error, category, status, caplog
+):
+    span = MagicMock()
+    counter = MagicMock()
+    with (
+        patch.object(github_errors, "_GITHUB_API_ERROR_COUNTER", counter),
+        patch.object(github_errors.trace, "get_current_span", return_value=span),
+    ):
+        result = github_error_to_result(error, event="github.test_failure")
+
+    attributes = {"error.type": category}
+    if status is not None:
+        attributes["http.response.status_code"] = status
+    assert {
+        call.args[0]: call.args[1] for call in span.set_attribute.call_args_list
+    } == (attributes)
+    span.add_event.assert_called_once_with("github.test_failure", attributes)
+    counter.add.assert_called_once_with(1, {"error.type": category})
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.levelname == "WARNING"
+    assert record.getMessage() == "github.test_failure"
+    assert getattr(record, "error.type") == category
+    assert getattr(record, "http.response.status_code", None) == status
+    assert "private" not in str(record.__dict__)
+    assert "private" not in result.message
+    assert not result.is_valid
+    assert not result.verification_completed
+    if status is None:
+        assert result.message == "Could not reach GitHub. Please try again later."
+    else:
+        assert result.message == f"GitHub API error ({status}). Try again later."
+
+
+@pytest.mark.parametrize(
+    "body", ["invalid JSON", "null", "[]", '"secret"', '{"message":42}']
+)
+def test_malformed_or_nonobject_403_body_remains_authorization(body):
+    response = httpx.Response(
+        403, text=body, request=httpx.Request("GET", "https://api.github.com/private")
+    )
+    error = httpx.HTTPStatusError(
+        "private", request=response.request, response=response
+    )
+    with patch.object(github_errors, "_GITHUB_API_ERROR_COUNTER") as counter:
+        result = github_error_to_result(error, event="github.test_failure")
+    counter.add.assert_called_once_with(1, {"error.type": "authorization"})
+    assert not result.verification_completed
+
+
+def test_404_is_completed_missing_work_without_operational_telemetry(caplog):
+    with (
+        patch.object(github_errors, "_GITHUB_API_ERROR_COUNTER") as counter,
+        patch.object(github_errors.trace, "get_current_span") as get_span,
+    ):
+        result = github_error_to_result(_status_error(404), event="github.test_failure")
+    assert result.verification_completed
+    assert not result.is_valid
+    assert "not found" in result.message
+    counter.add.assert_not_called()
+    get_span.assert_not_called()
+    assert not caplog.records
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ValueError("programming error"),
+        UpstreamResponseError("another response", status_code=503),
+        DeployedApiServerError("another provider", status_code=503),
+    ],
+)
+def test_unsupported_errors_propagate_without_github_telemetry(error, caplog):
+    with (
+        patch.object(github_errors, "_GITHUB_API_ERROR_COUNTER") as counter,
+        patch.object(github_errors.trace, "get_current_span") as get_span,
+        pytest.raises(type(error)) as raised,
+    ):
+        github_error_to_result(error, event="github.test_failure")
+    assert raised.value is error
+    counter.add.assert_not_called()
+    get_span.assert_not_called()
+    assert not caplog.records

--- a/packages/learn-to-cloud-shared/tests/verification/test_github_http.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_github_http.py
@@ -1,0 +1,192 @@
+"""Transport-level retry, status, and delay contracts for GitHub requests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from learn_to_cloud_shared.verification import github_errors, github_http
+from learn_to_cloud_shared.verification.github_errors import GitHubServerError
+
+
+@pytest.mark.parametrize("method", ["get", "head"])
+@pytest.mark.parametrize("status", [429, 500, 503])
+async def test_exhausted_http_errors_retain_status_and_map_once(method, status):
+    calls = []
+    sleeps = AsyncMock()
+    span = MagicMock()
+    counter = MagicMock()
+
+    def handler(request):
+        calls.append(request)
+        return httpx.Response(
+            status,
+            headers={"Retry-After": "120"},
+            text="private upstream body",
+        )
+
+    decorated = (
+        github_http.github_api_get
+        if method == "get"
+        else github_http.github_head_status
+    )
+    operation = decorated.retry_with(sleep=sleeps)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with (
+            patch.object(
+                github_http, "_get_github_client", AsyncMock(return_value=client)
+            ),
+            patch.object(github_http, "get_github_headers", return_value={}),
+            patch.object(github_errors, "_GITHUB_API_ERROR_COUNTER", counter),
+            patch.object(github_errors.trace, "get_current_span", return_value=span),
+            patch.object(github_errors.logger, "warning") as warning,
+        ):
+            with pytest.raises(GitHubServerError) as raised:
+                await operation("https://api.github.com/private-repo")
+            counter.add.assert_not_called()
+            result = github_errors.github_error_to_result(
+                raised.value, event="test.github.failed"
+            )
+
+    assert len(calls) == 3
+    assert [request.method for request in calls] == [method.upper()] * 3
+    assert sleeps.await_count == 2
+    error = raised.value
+    assert error.status_code == status
+    assert error.retry_after == (120 if status == 429 else None)
+    assert "private" not in str(error)
+    assert not result.verification_completed
+    assert result.message == f"GitHub API error ({status}). Try again later."
+    category = "rate_limit" if status == 429 else "provider_unavailable"
+    attributes = {"error.type": category, "http.response.status_code": status}
+    counter.add.assert_called_once_with(1, {"error.type": category})
+    span.add_event.assert_called_once_with("test.github.failed", attributes)
+    warning.assert_called_once_with("test.github.failed", extra=attributes)
+    if status == 429:
+        assert [call.args[0] for call in sleeps.await_args_list] == [60, 60]
+
+
+@pytest.mark.parametrize("method", ["get", "head"])
+@pytest.mark.parametrize("status", [429, 503])
+async def test_transient_http_recovery_returns_success(method, status):
+    calls = 0
+
+    def handler(request):
+        nonlocal calls
+        calls += 1
+        return httpx.Response(status if calls < 3 else 200, json={"ok": True})
+
+    decorated = (
+        github_http.github_api_get
+        if method == "get"
+        else github_http.github_head_status
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with (
+            patch.object(
+                github_http, "_get_github_client", AsyncMock(return_value=client)
+            ),
+            patch.object(github_http, "get_github_headers", return_value={}),
+        ):
+            result = await decorated.retry_with(sleep=AsyncMock())(
+                "https://github.com/x"
+            )
+    assert calls == 3
+    assert (result.status_code if method == "get" else result) == 200
+
+
+@pytest.mark.parametrize("method", ["get", "head"])
+@pytest.mark.parametrize("error_type", [httpx.ConnectError, httpx.ReadTimeout])
+async def test_request_failures_retain_original_exception(method, error_type):
+    calls = 0
+    error = error_type("private connectivity detail")
+
+    def handler(request):
+        nonlocal calls
+        calls += 1
+        raise error
+
+    decorated = (
+        github_http.github_api_get
+        if method == "get"
+        else github_http.github_head_status
+    )
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with (
+            patch.object(
+                github_http, "_get_github_client", AsyncMock(return_value=client)
+            ),
+            patch.object(github_http, "get_github_headers", return_value={}),
+            pytest.raises(error_type) as raised,
+        ):
+            await decorated.retry_with(sleep=AsyncMock())("https://github.com/x")
+    assert calls == 3
+    assert raised.value is error
+
+
+@pytest.mark.parametrize("method", ["get", "head"])
+@pytest.mark.parametrize("status", [401, 403, 404, 422])
+async def test_nonretriable_status_preserves_response(method, status):
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(
+            status, headers={"Retry-After": "55"}, text="private body"
+        )
+
+    decorated = (
+        github_http.github_api_get
+        if method == "get"
+        else github_http.github_head_status
+    )
+    sleep = AsyncMock()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with (
+            patch.object(
+                github_http, "_get_github_client", AsyncMock(return_value=client)
+            ),
+            patch.object(github_http, "get_github_headers", return_value={}),
+        ):
+            operation = decorated.retry_with(sleep=sleep)
+            if method == "head" and status == 404:
+                assert await operation("https://github.com/x") == 404
+            else:
+                with pytest.raises(httpx.HTTPStatusError) as raised:
+                    await operation("https://github.com/x")
+                assert raised.value.response.status_code == status
+                assert raised.value.response.headers["Retry-After"] == "55"
+    assert len(requests) == 1
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("header", "expected"),
+    [(None, None), ("", None), ("invalid", None), ("5", 5), ("1.5", 1.5), ("0", 0)],
+)
+def test_retry_after_numeric_parsing(header, expected):
+    assert github_http._parse_retry_after(header) == expected
+
+
+@pytest.mark.parametrize("delay", [None, 0])
+def test_missing_or_zero_retry_delay_preserves_jitter_fallback(delay):
+    state = MagicMock()
+    state.outcome.exception.return_value = GitHubServerError(
+        "rate limited", status_code=429, retry_after=delay
+    )
+    with patch.object(github_http, "wait_exponential_jitter") as jitter:
+        jitter.return_value.return_value = 0.75
+        assert github_http._wait_with_retry_after(state) == 0.75
+    jitter.assert_called_once_with(initial=0.5, max=10)
+    jitter.return_value.assert_called_once_with(state)
+
+
+@pytest.mark.parametrize(("delay", "expected"), [(1.5, 1.5), (120, 60)])
+def test_retry_after_wait_is_capped(delay, expected):
+    state = MagicMock()
+    state.outcome.exception.return_value = GitHubServerError(
+        "rate limited", status_code=429, retry_after=delay
+    )
+    with patch.object(github_http, "wait_exponential_jitter") as jitter:
+        assert github_http._wait_with_retry_after(state) == expected
+    jitter.assert_not_called()

--- a/packages/learn-to-cloud-shared/tests/verification/test_repo_files.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_repo_files.py
@@ -1,0 +1,73 @@
+"""Raw reads distinguish a missing file from an unsuccessful evidence fetch."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from learn_to_cloud_shared.verification import github_errors, repo_files
+from learn_to_cloud_shared.verification.github_errors import GitHubServerError
+
+
+@pytest.mark.parametrize("status", [200, 404, 401, 403, 429, 500, 503])
+async def test_raw_file_is_one_attempt_and_only_404_is_missing(status):
+    requests = []
+    counter = MagicMock()
+
+    def handler(request):
+        requests.append(request)
+        return httpx.Response(
+            status, text="private file content", headers={"Retry-After": "7"}
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with (
+            patch.object(
+                repo_files, "get_github_client", AsyncMock(return_value=client)
+            ),
+            patch.object(repo_files, "get_github_headers", return_value={}),
+            patch.object(github_errors, "_GITHUB_API_ERROR_COUNTER", counter),
+            patch.object(github_errors.logger, "warning") as warning,
+        ):
+            adapter = repo_files.GitHubRepoFiles()
+            if status in {200, 404}:
+                result = await adapter.file("owner", "repo", "README.md")
+                assert result == ("private file content" if status == 200 else None)
+            elif status == 429 or status >= 500:
+                with pytest.raises(GitHubServerError) as raised:
+                    await adapter.file("owner", "repo", "README.md")
+                assert raised.value.status_code == status
+                assert raised.value.retry_after == (7 if status == 429 else None)
+                assert "private" not in str(raised.value)
+            else:
+                with pytest.raises(httpx.HTTPStatusError) as raised:
+                    await adapter.file("owner", "repo", "README.md")
+                assert raised.value.response.status_code == status
+                assert raised.value.response.headers["Retry-After"] == "7"
+    assert len(requests) == 1
+    assert requests[0].url.host == "raw.githubusercontent.com"
+    warning.assert_not_called()
+    counter.add.assert_not_called()
+
+
+@pytest.mark.parametrize("error_type", [httpx.ConnectError, httpx.ReadTimeout])
+async def test_raw_file_preserves_request_error_without_retry(error_type):
+    calls = 0
+    error = error_type("private network details")
+
+    def handler(request):
+        nonlocal calls
+        calls += 1
+        raise error
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with (
+            patch.object(
+                repo_files, "get_github_client", AsyncMock(return_value=client)
+            ),
+            patch.object(repo_files, "get_github_headers", return_value={}),
+            pytest.raises(error_type) as raised,
+        ):
+            await repo_files.GitHubRepoFiles().file("owner", "repo", "README.md")
+    assert raised.value is error
+    assert calls == 1

--- a/packages/learn-to-cloud-shared/tests/verification/test_repository_ownership.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_repository_ownership.py
@@ -8,7 +8,7 @@ import pytest
 
 from learn_to_cloud_shared.github_repository_target import GitHubRepositoryTarget
 from learn_to_cloud_shared.schemas import ValidationResult
-from learn_to_cloud_shared.verification.errors import GitHubServerError
+from learn_to_cloud_shared.verification.github_errors import GitHubServerError
 from learn_to_cloud_shared.verification.github_metadata import (
     GitHubApiMetadata,
 )
@@ -149,7 +149,7 @@ async def test_provider_errors_do_not_fail_the_assignment(status, caplog):
     [
         httpx.ConnectError("private-network-details"),
         httpx.ReadTimeout("private-timeout-details"),
-        GitHubServerError("private-server-details"),
+        GitHubServerError("private-server-details", status_code=503),
         JSONDecodeError("private-json-details", "", 0),
         UnicodeDecodeError("utf-8", b"\xff", 0, 1, "private-decode-details"),
     ],


### PR DESCRIPTION
GitHub errors now leave verification incomplete instead of looking like missing files or failed learner work. If an attempted evidence fetch fails, the run stops without sending any work for grading, including evidence collected by earlier steps.

HTTP response failures keep their status after retries, so rate limits, GitHub outages, access problems, and network failures remain distinguishable. Each integration owns its errors, and existing retry counts, 404 behavior, evidence selection, and size limits are preserved. Deployed-API and GHCR telemetry retain safe response status without including response bodies.

Current cards and attempt history explain that incomplete work was not judged to have failed, retain saved safe feedback, and provide retry and issue-reporting guidance. Historical attempts without a known cause use a neutral explanation. Contributor and troubleshooting documentation describe the corrected behavior.

Closes #851.

Validation: full `uv run poe check` passed, including transport-level retries, evidence interruption, persistence, orchestration, and rendering regressions. Fresh API health, readiness, and OpenAPI requests passed.

No schema, dependency, infrastructure, retry-policy, or historical-data changes. This PR is not merged or deployed.