### PR TITLE
Simplify deployed API verification to create and analyze

### DIFF
--- a/api/tests/test_telemetry_contracts.py
+++ b/api/tests/test_telemetry_contracts.py
@@ -46,7 +46,6 @@ _ALLOWED_APPLICATION_ATTRIBUTES = {
     "verification.attempt.id",
     "verification.check.name",
     "verification.deployed_api.ai_verified",
-    "verification.deployed_api.challenge_verified",
     "verification.deployed_api.verified",
     "verification.durable.status",
     "verification.error.code",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -418,8 +418,9 @@ step, including actionable instructions for an unimplemented analysis endpoint
 behavior. The check remains deterministic and does not request grading.
 
 Created entries stay in the learner's journal even if analysis fails. The entry
-says "Nice work getting your Journal API online!" and encourages continued
-learning and building, without claiming verification passed. The verifier never
+records "Submitted deployed API for verification.", describes checking entry
+creation and AI analysis, and sets the intention to review the result and address
+reported issues. It does not claim verification passed. The verifier never
 deletes or updates entries; learners can keep or remove them themselves.
 
 #### Findings and boundaries (#855)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -380,7 +380,7 @@ shared engine has performed this preflight.
 GitHub response classification and telemetry belong to `github_errors.py`;
 deployed-API and GHCR errors stay in their respective integration modules.
 Native HTTPX request failures remain request failures, with no invented status.
-Each integration explicitly selects its retryable errors, never the common base.
+Integrations that retry explicitly select their errors, never the common base.
 
 GitHub network and non-404 HTTP failures leave an attempt incomplete, not failed
 learner work. Failed evidence fetches stop collection and prevent all grading,
@@ -395,59 +395,53 @@ Evidence selection, file caps, truncation, and rubric missing-file rules are
 unchanged; this is not a general guarantee of complete repository evidence.
 
 GitHub API GET/HEAD and GHCR retain three attempts for their existing transient
-errors; raw-file reads make one attempt per file. Learner-API create/list requests
-retain three attempts, while billable AI analysis makes exactly one request.
-Deployed-API failures keep their existing completed learner-failure behavior; transient GHCR
-failures remain incomplete. Response-status telemetry never includes provider
-bodies, headers, tokens, repository links, or learner endpoint URLs.
+errors; raw-file reads make one attempt per file. Learner-API creation and AI
+analysis each make one request, with no automatic retries. Deployed-API failures
+keep their existing completed learner-failure behavior; transient GHCR failures
+remain incomplete. Response-status telemetry never includes provider bodies,
+headers, tokens, repository links, or learner endpoint URLs.
 
-### Deployed API challenge verification
+### Deployed API verification
 
-The Phase 4 deployment check creates a unique nonce-bearing journal entry,
-finds the exact posted `work` text in `GET /entries`, and validates only that
-entry's UUID v4, text, and datetime fields before requesting live AI analysis.
-Historical entries, including malformed objects and previous verification challenges, cannot fail
-this check or substitute for the current nonce. The GET response must still wrap
-the list as `{"entries": [...], "count": N}`; the `count` value is not validated.
-Success confirms ownership and live AI analysis, not historical data quality or
-entry counts. The check remains deterministic and does not request grading.
+The Phase 4 deployment check makes two requests: `POST /entries`, then
+`POST /entries/{id}/analyze`. Creation must return 200 or 201 and a non-empty
+string ID, either in the response object or its `entry` object. Analysis must
+return 200 with the matching `entry_id`, a supported sentiment, a non-empty
+summary, and a non-empty list of topic strings. No GET, listing check, nonce,
+journal-field validation, or historical-data audit is involved.
 
-The verification entry stays in the learner's journal, whether the check succeeds
-or fails. Its `work` text starts with "Nice work getting your Journal API online!"
-and includes the unique attempt marker. The other fields encourage continued
-learning and building. This celebrates progress, not a passing verification
-result. The verifier never deletes or updates entries; each attempt creates a
-new entry, and learners can keep or remove them themselves.
+Each step runs once, including on network errors and 5xx responses. Creation
+failure stops before analysis; a missing ID is reported rather than recovered
+with a GET. Analysis has a 30-second timeout. Feedback identifies the failed
+step, including actionable instructions for an unimplemented analysis endpoint
+(501). Success confirms entry creation and analysis, not ownership or listing
+behavior. The check remains deterministic and does not request grading.
+
+Created entries stay in the learner's journal even if analysis fails. The entry
+says "Nice work getting your Journal API online!" and encourages continued
+learning and building, without claiming verification passed. The verifier never
+deletes or updates entries; learners can keep or remove them themselves.
 
 #### Findings and boundaries (#855)
 
-The [original request boundary][deployed-api-original-http] and
-[ownership workflow][deployed-api-original-workflow] explain the necessary
-complexity: pooled HTTP requests, target and response-peer checks, different
-endpoint contracts, and POST-ID precedence with GET-ID fallback for analysis.
-These remain together in `deployed_api.py`; the former cleanup workflow is
-unnecessary because verification entries are intentionally retained.
-HTTPS, redirects, base-path normalization, and absent-peer-metadata behavior are
-unchanged. The response-peer check runs after a request; it does not establish
-that all DNS-rebinding side effects are prevented.
-
+The [original workflow][deployed-api-original-workflow] combined ownership
+challenges, ID recovery, retries, and deletion with creation and analysis.
 The [original historical-entry filter and validation][deployed-api-original-history]
-mixed a deployment probe with a partial stored-data audit. Removing that work
-and its counts narrows the responsibility without requiring more modules.
-Single-entry field rules remain, now applied to the current challenge.
+also expanded a deployment probe into a partial stored-data audit. None of that
+is required by the two-request flow, so it has been removed rather than split
+into more modules.
 
-Create/list requests retain three attempts for the existing transient errors,
-with no retries for 4xx or 429. Potentially billable analysis makes one request
-with a 30-second timeout. A real analysis 501 is handled at the analysis boundary using the
-structured server-error status, so learners are told to implement and deploy the
-AI analysis task while safe `deployed_api.server_error` diagnostics remain.
-Malformed JSON encodings, non-string IDs, and non-string analysis sentiment
-are handled as learner-response problems rather than unexpected worker errors;
-an unusable POST ID can fall back to the GET-discovered ID.
+The [request boundary][deployed-api-original-http] remains necessary: connection
+pooling, timeouts, HTTPS, disabled redirects, and private-target checks protect
+our server while it requests a learner-supplied URL. Base-path normalization and
+absent-peer-metadata behavior are unchanged. Response-peer inspection occurs
+after a request and cannot undo its side effects.
 
-Existing target-block events remain. Diagnostics exclude URLs, entry IDs,
-nonces, bodies, headers, and raw exception messages. Programming errors and
-cancellation propagate instead of being silently suppressed.
+Safe timeout, server-error, request-error, and target-block diagnostics remain.
+Success records `verification.deployed_api.verified` and
+`verification.deployed_api.ai_verified`; challenge and cleanup diagnostics are
+not emitted. Diagnostics exclude URLs, entry IDs, bodies, headers, and raw
+exception messages. Programming errors and cancellation propagate.
 
 [deployed-api-original-http]: https://github.com/learntocloud/learn-to-cloud-app/blob/a070cfe9f8537e0a4d475f5933417ed6b9ba13c8/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py#L111-L249
 [deployed-api-original-workflow]: https://github.com/learntocloud/learn-to-cloud-app/blob/a070cfe9f8537e0a4d475f5933417ed6b9ba13c8/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py#L423-L828

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -401,6 +401,60 @@ failures keep their existing completed learner-failure behavior; transient GHCR
 failures remain incomplete. Response-status telemetry never includes provider
 bodies, headers, tokens, repository links, or learner endpoint URLs.
 
+### Deployed API challenge verification
+
+The Phase 4 deployment check creates a unique nonce-bearing journal entry,
+finds that exact nonce in `GET /entries`, and validates only that entry's UUID v4,
+text, and datetime fields before requesting live AI analysis. Historical entries,
+including malformed objects and previous verification challenges, cannot fail
+this check or substitute for the current nonce. The GET response must still wrap
+the list as `{"entries": [...], "count": N}`; the `count` value is not validated.
+Success confirms ownership and live AI analysis, not historical data quality or
+entry counts. The check remains deterministic and does not request grading.
+
+#### Findings and boundaries (#855)
+
+The [original request boundary][deployed-api-original-http] and
+[ownership workflow][deployed-api-original-workflow] explain the necessary
+complexity: pooled HTTP requests, target and response-peer checks, different
+endpoint contracts, POST-ID precedence with GET-ID fallback, and unconditional
+cleanup when a selected ID is known. These remain together in `deployed_api.py`.
+HTTPS, redirects, base-path normalization, and absent-peer-metadata behavior are
+unchanged. The response-peer check runs after a request; it does not establish
+that all DNS-rebinding side effects are prevented.
+
+The [original historical-entry filter and validation][deployed-api-original-history]
+mixed a deployment probe with a partial stored-data audit. Removing that work
+and its counts narrows the responsibility without requiring more modules.
+Single-entry field rules remain, now applied to the current challenge.
+
+CRUD retains three attempts for the existing transient errors, with no retries
+for 4xx or 429. Potentially billable analysis makes one request with a 30-second
+timeout. A real analysis 501 is handled at the analysis boundary using the
+structured server-error status, so learners are told to implement and deploy the
+AI analysis task while safe `deployed_api.server_error` diagnostics remain.
+Malformed JSON encodings, non-string IDs, and non-string analysis sentiment
+are handled as learner-response problems rather than unexpected worker errors;
+an unusable POST ID can fall back to the GET-discovered ID.
+
+Cleanup is best-effort, not a separate pass/fail gate. The
+[journal-starter DELETE contract][journal-delete-contract] specifies 200 for
+deletion and 404 for an absent entry; both complete cleanup, as does 204 for
+bodyless deletion. Other statuses and expected network or target-check failures
+emit `deployed_api.cleanup_failed` with `verification.operation` set to
+`DELETE /entries/{id}`, an `error.type` category (`timeout`, `request_error`,
+`server_error`, `ssrf_blocked`, or `unexpected_status`), and
+`http.response.status_code` when available. This event never sets span-level
+error attributes or changes the primary verification result. Existing target-block
+events remain. Diagnostics exclude URLs, entry IDs, nonces, bodies, headers, and
+raw exception messages. Programming errors and cancellation propagate instead
+of being silently suppressed.
+
+[deployed-api-original-http]: https://github.com/learntocloud/learn-to-cloud-app/blob/a070cfe9f8537e0a4d475f5933417ed6b9ba13c8/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py#L111-L249
+[deployed-api-original-workflow]: https://github.com/learntocloud/learn-to-cloud-app/blob/a070cfe9f8537e0a4d475f5933417ed6b9ba13c8/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py#L423-L828
+[deployed-api-original-history]: https://github.com/learntocloud/learn-to-cloud-app/blob/a070cfe9f8537e0a4d475f5933417ed6b9ba13c8/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py#L662-L692
+[journal-delete-contract]: https://github.com/learntocloud/journal-starter/blob/f7af5d4a39ee903027a43bf7cdbba43fc65ecb51/tests/test_api.py#L180-L200
+
 ### Authentication and sessions
 
 GitHub OAuth establishes an opaque login cookie, `ltc_session`, backed by

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -395,30 +395,38 @@ Evidence selection, file caps, truncation, and rubric missing-file rules are
 unchanged; this is not a general guarantee of complete repository evidence.
 
 GitHub API GET/HEAD and GHCR retain three attempts for their existing transient
-errors; raw-file reads make one attempt per file. Learner-API CRUD requests retain
-three attempts, while billable AI analysis makes exactly one request. Deployed-API
-failures keep their existing completed learner-failure behavior; transient GHCR
+errors; raw-file reads make one attempt per file. Learner-API create/list requests
+retain three attempts, while billable AI analysis makes exactly one request.
+Deployed-API failures keep their existing completed learner-failure behavior; transient GHCR
 failures remain incomplete. Response-status telemetry never includes provider
 bodies, headers, tokens, repository links, or learner endpoint URLs.
 
 ### Deployed API challenge verification
 
 The Phase 4 deployment check creates a unique nonce-bearing journal entry,
-finds that exact nonce in `GET /entries`, and validates only that entry's UUID v4,
-text, and datetime fields before requesting live AI analysis. Historical entries,
-including malformed objects and previous verification challenges, cannot fail
+finds the exact posted `work` text in `GET /entries`, and validates only that
+entry's UUID v4, text, and datetime fields before requesting live AI analysis.
+Historical entries, including malformed objects and previous verification challenges, cannot fail
 this check or substitute for the current nonce. The GET response must still wrap
 the list as `{"entries": [...], "count": N}`; the `count` value is not validated.
 Success confirms ownership and live AI analysis, not historical data quality or
 entry counts. The check remains deterministic and does not request grading.
+
+The verification entry stays in the learner's journal, whether the check succeeds
+or fails. Its `work` text starts with "Nice work getting your Journal API online!"
+and includes the unique attempt marker. The other fields encourage continued
+learning and building. This celebrates progress, not a passing verification
+result. The verifier never deletes or updates entries; each attempt creates a
+new entry, and learners can keep or remove them themselves.
 
 #### Findings and boundaries (#855)
 
 The [original request boundary][deployed-api-original-http] and
 [ownership workflow][deployed-api-original-workflow] explain the necessary
 complexity: pooled HTTP requests, target and response-peer checks, different
-endpoint contracts, POST-ID precedence with GET-ID fallback, and unconditional
-cleanup when a selected ID is known. These remain together in `deployed_api.py`.
+endpoint contracts, and POST-ID precedence with GET-ID fallback for analysis.
+These remain together in `deployed_api.py`; the former cleanup workflow is
+unnecessary because verification entries are intentionally retained.
 HTTPS, redirects, base-path normalization, and absent-peer-metadata behavior are
 unchanged. The response-peer check runs after a request; it does not establish
 that all DNS-rebinding side effects are prevented.
@@ -428,32 +436,22 @@ mixed a deployment probe with a partial stored-data audit. Removing that work
 and its counts narrows the responsibility without requiring more modules.
 Single-entry field rules remain, now applied to the current challenge.
 
-CRUD retains three attempts for the existing transient errors, with no retries
-for 4xx or 429. Potentially billable analysis makes one request with a 30-second
-timeout. A real analysis 501 is handled at the analysis boundary using the
+Create/list requests retain three attempts for the existing transient errors,
+with no retries for 4xx or 429. Potentially billable analysis makes one request
+with a 30-second timeout. A real analysis 501 is handled at the analysis boundary using the
 structured server-error status, so learners are told to implement and deploy the
 AI analysis task while safe `deployed_api.server_error` diagnostics remain.
 Malformed JSON encodings, non-string IDs, and non-string analysis sentiment
 are handled as learner-response problems rather than unexpected worker errors;
 an unusable POST ID can fall back to the GET-discovered ID.
 
-Cleanup is best-effort, not a separate pass/fail gate. The
-[journal-starter DELETE contract][journal-delete-contract] specifies 200 for
-deletion and 404 for an absent entry; both complete cleanup, as does 204 for
-bodyless deletion. Other statuses and expected network or target-check failures
-emit `deployed_api.cleanup_failed` with `verification.operation` set to
-`DELETE /entries/{id}`, an `error.type` category (`timeout`, `request_error`,
-`server_error`, `ssrf_blocked`, or `unexpected_status`), and
-`http.response.status_code` when available. This event never sets span-level
-error attributes or changes the primary verification result. Existing target-block
-events remain. Diagnostics exclude URLs, entry IDs, nonces, bodies, headers, and
-raw exception messages. Programming errors and cancellation propagate instead
-of being silently suppressed.
+Existing target-block events remain. Diagnostics exclude URLs, entry IDs,
+nonces, bodies, headers, and raw exception messages. Programming errors and
+cancellation propagate instead of being silently suppressed.
 
 [deployed-api-original-http]: https://github.com/learntocloud/learn-to-cloud-app/blob/a070cfe9f8537e0a4d475f5933417ed6b9ba13c8/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py#L111-L249
 [deployed-api-original-workflow]: https://github.com/learntocloud/learn-to-cloud-app/blob/a070cfe9f8537e0a4d475f5933417ed6b9ba13c8/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py#L423-L828
 [deployed-api-original-history]: https://github.com/learntocloud/learn-to-cloud-app/blob/a070cfe9f8537e0a4d475f5933417ed6b9ba13c8/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py#L662-L692
-[journal-delete-contract]: https://github.com/learntocloud/journal-starter/blob/f7af5d4a39ee903027a43bf7cdbba43fc65ecb51/tests/test_api.py#L180-L200
 
 ### Authentication and sessions
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
@@ -1,7 +1,7 @@
 {
   "artifact_schema_version": 1,
-  "content_hash": "63bb4e560e66daa0c1bfefbcdf44833397e9b1786d573ca964b1158915612477",
-  "curriculum_version": 12,
+  "content_hash": "7749e3cefd5b7b6b120ca2ec03b8209e9fe870a38f0d885ec61fef8b7a178d68",
+  "curriculum_version": 13,
   "phases": [
     {
       "capstone": null,
@@ -3586,7 +3586,7 @@
               "action": "practice",
               "checklist": [],
               "code": null,
-              "description": "Submit the HTTPS base URL. The verifier posts an encouraging journal entry, uses the returned entry ID to call its live AI analysis endpoint, and checks the analysis response. Both requests run once without automatic retries. The entry stays in your journal; no listing or deletion is performed.",
+              "description": "Submit the HTTPS base URL. The verifier posts a journal entry recording your verification submission, uses the returned entry ID to call its live AI analysis endpoint, and checks the analysis response. Both requests run once without automatic retries. The entry stays in your journal; no listing or deletion is performed.",
               "done_when": "The verifier reports that entry creation and live AI analysis passed.",
               "options": [],
               "order": 6,

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
@@ -1,7 +1,7 @@
 {
   "artifact_schema_version": 1,
-  "content_hash": "84d8eed265980201f5b195242b85f8d3fac3d1a311f59b15fc1895807053db6d",
-  "curriculum_version": 11,
+  "content_hash": "63bb4e560e66daa0c1bfefbcdf44833397e9b1786d573ca964b1158915612477",
+  "curriculum_version": 12,
   "phases": [
     {
       "capstone": null,
@@ -3586,8 +3586,8 @@
               "action": "practice",
               "checklist": [],
               "code": null,
-              "description": "Submit the HTTPS base URL. The verifier creates a unique challenge entry, confirms it appears in `GET /entries`, calls its live AI analysis endpoint, validates the response schema, and deletes the challenge entry.",
-              "done_when": "The verifier confirms API ownership and reports that live AI analysis passed.",
+              "description": "Submit the HTTPS base URL. The verifier posts an encouraging journal entry, uses the returned entry ID to call its live AI analysis endpoint, and checks the analysis response. Both requests run once without automatic retries. The entry stays in your journal; no listing or deletion is performed.",
+              "done_when": "The verifier reports that entry creation and live AI analysis passed.",
               "options": [],
               "order": 6,
               "slug": "phase4-topic9-practice-verify-submit-deployment",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
@@ -5,4 +5,4 @@
 # steps, objectives, or requirements). The compiler enforces that this
 # value strictly increases relative to the previously committed
 # curriculum.json artifact -- it will refuse to compile otherwise.
-curriculum_version: 12
+curriculum_version: 13

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
@@ -5,4 +5,4 @@
 # steps, objectives, or requirements). The compiler enforces that this
 # value strictly increases relative to the previously committed
 # curriculum.json artifact -- it will refuse to compile otherwise.
-curriculum_version: 11
+curriculum_version: 12

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/capstone.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/capstone.yaml
@@ -94,7 +94,7 @@ learning_steps:
   order: 6
   action: 'Practice:'
   title: Verify and submit the deployment
-  description: Submit the HTTPS base URL. The verifier posts an encouraging journal entry, uses the returned entry ID to call its live AI analysis endpoint, and checks the analysis response. Both requests run once without automatic retries. The entry stays in your journal; no listing or deletion is performed.
+  description: Submit the HTTPS base URL. The verifier posts a journal entry recording your verification submission, uses the returned entry ID to call its live AI analysis endpoint, and checks the analysis response. Both requests run once without automatic retries. The entry stays in your journal; no listing or deletion is performed.
   tips:
   - type: tip
     text: The API must return direct JSON responses without HTTP redirects. AI wording is nondeterministic, so verification checks the response schema rather than exact text.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/capstone.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/capstone.yaml
@@ -94,13 +94,13 @@ learning_steps:
   order: 6
   action: 'Practice:'
   title: Verify and submit the deployment
-  description: Submit the HTTPS base URL. The verifier creates a unique challenge entry, confirms it appears in `GET /entries`, calls its live AI analysis endpoint, validates the response schema, and deletes the challenge entry.
+  description: Submit the HTTPS base URL. The verifier posts an encouraging journal entry, uses the returned entry ID to call its live AI analysis endpoint, and checks the analysis response. Both requests run once without automatic retries. The entry stays in your journal; no listing or deletion is performed.
   tips:
   - type: tip
     text: The API must return direct JSON responses without HTTP redirects. AI wording is nondeterministic, so verification checks the response schema rather than exact text.
   - type: warning
     text: Verification makes one billable model request and allows additional time for that request to complete.
-  done_when: The verifier confirms API ownership and reports that live AI analysis passed.
+  done_when: The verifier reports that entry creation and live AI analysis passed.
   slug: phase4-topic9-practice-verify-submit-deployment
 - uuid: 8560edaf-a754-485a-93bc-42b20d6b18f6
   order: 7

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/__init__.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/__init__.py
@@ -8,7 +8,7 @@ Runs inside the Durable Function verify step. Submodules:
     token_base        - HMAC token verification for CTF + Networking Lab
     devops_analysis   - DevOps artifact analysis
     security_scanning - Dependabot + CodeQL verification
-    deployed_api      - Live API challenge-response testing
+    deployed_api      - Live journal creation and AI analysis
     errors            - Verification error types and error-to-result mappers
     tasks/            - Task definitions per phase
 """

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
@@ -5,13 +5,13 @@ by making a live HTTP request to their submitted endpoint.
 
 Verification uses a challenge-response protocol to prove API ownership:
 1. POST a unique challenge entry to /entries
-2. GET /entries and confirm the challenge nonce appears
+2. GET /entries and validate only the entry matching the current challenge nonce
 3. POST /entries/{id}/analyze and validate the live AI response
 4. DELETE the challenge entry to clean up
 
 The deployed API must:
 - Be publicly accessible via HTTPS
-- Have working create, list, analyze, and delete endpoints
+- Have working create, list, and analyze endpoints; deletion is best-effort
 - Return valid journal entry and AI analysis JSON
 
 SCALABILITY:
@@ -144,8 +144,15 @@ async def _get_client() -> httpx.AsyncClient:
 
 def _is_valid_url(value: str) -> bool:
     """Check if a string is a valid HTTPS URL."""
-    parsed = urlparse(value)
-    return parsed.scheme == "https" and bool(parsed.netloc)
+    try:
+        parsed = urlparse(value)
+        return (
+            parsed.scheme == "https"
+            and bool(parsed.hostname)
+            and (parsed.port is None or parsed.port > 0)
+        )
+    except ValueError:
+        return False
 
 
 def _is_private_ip(addr: str) -> bool:
@@ -268,41 +275,33 @@ def _validate_datetime(value: str) -> bool:
         return False
 
 
-def _validate_entry(entry: dict, index: int) -> tuple[bool, str | None]:
-    """Validate a single journal entry.
-
-    Args:
-        entry: The entry dict to validate
-        index: The index of this entry in the array (for error messages)
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
+def _validate_entry(entry: dict) -> tuple[bool, str | None]:
+    """Validate the current challenge entry's fields."""
     missing_fields = _REQUIRED_FIELDS - set(entry.keys())
     if missing_fields:
         return (
             False,
-            f"Entry {index + 1} missing fields: {', '.join(sorted(missing_fields))}",
+            f"Challenge entry missing fields: {', '.join(sorted(missing_fields))}",
         )
 
     if not isinstance(entry.get("id"), str) or not _validate_uuid(entry["id"]):
-        return False, f"Entry {index + 1} has invalid id (expected UUID format)"
+        return False, "Challenge entry has invalid id (expected UUID format)"
 
     for field in _STRING_FIELDS_WITH_LIMIT:
         value = entry.get(field)
         if not isinstance(value, str):
-            return False, f"Entry {index + 1} field '{field}' must be a string"
+            return False, f"Challenge entry field '{field}' must be a string"
         if len(value) > _MAX_STRING_LENGTH:
-            return False, f"Entry {index + 1} field '{field}' exceeds max length"
+            return False, f"Challenge entry field '{field}' exceeds max length"
         if not value.strip():
-            return False, f"Entry {index + 1} field '{field}' cannot be empty"
+            return False, f"Challenge entry field '{field}' cannot be empty"
 
     # Validate created_at is a datetime
     created_at = entry.get("created_at")
     if not isinstance(created_at, str) or not _validate_datetime(created_at):
         return (
             False,
-            f"Entry {index + 1} has invalid created_at (expected ISO 8601 datetime)",
+            "Challenge entry has invalid created_at (expected ISO 8601 datetime)",
         )
 
     # updated_at is optional but if present, must be valid datetime
@@ -310,46 +309,9 @@ def _validate_entry(entry: dict, index: int) -> tuple[bool, str | None]:
     if updated_at is not None and (
         not isinstance(updated_at, str) or not _validate_datetime(updated_at)
     ):
-        return False, f"Entry {index + 1} has invalid updated_at"
+        return False, "Challenge entry has invalid updated_at"
 
     return True, None
-
-
-def _validate_entries_json(data: list) -> ValidationResult:
-    """Validate the entries array from the API response.
-
-    Args:
-        data: The parsed JSON array from the API response
-
-    Returns:
-        ValidationResult with validation status and feedback
-    """
-    if len(data) == 0:
-        return ValidationResult(
-            is_valid=False,
-            message="No entries found. Create at least one journal entry first.",
-        )
-
-    for i, entry in enumerate(data):
-        if not isinstance(entry, dict):
-            return ValidationResult(
-                is_valid=False,
-                message=f"Entry {i + 1} is not a valid object.",
-            )
-
-        is_valid, error = _validate_entry(entry, i)
-        if not is_valid:
-            return ValidationResult(
-                is_valid=False,
-                message=error or "Entry validation failed",
-            )
-
-    count = len(data)
-    entry_word = "entry" if count == 1 else "entries"
-    return ValidationResult(
-        is_valid=True,
-        message=f"Deployed API verified! Found {count} valid {entry_word}.",
-    )
 
 
 def _validate_analysis_json(data: Any, entry_id: str) -> ValidationResult:
@@ -367,7 +329,7 @@ def _validate_analysis_json(data: Any, entry_id: str) -> ValidationResult:
         )
 
     sentiment = data.get("sentiment")
-    if sentiment not in _VALID_SENTIMENTS:
+    if not isinstance(sentiment, str) or sentiment not in _VALID_SENTIMENTS:
         return ValidationResult(
             is_valid=False,
             message=("AI analysis sentiment must be positive, negative, or neutral."),
@@ -488,18 +450,34 @@ async def _cleanup_challenge_entry(
     entries_url: str,
     entry_id: str,
 ) -> None:
-    """Best-effort DELETE of the challenge entry. Failures are logged, not raised."""
+    """Report expected DELETE failures without changing the verification outcome."""
+    attributes: dict[str, str | int] = {
+        "verification.operation": "DELETE /entries/{id}",
+    }
     try:
         delete_url = f"{entries_url}/{entry_id}"
-        await _fetch_with_retry(delete_url, method="DELETE")
+        response = await _fetch_with_retry(delete_url, method="DELETE")
     except _SsrfError:
         span = trace.get_current_span()
         span.add_event(
             "deployed_api.ssrf_blocked",
             {"verification.reason": "cleanup_dns_rebinding"},
         )
-    except Exception:
-        pass  # best-effort cleanup
+        attributes["error.type"] = "ssrf_blocked"
+    except httpx.TimeoutException:
+        attributes["error.type"] = "timeout"
+    except httpx.RequestError:
+        attributes["error.type"] = "request_error"
+    except DeployedApiServerError as exc:
+        attributes["error.type"] = "server_error"
+        attributes["http.response.status_code"] = exc.status_code
+    else:
+        if response.status_code in (200, 204, 404):
+            return
+        attributes["error.type"] = "unexpected_status"
+        attributes["http.response.status_code"] = response.status_code
+
+    trace.get_current_span().add_event("deployed_api.cleanup_failed", attributes)
 
 
 async def _post_challenge(
@@ -564,23 +542,19 @@ async def _post_challenge(
         if isinstance(post_data, dict):
             entry_obj = post_data.get("entry", post_data)
             if isinstance(entry_obj, dict):
-                return entry_obj.get("id")
-    except (json.JSONDecodeError, AttributeError):
+                entry_id = entry_obj.get("id")
+                if isinstance(entry_id, str):
+                    return entry_id
+    except (json.JSONDecodeError, UnicodeDecodeError):
         pass
 
     return None
 
 
 async def _verify_challenge(
-    entries_url: str, nonce: str, base_url: str
+    entries_url: str, nonce: str
 ) -> tuple[ValidationResult, str | None]:
-    """GET /entries and verify the challenge nonce appears.
-
-    Returns:
-        (result, discovered_entry_id) — the discovered_entry_id is the ID
-        of the challenge entry found during GET response scanning (used for
-        cleanup when the POST response didn't include one).
-    """
+    """Validate the exact nonce entry and return its ID for analysis and cleanup."""
     try:
         response = await _fetch_with_retry(entries_url)
     except _SsrfError:
@@ -612,7 +586,7 @@ async def _verify_challenge(
 
     try:
         get_data = response.json()
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return (
             ValidationResult(
                 is_valid=False,
@@ -634,16 +608,15 @@ async def _verify_challenge(
             None,
         )
 
-    # Find the challenge entry
-    nonce_found = False
-    discovered_id: str | None = None
-    for entry in entries:
-        if isinstance(entry, dict) and entry.get("work") == nonce:
-            nonce_found = True
-            discovered_id = entry.get("id")
-            break
-
-    if not nonce_found:
+    challenge_entry = next(
+        (
+            entry
+            for entry in entries
+            if isinstance(entry, dict) and entry.get("work") == nonce
+        ),
+        None,
+    )
+    if challenge_entry is None:
         span = trace.get_current_span()
         span.add_event("deployed_api.challenge_failed")
         return (
@@ -656,34 +629,29 @@ async def _verify_challenge(
                     "persists data and GET /entries returns all entries."
                 ),
             ),
-            discovered_id,
+            None,
         )
 
-    # Validate real entries (excluding challenge entries)
-    real_entries = [
-        e
-        for e in entries
-        if isinstance(e, dict)
-        and isinstance(e.get("work"), str)
-        and not e["work"].startswith(_CHALLENGE_PREFIX)
-    ]
-
-    if real_entries:
-        validation = _validate_entries_json(real_entries)
-        if not validation.is_valid:
-            return validation, discovered_id
+    entry_id = challenge_entry.get("id")
+    discovered_id = entry_id if isinstance(entry_id, str) else None
+    is_valid, error = _validate_entry(challenge_entry)
+    if not is_valid:
+        return (
+            ValidationResult(
+                is_valid=False,
+                message=error or "Challenge entry validation failed.",
+            ),
+            discovered_id,
+        )
 
     span = trace.get_current_span()
     span.set_attribute("verification.deployed_api.challenge_verified", True)
 
-    count = len(real_entries)
-    entry_word = "entry" if count == 1 else "entries"
     return (
         ValidationResult(
             is_valid=True,
             message=(
-                f"Deployed API verified! Ownership confirmed via challenge-response. "
-                f"Found {count} valid {entry_word}."
+                "Deployed API verified! Ownership confirmed via challenge-response."
             ),
         ),
         discovered_id,
@@ -709,10 +677,19 @@ async def _verify_analysis(base_url: str, entry_id: str) -> ValidationResult:
         httpx.RequestError,
         DeployedApiServerError,
     ) as exc:
-        return deployed_api_error_to_result(
+        result = deployed_api_error_to_result(
             exc,
             step="POST /entries/{id}/analyze",
         )
+        if isinstance(exc, DeployedApiServerError) and exc.status_code == 501:
+            return ValidationResult(
+                is_valid=False,
+                message=(
+                    "POST /entries/{id}/analyze is not implemented. Complete the "
+                    "Journal API AI analysis task and deploy it."
+                ),
+            )
+        return result
 
     if response.status_code == 404:
         return ValidationResult(
@@ -720,14 +697,6 @@ async def _verify_analysis(base_url: str, entry_id: str) -> ValidationResult:
             message=(
                 "POST /entries/{id}/analyze returned 404. Ensure the endpoint "
                 "exists and the challenge entry can be analyzed."
-            ),
-        )
-    if response.status_code == 501:
-        return ValidationResult(
-            is_valid=False,
-            message=(
-                "POST /entries/{id}/analyze is not implemented. Complete the "
-                "Journal API AI analysis task and deploy it."
             ),
         )
     if response.status_code != 200:
@@ -741,7 +710,7 @@ async def _verify_analysis(base_url: str, entry_id: str) -> ValidationResult:
 
     try:
         data = response.json()
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return ValidationResult(
             is_valid=False,
             message="POST /entries/{id}/analyze did not return valid JSON.",
@@ -750,20 +719,7 @@ async def _verify_analysis(base_url: str, entry_id: str) -> ValidationResult:
 
 
 async def validate_deployed_api(base_url: str) -> ValidationResult:
-    """Validate a deployed Journal API via challenge-response.
-
-    Proves the submitter owns and controls the API by:
-    1. POSTing a challenge entry with a unique nonce
-    2. GETting /entries and confirming the nonce appears
-    3. Calling the live AI analysis endpoint for that entry
-    4. DELETEing the challenge entry to clean up
-
-    Args:
-        base_url: The base URL of the deployed API (e.g., https://api.example.com)
-
-    Returns:
-        ValidationResult with validation status and feedback
-    """
+    """Verify ownership, challenge fields, and live AI analysis, then clean up."""
     base_url = _normalize_base_url(base_url)
 
     if not base_url:
@@ -796,9 +752,7 @@ async def validate_deployed_api(base_url: str) -> ValidationResult:
             return post_result
         challenge_entry_id = post_result
 
-        verify_result, discovered_id = await _verify_challenge(
-            entries_url, nonce, base_url
-        )
+        verify_result, discovered_id = await _verify_challenge(entries_url, nonce)
         if challenge_entry_id is None:
             challenge_entry_id = discovered_id
         if not verify_result.is_valid:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
@@ -272,11 +272,13 @@ async def _post_once(
 
 
 async def _create_entry(entries_url: str) -> ValidationResult | str:
-    """Create an encouraging entry and require its ID for analysis."""
+    """Record the verification submission and require its ID for analysis."""
     entry_body = {
-        "work": "Nice work getting your Journal API online!",
-        "struggle": "Every challenge is a chance to learn.",
-        "intention": "Keep building, learning, and making progress.",
+        "work": "Submitted deployed API for verification.",
+        "struggle": (
+            "Verifying that entry creation and AI analysis work after deployment."
+        ),
+        "intention": "Review the verification result and address any reported issues.",
     }
 
     try:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
@@ -1,58 +1,25 @@
-"""Deployed API verification for Phase 4 hands-on validation.
-
-This module validates that users have successfully deployed their Journal API
-by making a live HTTP request to their submitted endpoint.
-
-Verification uses a challenge-response protocol to prove API ownership:
-1. POST a unique challenge entry to /entries
-2. GET /entries and validate only the entry matching the current challenge nonce
-3. POST /entries/{id}/analyze and validate the live AI response
-
-The entry remains as an encouraging milestone, even if verification fails.
-
-The deployed API must:
-- Be publicly accessible via HTTPS
-- Have working create, list, and analyze endpoints
-- Return valid journal entry and AI analysis JSON
-
-SCALABILITY:
-- Retry create/list verification requests with exponential backoff (3 attempts)
-- Send exactly one potentially billable AI analysis request
-- Connection pooling via shared httpx.AsyncClient
-"""
+"""Create a journal entry and analyze it once, leaving the entry for the learner."""
 
 from __future__ import annotations
 
 import asyncio
 import ipaddress
 import json
-import secrets
 import socket
-from datetime import datetime
 from typing import Any
-from urllib.parse import urlparse
-from uuid import UUID
+from urllib.parse import quote, urlparse
 
 import httpx
 from opentelemetry import trace
-from tenacity import (
-    retry,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential_jitter,
-)
 
 from learn_to_cloud_shared.core.config import get_worker_settings
 from learn_to_cloud_shared.core.http_client import PooledClient
 from learn_to_cloud_shared.schemas import ValidationResult
-from learn_to_cloud_shared.verification.errors import (
-    UpstreamResponseError,
-    make_retriable,
-)
+from learn_to_cloud_shared.verification.errors import UpstreamResponseError
 
 
 class DeployedApiServerError(UpstreamResponseError):
-    """Raised when the learner's API returns a retriable 5xx response."""
+    """Raised when the learner's API returns a 5xx response."""
 
 
 def deployed_api_error_to_result(exc: Exception, *, step: str = "") -> ValidationResult:
@@ -123,17 +90,6 @@ def _build_deployed_api_client() -> httpx.AsyncClient:
 _pool = PooledClient(_build_deployed_api_client)
 
 
-# Exceptions that should trigger retry
-RETRIABLE_EXCEPTIONS: tuple[type[Exception], ...] = make_retriable(
-    DeployedApiServerError
-)
-
-# Required fields for a journal entry
-_REQUIRED_FIELDS = {"id", "work", "struggle", "intention", "created_at"}
-
-# String fields with max length constraint (256 chars per journal-starter schema)
-_STRING_FIELDS_WITH_LIMIT = {"work", "struggle", "intention"}
-_MAX_STRING_LENGTH = 256
 _VALID_SENTIMENTS = {"positive", "negative", "neutral"}
 _ANALYSIS_TIMEOUT_SECONDS = 30.0
 
@@ -169,15 +125,7 @@ def _is_private_ip(addr: str) -> bool:
 
 
 async def _validate_url_target(url: str) -> str | None:
-    """Validate that a URL's hostname does not target a private IP address.
-
-    Performs pre-flight DNS resolution to catch obvious SSRF attempts
-    (direct IPs, hostnames resolving to private ranges). A second
-    validation occurs post-connect in ``_check_response_ip`` to close
-    the DNS-rebinding TOCTOU window.
-
-    Returns None if safe, or an error message string.
-    """
+    """Reject private targets before sending requests from our server."""
     parsed = urlparse(url)
     hostname = parsed.hostname
     if not hostname:
@@ -227,11 +175,7 @@ class _SsrfError(Exception):
 
 
 def _check_response_ip(response: httpx.Response) -> None:
-    """Verify the actual connected IP is not private (closes DNS-rebinding gap).
-
-    Raises:
-        _SsrfError: If the connection was made to a private/internal IP.
-    """
+    """Reject a private response peer; this cannot undo the request already sent."""
     stream = response.extensions.get("network_stream")
     if stream is None:
         return
@@ -255,64 +199,6 @@ def _normalize_base_url(url: str) -> str:
     if url.endswith("/entries"):
         url = url[:-8]
     return url
-
-
-def _validate_uuid(value: str) -> bool:
-    """Check if a string is a valid UUID v4."""
-    try:
-        return UUID(value).version == 4
-    except (ValueError, AttributeError, TypeError):
-        return False
-
-
-def _validate_datetime(value: str) -> bool:
-    """Check if a string is a valid ISO 8601 datetime."""
-    try:
-        if value.endswith("Z"):
-            value = value[:-1] + "+00:00"
-        datetime.fromisoformat(value)
-        return True
-    except (ValueError, TypeError):
-        return False
-
-
-def _validate_entry(entry: dict) -> tuple[bool, str | None]:
-    """Validate the current challenge entry's fields."""
-    missing_fields = _REQUIRED_FIELDS - set(entry.keys())
-    if missing_fields:
-        return (
-            False,
-            f"Challenge entry missing fields: {', '.join(sorted(missing_fields))}",
-        )
-
-    if not isinstance(entry.get("id"), str) or not _validate_uuid(entry["id"]):
-        return False, "Challenge entry has invalid id (expected UUID format)"
-
-    for field in _STRING_FIELDS_WITH_LIMIT:
-        value = entry.get(field)
-        if not isinstance(value, str):
-            return False, f"Challenge entry field '{field}' must be a string"
-        if len(value) > _MAX_STRING_LENGTH:
-            return False, f"Challenge entry field '{field}' exceeds max length"
-        if not value.strip():
-            return False, f"Challenge entry field '{field}' cannot be empty"
-
-    # Validate created_at is a datetime
-    created_at = entry.get("created_at")
-    if not isinstance(created_at, str) or not _validate_datetime(created_at):
-        return (
-            False,
-            "Challenge entry has invalid created_at (expected ISO 8601 datetime)",
-        )
-
-    # updated_at is optional but if present, must be valid datetime
-    updated_at = entry.get("updated_at")
-    if updated_at is not None and (
-        not isinstance(updated_at, str) or not _validate_datetime(updated_at)
-    ):
-        return False, "Challenge entry has invalid updated_at"
-
-    return True, None
 
 
 def _validate_analysis_json(data: Any, entry_id: str) -> ValidationResult:
@@ -360,37 +246,13 @@ def _validate_analysis_json(data: Any, entry_id: str) -> ValidationResult:
     )
 
 
-_CHALLENGE_PREFIX = "ltc-verify-"
-
-
-def _generate_challenge_nonce() -> str:
-    """Generate a unique challenge nonce for ownership verification."""
-    return f"{_CHALLENGE_PREFIX}{secrets.token_hex(16)}"
-
-
-def _extract_entries_list(data: Any) -> list | None:
-    """Extract the entries list from a GET /entries response.
-
-    The journal-starter returns: {"entries": [...], "count": N}
-    This is the only format we accept.
-
-    Returns None if the format is unrecognised.
-    """
-    if isinstance(data, dict):
-        entries = data.get("entries")
-        if isinstance(entries, list):
-            return entries
-    return None
-
-
-async def _fetch_once(
+async def _post_once(
     url: str,
     *,
-    method: str = "GET",
     json_body: dict | None = None,
     timeout: float | None = None,
 ) -> httpx.Response:
-    """Make one HTTP request to the deployed API."""
+    """POST once with shared connection limits and response-peer checks."""
     client = await _get_client()
     request_options: dict[str, Any] = {
         "json": json_body,
@@ -398,7 +260,7 @@ async def _fetch_once(
     }
     if timeout is not None:
         request_options["timeout"] = timeout
-    response = await client.request(method, url, **request_options)
+    response = await client.post(url, **request_options)
 
     _check_response_ip(response)
     if response.status_code >= 500:
@@ -409,64 +271,16 @@ async def _fetch_once(
     return response
 
 
-@retry(
-    stop=stop_after_attempt(3),
-    wait=wait_exponential_jitter(initial=0.5, max=10),
-    retry=retry_if_exception_type(RETRIABLE_EXCEPTIONS),
-    reraise=True,
-)
-async def _fetch_with_retry(
-    url: str,
-    *,
-    method: str = "GET",
-    json_body: dict | None = None,
-    timeout: float | None = None,
-) -> httpx.Response:
-    """Make a retryable HTTP request to the deployed API.
-
-    Args:
-        url: The full URL to request
-        method: HTTP method (GET or POST)
-        json_body: Optional JSON body for POST requests
-        timeout: Optional per-request timeout override
-
-    Returns:
-        The httpx Response object
-
-    Raises:
-        _SsrfError: If the connection resolved to a private IP
-        DeployedApiServerError: If the API returns a 5xx error
-        httpx.RequestError: For connection/network errors
-        httpx.TimeoutException: If the request times out
-    """
-    return await _fetch_once(
-        url,
-        method=method,
-        json_body=json_body,
-        timeout=timeout,
-    )
-
-
-async def _post_challenge(
-    entries_url: str, challenge_work: str
-) -> ValidationResult | str | None:
-    """POST a challenge entry to prove API ownership.
-
-    Returns:
-        ValidationResult if the POST failed (error for user).
-        str if the entry_id was extracted from the response.
-        None if POST succeeded but entry_id couldn't be parsed.
-    """
-    challenge_body = {
-        "work": challenge_work,
+async def _create_entry(entries_url: str) -> ValidationResult | str:
+    """Create an encouraging entry and require its ID for analysis."""
+    entry_body = {
+        "work": "Nice work getting your Journal API online!",
         "struggle": "Every challenge is a chance to learn.",
         "intention": "Keep building, learning, and making progress.",
     }
 
     try:
-        response = await _fetch_with_retry(
-            entries_url, method="POST", json_body=challenge_body
-        )
+        response = await _post_once(entries_url, json_body=entry_body)
     except _SsrfError:
         return ValidationResult(
             is_valid=False,
@@ -503,135 +317,42 @@ async def _post_challenge(
             ),
         )
 
-    # The GET response can supply the ID if POST omits it.
     try:
         post_data = response.json()
-        if isinstance(post_data, dict):
-            entry_obj = post_data.get("entry", post_data)
-            if isinstance(entry_obj, dict):
-                entry_id = entry_obj.get("id")
-                if isinstance(entry_id, str):
-                    return entry_id
     except (json.JSONDecodeError, UnicodeDecodeError):
-        pass
-
-    return None
-
-
-async def _verify_challenge(
-    entries_url: str, challenge_work: str
-) -> tuple[ValidationResult, str | None]:
-    """Validate the exact challenge entry and return its ID for analysis."""
-    try:
-        response = await _fetch_with_retry(entries_url)
-    except _SsrfError:
-        return (
-            ValidationResult(
-                is_valid=False,
-                message="URL must point to a publicly accessible server.",
-            ),
-            None,
-        )
-    except (
-        httpx.TimeoutException,
-        httpx.RequestError,
-        DeployedApiServerError,
-    ) as exc:
-        return deployed_api_error_to_result(exc, step="GET /entries"), None
-
-    if response.status_code != 200:
-        return (
-            ValidationResult(
-                is_valid=False,
-                message=(
-                    f"GET /entries returned status {response.status_code}. "
-                    "Expected 200."
-                ),
-            ),
-            None,
+        return ValidationResult(
+            is_valid=False,
+            message="POST /entries did not return valid JSON.",
         )
 
-    try:
-        get_data = response.json()
-    except (json.JSONDecodeError, UnicodeDecodeError):
-        return (
-            ValidationResult(
-                is_valid=False,
-                message="GET /entries did not return valid JSON.",
-            ),
-            None,
-        )
+    if isinstance(post_data, dict):
+        entry = post_data.get("entry", post_data)
+        if isinstance(entry, dict):
+            entry_id = entry.get("id")
+            if isinstance(entry_id, str) and entry_id.strip():
+                return entry_id
 
-    entries = _extract_entries_list(get_data)
-    if entries is None:
-        return (
-            ValidationResult(
-                is_valid=False,
-                message=(
-                    'GET /entries must return {"entries": [...], "count": N}. '
-                    "See the journal-starter for the expected format."
-                ),
-            ),
-            None,
-        )
-
-    challenge_entry = next(
-        (
-            entry
-            for entry in entries
-            if isinstance(entry, dict) and entry.get("work") == challenge_work
+    return ValidationResult(
+        is_valid=False,
+        message=(
+            "POST /entries must return the created entry with a non-empty string id."
         ),
-        None,
-    )
-    if challenge_entry is None:
-        span = trace.get_current_span()
-        span.add_event("deployed_api.challenge_failed")
-        return (
-            ValidationResult(
-                is_valid=False,
-                message=(
-                    "Ownership verification failed. "
-                    "We posted a challenge entry to your API but could not "
-                    "find it in GET /entries. Make sure your POST /entries "
-                    "persists data and GET /entries returns all entries."
-                ),
-            ),
-            None,
-        )
-
-    entry_id = challenge_entry.get("id")
-    discovered_id = entry_id if isinstance(entry_id, str) else None
-    is_valid, error = _validate_entry(challenge_entry)
-    if not is_valid:
-        return (
-            ValidationResult(
-                is_valid=False,
-                message=error or "Challenge entry validation failed.",
-            ),
-            discovered_id,
-        )
-
-    span = trace.get_current_span()
-    span.set_attribute("verification.deployed_api.challenge_verified", True)
-
-    return (
-        ValidationResult(
-            is_valid=True,
-            message=(
-                "Deployed API verified! Ownership confirmed via challenge-response."
-            ),
-        ),
-        discovered_id,
     )
 
 
 async def _verify_analysis(base_url: str, entry_id: str) -> ValidationResult:
     """Call the deployed AI endpoint and validate its response contract."""
-    analysis_url = f"{base_url}/entries/{entry_id}/analyze"
     try:
-        response = await _fetch_once(
+        encoded_id = quote(entry_id, safe="")
+    except UnicodeEncodeError:
+        return ValidationResult(
+            is_valid=False,
+            message="POST /entries returned an invalid entry ID.",
+        )
+    analysis_url = f"{base_url}/entries/{encoded_id}/analyze"
+    try:
+        response = await _post_once(
             analysis_url,
-            method="POST",
             timeout=_ANALYSIS_TIMEOUT_SECONDS,
         )
     except _SsrfError:
@@ -663,7 +384,7 @@ async def _verify_analysis(base_url: str, entry_id: str) -> ValidationResult:
             is_valid=False,
             message=(
                 "POST /entries/{id}/analyze returned 404. Ensure the endpoint "
-                "exists and the challenge entry can be analyzed."
+                "exists and the created entry can be analyzed."
             ),
         )
     if response.status_code != 200:
@@ -686,7 +407,7 @@ async def _verify_analysis(base_url: str, entry_id: str) -> ValidationResult:
 
 
 async def validate_deployed_api(base_url: str) -> ValidationResult:
-    """Verify ownership, challenge fields, and live AI analysis, leaving the entry."""
+    """Create and analyze one entry, reporting the first failed step."""
     base_url = _normalize_base_url(base_url)
 
     if not base_url:
@@ -709,30 +430,11 @@ async def validate_deployed_api(base_url: str) -> ValidationResult:
             message=ssrf_error,
         )
 
-    entries_url = f"{base_url}/entries"
-    challenge_work = (
-        f"Nice work getting your Journal API online! ({_generate_challenge_nonce()})"
-    )
-    post_result = await _post_challenge(entries_url, challenge_work)
+    post_result = await _create_entry(f"{base_url}/entries")
     if isinstance(post_result, ValidationResult):
         return post_result
-    challenge_entry_id = post_result
 
-    verify_result, discovered_id = await _verify_challenge(entries_url, challenge_work)
-    if challenge_entry_id is None:
-        challenge_entry_id = discovered_id
-    if not verify_result.is_valid:
-        return verify_result
-    if not challenge_entry_id:
-        return ValidationResult(
-            is_valid=False,
-            message=(
-                "Ownership was confirmed, but the API did not return the "
-                "challenge entry ID required for AI analysis."
-            ),
-        )
-
-    analysis_result = await _verify_analysis(base_url, challenge_entry_id)
+    analysis_result = await _verify_analysis(base_url, post_result)
     if not analysis_result.is_valid:
         return analysis_result
 
@@ -741,5 +443,5 @@ async def validate_deployed_api(base_url: str) -> ValidationResult:
     span.set_attribute("verification.deployed_api.ai_verified", True)
     return ValidationResult(
         is_valid=True,
-        message=f"{verify_result.message} Live AI analysis verified.",
+        message="Deployed API verified! Entry creation and live AI analysis confirmed.",
     )

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/deployed_api.py
@@ -7,15 +7,16 @@ Verification uses a challenge-response protocol to prove API ownership:
 1. POST a unique challenge entry to /entries
 2. GET /entries and validate only the entry matching the current challenge nonce
 3. POST /entries/{id}/analyze and validate the live AI response
-4. DELETE the challenge entry to clean up
+
+The entry remains as an encouraging milestone, even if verification fails.
 
 The deployed API must:
 - Be publicly accessible via HTTPS
-- Have working create, list, and analyze endpoints; deletion is best-effort
+- Have working create, list, and analyze endpoints
 - Return valid journal entry and AI analysis JSON
 
 SCALABILITY:
-- Retry CRUD verification requests with exponential backoff (3 attempts)
+- Retry create/list verification requests with exponential backoff (3 attempts)
 - Send exactly one potentially billable AI analysis request
 - Connection pooling via shared httpx.AsyncClient
 """
@@ -425,7 +426,7 @@ async def _fetch_with_retry(
 
     Args:
         url: The full URL to request
-        method: HTTP method (GET, POST, DELETE)
+        method: HTTP method (GET or POST)
         json_body: Optional JSON body for POST requests
         timeout: Optional per-request timeout override
 
@@ -446,42 +447,8 @@ async def _fetch_with_retry(
     )
 
 
-async def _cleanup_challenge_entry(
-    entries_url: str,
-    entry_id: str,
-) -> None:
-    """Report expected DELETE failures without changing the verification outcome."""
-    attributes: dict[str, str | int] = {
-        "verification.operation": "DELETE /entries/{id}",
-    }
-    try:
-        delete_url = f"{entries_url}/{entry_id}"
-        response = await _fetch_with_retry(delete_url, method="DELETE")
-    except _SsrfError:
-        span = trace.get_current_span()
-        span.add_event(
-            "deployed_api.ssrf_blocked",
-            {"verification.reason": "cleanup_dns_rebinding"},
-        )
-        attributes["error.type"] = "ssrf_blocked"
-    except httpx.TimeoutException:
-        attributes["error.type"] = "timeout"
-    except httpx.RequestError:
-        attributes["error.type"] = "request_error"
-    except DeployedApiServerError as exc:
-        attributes["error.type"] = "server_error"
-        attributes["http.response.status_code"] = exc.status_code
-    else:
-        if response.status_code in (200, 204, 404):
-            return
-        attributes["error.type"] = "unexpected_status"
-        attributes["http.response.status_code"] = response.status_code
-
-    trace.get_current_span().add_event("deployed_api.cleanup_failed", attributes)
-
-
 async def _post_challenge(
-    entries_url: str, nonce: str
+    entries_url: str, challenge_work: str
 ) -> ValidationResult | str | None:
     """POST a challenge entry to prove API ownership.
 
@@ -491,9 +458,9 @@ async def _post_challenge(
         None if POST succeeded but entry_id couldn't be parsed.
     """
     challenge_body = {
-        "work": nonce,
-        "struggle": "LTC verification challenge",
-        "intention": "Proving API ownership",
+        "work": challenge_work,
+        "struggle": "Every challenge is a chance to learn.",
+        "intention": "Keep building, learning, and making progress.",
     }
 
     try:
@@ -536,7 +503,7 @@ async def _post_challenge(
             ),
         )
 
-    # Best-effort extraction of entry ID for cleanup
+    # The GET response can supply the ID if POST omits it.
     try:
         post_data = response.json()
         if isinstance(post_data, dict):
@@ -552,9 +519,9 @@ async def _post_challenge(
 
 
 async def _verify_challenge(
-    entries_url: str, nonce: str
+    entries_url: str, challenge_work: str
 ) -> tuple[ValidationResult, str | None]:
-    """Validate the exact nonce entry and return its ID for analysis and cleanup."""
+    """Validate the exact challenge entry and return its ID for analysis."""
     try:
         response = await _fetch_with_retry(entries_url)
     except _SsrfError:
@@ -612,7 +579,7 @@ async def _verify_challenge(
         (
             entry
             for entry in entries
-            if isinstance(entry, dict) and entry.get("work") == nonce
+            if isinstance(entry, dict) and entry.get("work") == challenge_work
         ),
         None,
     )
@@ -719,7 +686,7 @@ async def _verify_analysis(base_url: str, entry_id: str) -> ValidationResult:
 
 
 async def validate_deployed_api(base_url: str) -> ValidationResult:
-    """Verify ownership, challenge fields, and live AI analysis, then clean up."""
+    """Verify ownership, challenge fields, and live AI analysis, leaving the entry."""
     base_url = _normalize_base_url(base_url)
 
     if not base_url:
@@ -743,40 +710,36 @@ async def validate_deployed_api(base_url: str) -> ValidationResult:
         )
 
     entries_url = f"{base_url}/entries"
-    nonce = _generate_challenge_nonce()
-    challenge_entry_id: str | None = None
+    challenge_work = (
+        f"Nice work getting your Journal API online! ({_generate_challenge_nonce()})"
+    )
+    post_result = await _post_challenge(entries_url, challenge_work)
+    if isinstance(post_result, ValidationResult):
+        return post_result
+    challenge_entry_id = post_result
 
-    try:
-        post_result = await _post_challenge(entries_url, nonce)
-        if isinstance(post_result, ValidationResult):
-            return post_result
-        challenge_entry_id = post_result
-
-        verify_result, discovered_id = await _verify_challenge(entries_url, nonce)
-        if challenge_entry_id is None:
-            challenge_entry_id = discovered_id
-        if not verify_result.is_valid:
-            return verify_result
-        if not challenge_entry_id:
-            return ValidationResult(
-                is_valid=False,
-                message=(
-                    "Ownership was confirmed, but the API did not return the "
-                    "challenge entry ID required for AI analysis."
-                ),
-            )
-
-        analysis_result = await _verify_analysis(base_url, challenge_entry_id)
-        if not analysis_result.is_valid:
-            return analysis_result
-
-        span = trace.get_current_span()
-        span.set_attribute("verification.deployed_api.verified", True)
-        span.set_attribute("verification.deployed_api.ai_verified", True)
+    verify_result, discovered_id = await _verify_challenge(entries_url, challenge_work)
+    if challenge_entry_id is None:
+        challenge_entry_id = discovered_id
+    if not verify_result.is_valid:
+        return verify_result
+    if not challenge_entry_id:
         return ValidationResult(
-            is_valid=True,
-            message=f"{verify_result.message} Live AI analysis verified.",
+            is_valid=False,
+            message=(
+                "Ownership was confirmed, but the API did not return the "
+                "challenge entry ID required for AI analysis."
+            ),
         )
-    finally:
-        if challenge_entry_id:
-            await _cleanup_challenge_entry(entries_url, challenge_entry_id)
+
+    analysis_result = await _verify_analysis(base_url, challenge_entry_id)
+    if not analysis_result.is_valid:
+        return analysis_result
+
+    span = trace.get_current_span()
+    span.set_attribute("verification.deployed_api.verified", True)
+    span.set_attribute("verification.deployed_api.ai_verified", True)
+    return ValidationResult(
+        is_valid=True,
+        message=f"{verify_result.message} Live AI analysis verified.",
+    )

--- a/packages/learn-to-cloud-shared/tests/services/test_deployed_api_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_deployed_api_verification_service.py
@@ -6,7 +6,7 @@ Tests the challenge-response API ownership verification:
 - POST/GET/DELETE flow for ownership proof
 - HTTP request handling (success, errors, timeouts)
 - JSON response parsing and entry validation
-- Circuit breaker behavior
+- Transport retries and safe error diagnostics
 """
 
 import json
@@ -25,7 +25,6 @@ from learn_to_cloud_shared.verification.deployed_api import (
     _normalize_base_url,
     _SsrfError,
     _validate_analysis_json,
-    _validate_entries_json,
     _validate_entry,
     _validate_url_target,
     _verify_analysis,
@@ -83,7 +82,7 @@ class TestValidateEntry:
 
     def test_valid_entry_passes(self):
         """A valid entry should pass validation."""
-        is_valid, error = _validate_entry(self._valid_entry(), 0)
+        is_valid, error = _validate_entry(self._valid_entry())
         assert is_valid is True
         assert error is None
 
@@ -92,7 +91,7 @@ class TestValidateEntry:
         entry = self._valid_entry()
         del entry["work"]
 
-        is_valid, error = _validate_entry(entry, 0)
+        is_valid, error = _validate_entry(entry)
         assert is_valid is False
         assert error is not None
         assert "missing fields" in error.lower()
@@ -103,7 +102,7 @@ class TestValidateEntry:
         entry = self._valid_entry()
         entry["id"] = "not-a-uuid"
 
-        is_valid, error = _validate_entry(entry, 0)
+        is_valid, error = _validate_entry(entry)
         assert is_valid is False
         assert error is not None
         assert "invalid id" in error.lower()
@@ -113,7 +112,7 @@ class TestValidateEntry:
         entry = self._valid_entry()
         entry["work"] = "   "
 
-        is_valid, error = _validate_entry(entry, 0)
+        is_valid, error = _validate_entry(entry)
         assert is_valid is False
         assert error is not None
         assert "cannot be empty" in error.lower()
@@ -123,7 +122,7 @@ class TestValidateEntry:
         entry = self._valid_entry()
         entry["created_at"] = "not-a-date"
 
-        is_valid, error = _validate_entry(entry, 0)
+        is_valid, error = _validate_entry(entry)
         assert is_valid is False
         assert error is not None
         assert "invalid created_at" in error.lower()
@@ -133,51 +132,10 @@ class TestValidateEntry:
         entry = self._valid_entry()
         entry["updated_at"] = "invalid"
 
-        is_valid, error = _validate_entry(entry, 0)
+        is_valid, error = _validate_entry(entry)
         assert is_valid is False
         assert error is not None
         assert "invalid updated_at" in error.lower()
-
-
-class TestValidateEntriesJson:
-    """Tests for entries array validation."""
-
-    def _valid_entry(self) -> dict:
-        """Create a valid journal entry for testing."""
-        return {
-            "id": "12345678-1234-4567-89ab-123456789abc",
-            "work": "Built an API",
-            "struggle": "CORS issues",
-            "intention": "Deploy to cloud",
-            "created_at": "2025-01-25T10:30:00Z",
-        }
-
-    def test_valid_array_passes(self):
-        """Valid array with entries should pass."""
-        result = _validate_entries_json([self._valid_entry()])
-        assert result.is_valid is True
-        assert "1 valid entry" in result.message
-
-    def test_multiple_entries_passes(self):
-        """Multiple valid entries should pass."""
-        entries = [self._valid_entry(), self._valid_entry()]
-        entries[1]["id"] = "87654321-4321-4567-89ab-987654321abc"
-
-        result = _validate_entries_json(entries)
-        assert result.is_valid is True
-        assert "2 valid entries" in result.message
-
-    def test_empty_array_fails(self):
-        """Empty array should fail."""
-        result = _validate_entries_json([])
-        assert result.is_valid is False
-        assert "no entries" in result.message.lower()
-
-    def test_non_object_entry_fails(self):
-        """Non-object entries should fail."""
-        result = _validate_entries_json(["not an object"])
-        assert result.is_valid is False
-        assert "not a valid object" in result.message.lower()
 
 
 class TestValidateAnalysisJson:
@@ -248,24 +206,6 @@ class TestVerifyAnalysis:
         )
 
     @pytest.mark.asyncio
-    async def test_not_implemented_fails(self):
-        response = MagicMock(spec=httpx.Response)
-        response.status_code = 501
-
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api._fetch_once",
-            autospec=True,
-            return_value=response,
-        ):
-            result = await _verify_analysis(
-                "https://api.example.com",
-                "challenge-id",
-            )
-
-        assert result.is_valid is False
-        assert "not implemented" in result.message.lower()
-
-    @pytest.mark.asyncio
     async def test_timeout_fails(self):
         with patch(
             "learn_to_cloud_shared.verification.deployed_api._fetch_once",
@@ -317,70 +257,6 @@ class TestGenerateChallengeNonce:
         """Each call should produce a different nonce."""
         nonces = {_generate_challenge_nonce() for _ in range(10)}
         assert len(nonces) == 10
-
-
-def _mock_fetch_side_effect(
-    *,
-    nonce: str,
-    post_status: int = 200,
-    post_entry_id: str = "challenge-uuid",
-    get_status: int = 200,
-    get_entries: list | None = None,
-    get_response_format: str = "array",
-):
-    """Build a side_effect callable for _fetch_with_retry that handles POST then GET.
-
-    Args:
-        nonce: The nonce that will be in the POST body (matched dynamically)
-        post_status: HTTP status for the POST response
-        post_entry_id: ID returned for the created challenge entry
-        get_status: HTTP status for the GET response
-        get_entries: Entries to return from GET (nonce entry auto-added)
-        get_response_format: 'array' or 'wrapped'
-    """
-    real_entries = get_entries or []
-
-    async def side_effect(url, *, method="GET", json_body=None):
-        resp = MagicMock(spec=httpx.Response)
-
-        if method == "POST":
-            resp.status_code = post_status
-            # Build the nonce entry from what was posted
-            challenge_entry = {
-                "id": post_entry_id,
-                **(json_body or {}),
-                "created_at": "2026-01-01T00:00:00Z",
-            }
-            resp.json.return_value = {
-                "detail": "Entry created successfully",
-                "entry": challenge_entry,
-            }
-            return resp
-
-        if method == "GET":
-            resp.status_code = get_status
-            # Include the challenge entry (simulating real persistence)
-            challenge_entry = {
-                "id": post_entry_id,
-                "work": json_body["work"] if json_body else nonce,
-                "struggle": "LTC verification challenge",
-                "intention": "Proving API ownership",
-                "created_at": "2026-01-01T00:00:00Z",
-            }
-            # We need to capture the nonce from the POST call
-            all_entries = [*real_entries, challenge_entry]
-            if get_response_format == "wrapped":
-                resp.json.return_value = {
-                    "entries": all_entries,
-                    "count": len(all_entries),
-                }
-            else:
-                resp.json.return_value = all_entries
-            return resp
-
-        return resp
-
-    return side_effect
 
 
 @pytest.mark.unit
@@ -449,7 +325,7 @@ class TestValidateDeployedApi:
                 resp.json.return_value = {
                     "detail": "Entry created successfully",
                     "entry": {
-                        "id": "challenge-id",
+                        "id": "87654321-4321-4567-89ab-987654321abc",
                         "work": nonce,
                         "struggle": json_body["struggle"],
                         "intention": json_body["intention"],
@@ -461,7 +337,7 @@ class TestValidateDeployedApi:
             if method == "GET":
                 # Return the valid entry + challenge entry
                 nonce_entry = {
-                    "id": "challenge-id",
+                    "id": "87654321-4321-4567-89ab-987654321abc",
                     "work": call_log_nonce,
                     "struggle": "LTC verification challenge",
                     "intention": "Proving API ownership",
@@ -502,9 +378,10 @@ class TestValidateDeployedApi:
 
             assert result.is_valid is True
             assert "ownership confirmed" in result.message.lower()
-            assert "1 valid entry" in result.message
+            assert "valid entry" not in result.message
             mock_cleanup.assert_called_once_with(
-                "https://api.example.com/entries", "challenge-id"
+                "https://api.example.com/entries",
+                "87654321-4321-4567-89ab-987654321abc",
             )
 
     @pytest.mark.asyncio
@@ -595,6 +472,16 @@ class TestValidateDeployedApi:
             autospec=True,
         ) as mock_fetch:
             mock_fetch.return_value = mock_response
+
+            result = await validate_deployed_api("https://api.example.com")
+
+        assert result.verification_completed
+        assert result.is_valid is False
+        assert result.message == (
+            "POST /entries returned 422 (validation error). "
+            "Ensure POST /entries accepts {work, struggle, intention}."
+        )
+        mock_fetch.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_nonce_not_found_in_get(self, _mock_ssrf):
@@ -704,13 +591,16 @@ class TestValidateDeployedApi:
                 captured_nonce = json_body["work"]
                 resp.status_code = 200
                 resp.json.return_value = {
-                    "entry": {"id": "cid", "work": captured_nonce}
+                    "entry": {
+                        "id": "87654321-4321-4567-89ab-987654321abc",
+                        "work": captured_nonce,
+                    }
                 }
                 return resp
 
             if method == "GET":
                 nonce_entry = {
-                    "id": "cid",
+                    "id": "87654321-4321-4567-89ab-987654321abc",
                     "work": captured_nonce,
                     "struggle": "LTC verification challenge",
                     "intention": "Proving API ownership",
@@ -764,13 +654,16 @@ class TestValidateDeployedApi:
                 captured_nonce = json_body["work"]
                 resp.status_code = 200
                 resp.json.return_value = {
-                    "entry": {"id": "cid", "work": captured_nonce}
+                    "entry": {
+                        "id": "87654321-4321-4567-89ab-987654321abc",
+                        "work": captured_nonce,
+                    }
                 }
                 return resp
 
             if method == "GET":
                 nonce_entry = {
-                    "id": "cid",
+                    "id": "87654321-4321-4567-89ab-987654321abc",
                     "work": captured_nonce,
                     "struggle": "LTC verification challenge",
                     "intention": "Proving API ownership",

--- a/packages/learn-to-cloud-shared/tests/services/test_deployed_api_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_deployed_api_verification_service.py
@@ -1,14 +1,7 @@
-"""Unit tests for deployed_api_verification_service.
+"""Server-side target guards, one-shot transport, and safe error mapping."""
 
-Tests the challenge-response API ownership verification:
-- URL normalization and validation
-- Challenge nonce generation
-- POST/GET flow for ownership proof
-- HTTP request handling (success, errors, timeouts)
-- JSON response parsing and entry validation
-- Transport retries and safe error diagnostics
-"""
-
+import asyncio
+import socket
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -18,625 +11,124 @@ from learn_to_cloud_shared.verification import deployed_api
 from learn_to_cloud_shared.verification.deployed_api import (
     DeployedApiServerError,
     _check_response_ip,
-    _extract_entries_list,
-    _generate_challenge_nonce,
     _is_private_ip,
-    _normalize_base_url,
     _SsrfError,
-    _validate_analysis_json,
-    _validate_entry,
     _validate_url_target,
-    _verify_analysis,
     validate_deployed_api,
 )
 
 
-class TestNormalizeBaseUrl:
-    """Tests for URL normalization."""
-
-    def test_strips_trailing_slash(self):
-        """Trailing slashes should be removed."""
-        assert (
-            _normalize_base_url("https://api.example.com/") == "https://api.example.com"
-        )
-
-    def test_strips_entries_suffix(self):
-        """If user includes /entries, it should be stripped."""
-        assert (
-            _normalize_base_url("https://api.example.com/entries")
-            == "https://api.example.com"
-        )
-        assert (
-            _normalize_base_url("https://api.example.com/entries/")
-            == "https://api.example.com"
-        )
-
-    def test_strips_whitespace(self):
-        """Leading/trailing whitespace should be removed."""
-        assert (
-            _normalize_base_url("  https://api.example.com  ")
-            == "https://api.example.com"
-        )
-
-    def test_preserves_path(self):
-        """Path segments other than /entries should be preserved."""
-        assert (
-            _normalize_base_url("https://api.example.com/v1")
-            == "https://api.example.com/v1"
-        )
-
-
-class TestValidateEntry:
-    """Tests for individual entry validation."""
-
-    def _valid_entry(self) -> dict:
-        """Create a valid journal entry for testing."""
-        return {
-            "id": "12345678-1234-4567-89ab-123456789abc",
-            "work": "Built an API",
-            "struggle": "CORS issues",
-            "intention": "Deploy to cloud",
-            "created_at": "2025-01-25T10:30:00Z",
-        }
-
-    def test_valid_entry_passes(self):
-        """A valid entry should pass validation."""
-        is_valid, error = _validate_entry(self._valid_entry())
-        assert is_valid is True
-        assert error is None
-
-    def test_missing_field_fails(self):
-        """Entry missing required fields should fail."""
-        entry = self._valid_entry()
-        del entry["work"]
-
-        is_valid, error = _validate_entry(entry)
-        assert is_valid is False
-        assert error is not None
-        assert "missing fields" in error.lower()
-        assert "work" in error
-
-    def test_invalid_uuid_fails(self):
-        """Entry with invalid UUID should fail."""
-        entry = self._valid_entry()
-        entry["id"] = "not-a-uuid"
-
-        is_valid, error = _validate_entry(entry)
-        assert is_valid is False
-        assert error is not None
-        assert "invalid id" in error.lower()
-
-    def test_empty_string_field_fails(self):
-        """Entry with empty string field should fail."""
-        entry = self._valid_entry()
-        entry["work"] = "   "
-
-        is_valid, error = _validate_entry(entry)
-        assert is_valid is False
-        assert error is not None
-        assert "cannot be empty" in error.lower()
-
-    def test_invalid_datetime_fails(self):
-        """Entry with invalid datetime should fail."""
-        entry = self._valid_entry()
-        entry["created_at"] = "not-a-date"
-
-        is_valid, error = _validate_entry(entry)
-        assert is_valid is False
-        assert error is not None
-        assert "invalid created_at" in error.lower()
-
-    def test_optional_updated_at_validated(self):
-        """If updated_at is present, it must be valid."""
-        entry = self._valid_entry()
-        entry["updated_at"] = "invalid"
-
-        is_valid, error = _validate_entry(entry)
-        assert is_valid is False
-        assert error is not None
-        assert "invalid updated_at" in error.lower()
-
-
-class TestValidateAnalysisJson:
-    """Tests for live AI analysis response validation."""
-
-    def _valid_analysis(self) -> dict:
-        return {
-            "entry_id": "challenge-id",
-            "sentiment": "neutral",
-            "summary": "The learner made progress and identified a next step.",
-            "topics": ["FastAPI", "cloud"],
-        }
-
-    def test_valid_analysis_passes(self):
-        result = _validate_analysis_json(self._valid_analysis(), "challenge-id")
-        assert result.is_valid is True
-
-    @pytest.mark.parametrize(
-        ("field", "value", "message"),
-        [
-            ("entry_id", "different-id", "entry_id"),
-            ("sentiment", "mixed", "sentiment"),
-            ("summary", " ", "summary"),
-            ("topics", [], "topics"),
-            ("topics", ["cloud", ""], "topics"),
-        ],
-    )
-    def test_invalid_analysis_fails(self, field, value, message):
-        analysis = self._valid_analysis()
-        analysis[field] = value
-
-        result = _validate_analysis_json(analysis, "challenge-id")
-
-        assert result.is_valid is False
-        assert message in result.message
-
-
-@pytest.mark.unit
-class TestVerifyAnalysis:
-    """Tests for the deployed live AI request."""
-
-    @pytest.mark.asyncio
-    async def test_valid_response_passes(self):
-        response = MagicMock(spec=httpx.Response)
-        response.status_code = 200
-        response.json.return_value = {
-            "entry_id": "challenge-id",
-            "sentiment": "positive",
-            "summary": "The learner completed the deployment.",
-            "topics": ["deployment"],
-        }
-
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api._fetch_once",
-            autospec=True,
-            return_value=response,
-        ) as mock_fetch:
-            result = await _verify_analysis(
-                "https://api.example.com",
-                "challenge-id",
-            )
-
-        assert result.is_valid is True
-        mock_fetch.assert_awaited_once_with(
-            "https://api.example.com/entries/challenge-id/analyze",
-            method="POST",
-            timeout=30.0,
-        )
-
-    @pytest.mark.asyncio
-    async def test_timeout_fails(self):
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api._fetch_once",
-            autospec=True,
-            side_effect=httpx.TimeoutException("timed out"),
-        ):
-            result = await _verify_analysis(
-                "https://api.example.com",
-                "challenge-id",
-            )
-
-        assert result.is_valid is False
-        assert "timed out" in result.message.lower()
-
-
-class TestExtractEntriesList:
-    """Tests for _extract_entries_list helper."""
-
-    def test_raw_array_rejected(self):
-        """Raw array is not the journal-starter format and should return None."""
-        data = [{"id": "1"}]
-        assert _extract_entries_list(data) is None
-
-    def test_wrapped_object(self):
-        """Object with 'entries' key should extract the list."""
-        entries = [{"id": "1"}]
-        data = {"entries": entries, "count": 1}
-        assert _extract_entries_list(data) == entries
-
-    def test_unrecognised_format(self):
-        """Unrecognised format should return None."""
-        assert _extract_entries_list({"error": "bad"}) is None
-        assert _extract_entries_list("string") is None
-
-    def test_empty_entries_list(self):
-        """Empty entries list should still be returned."""
-        assert _extract_entries_list({"entries": [], "count": 0}) == []
-
-
-class TestGenerateChallengeNonce:
-    """Tests for challenge nonce generation."""
-
-    def test_nonce_has_prefix(self):
-        """Generated nonce should start with ltc-verify-."""
-        nonce = _generate_challenge_nonce()
-        assert nonce.startswith("ltc-verify-")
-
-    def test_nonces_are_unique(self):
-        """Each call should produce a different nonce."""
-        nonces = {_generate_challenge_nonce() for _ in range(10)}
-        assert len(nonces) == 10
-
-
-@pytest.mark.unit
-@patch(
-    "learn_to_cloud_shared.verification.deployed_api._validate_url_target",
-    new_callable=AsyncMock,
-    return_value=None,
+@pytest.mark.parametrize(
+    ("address", "blocked"),
+    [
+        ("127.0.0.1", True),
+        ("::1", True),
+        ("10.0.0.1", True),
+        ("172.16.0.1", True),
+        ("192.168.1.1", True),
+        ("169.254.169.254", True),
+        ("224.0.0.1", True),
+        ("0.0.0.0", True),
+        ("100.64.0.1", True),
+        ("not-an-ip", True),
+        ("8.8.8.8", False),
+        ("1.1.1.1", False),
+    ],
 )
-class TestValidateDeployedApi:
-    """Tests for the challenge-response validation function."""
-
-    @pytest.mark.asyncio
-    async def test_empty_url_fails(self, _mock_ssrf):
-        """Empty URL should fail."""
-        result = await validate_deployed_api("")
-        assert result.is_valid is False
-        assert "submit your deployed api" in result.message.lower()
-
-    @pytest.mark.asyncio
-    async def test_invalid_url_fails(self, _mock_ssrf):
-        """Invalid URL format should fail."""
-        result = await validate_deployed_api("not-a-url")
-        assert result.is_valid is False
-        assert "valid HTTP(S) URL" in result.message
-
-    @pytest.mark.asyncio
-    async def test_post_timeout_error(self, _mock_ssrf):
-        """Timeout on POST should return appropriate error."""
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
-            autospec=True,
-        ) as mock_fetch:
-            mock_fetch.side_effect = httpx.TimeoutException("Request timed out")
-
-            result = await validate_deployed_api("https://api.example.com")
-
-            assert result.is_valid is False
-            assert "timed out" in result.message.lower()
-
-    @pytest.mark.asyncio
-    async def test_post_connection_error(self, _mock_ssrf):
-        """Connection error on POST should return appropriate message."""
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
-            autospec=True,
-        ) as mock_fetch:
-            mock_fetch.side_effect = httpx.ConnectError("Connection refused")
-
-            result = await validate_deployed_api("https://api.example.com")
-
-            assert result.is_valid is False
-            assert "could not connect" in result.message.lower()
-
-    @pytest.mark.asyncio
-    async def test_post_server_error(self, _mock_ssrf):
-        """5xx errors on POST should return appropriate message."""
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
-            autospec=True,
-        ) as mock_fetch:
-            mock_fetch.side_effect = DeployedApiServerError(
-                "Server returned 500", status_code=500
-            )
-
-            result = await validate_deployed_api("https://api.example.com")
-
-            assert result.is_valid is False
-            assert "server error" in result.message.lower()
-
-    @pytest.mark.asyncio
-    async def test_transient_failure(self, _mock_ssrf):
-        """Transient connection failure should return retry message."""
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
-            autospec=True,
-        ) as mock_fetch:
-            mock_fetch.side_effect = httpx.ConnectError("connection refused")
-
-            result = await validate_deployed_api("https://api.example.com")
-
-            assert result.is_valid is False
-            assert (
-                "connect" in result.message.lower() or "error" in result.message.lower()
-            )
-
-    @pytest.mark.asyncio
-    async def test_post_404_not_found(self, _mock_ssrf):
-        """POST 404 should indicate endpoint doesn't exist."""
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 404
-
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
-            autospec=True,
-        ) as mock_fetch:
-            mock_fetch.return_value = mock_response
-
-            result = await validate_deployed_api("https://api.example.com")
-
-            assert result.is_valid is False
-            assert "404" in result.message
-
-    @pytest.mark.asyncio
-    async def test_post_422_validation_error(self, _mock_ssrf):
-        """POST 422 should indicate validation error."""
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 422
-
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
-            autospec=True,
-        ) as mock_fetch:
-            mock_fetch.return_value = mock_response
-
-            result = await validate_deployed_api("https://api.example.com")
-
-        assert result.verification_completed
-        assert result.is_valid is False
-        assert result.message == (
-            "POST /entries returned 422 (validation error). "
-            "Ensure POST /entries accepts {work, struggle, intention}."
-        )
-        mock_fetch.assert_awaited_once()
-
-
-@pytest.mark.unit
-class TestIsPrivateIp:
-    """Tests for _is_private_ip helper."""
-
-    def test_loopback_ipv4(self):
-        assert _is_private_ip("127.0.0.1") is True
-
-    def test_loopback_ipv6(self):
-        assert _is_private_ip("::1") is True
-
-    def test_private_10_range(self):
-        assert _is_private_ip("10.0.0.1") is True
-
-    def test_private_172_range(self):
-        assert _is_private_ip("172.16.0.1") is True
-
-    def test_private_192_range(self):
-        assert _is_private_ip("192.168.1.1") is True
-
-    def test_link_local(self):
-        assert _is_private_ip("169.254.169.254") is True
-
-    def test_multicast(self):
-        assert _is_private_ip("224.0.0.1") is True
-
-    def test_unspecified(self):
-        assert _is_private_ip("0.0.0.0") is True
-
-    def test_public_ip(self):
-        assert _is_private_ip("8.8.8.8") is False
-
-    def test_public_ip_2(self):
-        assert _is_private_ip("1.1.1.1") is False
-
-    def test_invalid_string(self):
-        assert _is_private_ip("not-an-ip") is True
-
-    def test_cgnat_range(self):
-        assert _is_private_ip("100.64.0.1") is True
-
-
-@pytest.mark.unit
-class TestValidateUrlTarget:
-    """Tests for SSRF protection via _validate_url_target."""
-
-    @pytest.mark.asyncio
-    async def test_blocks_localhost(self):
-        """URLs pointing to localhost should be blocked."""
-        result = await _validate_url_target("https://127.0.0.1/entries")
-        assert result is not None
-        assert "publicly accessible" in result
-
-    @pytest.mark.asyncio
-    async def test_blocks_metadata_endpoint(self):
-        """Cloud metadata endpoint (169.254.169.254) should be blocked."""
-        result = await _validate_url_target("https://169.254.169.254/latest/meta-data/")
-        assert result is not None
-        assert "publicly accessible" in result
-
-    @pytest.mark.asyncio
-    async def test_blocks_private_10_range(self):
-        """Private 10.x.x.x IPs should be blocked."""
-        result = await _validate_url_target("https://10.0.0.1/entries")
-        assert result is not None
-        assert "publicly accessible" in result
-
-    @pytest.mark.asyncio
-    async def test_blocks_private_192_range(self):
-        """Private 192.168.x.x IPs should be blocked."""
-        result = await _validate_url_target("https://192.168.1.1/entries")
-        assert result is not None
-        assert "publicly accessible" in result
-
-    @pytest.mark.asyncio
-    async def test_blocks_dns_resolving_to_private(self):
-        """Hostnames resolving to private IPs should be blocked."""
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api.asyncio.get_running_loop"
-        ) as mock_loop:
-            mock_loop.return_value.getaddrinfo = AsyncMock(
-                return_value=[(2, 1, 6, "", ("127.0.0.1", 443))]
-            )
-            result = await _validate_url_target("https://evil.example.com/entries")
-            assert result is not None
-            assert "publicly accessible" in result
-
-    @pytest.mark.asyncio
-    async def test_allows_dns_resolving_to_public(self):
-        """Hostnames resolving to public IPs should be allowed."""
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api.asyncio.get_running_loop"
-        ) as mock_loop:
-            mock_loop.return_value.getaddrinfo = AsyncMock(
-                return_value=[(2, 1, 6, "", ("20.50.2.100", 443))]
-            )
-            result = await _validate_url_target("https://myapi.azurewebsites.net")
-            assert result is None
-
-    @pytest.mark.asyncio
-    async def test_blocks_unresolvable_host(self):
-        """Hostnames that cannot be resolved should be blocked."""
-        import socket as _socket
-
-        with patch(
-            "learn_to_cloud_shared.verification.deployed_api.asyncio.get_running_loop"
-        ) as mock_loop:
-            mock_loop.return_value.getaddrinfo = AsyncMock(
-                side_effect=_socket.gaierror("Name resolution failed")
-            )
-            result = await _validate_url_target("https://nonexistent.invalid/entries")
-            assert result is not None
-            assert "could not resolve" in result.lower()
-
-    @pytest.mark.asyncio
-    async def test_blocks_ipv6_loopback(self):
-        """IPv6 loopback should be blocked."""
-        result = await _validate_url_target("https://[::1]/entries")
-        assert result is not None
-        assert "publicly accessible" in result
-
-
-@pytest.mark.unit
-class TestSsrfIntegration:
-    """Integration tests ensuring SSRF protection in validate_deployed_api."""
-
-    @pytest.mark.asyncio
-    async def test_rejects_private_ip_url(self):
-        """validate_deployed_api should reject private IP URLs."""
-        result = await validate_deployed_api("https://10.0.0.1")
-        assert result.is_valid is False
-        assert "publicly accessible" in result.message
-
-    @pytest.mark.asyncio
-    async def test_rejects_metadata_url(self):
-        """validate_deployed_api should reject cloud metadata URLs."""
-        result = await validate_deployed_api("https://169.254.169.254")
-        assert result.is_valid is False
-        assert "publicly accessible" in result.message
-
-    @pytest.mark.asyncio
-    async def test_rejects_localhost(self):
-        """validate_deployed_api should reject localhost URLs."""
-        result = await validate_deployed_api("https://127.0.0.1")
-        assert result.is_valid is False
-        assert "publicly accessible" in result.message
-
-    @pytest.mark.asyncio
-    async def test_rejects_cgnat_ip(self):
-        """validate_deployed_api should reject CGNAT (100.64.0.0/10) URLs."""
-        result = await validate_deployed_api("https://100.64.0.1")
-        assert result.is_valid is False
-        assert "publicly accessible" in result.message
-
-
-@pytest.mark.unit
-class TestCheckResponseIp:
-    """Tests for post-connect SSRF validation via _check_response_ip."""
-
-    def test_raises_on_private_ip(self):
-        """Should raise _SsrfError when connected IP is private."""
-        stream = MagicMock()
-        stream.get_extra_info.return_value = ("10.0.0.1", 443)
-        response = MagicMock(spec=httpx.Response)
-        response.extensions = {"network_stream": stream}
-
-        with pytest.raises(_SsrfError):
-            _check_response_ip(response)
-
-    def test_allows_public_ip(self):
-        """Should not raise when connected IP is public."""
-        stream = MagicMock()
-        stream.get_extra_info.return_value = ("20.50.2.100", 443)
-        response = MagicMock(spec=httpx.Response)
-        response.extensions = {"network_stream": stream}
-
-        _check_response_ip(response)  # Should not raise
-
-    def test_no_stream_is_safe(self):
-        """Should not raise when no network_stream (e.g. mocked response)."""
-        response = MagicMock(spec=httpx.Response)
-        response.extensions = {}
-
-        _check_response_ip(response)  # Should not raise
-
-    def test_raises_on_metadata_ip(self):
-        """Should catch DNS rebinding to cloud metadata endpoint."""
-        stream = MagicMock()
-        stream.get_extra_info.return_value = ("169.254.169.254", 80)
-        response = MagicMock(spec=httpx.Response)
-        response.extensions = {"network_stream": stream}
-
-        with pytest.raises(_SsrfError):
-            _check_response_ip(response)
-
-
-@pytest.mark.parametrize("status", [500, 503])
-@pytest.mark.parametrize("method", ["GET", "POST"])
-async def test_crud_exhaustion_retains_safe_status_after_three_requests(status, method):
+def test_private_ip_classification(address, blocked):
+    assert _is_private_ip(address) is blocked
+
+
+@pytest.mark.parametrize(
+    "host", ["127.0.0.1", "[::1]", "10.0.0.1", "169.254.169.254", "100.64.0.1"]
+)
+async def test_private_target_is_rejected_before_any_request(host):
+    with patch.object(deployed_api, "_get_client", AsyncMock()) as get_client:
+        result = await validate_deployed_api(f"https://{host}")
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert "publicly accessible" in result.message
+    get_client.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("addresses", "message"),
+    [
+        (["20.50.2.100"], None),
+        (["127.0.0.1"], "publicly accessible"),
+        (["20.50.2.100", "10.0.0.1"], "publicly accessible"),
+        ([], "Could not resolve hostname"),
+    ],
+)
+async def test_dns_target_validation(addresses, message):
+    addrinfo = [(2, 1, 6, "", (address, 443)) for address in addresses]
+    with patch.object(
+        asyncio.get_running_loop(), "getaddrinfo", AsyncMock(return_value=addrinfo)
+    ):
+        result = await _validate_url_target("https://learner.example")
+
+    if message is None:
+        assert result is None
+    else:
+        assert message in result
+
+
+async def test_unresolvable_dns_returns_learner_feedback():
+    with patch.object(
+        asyncio.get_running_loop(),
+        "getaddrinfo",
+        AsyncMock(side_effect=socket.gaierror("Name resolution failed")),
+    ):
+        result = await _validate_url_target("https://nonexistent.invalid")
+
+    assert result == "Could not resolve hostname: nonexistent.invalid"
+
+
+@pytest.mark.parametrize("peer", [None, ("20.50.2.100", 443)])
+def test_public_or_unavailable_response_peer_is_allowed(peer):
+    stream = MagicMock()
+    stream.get_extra_info.return_value = peer
+    _check_response_ip(httpx.Response(200, extensions={"network_stream": stream}))
+
+
+def test_missing_response_stream_is_allowed():
+    _check_response_ip(httpx.Response(200))
+
+
+@pytest.mark.parametrize("address", ["10.0.0.1", "169.254.169.254"])
+def test_private_response_peer_is_blocked(address):
+    stream = MagicMock()
+    stream.get_extra_info.return_value = (address, 443)
+    response = httpx.Response(200, extensions={"network_stream": stream})
+    with pytest.raises(_SsrfError):
+        _check_response_ip(response)
+
+
+@pytest.mark.parametrize("status", [500, 501, 503])
+async def test_post_once_preserves_safe_server_error_data(status):
     requests = []
-    span = MagicMock()
 
     def handler(request):
         requests.append(request)
         return httpx.Response(status, text="private learner response body")
 
-    operation = deployed_api._fetch_with_retry.retry_with(sleep=AsyncMock())
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         with (
             patch.object(deployed_api, "_get_client", AsyncMock(return_value=client)),
-            patch.object(deployed_api.trace, "get_current_span", return_value=span),
+            pytest.raises(DeployedApiServerError) as raised,
         ):
-            with pytest.raises(DeployedApiServerError) as raised:
-                await operation("https://learner.example/entries", method=method)
-            error = raised.value
-            result = deployed_api.deployed_api_error_to_result(
-                error, step="GET /entries"
-            )
-    assert len(requests) == 3
-    assert [request.method for request in requests] == [method] * 3
-    assert error.status_code == status
-    assert error.retry_after is None
-    assert str(error) == f"Server returned {status}"
-    assert result.verification_completed
-    assert not result.is_valid
-    span.add_event.assert_called_once_with(
-        "deployed_api.server_error",
-        {
-            "error.type": "server_error",
-            "verification.operation": "GET /entries",
-            "http.response.status_code": status,
-        },
-    )
-    span.set_attribute.assert_any_call("http.response.status_code", status)
-    assert "private learner" not in str(span.mock_calls)
-    assert "learner.example" not in str(span.mock_calls)
+            await deployed_api._post_once("https://learner.example/entries")
 
-
-@pytest.mark.parametrize("status", [400, 401, 403, 404, 429])
-async def test_crud_nonserver_responses_are_not_newly_retried(status):
-    requests = []
-
-    def handler(request):
-        requests.append(request)
-        return httpx.Response(status)
-
-    operation = deployed_api._fetch_with_retry.retry_with(sleep=AsyncMock())
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        with patch.object(deployed_api, "_get_client", AsyncMock(return_value=client)):
-            response = await operation("https://learner.example/entries")
-    assert response.status_code == status
     assert len(requests) == 1
+    assert requests[0].method == "POST"
+    assert raised.value.status_code == status
+    assert raised.value.retry_after is None
+    assert str(raised.value) == f"Server returned {status}"
 
 
 @pytest.mark.parametrize("error_type", [httpx.ConnectError, httpx.ReadTimeout])
-@pytest.mark.parametrize("retried", [False, True])
-async def test_fetch_preserves_native_request_exceptions(error_type, retried):
+async def test_post_once_preserves_native_request_exceptions(error_type):
     requests = []
     error = error_type("private transport detail")
 
@@ -644,49 +136,16 @@ async def test_fetch_preserves_native_request_exceptions(error_type, retried):
         requests.append(request)
         raise error
 
-    operation = (
-        deployed_api._fetch_with_retry.retry_with(sleep=AsyncMock())
-        if retried
-        else deployed_api._fetch_once
-    )
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         with (
             patch.object(deployed_api, "_get_client", AsyncMock(return_value=client)),
             pytest.raises(error_type) as raised,
         ):
-            await operation("https://learner.example/entries")
+            await deployed_api._post_once("https://learner.example/entries")
+
     assert raised.value is error
-    assert len(requests) == (3 if retried else 1)
-
-
-@pytest.mark.parametrize("failure", [500, 503, httpx.ReadTimeout, httpx.ConnectError])
-async def test_live_analysis_failure_sends_exactly_one_request(failure):
-    requests = []
-    span = MagicMock()
-
-    def handler(request):
-        requests.append(request)
-        if isinstance(failure, int):
-            return httpx.Response(failure, text="private analysis details")
-        raise failure("private analysis details")
-
-    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        with (
-            patch.object(deployed_api, "_get_client", AsyncMock(return_value=client)),
-            patch.object(deployed_api.trace, "get_current_span", return_value=span),
-        ):
-            result = await deployed_api._verify_analysis(
-                "https://learner.example", "challenge-id"
-            )
     assert len(requests) == 1
     assert requests[0].method == "POST"
-    assert requests[0].url.path == "/entries/challenge-id/analyze"
-    assert result.verification_completed
-    assert not result.is_valid
-    assert result.message.startswith("POST /entries/{id}/analyze:")
-    assert "private" not in result.message
-    assert "private" not in str(span.mock_calls)
-    assert "learner.example" not in str(span.mock_calls)
 
 
 @pytest.mark.parametrize(
@@ -704,12 +163,11 @@ async def test_live_analysis_failure_sends_exactly_one_request(failure):
         ),
     ],
 )
-def test_deployed_request_mapper_preserves_messages_and_completion(
-    error, category, message
-):
+def test_request_mapper_preserves_messages_and_completion(error, category, message):
     span = MagicMock()
     with patch.object(deployed_api.trace, "get_current_span", return_value=span):
         result = deployed_api.deployed_api_error_to_result(error)
+
     assert result.message == message
     assert result.verification_completed
     assert not result.is_valid
@@ -720,7 +178,7 @@ def test_deployed_request_mapper_preserves_messages_and_completion(
     )
 
 
-def test_deployed_mapper_rethrows_unsupported_exception():
+def test_mapper_rethrows_unsupported_exception():
     error = ValueError("programming error")
     with pytest.raises(ValueError) as raised:
         deployed_api.deployed_api_error_to_result(error)

--- a/packages/learn-to-cloud-shared/tests/services/test_deployed_api_verification_service.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_deployed_api_verification_service.py
@@ -3,13 +3,12 @@
 Tests the challenge-response API ownership verification:
 - URL normalization and validation
 - Challenge nonce generation
-- POST/GET/DELETE flow for ownership proof
+- POST/GET flow for ownership proof
 - HTTP request handling (success, errors, timeouts)
 - JSON response parsing and entry validation
 - Transport retries and safe error diagnostics
 """
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -268,24 +267,6 @@ class TestGenerateChallengeNonce:
 class TestValidateDeployedApi:
     """Tests for the challenge-response validation function."""
 
-    @pytest.fixture(autouse=True)
-    def _stub_live_analysis(self, monkeypatch):
-        async def valid_analysis(_base_url: str, entry_id: str):
-            return _validate_analysis_json(
-                {
-                    "entry_id": entry_id,
-                    "sentiment": "neutral",
-                    "summary": "The deployed AI endpoint returned a valid result.",
-                    "topics": ["verification"],
-                },
-                entry_id,
-            )
-
-        monkeypatch.setattr(
-            "learn_to_cloud_shared.verification.deployed_api._verify_analysis",
-            valid_analysis,
-        )
-
     @pytest.mark.asyncio
     async def test_empty_url_fails(self, _mock_ssrf):
         """Empty URL should fail."""
@@ -299,90 +280,6 @@ class TestValidateDeployedApi:
         result = await validate_deployed_api("not-a-url")
         assert result.is_valid is False
         assert "valid HTTP(S) URL" in result.message
-
-    @pytest.mark.asyncio
-    async def test_successful_challenge_response(self, _mock_ssrf):
-        """Full POST-GET-DELETE flow should verify ownership."""
-        valid_entry = {
-            "id": "12345678-1234-4567-89ab-123456789abc",
-            "work": "Built an API",
-            "struggle": "CORS issues",
-            "intention": "Deploy to cloud",
-            "created_at": "2025-01-25T10:30:00Z",
-        }
-
-        # Track calls to distinguish POST vs GET
-        call_log = []
-
-        async def mock_fetch(url, *, method="GET", json_body=None):
-            call_log.append(method)
-            resp = MagicMock(spec=httpx.Response)
-
-            if method == "POST":
-                assert json_body is not None
-                resp.status_code = 200
-                nonce = json_body["work"]
-                resp.json.return_value = {
-                    "detail": "Entry created successfully",
-                    "entry": {
-                        "id": "87654321-4321-4567-89ab-987654321abc",
-                        "work": nonce,
-                        "struggle": json_body["struggle"],
-                        "intention": json_body["intention"],
-                        "created_at": "2026-01-01T00:00:00Z",
-                    },
-                }
-                return resp
-
-            if method == "GET":
-                # Return the valid entry + challenge entry
-                nonce_entry = {
-                    "id": "87654321-4321-4567-89ab-987654321abc",
-                    "work": call_log_nonce,
-                    "struggle": "LTC verification challenge",
-                    "intention": "Proving API ownership",
-                    "created_at": "2026-01-01T00:00:00Z",
-                }
-                all_entries = [valid_entry, nonce_entry]
-                resp.status_code = 200
-                resp.json.return_value = {
-                    "entries": all_entries,
-                    "count": len(all_entries),
-                }
-                return resp
-
-            return resp
-
-        # We need to capture the nonce from the POST call
-        call_log_nonce = None
-        original_mock_fetch = mock_fetch
-
-        async def capturing_mock_fetch(url, *, method="GET", json_body=None):
-            nonlocal call_log_nonce
-            if method == "POST" and json_body:
-                call_log_nonce = json_body["work"]
-            return await original_mock_fetch(url, method=method, json_body=json_body)
-
-        with (
-            patch(
-                "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
-                autospec=True,
-                side_effect=capturing_mock_fetch,
-            ),
-            patch(
-                "learn_to_cloud_shared.verification.deployed_api._cleanup_challenge_entry",
-                autospec=True,
-            ) as mock_cleanup,
-        ):
-            result = await validate_deployed_api("https://api.example.com")
-
-            assert result.is_valid is True
-            assert "ownership confirmed" in result.message.lower()
-            assert "valid entry" not in result.message
-            mock_cleanup.assert_called_once_with(
-                "https://api.example.com/entries",
-                "87654321-4321-4567-89ab-987654321abc",
-            )
 
     @pytest.mark.asyncio
     async def test_post_timeout_error(self, _mock_ssrf):
@@ -482,220 +379,6 @@ class TestValidateDeployedApi:
             "Ensure POST /entries accepts {work, struggle, intention}."
         )
         mock_fetch.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_nonce_not_found_in_get(self, _mock_ssrf):
-        """If nonce is not in GET response, ownership verification fails."""
-        post_response = MagicMock(spec=httpx.Response)
-        post_response.status_code = 200
-        post_response.json.return_value = {
-            "entry": {"id": "challenge-id", "work": "ltc-verify-abc"}
-        }
-
-        get_response = MagicMock(spec=httpx.Response)
-        get_response.status_code = 200
-        # Return entries that don't contain the nonce (wrapped format)
-        get_response.json.return_value = {
-            "entries": [
-                {
-                    "id": "12345678-1234-4567-89ab-123456789abc",
-                    "work": "Some real work",
-                    "struggle": "stuff",
-                    "intention": "things",
-                    "created_at": "2025-01-01T00:00:00Z",
-                }
-            ],
-            "count": 1,
-        }
-
-        call_count = 0
-
-        async def mock_fetch(url, *, method="GET", json_body=None):
-            nonlocal call_count
-            call_count += 1
-            if method == "POST":
-                return post_response
-            return get_response
-
-        with (
-            patch(
-                "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
-                autospec=True,
-                side_effect=mock_fetch,
-            ),
-            patch(
-                "learn_to_cloud_shared.verification.deployed_api._cleanup_challenge_entry",
-                autospec=True,
-            ),
-        ):
-            result = await validate_deployed_api("https://api.example.com")
-
-            assert result.is_valid is False
-            assert "ownership verification failed" in result.message.lower()
-
-    @pytest.mark.asyncio
-    async def test_get_returns_invalid_json(self, _mock_ssrf):
-        """Non-JSON GET response should fail after POST succeeds."""
-        post_response = MagicMock(spec=httpx.Response)
-        post_response.status_code = 200
-        post_response.json.return_value = {"entry": {"id": "cid"}}
-
-        get_response = MagicMock(spec=httpx.Response)
-        get_response.status_code = 200
-        get_response.json.side_effect = json.JSONDecodeError("Invalid", "", 0)
-
-        call_count = 0
-
-        async def mock_fetch(url, *, method="GET", json_body=None):
-            nonlocal call_count
-            call_count += 1
-            if method == "POST":
-                return post_response
-            return get_response
-
-        with (
-            patch(
-                "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
-                autospec=True,
-                side_effect=mock_fetch,
-            ),
-            patch(
-                "learn_to_cloud_shared.verification.deployed_api._cleanup_challenge_entry",
-                autospec=True,
-            ),
-        ):
-            result = await validate_deployed_api("https://api.example.com")
-
-            assert result.is_valid is False
-            assert "valid JSON" in result.message
-
-    @pytest.mark.asyncio
-    async def test_wrapped_response_format(self, _mock_ssrf):
-        """API returning {"entries": [...], "count": N} should also work."""
-        valid_entry = {
-            "id": "12345678-1234-4567-89ab-123456789abc",
-            "work": "Built an API",
-            "struggle": "CORS issues",
-            "intention": "Deploy to cloud",
-            "created_at": "2025-01-25T10:30:00Z",
-        }
-
-        captured_nonce = None
-
-        async def mock_fetch(url, *, method="GET", json_body=None):
-            nonlocal captured_nonce
-            resp = MagicMock(spec=httpx.Response)
-
-            if method == "POST":
-                assert json_body is not None
-                captured_nonce = json_body["work"]
-                resp.status_code = 200
-                resp.json.return_value = {
-                    "entry": {
-                        "id": "87654321-4321-4567-89ab-987654321abc",
-                        "work": captured_nonce,
-                    }
-                }
-                return resp
-
-            if method == "GET":
-                nonce_entry = {
-                    "id": "87654321-4321-4567-89ab-987654321abc",
-                    "work": captured_nonce,
-                    "struggle": "LTC verification challenge",
-                    "intention": "Proving API ownership",
-                    "created_at": "2026-01-01T00:00:00Z",
-                }
-                resp.status_code = 200
-                all_entries = [valid_entry, nonce_entry]
-                resp.json.return_value = {
-                    "entries": all_entries,
-                    "count": len(all_entries),
-                }
-                return resp
-
-            return resp
-
-        with (
-            patch(
-                "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
-                autospec=True,
-                side_effect=mock_fetch,
-            ),
-            patch(
-                "learn_to_cloud_shared.verification.deployed_api._cleanup_challenge_entry",
-                autospec=True,
-            ),
-        ):
-            result = await validate_deployed_api("https://api.example.com")
-
-            assert result.is_valid is True
-            assert "ownership confirmed" in result.message.lower()
-
-    @pytest.mark.asyncio
-    async def test_url_with_entries_suffix_normalized(self, _mock_ssrf):
-        """URL ending in /entries should be normalized."""
-        captured_nonce = None
-
-        valid_entry = {
-            "id": "12345678-1234-4567-89ab-123456789abc",
-            "work": "Built an API",
-            "struggle": "CORS issues",
-            "intention": "Deploy to cloud",
-            "created_at": "2025-01-25T10:30:00Z",
-        }
-
-        async def mock_fetch(url, *, method="GET", json_body=None):
-            nonlocal captured_nonce
-            resp = MagicMock(spec=httpx.Response)
-
-            if method == "POST":
-                assert json_body is not None
-                captured_nonce = json_body["work"]
-                resp.status_code = 200
-                resp.json.return_value = {
-                    "entry": {
-                        "id": "87654321-4321-4567-89ab-987654321abc",
-                        "work": captured_nonce,
-                    }
-                }
-                return resp
-
-            if method == "GET":
-                nonce_entry = {
-                    "id": "87654321-4321-4567-89ab-987654321abc",
-                    "work": captured_nonce,
-                    "struggle": "LTC verification challenge",
-                    "intention": "Proving API ownership",
-                    "created_at": "2026-01-01T00:00:00Z",
-                }
-                all_entries = [valid_entry, nonce_entry]
-                resp.status_code = 200
-                resp.json.return_value = {
-                    "entries": all_entries,
-                    "count": len(all_entries),
-                }
-                return resp
-
-            return resp
-
-        with (
-            patch(
-                "learn_to_cloud_shared.verification.deployed_api._fetch_with_retry",
-                autospec=True,
-                side_effect=mock_fetch,
-            ) as mock,
-            patch(
-                "learn_to_cloud_shared.verification.deployed_api._cleanup_challenge_entry",
-                autospec=True,
-            ),
-        ):
-            result = await validate_deployed_api("https://api.example.com/entries")
-
-            # Should call /entries (not /entries/entries)
-            for call in mock.call_args_list:
-                assert "/entries/entries" not in call.args[0]
-            assert result.is_valid is True
 
 
 @pytest.mark.unit
@@ -894,7 +577,7 @@ class TestCheckResponseIp:
 
 
 @pytest.mark.parametrize("status", [500, 503])
-@pytest.mark.parametrize("method", ["GET", "POST", "DELETE"])
+@pytest.mark.parametrize("method", ["GET", "POST"])
 async def test_crud_exhaustion_retains_safe_status_after_three_requests(status, method):
     requests = []
     span = MagicMock()

--- a/packages/learn-to-cloud-shared/tests/services/test_deployed_api_workflow.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_deployed_api_workflow.py
@@ -1,8 +1,7 @@
-"""Exercise challenge-only verification through the real HTTP request boundary."""
+"""CREATE -> ANALYZE -> REPORT uses two POSTs and leaves the entry untouched."""
 
 import asyncio
 import json
-import re
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
@@ -10,70 +9,48 @@ import pytest
 
 from learn_to_cloud_shared.verification import deployed_api
 
-_CHALLENGE_ID = "12345678-1234-4567-89ab-123456789abc"
-_POST_ID = "87654321-4321-4567-89ab-987654321abc"
+_ENTRY_ID = "entry-123"
 _SUCCESS_MESSAGE = (
-    "Deployed API verified! Ownership confirmed via challenge-response. "
-    "Live AI analysis verified."
+    "Deployed API verified! Entry creation and live AI analysis confirmed."
 )
+_ENTRY_BODY = {
+    "work": "Nice work getting your Journal API online!",
+    "struggle": "Every challenge is a chance to learn.",
+    "intention": "Keep building, learning, and making progress.",
+}
+
+
+def _analysis(entry_id=_ENTRY_ID):
+    return {
+        "entry_id": entry_id,
+        "sentiment": "neutral",
+        "summary": "The learner deployed a working API.",
+        "topics": ["deployment"],
+    }
 
 
 class JournalApi:
-    """A transport-backed Journal API with independently configurable responses."""
+    """A transport fixture with independently configurable create/analyze responses."""
 
     def __init__(self):
         self.requests = []
         self.span = MagicMock()
-        self.responses = {}
-        self.current_changes = {}
-        self.work_transform = None
-        self.missing_fields = ()
-        self.historical = []
-        self.include_current = True
-        self.challenge = {}
+        self.responses = {
+            "create": httpx.Response(201, json={"entry": {"id": _ENTRY_ID}}),
+            "analyze": httpx.Response(200, json=_analysis()),
+        }
 
     def handle(self, request):
         self.requests.append(request)
-        assert request.method in {"GET", "POST"}
-        if request.url.path.endswith("/analyze"):
-            operation = "analyze"
-            response = httpx.Response(
-                200,
-                json={
-                    "entry_id": request.url.path.split("/")[-2],
-                    "sentiment": "neutral",
-                    "summary": "The learner deployed a working API.",
-                    "topics": ["deployment"],
-                },
-            )
-        elif request.method == "POST":
-            operation = "create"
-            self.challenge = {
-                "id": _CHALLENGE_ID,
-                **json.loads(request.content),
-                "created_at": "2026-01-01T00:00:00Z",
-            }
-            response = httpx.Response(201, json={"entry": self.challenge})
-        else:
-            assert request.method == "GET"
-            operation = "list"
-            current = {**self.challenge, **self.current_changes}
-            if self.work_transform is not None:
-                current["work"] = self.work_transform(current["work"])
-            for field in self.missing_fields:
-                current.pop(field)
-            entries = [*self.historical]
-            if self.include_current:
-                entries.append(current)
-            response = httpx.Response(200, json={"entries": entries, "count": 0})
-
-        response = self.responses.get(operation, response)
+        assert request.method == "POST"
+        assert len(self.requests) <= 2
+        operation = "analyze" if request.url.path.endswith("/analyze") else "create"
+        response = self.responses[operation]
         if isinstance(response, BaseException):
             raise response
         return response
 
     async def run(self, url="https://learner.example"):
-        operation = deployed_api._fetch_with_retry.retry_with(sleep=AsyncMock())
         async with httpx.AsyncClient(
             transport=httpx.MockTransport(self.handle),
             timeout=7.0,
@@ -91,7 +68,6 @@ class JournalApi:
                 patch.object(
                     deployed_api.trace, "get_current_span", return_value=self.span
                 ),
-                patch.object(deployed_api, "_fetch_with_retry", operation),
             ):
                 return await deployed_api.validate_deployed_api(url)
 
@@ -100,7 +76,8 @@ class JournalApi:
 def journal():
     api = JournalApi()
     yield api
-    assert all(request.method != "DELETE" for request in api.requests)
+    assert all(request.method == "POST" for request in api.requests)
+    assert len(api.requests) <= 2
 
 
 @pytest.mark.parametrize(
@@ -112,7 +89,7 @@ def journal():
         (" https://learner.example/v1/entries/ ", "/v1"),
     ],
 )
-async def test_current_challenge_alone_verifies_full_request_contract(
+async def test_success_creates_then_analyzes_with_no_other_requests(
     journal, url, base_path
 ):
     result = await journal.run(url)
@@ -122,22 +99,12 @@ async def test_current_challenge_alone_verifies_full_request_contract(
     assert result.message == _SUCCESS_MESSAGE
     assert [(request.method, request.url.path) for request in journal.requests] == [
         ("POST", f"{base_path}/entries"),
-        ("GET", f"{base_path}/entries"),
-        ("POST", f"{base_path}/entries/{_CHALLENGE_ID}/analyze"),
+        ("POST", f"{base_path}/entries/{_ENTRY_ID}/analyze"),
     ]
-    create, listing, analysis = journal.requests
-    body = json.loads(create.content)
-    assert body == {
-        "work": journal.challenge["work"],
-        "struggle": "Every challenge is a chance to learn.",
-        "intention": "Keep building, learning, and making progress.",
-    }
-    assert re.fullmatch(
-        r"Nice work getting your Journal API online! \(ltc-verify-[0-9a-f]{32}\)",
-        body["work"],
-    )
-    assert all(0 < len(value) <= 256 for value in body.values())
-    assert all(request.content == b"" for request in (listing, analysis))
+    create, analysis = journal.requests
+    assert json.loads(create.content) == _ENTRY_BODY
+    assert all(0 < len(value) <= 256 for value in _ENTRY_BODY.values())
+    assert analysis.content == b""
     assert all(
         request.headers["Accept"] == "application/json" for request in journal.requests
     )
@@ -148,226 +115,100 @@ async def test_current_challenge_alone_verifies_full_request_contract(
         "pool": 30.0,
     }
     assert create.extensions["timeout"]["read"] == 7.0
-    journal.span.set_attribute.assert_has_calls(
-        [
-            call("verification.deployed_api.challenge_verified", True),
-            call("verification.deployed_api.verified", True),
-            call("verification.deployed_api.ai_verified", True),
-        ]
-    )
+    assert journal.span.set_attribute.call_args_list == [
+        call("verification.deployed_api.verified", True),
+        call("verification.deployed_api.ai_verified", True),
+    ]
     journal.span.add_event.assert_not_called()
 
 
-async def test_malformed_historical_entries_are_not_validated(journal):
-    journal.historical = [
-        None,
-        [],
-        "not an entry",
-        123,
-        {},
-        {"work": "historical entry with missing fields"},
-        {
-            "id": "not-a-uuid",
-            "work": "old work",
-            "struggle": [],
-            "intention": "x" * 257,
-            "created_at": "not-a-date",
-            "updated_at": 123,
-        },
-        {"id": None, "work": "ltc-verify-previous-attempt"},
-    ]
+@pytest.mark.parametrize("status", [200, 201])
+@pytest.mark.parametrize("wrapped", [False, True])
+async def test_create_requires_only_a_string_id_not_entry_fields(
+    journal, status, wrapped
+):
+    entry = {"id": _ENTRY_ID, "work": [], "created_at": "not-a-date"}
+    journal.responses["create"] = httpx.Response(
+        status, json={"entry": entry} if wrapped else entry
+    )
 
     result = await journal.run()
 
     assert result.verification_completed
     assert result.is_valid
-    assert result.message == _SUCCESS_MESSAGE
-    assert len(journal.requests) == 3
-
-
-@pytest.mark.parametrize("previous_challenge", [False, True])
-async def test_historical_entries_cannot_replace_current_nonce(
-    journal, previous_challenge
-):
-    journal.include_current = False
-    if previous_challenge:
-        journal.historical = [
-            {
-                "id": _POST_ID,
-                "work": (
-                    "Nice work getting your Journal API online! "
-                    "(ltc-verify-00000000000000000000000000000000)"
-                ),
-                "struggle": "Every challenge is a chance to learn.",
-                "intention": "Keep building, learning, and making progress.",
-                "created_at": "2026-01-01T00:00:00Z",
-            }
-        ]
-
-    result = await journal.run()
-
-    assert result.verification_completed
-    assert not result.is_valid
-    assert "Ownership verification failed" in result.message
-    assert [request.method for request in journal.requests] == ["POST", "GET"]
-    journal.span.add_event.assert_called_once_with("deployed_api.challenge_failed")
-
-
-async def test_retained_friendly_entry_cannot_verify_a_later_attempt(journal):
-    first_result = await journal.run()
-    assert first_result.is_valid
-    retained_entry = dict(journal.challenge)
-    journal.historical = [retained_entry]
-    journal.include_current = False
-    journal.requests.clear()
-
-    result = await journal.run()
-
-    assert journal.challenge["work"] != retained_entry["work"]
-    assert result.verification_completed
-    assert not result.is_valid
-    assert "Ownership verification failed" in result.message
-    assert [request.method for request in journal.requests] == ["POST", "GET"]
-    assert journal.historical == [retained_entry]
+    assert len(journal.requests) == 2
 
 
 @pytest.mark.parametrize(
-    "transform",
+    ("entry_id", "encoded"),
     [
-        pytest.param(lambda work: work.split("(")[1][:-1], id="nonce-only"),
-        pytest.param(lambda work: f"Extra text {work}", id="prepended-text"),
-        pytest.param(lambda work: f"{work} Extra text", id="appended-text"),
+        ("not-a-uuid", b"not-a-uuid"),
+        ("part/child", b"part%2Fchild"),
+        ("part?query#fragment", b"part%3Fquery%23fragment"),
+        ("100% ready", b"100%25%20ready"),
+        (" entry ", b"%20entry%20"),
+        ("caf\u00e9", b"caf%C3%A9"),
     ],
 )
-async def test_challenge_matching_requires_exact_friendly_work(journal, transform):
-    journal.work_transform = transform
+async def test_created_id_is_encoded_as_one_path_segment(journal, entry_id, encoded):
+    journal.responses["create"] = httpx.Response(201, json={"id": entry_id})
+    journal.responses["analyze"] = httpx.Response(200, json=_analysis(entry_id))
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert result.is_valid
+    assert len(journal.requests) == 2
+    assert journal.requests[1].url.raw_path == b"/entries/" + encoded + b"/analyze"
+    assert journal.requests[1].url.query == b""
+    assert journal.requests[1].url.fragment == ""
+
+
+async def test_invalid_unicode_id_fails_before_analysis(journal):
+    journal.responses["create"] = httpx.Response(
+        201, content=b'{"entry":{"id":"\\ud800"}}'
+    )
 
     result = await journal.run()
 
     assert result.verification_completed
     assert not result.is_valid
-    assert "Ownership verification failed" in result.message
-    assert [request.method for request in journal.requests] == ["POST", "GET"]
-    journal.span.add_event.assert_called_once_with("deployed_api.challenge_failed")
+    assert result.message == "POST /entries returned an invalid entry ID."
+    assert len(journal.requests) == 1
 
 
 @pytest.mark.parametrize(
-    ("field", "value", "message"),
+    "body",
     [
-        ("id", "not-a-uuid", "invalid id"),
-        ("id", "12345678-1234-1567-89ab-123456789abc", "invalid id"),
-        ("id", "", "invalid id"),
-        ("struggle", None, "must be a string"),
-        ("struggle", [], "must be a string"),
-        ("struggle", " ", "cannot be empty"),
-        ("intention", "x" * 257, "exceeds max length"),
-        ("created_at", "not-a-date", "invalid created_at"),
-        ("created_at", 123, "invalid created_at"),
-        ("updated_at", "not-a-date", "invalid updated_at"),
-        ("updated_at", [], "invalid updated_at"),
-    ],
-)
-async def test_invalid_current_fields_fail_without_analysis_or_deletion(
-    journal, field, value, message
-):
-    journal.current_changes[field] = value
-
-    result = await journal.run()
-
-    assert result.verification_completed
-    assert not result.is_valid
-    assert result.message.startswith("Challenge entry")
-    assert message in result.message
-    assert [request.method for request in journal.requests] == ["POST", "GET"]
-
-
-@pytest.mark.parametrize("field", ["id", "struggle", "intention", "created_at"])
-@pytest.mark.parametrize("post_has_id", [False, True])
-async def test_missing_current_fields_fail_regardless_of_post_id(
-    journal, field, post_has_id
-):
-    journal.missing_fields = (field,)
-    if not post_has_id:
-        journal.responses["create"] = httpx.Response(201, json={})
-
-    result = await journal.run()
-
-    assert result.verification_completed
-    assert not result.is_valid
-    assert result.message == f"Challenge entry missing fields: {field}"
-    assert [request.method for request in journal.requests] == ["POST", "GET"]
-
-
-@pytest.mark.parametrize("invalid_id", [None, 123, [], {}, ["not-an-id"]])
-@pytest.mark.parametrize("post_has_id", [False, True])
-async def test_nonstring_get_ids_fail_without_analysis_or_deletion(
-    journal, invalid_id, post_has_id
-):
-    journal.current_changes["id"] = invalid_id
-    if not post_has_id:
-        journal.responses["create"] = httpx.Response(201, json={})
-
-    result = await journal.run()
-
-    assert result.verification_completed
-    assert not result.is_valid
-    assert result.message == "Challenge entry has invalid id (expected UUID format)"
-    assert [request.method for request in journal.requests] == ["POST", "GET"]
-
-
-async def test_invalid_string_get_id_without_post_id_is_completed_failure(journal):
-    journal.responses["create"] = httpx.Response(201, json={})
-    journal.current_changes["id"] = "invalid-uuid"
-
-    result = await journal.run()
-
-    assert result.verification_completed
-    assert not result.is_valid
-    assert "invalid id" in result.message
-    assert [request.method for request in journal.requests] == ["POST", "GET"]
-
-
-@pytest.mark.parametrize(
-    "post_body",
-    [
+        None,
+        [],
         {},
         {"entry": {}},
         {"entry": None},
         {"entry": {"id": None}},
         {"entry": {"id": 123}},
         {"entry": {"id": []}},
-        {"entry": {"id": {"private": "value"}}},
+        {"entry": {"id": {}}},
+        {"id": ""},
+        {"id": " \t\n "},
     ],
 )
-async def test_missing_or_nonstring_post_id_falls_back_to_get(journal, post_body):
-    journal.responses["create"] = httpx.Response(201, json=post_body)
+async def test_missing_nonstring_or_blank_id_stops_after_create(journal, body):
+    journal.responses["create"] = httpx.Response(201, content=json.dumps(body).encode())
 
     result = await journal.run()
 
     assert result.verification_completed
-    assert result.is_valid
-    assert journal.requests[2].url.path == f"/entries/{_CHALLENGE_ID}/analyze"
-    assert len(journal.requests) == 3
-
-
-@pytest.mark.parametrize("wrapped", [False, True])
-async def test_post_id_takes_precedence_over_discovered_get_id(journal, wrapped):
-    post_body = {"id": _POST_ID}
-    journal.responses["create"] = httpx.Response(
-        200, json={"entry": post_body} if wrapped else post_body
+    assert not result.is_valid
+    assert result.message == (
+        "POST /entries must return the created entry with a non-empty string id."
     )
-
-    result = await journal.run()
-
-    assert result.verification_completed
-    assert result.is_valid
-    assert journal.requests[2].url.path == f"/entries/{_POST_ID}/analyze"
-    assert len(journal.requests) == 3
+    assert len(journal.requests) == 1
 
 
 @pytest.mark.parametrize("content", [b"not-json", b"\xff"])
-@pytest.mark.parametrize("operation", ["create", "list", "analyze"])
-async def test_malformed_response_json_completes_without_deleting_entry(
+@pytest.mark.parametrize("operation", ["create", "analyze"])
+async def test_malformed_response_json_is_a_completed_failure(
     journal, operation, content
 ):
     journal.responses[operation] = httpx.Response(200, content=content)
@@ -375,66 +216,98 @@ async def test_malformed_response_json_completes_without_deleting_entry(
     result = await journal.run()
 
     assert result.verification_completed
-    assert result.is_valid is (operation == "create")
-    if operation != "create":
-        assert "did not return valid JSON" in result.message
-    expected_methods = ["POST", "GET"]
-    if operation != "list":
-        expected_methods.append("POST")
-    assert [request.method for request in journal.requests] == expected_methods
-
-
-@pytest.mark.parametrize(
-    "envelope", [[], {}, {"entries": {}}, {"entries": None}, {"entries": "bad"}]
-)
-async def test_malformed_get_envelope_fails_before_analysis(journal, envelope):
-    journal.responses["list"] = httpx.Response(200, json=envelope)
-
-    result = await journal.run()
-
-    assert result.verification_completed
     assert not result.is_valid
-    assert 'must return {"entries": [...], "count": N}' in result.message
-    assert [request.method for request in journal.requests] == ["POST", "GET"]
+    step = "POST /entries" if operation == "create" else "POST /entries/{id}/analyze"
+    assert result.message == f"{step} did not return valid JSON."
+    assert len(journal.requests) == (1 if operation == "create" else 2)
 
 
-@pytest.mark.parametrize("sentiment", [None, 123, [], {}])
-async def test_nonstring_analysis_sentiment_is_completed_failure(journal, sentiment):
-    journal.responses["analyze"] = httpx.Response(
-        200,
-        json={
-            "entry_id": _CHALLENGE_ID,
-            "sentiment": sentiment,
-            "summary": "A summary",
-            "topics": ["cloud"],
-        },
+@pytest.mark.parametrize("status", [202, 204, 301, 400, 401, 403, 404, 422, 429])
+@pytest.mark.parametrize("operation", ["create", "analyze"])
+async def test_unexpected_status_stops_without_retries_or_redirects(
+    journal, operation, status
+):
+    journal.responses[operation] = httpx.Response(
+        status, headers={"Location": "https://redirect.example"}
     )
 
     result = await journal.run()
 
     assert result.verification_completed
     assert not result.is_valid
-    assert "sentiment" in result.message
-    assert [request.method for request in journal.requests] == [
-        "POST",
-        "GET",
-        "POST",
-    ]
+    assert str(status) in result.message
+    if operation == "create" and status == 422:
+        assert result.message == (
+            "POST /entries returned 422 (validation error). "
+            "Ensure POST /entries accepts {work, struggle, intention}."
+        )
+    assert len(journal.requests) == (1 if operation == "create" else 2)
+    assert all(request.url.host == "learner.example" for request in journal.requests)
 
 
 @pytest.mark.parametrize(
-    ("failure", "category", "status"),
+    ("field", "value", "message"),
     [
-        (501, "server_error", 501),
-        (503, "server_error", 503),
-        (httpx.ReadTimeout, "timeout", None),
-        (httpx.ConnectError, "request_error", None),
+        ("entry_id", "other-entry", "entry_id"),
+        ("sentiment", "mixed", "sentiment"),
+        ("sentiment", None, "sentiment"),
+        ("sentiment", 123, "sentiment"),
+        ("sentiment", [], "sentiment"),
+        ("sentiment", {}, "sentiment"),
+        ("summary", "", "summary"),
+        ("summary", " ", "summary"),
+        ("summary", None, "summary"),
+        ("topics", [], "topics"),
+        ("topics", "cloud", "topics"),
+        ("topics", ["cloud", ""], "topics"),
+        ("topics", ["cloud", 123], "topics"),
     ],
 )
-async def test_analysis_failure_preserves_entry_and_safe_diagnostics_without_retry(
-    journal, failure, category, status
+async def test_invalid_analysis_fields_are_completed_failures(
+    journal, field, value, message
 ):
-    journal.responses["analyze"] = (
+    analysis = _analysis()
+    analysis[field] = value
+    journal.responses["analyze"] = httpx.Response(200, json=analysis)
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert message in result.message
+    assert len(journal.requests) == 2
+    journal.span.set_attribute.assert_not_called()
+
+
+@pytest.mark.parametrize("body", [[], "not an object", None])
+async def test_analysis_requires_a_json_object(journal, body):
+    journal.responses["analyze"] = httpx.Response(
+        200, content=json.dumps(body).encode()
+    )
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert result.message == "AI analysis must return a JSON object."
+    assert len(journal.requests) == 2
+
+
+@pytest.mark.parametrize("operation", ["create", "analyze"])
+@pytest.mark.parametrize(
+    ("failure", "category"),
+    [
+        (500, "server_error"),
+        (501, "server_error"),
+        (503, "server_error"),
+        (httpx.ReadTimeout, "timeout"),
+        (httpx.ConnectError, "request_error"),
+    ],
+)
+async def test_failures_are_not_retried_and_emit_safe_step_diagnostics(
+    journal, operation, failure, category
+):
+    journal.responses[operation] = (
         httpx.Response(failure, text="private learner details")
         if isinstance(failure, int)
         else failure("private learner details")
@@ -444,35 +317,31 @@ async def test_analysis_failure_preserves_entry_and_safe_diagnostics_without_ret
 
     assert result.verification_completed
     assert not result.is_valid
-    if status == 501:
+    assert len(journal.requests) == (1 if operation == "create" else 2)
+    step = "POST /entries" if operation == "create" else "POST /entries/{id}/analyze"
+    if operation == "analyze" and failure == 501:
         assert result.message == (
             "POST /entries/{id}/analyze is not implemented. Complete the "
             "Journal API AI analysis task and deploy it."
         )
-    assert [request.method for request in journal.requests] == [
-        "POST",
-        "GET",
-        "POST",
-    ]
-    assert journal.requests[2].extensions["timeout"]["read"] == 30.0
-    attributes = {
-        "error.type": category,
-        "verification.operation": "POST /entries/{id}/analyze",
-    }
-    if status is not None:
-        attributes["http.response.status_code"] = status
-        journal.span.set_attribute.assert_any_call("http.response.status_code", status)
+    else:
+        assert result.message.startswith(f"{step}:")
+    attributes = {"error.type": category, "verification.operation": step}
+    if isinstance(failure, int):
+        attributes["http.response.status_code"] = failure
+        journal.span.set_attribute.assert_any_call("http.response.status_code", failure)
+    journal.span.set_attribute.assert_any_call("error.type", category)
     journal.span.add_event.assert_called_once_with(
         f"deployed_api.{category}", attributes
     )
-    assert "private learner" not in result.message
-    assert "private learner" not in str(journal.span.mock_calls)
-    assert "learner.example" not in str(journal.span.mock_calls)
-    assert journal.challenge["work"] not in str(journal.span.mock_calls)
+    for private_value in ("private learner", "learner.example", _ENTRY_BODY["work"]):
+        assert private_value not in result.message
+        assert private_value not in str(journal.span.mock_calls)
+    journal.span.record_exception.assert_not_called()
 
 
-@pytest.mark.parametrize("operation", ["create", "list", "analyze"])
-async def test_private_response_peer_fails_without_deleting_entry(journal, operation):
+@pytest.mark.parametrize("operation", ["create", "analyze"])
+async def test_private_response_peer_stops_without_more_requests(journal, operation):
     stream = MagicMock()
     stream.get_extra_info.return_value = ("10.0.0.1", 443)
     journal.responses[operation] = httpx.Response(
@@ -484,23 +353,16 @@ async def test_private_response_peer_fails_without_deleting_entry(journal, opera
     assert result.verification_completed
     assert not result.is_valid
     assert result.message == "URL must point to a publicly accessible server."
-    expected_methods = {
-        "create": ["POST"],
-        "list": ["POST", "GET"],
-        "analyze": ["POST", "GET", "POST"],
-    }
-    assert [request.method for request in journal.requests] == (
-        expected_methods[operation]
-    )
+    assert len(journal.requests) == (1 if operation == "create" else 2)
     journal.span.add_event.assert_called_once_with(
         "deployed_api.ssrf_blocked", {"verification.reason": "dns_rebinding"}
     )
     assert "10.0.0.1" not in str(journal.span.mock_calls)
 
 
-@pytest.mark.parametrize("operation", ["create", "list", "analyze"])
+@pytest.mark.parametrize("operation", ["create", "analyze"])
 @pytest.mark.parametrize("error_type", [ValueError, TypeError, asyncio.CancelledError])
-async def test_unexpected_errors_and_cancellation_propagate_without_deletion(
+async def test_programming_errors_and_cancellation_propagate_without_more_requests(
     journal, operation, error_type
 ):
     error = error_type("unexpected failure")
@@ -510,20 +372,15 @@ async def test_unexpected_errors_and_cancellation_propagate_without_deletion(
         await journal.run()
 
     assert raised.value is error
-    expected_methods = {
-        "create": ["POST"],
-        "list": ["POST", "GET"],
-        "analyze": ["POST", "GET", "POST"],
-    }
-    assert [request.method for request in journal.requests] == (
-        expected_methods[operation]
-    )
+    assert len(journal.requests) == (1 if operation == "create" else 2)
     journal.span.add_event.assert_not_called()
 
 
 @pytest.mark.parametrize(
     "url",
     [
+        "",
+        "not-a-url",
         "http://learner.example",
         "https://learner.example:invalid",
         "https://learner.example:70000",
@@ -531,10 +388,14 @@ async def test_unexpected_errors_and_cancellation_propagate_without_deletion(
         "https://[invalid",
     ],
 )
-async def test_invalid_url_is_a_completed_failure_without_requests(journal, url):
+async def test_invalid_url_is_completed_without_requests(journal, url):
     result = await journal.run(url)
 
     assert result.verification_completed
     assert not result.is_valid
-    assert "valid HTTP(S) URL" in result.message
+    assert result.message == (
+        "Please submit a valid HTTP(S) URL."
+        if url
+        else "Please submit your deployed API base URL."
+    )
     assert journal.requests == []

--- a/packages/learn-to-cloud-shared/tests/services/test_deployed_api_workflow.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_deployed_api_workflow.py
@@ -14,9 +14,9 @@ _SUCCESS_MESSAGE = (
     "Deployed API verified! Entry creation and live AI analysis confirmed."
 )
 _ENTRY_BODY = {
-    "work": "Nice work getting your Journal API online!",
-    "struggle": "Every challenge is a chance to learn.",
-    "intention": "Keep building, learning, and making progress.",
+    "work": "Submitted deployed API for verification.",
+    "struggle": "Verifying that entry creation and AI analysis work after deployment.",
+    "intention": "Review the verification result and address any reported issues.",
 }
 
 

--- a/packages/learn-to-cloud-shared/tests/services/test_deployed_api_workflow.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_deployed_api_workflow.py
@@ -1,0 +1,576 @@
+"""Exercise challenge-only verification through the real HTTP request boundary."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import httpx
+import pytest
+
+from learn_to_cloud_shared.verification import deployed_api
+
+_CHALLENGE_ID = "12345678-1234-4567-89ab-123456789abc"
+_POST_ID = "87654321-4321-4567-89ab-987654321abc"
+_SUCCESS_MESSAGE = (
+    "Deployed API verified! Ownership confirmed via challenge-response. "
+    "Live AI analysis verified."
+)
+
+
+class JournalApi:
+    """A transport-backed Journal API with independently configurable responses."""
+
+    def __init__(self):
+        self.requests = []
+        self.span = MagicMock()
+        self.responses = {}
+        self.current_changes = {}
+        self.missing_fields = ()
+        self.historical = []
+        self.include_current = True
+        self.challenge = {}
+
+    def handle(self, request):
+        self.requests.append(request)
+        if request.method == "DELETE":
+            operation = "delete"
+            response = httpx.Response(200, json={"detail": "Entry deleted"})
+        elif request.url.path.endswith("/analyze"):
+            operation = "analyze"
+            response = httpx.Response(
+                200,
+                json={
+                    "entry_id": request.url.path.split("/")[-2],
+                    "sentiment": "neutral",
+                    "summary": "The learner deployed a working API.",
+                    "topics": ["deployment"],
+                },
+            )
+        elif request.method == "POST":
+            operation = "create"
+            self.challenge = {
+                "id": _CHALLENGE_ID,
+                **json.loads(request.content),
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+            response = httpx.Response(201, json={"entry": self.challenge})
+        else:
+            assert request.method == "GET"
+            operation = "list"
+            current = {**self.challenge, **self.current_changes}
+            for field in self.missing_fields:
+                current.pop(field)
+            entries = [*self.historical]
+            if self.include_current:
+                entries.append(current)
+            response = httpx.Response(200, json={"entries": entries, "count": 0})
+
+        response = self.responses.get(operation, response)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+    async def run(self, url="https://learner.example"):
+        operation = deployed_api._fetch_with_retry.retry_with(sleep=AsyncMock())
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(self.handle),
+            timeout=7.0,
+            follow_redirects=False,
+        ) as client:
+            with (
+                patch.object(
+                    asyncio.get_running_loop(),
+                    "getaddrinfo",
+                    AsyncMock(return_value=[(2, 1, 6, "", ("8.8.8.8", 443))]),
+                ),
+                patch.object(
+                    deployed_api, "_get_client", AsyncMock(return_value=client)
+                ),
+                patch.object(
+                    deployed_api.trace, "get_current_span", return_value=self.span
+                ),
+                patch.object(deployed_api, "_fetch_with_retry", operation),
+            ):
+                return await deployed_api.validate_deployed_api(url)
+
+
+@pytest.fixture
+def journal():
+    return JournalApi()
+
+
+@pytest.mark.parametrize(
+    ("url", "base_path"),
+    [
+        ("https://learner.example", ""),
+        (" https://learner.example/entries/ ", ""),
+        ("https://learner.example/v1/", "/v1"),
+        (" https://learner.example/v1/entries/ ", "/v1"),
+    ],
+)
+async def test_current_challenge_alone_verifies_full_request_contract(
+    journal, url, base_path
+):
+    result = await journal.run(url)
+
+    assert result.verification_completed
+    assert result.is_valid
+    assert result.message == _SUCCESS_MESSAGE
+    assert [(request.method, request.url.path) for request in journal.requests] == [
+        ("POST", f"{base_path}/entries"),
+        ("GET", f"{base_path}/entries"),
+        ("POST", f"{base_path}/entries/{_CHALLENGE_ID}/analyze"),
+        ("DELETE", f"{base_path}/entries/{_CHALLENGE_ID}"),
+    ]
+    create, listing, analysis, delete = journal.requests
+    body = json.loads(create.content)
+    assert body == {
+        "work": journal.challenge["work"],
+        "struggle": "LTC verification challenge",
+        "intention": "Proving API ownership",
+    }
+    assert body["work"].startswith("ltc-verify-")
+    assert len(body["work"]) == len("ltc-verify-") + 32
+    assert all(request.content == b"" for request in (listing, analysis, delete))
+    assert all(
+        request.headers["Accept"] == "application/json" for request in journal.requests
+    )
+    assert analysis.extensions["timeout"] == {
+        "connect": 30.0,
+        "read": 30.0,
+        "write": 30.0,
+        "pool": 30.0,
+    }
+    assert create.extensions["timeout"]["read"] == 7.0
+    journal.span.set_attribute.assert_has_calls(
+        [
+            call("verification.deployed_api.challenge_verified", True),
+            call("verification.deployed_api.verified", True),
+            call("verification.deployed_api.ai_verified", True),
+        ]
+    )
+    journal.span.add_event.assert_not_called()
+
+
+async def test_malformed_historical_entries_are_not_validated(journal):
+    journal.historical = [
+        None,
+        [],
+        "not an entry",
+        123,
+        {},
+        {"work": "historical entry with missing fields"},
+        {
+            "id": "not-a-uuid",
+            "work": "old work",
+            "struggle": [],
+            "intention": "x" * 257,
+            "created_at": "not-a-date",
+            "updated_at": 123,
+        },
+        {"id": None, "work": "ltc-verify-previous-attempt"},
+    ]
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert result.is_valid
+    assert result.message == _SUCCESS_MESSAGE
+    assert len(journal.requests) == 4
+
+
+@pytest.mark.parametrize("previous_challenge", [False, True])
+async def test_historical_entries_cannot_replace_current_nonce(
+    journal, previous_challenge
+):
+    journal.include_current = False
+    if previous_challenge:
+        journal.historical = [
+            {
+                "id": _POST_ID,
+                "work": "ltc-verify-previous-attempt",
+                "struggle": "LTC verification challenge",
+                "intention": "Proving API ownership",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        ]
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert "Ownership verification failed" in result.message
+    assert [request.method for request in journal.requests] == ["POST", "GET", "DELETE"]
+    assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
+    journal.span.add_event.assert_called_once_with("deployed_api.challenge_failed")
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("id", "not-a-uuid", "invalid id"),
+        ("id", "12345678-1234-1567-89ab-123456789abc", "invalid id"),
+        ("id", "", "invalid id"),
+        ("struggle", None, "must be a string"),
+        ("struggle", [], "must be a string"),
+        ("struggle", " ", "cannot be empty"),
+        ("intention", "x" * 257, "exceeds max length"),
+        ("created_at", "not-a-date", "invalid created_at"),
+        ("created_at", 123, "invalid created_at"),
+        ("updated_at", "not-a-date", "invalid updated_at"),
+        ("updated_at", [], "invalid updated_at"),
+    ],
+)
+async def test_invalid_current_fields_fail_before_analysis_with_cleanup(
+    journal, field, value, message
+):
+    journal.current_changes[field] = value
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert result.message.startswith("Challenge entry")
+    assert message in result.message
+    assert [request.method for request in journal.requests] == ["POST", "GET", "DELETE"]
+    assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
+
+
+@pytest.mark.parametrize("field", ["id", "struggle", "intention", "created_at"])
+@pytest.mark.parametrize("post_has_id", [False, True])
+async def test_missing_current_fields_retain_any_known_cleanup_id(
+    journal, field, post_has_id
+):
+    journal.missing_fields = (field,)
+    if not post_has_id:
+        journal.responses["create"] = httpx.Response(201, json={})
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert result.message == f"Challenge entry missing fields: {field}"
+    expected_methods = ["POST", "GET"]
+    if post_has_id or field != "id":
+        expected_methods.append("DELETE")
+        assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
+    assert [request.method for request in journal.requests] == expected_methods
+
+
+@pytest.mark.parametrize("invalid_id", [None, 123, [], {}, ["not-an-id"]])
+@pytest.mark.parametrize("post_has_id", [False, True])
+async def test_nonstring_get_ids_never_become_cleanup_paths(
+    journal, invalid_id, post_has_id
+):
+    journal.current_changes["id"] = invalid_id
+    if not post_has_id:
+        journal.responses["create"] = httpx.Response(201, json={})
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert result.message == "Challenge entry has invalid id (expected UUID format)"
+    assert [request.method for request in journal.requests] == (
+        ["POST", "GET", "DELETE"] if post_has_id else ["POST", "GET"]
+    )
+    if post_has_id:
+        assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
+
+
+async def test_invalid_string_get_id_is_available_for_cleanup(journal):
+    journal.responses["create"] = httpx.Response(201, json={})
+    journal.current_changes["id"] = "invalid-uuid"
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert "invalid id" in result.message
+    assert [request.method for request in journal.requests] == ["POST", "GET", "DELETE"]
+    assert journal.requests[-1].url.path == "/entries/invalid-uuid"
+
+
+@pytest.mark.parametrize(
+    "post_body",
+    [
+        {},
+        {"entry": {}},
+        {"entry": None},
+        {"entry": {"id": None}},
+        {"entry": {"id": 123}},
+        {"entry": {"id": []}},
+        {"entry": {"id": {"private": "value"}}},
+    ],
+)
+async def test_missing_or_nonstring_post_id_falls_back_to_get(journal, post_body):
+    journal.responses["create"] = httpx.Response(201, json=post_body)
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert result.is_valid
+    assert journal.requests[2].url.path == f"/entries/{_CHALLENGE_ID}/analyze"
+    assert journal.requests[3].url.path == f"/entries/{_CHALLENGE_ID}"
+
+
+@pytest.mark.parametrize("wrapped", [False, True])
+async def test_post_id_takes_precedence_over_discovered_get_id(journal, wrapped):
+    post_body = {"id": _POST_ID}
+    journal.responses["create"] = httpx.Response(
+        200, json={"entry": post_body} if wrapped else post_body
+    )
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert result.is_valid
+    assert journal.requests[2].url.path == f"/entries/{_POST_ID}/analyze"
+    assert journal.requests[3].url.path == f"/entries/{_POST_ID}"
+
+
+@pytest.mark.parametrize("content", [b"not-json", b"\xff"])
+@pytest.mark.parametrize("operation", ["create", "list", "analyze"])
+async def test_malformed_response_json_completes_and_cleans_up(
+    journal, operation, content
+):
+    journal.responses[operation] = httpx.Response(200, content=content)
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert result.is_valid is (operation == "create")
+    if operation != "create":
+        assert "did not return valid JSON" in result.message
+    expected_methods = ["POST", "GET"]
+    if operation != "list":
+        expected_methods.append("POST")
+    assert [request.method for request in journal.requests] == [
+        *expected_methods,
+        "DELETE",
+    ]
+    assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
+
+
+@pytest.mark.parametrize(
+    "envelope", [[], {}, {"entries": {}}, {"entries": None}, {"entries": "bad"}]
+)
+async def test_malformed_get_envelope_fails_before_analysis(journal, envelope):
+    journal.responses["list"] = httpx.Response(200, json=envelope)
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert 'must return {"entries": [...], "count": N}' in result.message
+    assert [request.method for request in journal.requests] == ["POST", "GET", "DELETE"]
+
+
+@pytest.mark.parametrize("sentiment", [None, 123, [], {}])
+async def test_nonstring_analysis_sentiment_is_completed_failure(journal, sentiment):
+    journal.responses["analyze"] = httpx.Response(
+        200,
+        json={
+            "entry_id": _CHALLENGE_ID,
+            "sentiment": sentiment,
+            "summary": "A summary",
+            "topics": ["cloud"],
+        },
+    )
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert "sentiment" in result.message
+    assert [request.method for request in journal.requests] == [
+        "POST",
+        "GET",
+        "POST",
+        "DELETE",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("failure", "category", "status"),
+    [
+        (501, "server_error", 501),
+        (503, "server_error", 503),
+        (httpx.ReadTimeout, "timeout", None),
+        (httpx.ConnectError, "request_error", None),
+    ],
+)
+async def test_analysis_failure_is_not_retried_and_cleanup_preserves_diagnostics(
+    journal, failure, category, status
+):
+    journal.responses["analyze"] = (
+        httpx.Response(failure, text="private learner details")
+        if isinstance(failure, int)
+        else failure("private learner details")
+    )
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    if status == 501:
+        assert result.message == (
+            "POST /entries/{id}/analyze is not implemented. Complete the "
+            "Journal API AI analysis task and deploy it."
+        )
+    assert [request.method for request in journal.requests] == [
+        "POST",
+        "GET",
+        "POST",
+        "DELETE",
+    ]
+    assert journal.requests[2].extensions["timeout"]["read"] == 30.0
+    attributes = {
+        "error.type": category,
+        "verification.operation": "POST /entries/{id}/analyze",
+    }
+    if status is not None:
+        attributes["http.response.status_code"] = status
+        journal.span.set_attribute.assert_any_call("http.response.status_code", status)
+    journal.span.add_event.assert_called_once_with(
+        f"deployed_api.{category}", attributes
+    )
+    assert "private learner" not in result.message
+    assert "private learner" not in str(journal.span.mock_calls)
+    assert "learner.example" not in str(journal.span.mock_calls)
+
+
+@pytest.mark.parametrize("status", [200, 204, 404])
+async def test_completed_or_already_absent_cleanup_is_not_a_failure(journal, status):
+    journal.responses["delete"] = httpx.Response(status)
+
+    result = await journal.run()
+
+    assert result.is_valid
+    assert result.verification_completed
+    assert len(journal.requests) == 4
+    journal.span.add_event.assert_not_called()
+
+
+@pytest.mark.parametrize("primary_success", [False, True])
+@pytest.mark.parametrize(
+    ("failure", "category", "attempts"),
+    [
+        (202, "unexpected_status", 1),
+        (301, "unexpected_status", 1),
+        (400, "unexpected_status", 1),
+        (401, "unexpected_status", 1),
+        (403, "unexpected_status", 1),
+        (429, "unexpected_status", 1),
+        (500, "server_error", 3),
+        (httpx.ReadTimeout, "timeout", 3),
+        (httpx.ConnectError, "request_error", 3),
+        ("ssrf", "ssrf_blocked", 1),
+    ],
+)
+async def test_expected_cleanup_failures_do_not_replace_primary_result(
+    journal, primary_success, failure, category, attempts
+):
+    if not primary_success:
+        journal.responses["analyze"] = httpx.Response(200, json={})
+    if failure == "ssrf":
+        stream = MagicMock()
+        stream.get_extra_info.return_value = ("10.0.0.1", 443)
+        journal.responses["delete"] = httpx.Response(
+            200, extensions={"network_stream": stream}
+        )
+    elif isinstance(failure, int):
+        journal.responses["delete"] = httpx.Response(
+            failure,
+            text="private learner details",
+            headers={"Location": "https://private.example", "X-Secret": "secret"},
+        )
+    else:
+        journal.responses["delete"] = failure("private learner details")
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert result.is_valid is primary_success
+    assert result.message == (
+        _SUCCESS_MESSAGE
+        if primary_success
+        else "AI analysis returned an unexpected entry_id."
+    )
+    deletes = [request for request in journal.requests if request.method == "DELETE"]
+    assert len(deletes) == attempts
+    assert all(request.url.path == f"/entries/{_CHALLENGE_ID}" for request in deletes)
+    attributes = {
+        "verification.operation": "DELETE /entries/{id}",
+        "error.type": category,
+    }
+    if isinstance(failure, int):
+        attributes["http.response.status_code"] = failure
+    cleanup_events = [
+        event
+        for event in journal.span.add_event.call_args_list
+        if event.args[0] == "deployed_api.cleanup_failed"
+    ]
+    assert cleanup_events == [call("deployed_api.cleanup_failed", attributes)]
+    if failure == "ssrf":
+        journal.span.add_event.assert_any_call(
+            "deployed_api.ssrf_blocked",
+            {"verification.reason": "cleanup_dns_rebinding"},
+        )
+    assert all(
+        attribute.args[0].startswith("verification.deployed_api.")
+        for attribute in journal.span.set_attribute.call_args_list
+    )
+    journal.span.set_status.assert_not_called()
+    journal.span.record_exception.assert_not_called()
+    diagnostics = str(journal.span.mock_calls)
+    for private_value in (
+        "private learner",
+        "learner.example",
+        "private.example",
+        "secret",
+        journal.challenge["work"],
+    ):
+        assert private_value not in diagnostics
+
+
+@pytest.mark.parametrize("operation", ["create", "list", "analyze", "delete"])
+@pytest.mark.parametrize("error_type", [ValueError, TypeError, asyncio.CancelledError])
+async def test_unexpected_errors_and_cancellation_propagate(
+    journal, operation, error_type
+):
+    error = error_type("unexpected failure")
+    journal.responses[operation] = error
+
+    with pytest.raises(error_type) as raised:
+        await journal.run()
+
+    assert raised.value is error
+    if operation == "create":
+        assert [request.method for request in journal.requests] == ["POST"]
+    else:
+        assert journal.requests[-1].method == "DELETE"
+        assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
+    assert not any(
+        event.args[0] == "deployed_api.cleanup_failed"
+        for event in journal.span.add_event.call_args_list
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://learner.example",
+        "https://learner.example:invalid",
+        "https://learner.example:70000",
+        "https://learner.example:0",
+        "https://[invalid",
+    ],
+)
+async def test_invalid_url_is_a_completed_failure_without_requests(journal, url):
+    result = await journal.run(url)
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert "valid HTTP(S) URL" in result.message
+    assert journal.requests == []

--- a/packages/learn-to-cloud-shared/tests/services/test_deployed_api_workflow.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_deployed_api_workflow.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import re
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
@@ -25,6 +26,7 @@ class JournalApi:
         self.span = MagicMock()
         self.responses = {}
         self.current_changes = {}
+        self.work_transform = None
         self.missing_fields = ()
         self.historical = []
         self.include_current = True
@@ -32,10 +34,8 @@ class JournalApi:
 
     def handle(self, request):
         self.requests.append(request)
-        if request.method == "DELETE":
-            operation = "delete"
-            response = httpx.Response(200, json={"detail": "Entry deleted"})
-        elif request.url.path.endswith("/analyze"):
+        assert request.method in {"GET", "POST"}
+        if request.url.path.endswith("/analyze"):
             operation = "analyze"
             response = httpx.Response(
                 200,
@@ -58,6 +58,8 @@ class JournalApi:
             assert request.method == "GET"
             operation = "list"
             current = {**self.challenge, **self.current_changes}
+            if self.work_transform is not None:
+                current["work"] = self.work_transform(current["work"])
             for field in self.missing_fields:
                 current.pop(field)
             entries = [*self.historical]
@@ -96,7 +98,9 @@ class JournalApi:
 
 @pytest.fixture
 def journal():
-    return JournalApi()
+    api = JournalApi()
+    yield api
+    assert all(request.method != "DELETE" for request in api.requests)
 
 
 @pytest.mark.parametrize(
@@ -120,18 +124,20 @@ async def test_current_challenge_alone_verifies_full_request_contract(
         ("POST", f"{base_path}/entries"),
         ("GET", f"{base_path}/entries"),
         ("POST", f"{base_path}/entries/{_CHALLENGE_ID}/analyze"),
-        ("DELETE", f"{base_path}/entries/{_CHALLENGE_ID}"),
     ]
-    create, listing, analysis, delete = journal.requests
+    create, listing, analysis = journal.requests
     body = json.loads(create.content)
     assert body == {
         "work": journal.challenge["work"],
-        "struggle": "LTC verification challenge",
-        "intention": "Proving API ownership",
+        "struggle": "Every challenge is a chance to learn.",
+        "intention": "Keep building, learning, and making progress.",
     }
-    assert body["work"].startswith("ltc-verify-")
-    assert len(body["work"]) == len("ltc-verify-") + 32
-    assert all(request.content == b"" for request in (listing, analysis, delete))
+    assert re.fullmatch(
+        r"Nice work getting your Journal API online! \(ltc-verify-[0-9a-f]{32}\)",
+        body["work"],
+    )
+    assert all(0 < len(value) <= 256 for value in body.values())
+    assert all(request.content == b"" for request in (listing, analysis))
     assert all(
         request.headers["Accept"] == "application/json" for request in journal.requests
     )
@@ -176,7 +182,7 @@ async def test_malformed_historical_entries_are_not_validated(journal):
     assert result.verification_completed
     assert result.is_valid
     assert result.message == _SUCCESS_MESSAGE
-    assert len(journal.requests) == 4
+    assert len(journal.requests) == 3
 
 
 @pytest.mark.parametrize("previous_challenge", [False, True])
@@ -188,9 +194,12 @@ async def test_historical_entries_cannot_replace_current_nonce(
         journal.historical = [
             {
                 "id": _POST_ID,
-                "work": "ltc-verify-previous-attempt",
-                "struggle": "LTC verification challenge",
-                "intention": "Proving API ownership",
+                "work": (
+                    "Nice work getting your Journal API online! "
+                    "(ltc-verify-00000000000000000000000000000000)"
+                ),
+                "struggle": "Every challenge is a chance to learn.",
+                "intention": "Keep building, learning, and making progress.",
                 "created_at": "2026-01-01T00:00:00Z",
             }
         ]
@@ -200,8 +209,45 @@ async def test_historical_entries_cannot_replace_current_nonce(
     assert result.verification_completed
     assert not result.is_valid
     assert "Ownership verification failed" in result.message
-    assert [request.method for request in journal.requests] == ["POST", "GET", "DELETE"]
-    assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
+    assert [request.method for request in journal.requests] == ["POST", "GET"]
+    journal.span.add_event.assert_called_once_with("deployed_api.challenge_failed")
+
+
+async def test_retained_friendly_entry_cannot_verify_a_later_attempt(journal):
+    first_result = await journal.run()
+    assert first_result.is_valid
+    retained_entry = dict(journal.challenge)
+    journal.historical = [retained_entry]
+    journal.include_current = False
+    journal.requests.clear()
+
+    result = await journal.run()
+
+    assert journal.challenge["work"] != retained_entry["work"]
+    assert result.verification_completed
+    assert not result.is_valid
+    assert "Ownership verification failed" in result.message
+    assert [request.method for request in journal.requests] == ["POST", "GET"]
+    assert journal.historical == [retained_entry]
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        pytest.param(lambda work: work.split("(")[1][:-1], id="nonce-only"),
+        pytest.param(lambda work: f"Extra text {work}", id="prepended-text"),
+        pytest.param(lambda work: f"{work} Extra text", id="appended-text"),
+    ],
+)
+async def test_challenge_matching_requires_exact_friendly_work(journal, transform):
+    journal.work_transform = transform
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert "Ownership verification failed" in result.message
+    assert [request.method for request in journal.requests] == ["POST", "GET"]
     journal.span.add_event.assert_called_once_with("deployed_api.challenge_failed")
 
 
@@ -221,7 +267,7 @@ async def test_historical_entries_cannot_replace_current_nonce(
         ("updated_at", [], "invalid updated_at"),
     ],
 )
-async def test_invalid_current_fields_fail_before_analysis_with_cleanup(
+async def test_invalid_current_fields_fail_without_analysis_or_deletion(
     journal, field, value, message
 ):
     journal.current_changes[field] = value
@@ -232,13 +278,12 @@ async def test_invalid_current_fields_fail_before_analysis_with_cleanup(
     assert not result.is_valid
     assert result.message.startswith("Challenge entry")
     assert message in result.message
-    assert [request.method for request in journal.requests] == ["POST", "GET", "DELETE"]
-    assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
+    assert [request.method for request in journal.requests] == ["POST", "GET"]
 
 
 @pytest.mark.parametrize("field", ["id", "struggle", "intention", "created_at"])
 @pytest.mark.parametrize("post_has_id", [False, True])
-async def test_missing_current_fields_retain_any_known_cleanup_id(
+async def test_missing_current_fields_fail_regardless_of_post_id(
     journal, field, post_has_id
 ):
     journal.missing_fields = (field,)
@@ -250,16 +295,12 @@ async def test_missing_current_fields_retain_any_known_cleanup_id(
     assert result.verification_completed
     assert not result.is_valid
     assert result.message == f"Challenge entry missing fields: {field}"
-    expected_methods = ["POST", "GET"]
-    if post_has_id or field != "id":
-        expected_methods.append("DELETE")
-        assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
-    assert [request.method for request in journal.requests] == expected_methods
+    assert [request.method for request in journal.requests] == ["POST", "GET"]
 
 
 @pytest.mark.parametrize("invalid_id", [None, 123, [], {}, ["not-an-id"]])
 @pytest.mark.parametrize("post_has_id", [False, True])
-async def test_nonstring_get_ids_never_become_cleanup_paths(
+async def test_nonstring_get_ids_fail_without_analysis_or_deletion(
     journal, invalid_id, post_has_id
 ):
     journal.current_changes["id"] = invalid_id
@@ -271,14 +312,10 @@ async def test_nonstring_get_ids_never_become_cleanup_paths(
     assert result.verification_completed
     assert not result.is_valid
     assert result.message == "Challenge entry has invalid id (expected UUID format)"
-    assert [request.method for request in journal.requests] == (
-        ["POST", "GET", "DELETE"] if post_has_id else ["POST", "GET"]
-    )
-    if post_has_id:
-        assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
+    assert [request.method for request in journal.requests] == ["POST", "GET"]
 
 
-async def test_invalid_string_get_id_is_available_for_cleanup(journal):
+async def test_invalid_string_get_id_without_post_id_is_completed_failure(journal):
     journal.responses["create"] = httpx.Response(201, json={})
     journal.current_changes["id"] = "invalid-uuid"
 
@@ -287,8 +324,7 @@ async def test_invalid_string_get_id_is_available_for_cleanup(journal):
     assert result.verification_completed
     assert not result.is_valid
     assert "invalid id" in result.message
-    assert [request.method for request in journal.requests] == ["POST", "GET", "DELETE"]
-    assert journal.requests[-1].url.path == "/entries/invalid-uuid"
+    assert [request.method for request in journal.requests] == ["POST", "GET"]
 
 
 @pytest.mark.parametrize(
@@ -311,7 +347,7 @@ async def test_missing_or_nonstring_post_id_falls_back_to_get(journal, post_body
     assert result.verification_completed
     assert result.is_valid
     assert journal.requests[2].url.path == f"/entries/{_CHALLENGE_ID}/analyze"
-    assert journal.requests[3].url.path == f"/entries/{_CHALLENGE_ID}"
+    assert len(journal.requests) == 3
 
 
 @pytest.mark.parametrize("wrapped", [False, True])
@@ -326,12 +362,12 @@ async def test_post_id_takes_precedence_over_discovered_get_id(journal, wrapped)
     assert result.verification_completed
     assert result.is_valid
     assert journal.requests[2].url.path == f"/entries/{_POST_ID}/analyze"
-    assert journal.requests[3].url.path == f"/entries/{_POST_ID}"
+    assert len(journal.requests) == 3
 
 
 @pytest.mark.parametrize("content", [b"not-json", b"\xff"])
 @pytest.mark.parametrize("operation", ["create", "list", "analyze"])
-async def test_malformed_response_json_completes_and_cleans_up(
+async def test_malformed_response_json_completes_without_deleting_entry(
     journal, operation, content
 ):
     journal.responses[operation] = httpx.Response(200, content=content)
@@ -345,11 +381,7 @@ async def test_malformed_response_json_completes_and_cleans_up(
     expected_methods = ["POST", "GET"]
     if operation != "list":
         expected_methods.append("POST")
-    assert [request.method for request in journal.requests] == [
-        *expected_methods,
-        "DELETE",
-    ]
-    assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
+    assert [request.method for request in journal.requests] == expected_methods
 
 
 @pytest.mark.parametrize(
@@ -363,7 +395,7 @@ async def test_malformed_get_envelope_fails_before_analysis(journal, envelope):
     assert result.verification_completed
     assert not result.is_valid
     assert 'must return {"entries": [...], "count": N}' in result.message
-    assert [request.method for request in journal.requests] == ["POST", "GET", "DELETE"]
+    assert [request.method for request in journal.requests] == ["POST", "GET"]
 
 
 @pytest.mark.parametrize("sentiment", [None, 123, [], {}])
@@ -387,7 +419,6 @@ async def test_nonstring_analysis_sentiment_is_completed_failure(journal, sentim
         "POST",
         "GET",
         "POST",
-        "DELETE",
     ]
 
 
@@ -400,7 +431,7 @@ async def test_nonstring_analysis_sentiment_is_completed_failure(journal, sentim
         (httpx.ConnectError, "request_error", None),
     ],
 )
-async def test_analysis_failure_is_not_retried_and_cleanup_preserves_diagnostics(
+async def test_analysis_failure_preserves_entry_and_safe_diagnostics_without_retry(
     journal, failure, category, status
 ):
     journal.responses["analyze"] = (
@@ -422,7 +453,6 @@ async def test_analysis_failure_is_not_retried_and_cleanup_preserves_diagnostics
         "POST",
         "GET",
         "POST",
-        "DELETE",
     ]
     assert journal.requests[2].extensions["timeout"]["read"] == 30.0
     attributes = {
@@ -438,105 +468,39 @@ async def test_analysis_failure_is_not_retried_and_cleanup_preserves_diagnostics
     assert "private learner" not in result.message
     assert "private learner" not in str(journal.span.mock_calls)
     assert "learner.example" not in str(journal.span.mock_calls)
+    assert journal.challenge["work"] not in str(journal.span.mock_calls)
 
 
-@pytest.mark.parametrize("status", [200, 204, 404])
-async def test_completed_or_already_absent_cleanup_is_not_a_failure(journal, status):
-    journal.responses["delete"] = httpx.Response(status)
-
-    result = await journal.run()
-
-    assert result.is_valid
-    assert result.verification_completed
-    assert len(journal.requests) == 4
-    journal.span.add_event.assert_not_called()
-
-
-@pytest.mark.parametrize("primary_success", [False, True])
-@pytest.mark.parametrize(
-    ("failure", "category", "attempts"),
-    [
-        (202, "unexpected_status", 1),
-        (301, "unexpected_status", 1),
-        (400, "unexpected_status", 1),
-        (401, "unexpected_status", 1),
-        (403, "unexpected_status", 1),
-        (429, "unexpected_status", 1),
-        (500, "server_error", 3),
-        (httpx.ReadTimeout, "timeout", 3),
-        (httpx.ConnectError, "request_error", 3),
-        ("ssrf", "ssrf_blocked", 1),
-    ],
-)
-async def test_expected_cleanup_failures_do_not_replace_primary_result(
-    journal, primary_success, failure, category, attempts
-):
-    if not primary_success:
-        journal.responses["analyze"] = httpx.Response(200, json={})
-    if failure == "ssrf":
-        stream = MagicMock()
-        stream.get_extra_info.return_value = ("10.0.0.1", 443)
-        journal.responses["delete"] = httpx.Response(
-            200, extensions={"network_stream": stream}
-        )
-    elif isinstance(failure, int):
-        journal.responses["delete"] = httpx.Response(
-            failure,
-            text="private learner details",
-            headers={"Location": "https://private.example", "X-Secret": "secret"},
-        )
-    else:
-        journal.responses["delete"] = failure("private learner details")
-
-    result = await journal.run()
-
-    assert result.verification_completed
-    assert result.is_valid is primary_success
-    assert result.message == (
-        _SUCCESS_MESSAGE
-        if primary_success
-        else "AI analysis returned an unexpected entry_id."
+@pytest.mark.parametrize("operation", ["create", "list", "analyze"])
+async def test_private_response_peer_fails_without_deleting_entry(journal, operation):
+    stream = MagicMock()
+    stream.get_extra_info.return_value = ("10.0.0.1", 443)
+    journal.responses[operation] = httpx.Response(
+        200, extensions={"network_stream": stream}
     )
-    deletes = [request for request in journal.requests if request.method == "DELETE"]
-    assert len(deletes) == attempts
-    assert all(request.url.path == f"/entries/{_CHALLENGE_ID}" for request in deletes)
-    attributes = {
-        "verification.operation": "DELETE /entries/{id}",
-        "error.type": category,
+
+    result = await journal.run()
+
+    assert result.verification_completed
+    assert not result.is_valid
+    assert result.message == "URL must point to a publicly accessible server."
+    expected_methods = {
+        "create": ["POST"],
+        "list": ["POST", "GET"],
+        "analyze": ["POST", "GET", "POST"],
     }
-    if isinstance(failure, int):
-        attributes["http.response.status_code"] = failure
-    cleanup_events = [
-        event
-        for event in journal.span.add_event.call_args_list
-        if event.args[0] == "deployed_api.cleanup_failed"
-    ]
-    assert cleanup_events == [call("deployed_api.cleanup_failed", attributes)]
-    if failure == "ssrf":
-        journal.span.add_event.assert_any_call(
-            "deployed_api.ssrf_blocked",
-            {"verification.reason": "cleanup_dns_rebinding"},
-        )
-    assert all(
-        attribute.args[0].startswith("verification.deployed_api.")
-        for attribute in journal.span.set_attribute.call_args_list
+    assert [request.method for request in journal.requests] == (
+        expected_methods[operation]
     )
-    journal.span.set_status.assert_not_called()
-    journal.span.record_exception.assert_not_called()
-    diagnostics = str(journal.span.mock_calls)
-    for private_value in (
-        "private learner",
-        "learner.example",
-        "private.example",
-        "secret",
-        journal.challenge["work"],
-    ):
-        assert private_value not in diagnostics
+    journal.span.add_event.assert_called_once_with(
+        "deployed_api.ssrf_blocked", {"verification.reason": "dns_rebinding"}
+    )
+    assert "10.0.0.1" not in str(journal.span.mock_calls)
 
 
-@pytest.mark.parametrize("operation", ["create", "list", "analyze", "delete"])
+@pytest.mark.parametrize("operation", ["create", "list", "analyze"])
 @pytest.mark.parametrize("error_type", [ValueError, TypeError, asyncio.CancelledError])
-async def test_unexpected_errors_and_cancellation_propagate(
+async def test_unexpected_errors_and_cancellation_propagate_without_deletion(
     journal, operation, error_type
 ):
     error = error_type("unexpected failure")
@@ -546,15 +510,15 @@ async def test_unexpected_errors_and_cancellation_propagate(
         await journal.run()
 
     assert raised.value is error
-    if operation == "create":
-        assert [request.method for request in journal.requests] == ["POST"]
-    else:
-        assert journal.requests[-1].method == "DELETE"
-        assert journal.requests[-1].url.path == f"/entries/{_CHALLENGE_ID}"
-    assert not any(
-        event.args[0] == "deployed_api.cleanup_failed"
-        for event in journal.span.add_event.call_args_list
+    expected_methods = {
+        "create": ["POST"],
+        "list": ["POST", "GET"],
+        "analyze": ["POST", "GET", "POST"],
+    }
+    assert [request.method for request in journal.requests] == (
+        expected_methods[operation]
     )
+    journal.span.add_event.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/packages/learn-to-cloud-shared/tests/verification/test_errors.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_errors.py
@@ -36,7 +36,6 @@ def test_make_retriable_preserves_explicit_network_types():
     ("module", "own_error"),
     [
         (github_http, GitHubServerError),
-        (deployed_api, deployed_api.DeployedApiServerError),
         (ghcr, ghcr._GhcrServerError),
     ],
 )
@@ -54,3 +53,12 @@ def test_retry_policies_do_not_include_base_or_other_integrations(module, own_er
         assert isinstance(
             other("response", status_code=503), module.RETRIABLE_EXCEPTIONS
         ) == (other is own_error)
+
+
+def test_deployed_api_retains_its_distinct_public_error_type():
+    error = deployed_api.DeployedApiServerError("Server returned 503", status_code=503)
+
+    assert deployed_api.DeployedApiServerError.__bases__ == (UpstreamResponseError,)
+    assert error.status_code == 503
+    assert error.retry_after is None
+    assert not isinstance(error, (GitHubServerError, ghcr._GhcrServerError))


### PR DESCRIPTION
Deployment verification now creates a journal entry, takes the ID from the creation response, and calls that entry's AI analysis endpoint. Each request runs once. If either step fails, feedback identifies the problem; a creation failure stops before analysis.

Removes GET/listing, random challenge markers, journal-field validation, historical-entry checks, ID recovery, automatic retries, and deletion. The entry records the verification submission and stays in the learner's journal, without claiming the verification passed. Success confirms creation and analysis rather than ownership.

Retains timeouts, connection pooling, disabled redirects, and private-target checks to protect our server when it calls submitted URLs. Analysis responses still require the matching entry ID, sentiment, summary, and topics, with actionable feedback for 501 responses.

Updates learner-facing instructions, the compiled curriculum, contributor documentation, and transport-backed regression coverage. No infrastructure changes; no merge or deployment is authorized.

Closes #855.
