### PR TITLE
Simplify telemetry around SDK defaults

### DIFF
--- a/api/src/learn_to_cloud/core/middleware.py
+++ b/api/src/learn_to_cloud/core/middleware.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from fastapi.routing import iter_route_contexts
 from opentelemetry import trace
-from starlette.routing import Match
+from starlette.datastructures import URL
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
@@ -59,26 +58,10 @@ class SecurityHeadersMiddleware:
 
 
 class TelemetrySanitizationMiddleware:
-    """Replace request URL attributes with a bounded route template."""
+    """Keep credentials and query values out of request URL attributes."""
 
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
-
-    @staticmethod
-    def _route_template(scope: Scope) -> str:
-        partial_match: str | None = None
-        app = scope.get("app")
-        router = getattr(app, "router", None)
-        for route in iter_route_contexts(getattr(router, "routes", ())):
-            match, _ = route.matches(scope)
-            route_path = getattr(route, "path", None)
-            if not isinstance(route_path, str):
-                continue
-            if match is Match.FULL:
-                return route_path
-            if match is Match.PARTIAL and partial_match is None:
-                partial_match = route_path
-        return partial_match or "/unmatched"
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -87,11 +70,13 @@ class TelemetrySanitizationMiddleware:
 
         span = trace.get_current_span()
         if span.is_recording():
-            route_path = self._route_template(scope)
-            span.set_attribute("http.target", route_path)
-            span.set_attribute("http.url", route_path)
-            span.set_attribute("url.full", route_path)
-            span.set_attribute("url.path", route_path)
+            url = URL(scope=scope).replace(
+                query="", fragment="", username=None, password=None
+            )
+            span.set_attribute("http.target", url.path)
+            span.set_attribute("http.url", str(url))
+            span.set_attribute("url.full", str(url))
+            span.set_attribute("url.path", url.path)
             span.set_attribute("url.query", "")
 
         await self.app(scope, receive, send)

--- a/api/src/learn_to_cloud/core/templates.py
+++ b/api/src/learn_to_cloud/core/templates.py
@@ -52,23 +52,17 @@ def _static_url_context(request: Request) -> dict[str, object]:
     return {"static_url": static_url, "logout_all_csrf": csrf_token(request)}
 
 
-def _frontend_telemetry_context(request: Request) -> dict[str, object]:
+def _frontend_telemetry_context(_request: Request) -> dict[str, object]:
     """Inject browser telemetry config when frontend telemetry is enabled."""
     settings = get_web_settings()
     conn_str = settings.frontend_telemetry.applicationinsights_connection_string
     if not conn_str:
         return {"frontend_telemetry": None}
 
-    route = request.scope.get("route")
-    route_path = getattr(route, "path", None)
-    if not isinstance(route_path, str):
-        route_path = "/unmatched"
-
     return {
         "frontend_telemetry": {
             "connection_string": conn_str,
             "sampling_percentage": settings.frontend_telemetry.sampling_percentage,
-            "route_path": route_path,
         }
     }
 

--- a/api/src/learn_to_cloud/rendering/page_content.py
+++ b/api/src/learn_to_cloud/rendering/page_content.py
@@ -53,15 +53,18 @@ FAQS: list[tuple[str, str]] = [
     ),
     (
         "What data do you collect about me?",
-        "We only store information from your public GitHub profile: your GitHub user"
-        " ID, username, display name, and avatar URL. We do not collect your email"
-        " address, password, or any other personal information.",
+        "We store your GitHub ID, username, display name, avatar URL, learning"
+        " progress, submissions, and feedback. We also collect operational"
+        ' diagnostics. See our <a href="/privacy" class="text-blue-600'
+        ' dark:text-blue-400 underline">Privacy Policy</a> for details.',
     ),
     (
         "Can I delete my account?",
         'Yes. Go to your <a href="/account" class="text-blue-600 dark:text-blue-400'
-        ' underline">Account page</a>. Clicking "Delete Account" will permanently'
-        " remove your profile and all associated data (progress and submissions).",
+        ' underline">Account page</a> to remove your account-linked records from'
+        " the active application database. Backups, diagnostics, and workflow"
+        ' history have separate retention; see the <a href="/privacy"'
+        ' class="text-blue-600 dark:text-blue-400 underline">Privacy Policy</a>.',
     ),
     (
         "How can I support Learn to Cloud?",

--- a/api/src/learn_to_cloud/static/js/frontend-telemetry.js
+++ b/api/src/learn_to_cloud/static/js/frontend-telemetry.js
@@ -1,81 +1,56 @@
 (function () {
     'use strict';
 
-    function pageUri() {
-        var marker = document.querySelector('[data-telemetry-route]');
-        var route = marker ? marker.getAttribute('data-telemetry-route') : '/unmatched';
-        return window.location.origin + route;
+    var telemetry = window.appInsights;
+    if (!telemetry) {
+        return;
     }
 
-    function appInsights() {
-        if (window.appInsights && typeof window.appInsights.trackEvent === 'function') {
-            return window.appInsights;
-        }
-        return null;
+    function cleanUrl(value) {
+        var url = new URL(value, window.location.origin);
+        url.username = '';
+        url.password = '';
+        url.search = '';
+        url.hash = '';
+        return url.href;
     }
 
-    function removeUrlProperties(envelope) {
-        var baseData = envelope && envelope.baseData;
-        if (!baseData) {
-            return true;
-        }
-
-        delete baseData.refUri;
-        if (envelope.baseType === 'PageviewData') {
-            baseData.uri = pageUri();
+    telemetry.addTelemetryInitializer(function (envelope) {
+        var data = envelope.baseData;
+        if (data) {
+            ['uri', 'url', 'refUri'].forEach(function (key) {
+                if (data[key]) {
+                    data[key] = cleanUrl(data[key]);
+                }
+            });
+            if (envelope.baseType === 'RemoteDependencyData') {
+                data.target = cleanUrl(data.target);
+                data.name = data.name.split(/[?#]/, 1)[0];
+            }
+            if (envelope.baseType === 'ExceptionData') {
+                // The SDK merges both sources into the exported properties.
+                [data.properties, envelope.data].forEach(function (properties) {
+                    if (properties) {
+                        if (properties.url) {
+                            properties.url = cleanUrl(properties.url);
+                        }
+                        delete properties.errorSrc;
+                    }
+                });
+            }
         }
         return true;
-    }
+    });
+    telemetry.loadAppInsights();
+    telemetry.trackPageView();
 
-    function trackPageView(navigationKind) {
-        var telemetry = appInsights();
-        var currentUrl = pageUri();
-        if (!telemetry) {
-            return;
-        }
-
-        telemetry.trackPageView({
-            name: document.title,
-            uri: currentUrl,
-            properties: {
-                'navigation.type': navigationKind
-            }
-        });
-    }
-
-    function trackHtmxTransportError(event) {
-        var telemetry = appInsights();
-        if (!telemetry || !event.detail) {
-            return;
-        }
-
-        var requestConfig = event.detail.requestConfig || {};
-        telemetry.trackEvent({
-            name: 'htmx.transport_error',
-            properties: {
-                'http.request.method': requestConfig.verb || '',
-                'htmx.boosted': Boolean(event.detail.boosted)
-            }
-        });
-    }
-
-    var telemetry = appInsights();
-    if (telemetry) {
-        telemetry.addTelemetryInitializer(removeUrlProperties);
-        trackPageView('initial');
-    }
-
+    // SDK history tracking counts HTMX's replaceState + pushState twice.
     document.addEventListener('htmx:afterSettle', function (event) {
         if (event.detail && event.detail.boosted) {
-            trackPageView('htmx');
+            telemetry.trackPageView();
         }
     });
-
     document.addEventListener('htmx:historyRestore', function () {
-        trackPageView('history');
-    });
-
-    document.addEventListener('htmx:sendError', function (event) {
-        trackHtmxTransportError(event);
+        telemetry.trackPageView();
     });
 })();

--- a/api/src/learn_to_cloud/templates/base.html
+++ b/api/src/learn_to_cloud/templates/base.html
@@ -18,22 +18,16 @@
             window.appInsights = new Microsoft.ApplicationInsights.ApplicationInsights({
                 config: {
                     connectionString: {{ frontend_telemetry.connection_string | tojson }},
-                    disableCookiesUsage: true,
                     cookieCfg: { enabled: false },
                     isStorageUseDisabled: true,
                     enableSessionStorageBuffer: false,
-                    enableAutoRouteTracking: false,
-                    disableAjaxTracking: true,
-                    disableFetchTracking: true,
-                    disableExceptionTracking: true,
                     samplingPercentage: {{ frontend_telemetry.sampling_percentage | tojson }},
-                    enableUnhandledPromiseRejectionTracking: false
+                    enableUnhandledPromiseRejectionTracking: true
                 }
             });
-            window.appInsights.loadAppInsights();
         }
     </script>
-    <script defer src="{{ static_url('js/frontend-telemetry.js') }}"></script>
+    <script src="{{ static_url('js/frontend-telemetry.js') }}"></script>
     {% endif %}
 
     <!-- Apply dark class synchronously to prevent FOUC -->
@@ -156,7 +150,6 @@
 
     <main
         class="flex-1 w-full mx-auto max-w-content px-4 sm:px-6 lg:px-8 py-10 sm:py-12"
-        {% if frontend_telemetry %}data-telemetry-route="{{ frontend_telemetry.route_path }}"{% endif %}
     >
         {% block content %}{% endblock %}
     </main>

--- a/api/src/learn_to_cloud/templates/pages/account.html
+++ b/api/src/learn_to_cloud/templates/pages/account.html
@@ -25,7 +25,9 @@
 <div x-data="{ confirmDelete: false }">
     <h2 class="section-title mb-3">Delete Account</h2>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-        Deleting your account will permanently remove your profile, progress, and submissions. This cannot be undone.
+        Deleting your account removes your profile, progress, submissions, feedback, and sessions from the active
+        application database. This cannot be undone through the app.
+        See the <a href="/privacy" class="underline">Privacy Policy</a> for backup and service retention.
     </p>
 
     <button
@@ -51,7 +53,7 @@
         >
             <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">Are you sure?</h3>
             <p class="text-sm text-gray-600 dark:text-gray-400 mb-6">
-                This will permanently delete your account, all progress, and submissions. This action cannot be undone.
+                This removes your account-linked records from the active application database. This action cannot be undone through the app.
             </p>
             <div class="flex gap-3 justify-end">
                 <button

--- a/api/src/learn_to_cloud/templates/pages/privacy.html
+++ b/api/src/learn_to_cloud/templates/pages/privacy.html
@@ -3,7 +3,7 @@
 
 {% block page_header %}
 <h1 class="page-title">Privacy Policy</h1>
-<p class="mt-3 text-sm text-gray-500 dark:text-gray-400">Last updated: September 5, 2026</p>
+<p class="mt-3 text-sm text-gray-500 dark:text-gray-400">Last updated: September 8, 2026</p>
 {% endblock %}
 
 {% block page_body %}
@@ -21,7 +21,7 @@
     <section>
         <h2>Data We Collect</h2>
         <p>
-            When you sign in with GitHub, we collect only the following from your <strong>public</strong> GitHub profile:
+            During sign-in, we read your GitHub profile and save these fields:
         </p>
         <ul>
             <li><strong>GitHub user ID</strong> — used as your account identifier</li>
@@ -30,18 +30,18 @@
             <li><strong>Avatar URL</strong> — shown in the navigation bar</li>
         </ul>
         <p>
-            We do <strong>not</strong> collect your email address, password, private repositories, or any other personal
-            profile information beyond what is listed above.
+            We do not save other fields from the profile response or request your GitHub password.
         </p>
         <p>
-            We collect basic browser telemetry, such as page views, performance timings, and client-side errors, to
-            diagnose reliability issues. Browser telemetry is not linked to your GitHub account, username, or internal
-            user ID. Profile names are not included in browser telemetry.
+            We collect browser page views, request outcomes, performance timings, and client-side errors to
+            diagnose reliability issues. We do not set a GitHub account identity in browser telemetry.
+            Normal URL paths and error details are included; query values are removed from URL fields.
         </p>
         <p>
-            We also collect server diagnostics to investigate failures. We do not deliberately log profile payloads,
-            and database query parameters are hidden, but database error messages may include public GitHub profile
-            values such as your username, display name, or avatar URL.
+            Server diagnostics record actions, outcomes, timing, and errors. Attempt IDs let authorized maintainers
+            look up submission details in the database without copying them into routine logs. We do not deliberately
+            log credentials or submission payloads, and database query parameters are hidden. Ordinary error
+            diagnostics may include public GitHub profile values.
         </p>
     </section>
 
@@ -49,18 +49,17 @@
         <h2>GitHub OAuth Scope</h2>
         <p>
             We request the <code>read:user</code>
-            OAuth scope, which grants read-only access to your public profile information. We do not request access to
-            your repositories, organizations, or any private data. Your GitHub access token is used only during
-            sign-in and is never stored.
+            OAuth scope to read your profile. We do not request repository or organization scopes for sign-in.
+            Your GitHub access token is used during sign-in and is not saved in our database or session cookies.
         </p>
     </section>
 
     <section>
         <h2>Data You Submit</h2>
         <p>
-            As part of hands-on verification, you voluntarily submit URLs and tokens (such as GitHub repository URLs,
-            deployed application URLs, and CTF tokens) to prove completion of exercises. This submitted data is stored
-            alongside your account.
+            Verification submissions include URLs, lab tokens, and reflection text. We store submitted values,
+            learning progress, verification outcomes, and feedback alongside your account. Verification can also
+            fetch repository files and send selected evidence to automated grading.
         </p>
     </section>
 
@@ -71,7 +70,7 @@
             <li>Identify your account and maintain your session</li>
             <li>Track your learning progress across phases</li>
             <li>Verify completion of hands-on exercises</li>
-            <li>Compute anonymous, aggregate community statistics</li>
+            <li>Compute aggregate community statistics and display graduates' public usernames and avatars</li>
             <li>Diagnose server and client-side errors and performance issues</li>
         </ul>
     </section>
@@ -81,8 +80,7 @@
         <ul>
             <li>We do not sell or rent your personal information; service providers below process data to operate the platform</li>
             <li>We do not use your data for advertising, recruiting, or marketing purposes</li>
-            <li>We do not send unsolicited emails (we don't even collect your email)</li>
-            <li>We do not scrape or crawl GitHub profiles beyond your own authenticated data</li>
+            <li>We do not send unsolicited emails</li>
             <li>We do not store your GitHub access token</li>
         </ul>
     </section>
@@ -102,10 +100,9 @@
     <section>
         <h2>Data Retention &amp; Deletion</h2>
         <p>
-            Your data is retained as long as your account exists. You can permanently delete your account and all
-            associated data (progress and submissions) at any time from your
-            <a href="/account">Account page</a>.
-            Deletion is immediate and irreversible.
+            Your account-linked database records are retained while your account exists. Deleting your account
+            from the <a href="/account">Account page</a> removes your profile, progress, submissions, feedback,
+            and sessions from the active application database. This cannot be undone through the app.
         </p>
         <p>
             Sessions stop working after 7 days without authenticated activity or 30 days after sign-in.
@@ -115,8 +112,10 @@
             cannot authenticate while waiting for cleanup.
         </p>
         <p>
-            Account deletion does not remove existing diagnostic logs. Those logs follow the telemetry
-            service's separate retention settings and have restricted access.
+            Account deletion does not erase database backups, existing diagnostic logs, or verification history
+            held by workflow and grading services. Those records have separate retention settings.
+            Already-running verification work is not cancelled, and data on GitHub or your own deployments
+            is not deleted.
         </p>
     </section>
 
@@ -127,7 +126,8 @@
         </p>
         <ul>
             <li><strong>GitHub API</strong> — to sign you in and verify repositories and profiles you submit</li>
-            <li><strong>Azure OpenAI</strong> — to analyze code you submit for verification (code is not stored by the LLM)</li>
+            <li><strong>Microsoft Foundry / Azure OpenAI</strong> — to grade selected code, reflection text, and related metadata; service storage and abuse monitoring follow Microsoft's data-handling terms</li>
+            <li><strong>Azure Durable Task Scheduler</strong> — to run verification workflows and retain their inputs and results</li>
             <li><strong>Azure Application Insights</strong> — to collect server and browser diagnostics</li>
         </ul>
     </section>

--- a/api/tests/core/test_middleware.py
+++ b/api/tests/core/test_middleware.py
@@ -4,20 +4,17 @@ Tests ASGI middleware:
 - SecurityHeadersMiddleware adds security headers to HTTP responses
 - SecurityHeadersMiddleware skips non-HTTP scopes
 - SecurityHeadersMiddleware adds cache-control for static paths
-- TelemetrySanitizationMiddleware removes raw URLs and query strings
+- TelemetrySanitizationMiddleware preserves paths without query credentials
 """
 
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from fastapi import APIRouter, FastAPI
-from fastapi.routing import APIRoute
 
 from learn_to_cloud.core.middleware import (
     SecurityHeadersMiddleware,
     TelemetrySanitizationMiddleware,
 )
-from learn_to_cloud.core.routing import LoginRedirectRoute
 
 
 async def _noop_receive():
@@ -153,35 +150,36 @@ class TestSecurityHeadersMiddleware:
 
 @pytest.mark.unit
 class TestTelemetrySanitizationMiddleware:
+    @pytest.mark.parametrize("path", ["/steps/2ea4225e", "/unregistered/path"])
     @patch("learn_to_cloud.core.middleware.trace", autospec=True)
-    async def test_replaces_url_attributes_with_route_template(self, mock_trace):
+    async def test_preserves_path_without_query_credentials(self, mock_trace, path):
         span = MagicMock()
         span.is_recording.return_value = True
         mock_trace.get_current_span.return_value = span
 
-        app = FastAPI()
-        app.add_api_route("/steps/{step_uuid}", lambda: None)
         middleware = TelemetrySanitizationMiddleware(_make_app_that_sends_response)
         scope = {
             "type": "http",
+            "scheme": "https",
+            "headers": [(b"host", b"testserver")],
             "method": "GET",
-            "path": "/steps/2ea4225e",
+            "path": path,
             "query_string": b"token=sensitive",
-            "app": app,
         }
 
         await middleware(scope, _noop_receive, _noop_send)
 
         assert span.set_attribute.call_args_list == [
-            call("http.target", "/steps/{step_uuid}"),
-            call("http.url", "/steps/{step_uuid}"),
-            call("url.full", "/steps/{step_uuid}"),
-            call("url.path", "/steps/{step_uuid}"),
+            call("http.target", path),
+            call("http.url", f"https://testserver{path}"),
+            call("url.full", f"https://testserver{path}"),
+            call("url.path", path),
             call("url.query", ""),
         ]
+        assert scope["query_string"] == b"token=sensitive"
 
     @patch("learn_to_cloud.core.middleware.trace", autospec=True)
-    async def test_uses_fixed_value_for_unmatched_routes(self, mock_trace):
+    async def test_does_not_export_invalid_host_credentials(self, mock_trace):
         span = MagicMock()
         span.is_recording.return_value = True
         mock_trace.get_current_span.return_value = span
@@ -189,34 +187,13 @@ class TestTelemetrySanitizationMiddleware:
         middleware = TelemetrySanitizationMiddleware(_make_app_that_sends_response)
         scope = {
             "type": "http",
+            "scheme": "https",
+            "headers": [(b"host", b"username:password@testserver")],
             "path": "/arbitrary",
             "query_string": b"code=secret",
             "method": "GET",
-            "app": FastAPI(),
         }
 
         await middleware(scope, _noop_receive, _noop_send)
 
-        span.set_attribute.assert_any_call("url.full", "/unmatched")
-
-    @pytest.mark.parametrize("route_class", [APIRoute, LoginRedirectRoute])
-    @pytest.mark.parametrize("method", ["GET", "POST"])
-    def test_resolves_nested_router_prefixes_for_full_and_partial_matches(
-        self, route_class, method
-    ):
-        app = FastAPI()
-        child = APIRouter(prefix="/child", route_class=route_class)
-        child.add_api_route("/items/{item_id}", lambda: None, methods=["GET"])
-        parent = APIRouter(prefix="/parent")
-        parent.include_router(child, prefix="/nested")
-        app.include_router(parent, prefix="/api")
-        scope = {
-            "type": "http",
-            "method": method,
-            "path": "/api/parent/nested/child/items/private-item",
-            "app": app,
-        }
-
-        assert TelemetrySanitizationMiddleware._route_template(scope) == (
-            "/api/parent/nested/child/items/{item_id}"
-        )
+        span.set_attribute.assert_any_call("url.full", "/arbitrary")

--- a/api/tests/core/test_templates.py
+++ b/api/tests/core/test_templates.py
@@ -1,6 +1,5 @@
 """Unit tests for template context processors."""
 
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -36,15 +35,12 @@ def test_frontend_telemetry_context_includes_connection_string(monkeypatch):
         conn_str,
     )
 
-    context = _frontend_telemetry_context(
-        MagicMock(scope={"route": SimpleNamespace(path="/phases/{phase_slug}")})
-    )
+    context = _frontend_telemetry_context(MagicMock())
 
     assert context == {
         "frontend_telemetry": {
             "connection_string": conn_str,
             "sampling_percentage": 100.0,
-            "route_path": "/phases/{phase_slug}",
         }
     }
 
@@ -64,6 +60,5 @@ def test_frontend_telemetry_context_includes_sampling_percentage(monkeypatch):
         "frontend_telemetry": {
             "connection_string": conn_str,
             "sampling_percentage": 10.0,
-            "route_path": "/unmatched",
         }
     }

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -17,6 +17,7 @@ from learn_to_cloud.rendering.feedback import feedback_tasks_and_passed
 from learn_to_cloud.rendering.htmx_responses import render_step_toggle
 from learn_to_cloud.rendering.page_content import (
     COMMUNITY_LINKS,
+    FAQS,
     HELP_LINKS,
 )
 from learn_to_cloud.rendering.requirement_cards import (
@@ -78,6 +79,44 @@ def _base_ctx(**overrides: object) -> dict[str, object]:
 
 def _render(template_name: str, **ctx: object) -> str:
     return _ENV.get_template(template_name).render(**_base_ctx(**ctx))
+
+
+@pytest.mark.unit
+def test_privacy_describes_diagnostics_and_separate_retention():
+    html = _render("pages/privacy.html")
+    assert "request outcomes" in html
+    assert "client-side errors" in html
+    assert "query values are removed from URL fields" in html
+    assert "Attempt IDs" in html
+    assert "reflection text" in html
+    assert "does not erase database backups" in html
+    assert "Azure Durable Task Scheduler" in html
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("page", ["account", "faq"])
+def test_account_deletion_copy_scopes_removal_to_active_database(page):
+    html = _render(f"pages/{page}.html", faqs=FAQS)
+    assert "active" in html and "application database" in html
+    assert 'href="/privacy"' in html
+
+
+@pytest.mark.unit
+def test_browser_sdk_collects_errors_without_persistent_tracking():
+    html = _render(
+        "pages/privacy.html",
+        frontend_telemetry={
+            "connection_string": "InstrumentationKey=synthetic",
+            "sampling_percentage": 100,
+        },
+    )
+    assert "cookieCfg: { enabled: false }" in html
+    assert "isStorageUseDisabled: true" in html
+    assert "enableUnhandledPromiseRejectionTracking: true" in html
+    assert "disableAjaxTracking: true" not in html
+    assert "disableFetchTracking: true" not in html
+    assert "disableExceptionTracking: true" not in html
+    assert "enableAutoRouteTracking: true" not in html
 
 
 @pytest.mark.unit

--- a/api/tests/routes/test_auth_http.py
+++ b/api/tests/routes/test_auth_http.py
@@ -1021,8 +1021,10 @@ async def test_malformed_identity_telemetry_has_no_private_values(
         )
         == status
     )
-    for attribute in ("http.target", "http.url", "url.full", "url.path"):
+    for attribute in ("http.target", "url.path"):
         assert server.attributes[attribute] == path
+    for attribute in ("http.url", "url.full"):
+        assert server.attributes[attribute] == f"http://testserver{path}"
     assert server.attributes["url.query"] == ""
     for span in spans:
         assert not any(event.name == "exception" for event in span.events)
@@ -1064,7 +1066,7 @@ async def test_malformed_identity_telemetry_has_no_private_values(
         ("GET", "/private-unmatched-probe", False, False, 404, None),
     ],
 )
-async def test_auth_request_telemetry_is_bounded_and_has_no_exception_events(
+async def test_auth_request_telemetry_keeps_paths_but_not_credentials(
     telemetry_client, auth_cookie, method, path, htmx, authenticated, status, route
 ):
     client, exporter = telemetry_client
@@ -1091,8 +1093,10 @@ async def test_auth_request_telemetry_is_bounded_and_has_no_exception_events(
         == status
     )
     assert server.status.status_code == StatusCode.UNSET
-    for attribute in ("http.target", "http.url", "url.full", "url.path"):
-        assert attributes[attribute] == (route or "/unmatched")
+    for attribute in ("http.target", "url.path"):
+        assert attributes[attribute] == path
+    for attribute in ("http.url", "url.full"):
+        assert attributes[attribute] == f"http://testserver{path}"
     assert attributes["url.query"] == ""
 
     for span in spans:
@@ -1102,8 +1106,6 @@ async def test_auth_request_telemetry_is_bounded_and_has_no_exception_events(
         )
     telemetry = "\n".join(span.to_json() for span in spans)
     for prohibited in (
-        "private-topic-probe",
-        "private-unmatched-probe",
         "private-token-probe",
         "testuser",
         cookie,

--- a/api/tests/test_telemetry_contracts.py
+++ b/api/tests/test_telemetry_contracts.py
@@ -1,10 +1,8 @@
-"""Static contracts for production telemetry and Azure Monitor alerts."""
+"""Contracts for alert signals and browser telemetry."""
 
-import ast
 import json
 import re
 import subprocess
-from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -12,113 +10,6 @@ import pytest
 pytestmark = pytest.mark.unit
 
 _ROOT = Path(__file__).parents[2]
-_PYTHON_TELEMETRY_ROOTS = (
-    _ROOT / "api" / "src",
-    _ROOT / "apps" / "verification-functions",
-    _ROOT / "packages" / "learn-to-cloud-shared" / "src" / "learn_to_cloud_shared",
-)
-
-_ALLOWED_APPLICATION_ATTRIBUTES = {
-    "auth.configuration.reason",
-    "auth.identity.reason",
-    "auth.session.reason",
-    "auth.session.scope",
-    "auth.session.count",
-    "content.artifact.hash",
-    "content.artifact_schema.version",
-    "content.curriculum.version",
-    "content.phase.slug",
-    "content.requirement.slug",
-    "content.topic.slug",
-    "database.schema.current_revision",
-    "database.schema.expected_revision",
-    "error.type",
-    "evidence.collected_count",
-    "evidence.outcome",
-    "evidence.reason",
-    "evidence.selected_count",
-    "evidence.total_bytes",
-    "github.repository",
-    "http.response.status_code",
-    "http.target",
-    "http.url",
-    "startup.initialized",
-    "telemetry.configuration.reason",
-    "url.full",
-    "url.path",
-    "url.query",
-    "verification.attempt.age_seconds",
-    "verification.attempt.created",
-    "verification.attempt.id",
-    "verification.check.name",
-    "verification.deployed_api.ai_verified",
-    "verification.deployed_api.verified",
-    "verification.durable.status",
-    "verification.error.code",
-    "verification.failure.kind",
-    "verification.failure.stage",
-    "verification.operation",
-    "verification.outcome",
-    "verification.reason",
-    "verification.reconciler.candidate_count",
-    "verification.reconciler.stuck_count",
-    "verification.reconciler.terminalized_count",
-    "verification.requirement.slug",
-    "verification.step.result",
-    "verification.stuck.reason",
-    "verification.task.id",
-    "verification.terminal.source",
-    "verification.terminal.write_won",
-}
-
-_PROHIBITED_APPLICATION_ATTRIBUTES = {
-    "session.id",
-    "session.token",
-    "session.digest",
-    "csrf",
-    "attempt_age_seconds",
-    "attempt_created",
-    "attempt_id",
-    "candidate_count",
-    "cas_won",
-    "code_head",
-    "content_hash",
-    "cutoff",
-    "db_head",
-    "durable_status",
-    "error",
-    "error_code",
-    "error_type",
-    "evidence.content",
-    "evidence.path",
-    "evidence.sha256",
-    "evidence.repository_url",
-    "failure_kind",
-    "github_username",
-    "display_name",
-    "first_name",
-    "last_name",
-    "user.display_name",
-    "user.first_name",
-    "user.last_name",
-    "hint",
-    "orchestrator_name",
-    "outcome",
-    "path",
-    "phase_slug",
-    "reason",
-    "repo",
-    "requirement_slug",
-    "runtime_status",
-    "status",
-    "status_code",
-    "stuck_count",
-    "stuck_reason",
-    "terminal_source",
-    "terminalized_count",
-    "topic_slug",
-    "user_id",
-}
 
 
 def _resource_block(source: str, resource_name: str) -> str:
@@ -129,181 +20,9 @@ def _resource_block(source: str, resource_name: str) -> str:
     return source[start:] if next_resource == -1 else source[start:next_resource]
 
 
-def _dict_keys(
-    node: ast.AST | None,
-    bindings: dict[str, set[str]],
-) -> set[str] | None:
-    if not isinstance(node, ast.Dict):
-        if isinstance(node, ast.Name):
-            return bindings.get(node.id)
-        return None
-    keys = {
-        key.value
-        for key in node.keys
-        if isinstance(key, ast.Constant) and isinstance(key.value, str)
-    }
-    return keys if len(keys) == len(node.keys) else None
-
-
-def _application_python_files(root: Path) -> Iterator[Path]:
-    """Scan authored Python, not dependencies or generated package copies."""
-    for directory, subdirectories, filenames in root.walk():
-        subdirectories[:] = [
-            name
-            for name in subdirectories
-            if name not in {".venv", ".python_packages", "build"}
-        ]
-        for name in filenames:
-            if name.endswith(".py"):
-                yield directory / name
-
-
-@pytest.mark.parametrize("dependency_directory", [".venv", ".python_packages", "build"])
-def test_application_scan_excludes_generated_dependencies(
-    tmp_path, monkeypatch, dependency_directory
-):
-    source = tmp_path / "app" / "main.py"
-    source.parent.mkdir()
-    source.write_text(
-        'logger.info("app.event", extra={"verification.reason": "example"})\n'
-        'logger.exception("app.failure")\n'
-    )
-    dependency = tmp_path / dependency_directory / "lib" / "vendor.py"
-    dependency.parent.mkdir(parents=True)
-    dependency.write_bytes(b'\xef\xbb\xbflogger.exception("vendor.failure")\n')
-    monkeypatch.setitem(globals(), "_PYTHON_TELEMETRY_ROOTS", (tmp_path,))
-
-    assert list(_application_python_files(tmp_path)) == [source]
-    assert _application_attribute_names() == ({"verification.reason"}, [])
-    assert _exception_log_events() == {"app.failure"}
-
-
-def _application_attribute_names() -> tuple[set[str], list[str]]:
-    attributes: set[str] = set()
-    unresolved: list[str] = []
-    log_methods = {"critical", "debug", "error", "exception", "info", "warning"}
-
-    for root in _PYTHON_TELEMETRY_ROOTS:
-        for path in _application_python_files(root):
-            tree = ast.parse(path.read_text())
-            bindings: dict[str, set[str]] = {}
-            log_aliases: set[str] = set()
-            for node in ast.walk(tree):
-                if isinstance(node, ast.AnnAssign):
-                    if isinstance(node.target, ast.Name):
-                        keys = _dict_keys(node.value, bindings)
-                        if keys is not None:
-                            bindings.setdefault(node.target.id, set()).update(keys)
-                    continue
-                if not isinstance(node, ast.Assign):
-                    continue
-                for target in node.targets:
-                    if isinstance(target, ast.Name):
-                        candidates = (
-                            (node.value.body, node.value.orelse)
-                            if isinstance(node.value, ast.IfExp)
-                            else (node.value,)
-                        )
-                        if any(
-                            isinstance(candidate, ast.Attribute)
-                            and candidate.attr in log_methods
-                            for candidate in candidates
-                        ):
-                            log_aliases.add(target.id)
-                        keys = _dict_keys(node.value, bindings)
-                        if keys is not None:
-                            bindings.setdefault(target.id, set()).update(keys)
-                    elif (
-                        isinstance(target, ast.Subscript)
-                        and isinstance(target.value, ast.Name)
-                        and isinstance(target.slice, ast.Constant)
-                        and isinstance(target.slice.value, str)
-                    ):
-                        bindings.setdefault(target.value.id, set()).add(
-                            target.slice.value
-                        )
-
-            for node in ast.walk(tree):
-                if not isinstance(node, ast.Call):
-                    continue
-
-                name = (
-                    node.func.attr
-                    if isinstance(node.func, ast.Attribute)
-                    else node.func.id
-                    if isinstance(node.func, ast.Name)
-                    else ""
-                )
-                extra_keywords = [
-                    keyword for keyword in node.keywords if keyword.arg == "extra"
-                ]
-                if name in log_methods or name in log_aliases:
-                    for keyword in extra_keywords:
-                        keys = _dict_keys(keyword.value, bindings)
-                        if keys is None:
-                            unresolved.append(f"{path}:{node.lineno}:log extra")
-                        else:
-                            attributes.update(keys)
-                elif name == "set_attribute" and node.args:
-                    attribute = node.args[0]
-                    if isinstance(attribute, ast.Constant) and isinstance(
-                        attribute.value, str
-                    ):
-                        attributes.add(attribute.value)
-                elif name == "set_attributes" and node.args:
-                    keys = _dict_keys(node.args[0], bindings)
-                    if keys is None:
-                        unresolved.append(f"{path}:{node.lineno}:span attributes")
-                    else:
-                        attributes.update(keys)
-                elif name == "add_event" and len(node.args) > 1:
-                    keys = _dict_keys(node.args[1], bindings)
-                    if keys is None:
-                        unresolved.append(f"{path}:{node.lineno}:span event")
-                    else:
-                        attributes.update(keys)
-                elif name in {"start_as_current_span", "start_span"}:
-                    for keyword in node.keywords:
-                        if keyword.arg == "attributes":
-                            keys = _dict_keys(keyword.value, bindings)
-                            if keys is None:
-                                unresolved.append(
-                                    f"{path}:{node.lineno}:span attributes"
-                                )
-                            else:
-                                attributes.update(keys)
-                elif name in {"add", "record"} and len(node.args) > 1:
-                    keys = _dict_keys(node.args[1], bindings)
-                    if keys is None:
-                        unresolved.append(f"{path}:{node.lineno}:metric attributes")
-                    else:
-                        attributes.update(keys)
-
-    return attributes, unresolved
-
-
-def _exception_log_events() -> set[str]:
-    events: set[str] = set()
-    for root in _PYTHON_TELEMETRY_ROOTS:
-        for path in _application_python_files(root):
-            tree = ast.parse(path.read_text())
-            for node in ast.walk(tree):
-                if (
-                    isinstance(node, ast.Call)
-                    and isinstance(node.func, ast.Attribute)
-                    and node.func.attr == "exception"
-                    and node.args
-                    and isinstance(node.args[0], ast.Constant)
-                    and isinstance(node.args[0].value, str)
-                ):
-                    events.add(node.args[0].value)
-    return events
-
-
 def test_every_alert_has_a_documented_signal_contract():
     monitoring = (_ROOT / "infra" / "monitoring.tf").read_text()
     runbook = (_ROOT / "docs" / "runbooks" / "alerts.md").read_text()
-
     scheduled_alerts = set(
         re.findall(
             r'resource "azurerm_monitor_scheduled_query_rules_alert_v2" "([^"]+)"',
@@ -319,7 +38,6 @@ def test_every_alert_has_a_documented_signal_contract():
         "verification_attempt_stuck",
         "schema_drift",
     }
-
     assert scheduled_alerts == expected
     assert "`availability`" in runbook
     for alert in expected:
@@ -329,7 +47,6 @@ def test_every_alert_has_a_documented_signal_contract():
 def test_telemetry_alert_uses_only_the_app_owned_setup_signal():
     monitoring = (_ROOT / "infra" / "monitoring.tf").read_text()
     block = _resource_block(monitoring, "api_telemetry_pipeline_failure")
-
     assert 'tostring(ParsedLog.event) == "telemetry.configure.failed"' in block
     assert "azure.monitor.opentelemetry.exporter" not in block
     assert "Envelopes could not be exported" not in block
@@ -339,154 +56,76 @@ def test_api_trace_sampling_policy_is_explicit_and_alert_logs_are_unsampled():
     container_app = (_ROOT / "infra" / "container-apps.tf").read_text()
     observability = (
         _ROOT
-        / "packages"
-        / "learn-to-cloud-shared"
-        / "src"
-        / "learn_to_cloud_shared"
-        / "core"
-        / "observability.py"
+        / "packages/learn-to-cloud-shared/src/learn_to_cloud_shared"
+        / "core/observability.py"
     ).read_text()
-
     assert 'name  = "OTEL_TRACES_SAMPLER"' in container_app
     assert 'value = "microsoft.rate_limited"' in container_app
     assert 'name  = "OTEL_TRACES_SAMPLER_ARG"' in container_app
     assert "enable_trace_based_sampling_for_logs=False" in observability
 
 
-def test_application_owned_attributes_match_the_canonical_schema():
-    emitted, unresolved = _application_attribute_names()
-
-    assert unresolved == []
-    assert emitted == _ALLOWED_APPLICATION_ATTRIBUTES
-    assert emitted.isdisjoint(_PROHIBITED_APPLICATION_ATTRIBUTES)
-
-
-def test_raw_exception_details_are_limited_to_application_boundaries():
-    assert _exception_log_events() == {
-        "init.failed",
-        "init.timeout",
-        "unhandled.exception",
-    }
-
-
-def test_application_code_does_not_explicitly_record_raw_span_exceptions():
-    calls: list[str] = []
-    for root in _PYTHON_TELEMETRY_ROOTS:
-        for path in _application_python_files(root):
-            tree = ast.parse(path.read_text())
-            for node in ast.walk(tree):
-                if (
-                    isinstance(node, ast.Call)
-                    and isinstance(node.func, ast.Attribute)
-                    and node.func.attr == "record_exception"
-                ):
-                    calls.append(f"{path}:{node.lineno}")
-
-    assert calls == []
-
-
-def test_frontend_telemetry_uses_only_bounded_properties():
-    script = (
-        _ROOT
-        / "api"
-        / "src"
-        / "learn_to_cloud"
-        / "static"
-        / "js"
-        / "frontend-telemetry.js"
-    ).read_text()
-    template = (
-        _ROOT / "api" / "src" / "learn_to_cloud" / "templates" / "base.html"
-    ).read_text()
-
-    assert "window.location.href" not in script
-    assert "window.location.pathname" not in script
-    assert "requestConfig.path" not in script
-    assert "data-telemetry-route" in template
-    assert "disableExceptionTracking: true" in template
-    assert "enableUnhandledPromiseRejectionTracking: false" in template
-    assert "delete baseData.refUri" in script
-    assert "'navigation.type'" in script
-    assert "'http.request.method'" in script
-    assert "'htmx.boosted'" in script
-    assert "navigationType" not in script
-    assert "statusCode" not in script
-    assert "htmx:responseError" not in script
-    assert "htmx:sendError" in script
-
-
-def test_frontend_initializer_removes_urls_and_tracks_same_route_navigation():
-    script = (
-        _ROOT
-        / "api"
-        / "src"
-        / "learn_to_cloud"
-        / "static"
-        / "js"
-        / "frontend-telemetry.js"
-    )
+def test_frontend_initializer_keeps_paths_without_query_credentials():
+    script = _ROOT / "api/src/learn_to_cloud/static/js/frontend-telemetry.js"
     test_script = f"""
-const fs = require('fs');
-const tracked = [];
+const calls = [];
 const listeners = {{}};
-let initializer = null;
-let marker = {{
-  getAttribute: () => '/phase/{{phase_slug}}'
+let initializer;
+global.document = {{
+  addEventListener: (name, callback) => {{ listeners[name] = callback; }}
 }};
 global.window = {{
   location: {{ origin: 'https://learntocloud.guide' }},
   appInsights: {{
-    addTelemetryInitializer: (value) => {{ initializer = value; }},
-    trackEvent: (value) => tracked.push(value),
-    trackPageView: (value) => tracked.push(value)
+    addTelemetryInitializer: value => {{ initializer = value; calls.push('init'); }},
+    loadAppInsights: () => calls.push('load'),
+    trackPageView: () => calls.push('page')
   }}
 }};
-global.document = {{
-  title: 'Phase',
-  querySelector: () => marker,
-  addEventListener: (name, callback) => {{ listeners[name] = callback; }}
-}};
-eval(fs.readFileSync({str(script)!r}, 'utf8'));
-const item = {{
-  baseType: 'PageviewData',
-  baseData: {{
-    uri: 'https://learntocloud.guide/phase/1?token=secret',
-    refUri: 'https://example.com/private?token=secret'
-  }}
-}};
-initializer(item);
-listeners['htmx:afterSettle']({{ detail: {{ boosted: true }} }});
+require({str(script)!r});
+const url = 'https://user:password@example.com/normal/path?token=secret#secret';
+const items = [
+  {{ baseType: 'PageviewData', baseData: {{ uri: url, refUri: url }} }},
+  {{ baseType: 'PageviewPerformanceData', baseData: {{ uri: url }} }},
+  {{ baseType: 'RemoteDependencyData',
+     baseData: {{ target: url, name: 'GET /normal/path?token=secret' }} }},
+  {{ baseType: 'ExceptionData',
+     data: {{ url, errorSrc: 'window.onerror@' + url }},
+     baseData: {{
+       properties: {{ url, errorSrc: 'window.onerror@' + url }},
+       exceptions: [{{ message: 'Script failed' }}]
+     }} }},
+  {{ baseType: 'EventData', baseData: {{ name: 'action' }} }}
+];
+items.forEach(initializer);
 listeners['htmx:afterSettle']({{ detail: {{ boosted: false }} }});
-marker = null;
+listeners['htmx:afterSettle']({{ detail: {{ boosted: true }} }});
 listeners['htmx:historyRestore']();
-console.log(JSON.stringify({{ item, tracked }}));
+console.log(JSON.stringify({{ items, calls }}));
 """
     result = subprocess.run(
-        ["node", "-e", test_script],
-        check=True,
-        capture_output=True,
-        text=True,
+        ["node", "-e", test_script], check=True, capture_output=True, text=True
     )
     payload = json.loads(result.stdout)
-
-    assert "refUri" not in payload["item"]["baseData"]
-    assert (
-        payload["item"]["baseData"]["uri"]
-        == "https://learntocloud.guide/phase/{phase_slug}"
-    )
-    assert [item["properties"]["navigation.type"] for item in payload["tracked"]] == [
-        "initial",
-        "htmx",
-        "history",
-    ]
-    assert payload["tracked"][2]["uri"] == "https://learntocloud.guide/unmatched"
+    assert payload["calls"] == ["init", "load", "page", "page", "page"]
+    page, performance, dependency, exception, event = payload["items"]
+    url = "https://example.com/normal/path"
+    assert page["baseData"] == {"uri": url, "refUri": url}
+    assert performance["baseData"]["uri"] == url
+    assert dependency["baseData"] == {"target": url, "name": "GET /normal/path"}
+    assert exception["baseData"]["properties"]["url"] == url
+    assert "errorSrc" not in exception["baseData"]["properties"]
+    assert exception["data"] == {"url": url}
+    assert exception["baseData"]["exceptions"] == [{"message": "Script failed"}]
+    assert event["baseData"]["name"] == "action"
+    assert "secret" not in result.stdout
+    assert "password" not in result.stdout
 
 
 def test_stuck_alert_uses_only_canonical_attributes():
     monitoring = (_ROOT / "infra" / "monitoring.tf").read_text()
     runbook = (_ROOT / "docs" / "runbooks" / "alerts.md").read_text()
     block = _resource_block(monitoring, "verification_attempt_stuck")
-
     for canonical in (
         "verification.durable.status",
         "verification.attempt.age_seconds",
@@ -494,7 +133,6 @@ def test_stuck_alert_uses_only_canonical_attributes():
     ):
         assert f'customDimensions["{canonical}"]' in block
         assert f'customDimensions["{canonical}"]' in runbook
-
     for historical in ("durable_status", "attempt_age_seconds", "stuck_reason"):
         assert f'customDimensions["{historical}"]' not in block
         assert f'customDimensions["{historical}"]' not in runbook

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -361,7 +361,7 @@ The shared package separates workflow configuration from execution:
 | `core.py` | Typed check callables, steps, results, contexts, and workflows. |
 | `checks/` | Focused adapters around domain validators and evidence collectors. |
 | `workflows.py` | Ordered steps, username requirements, and rubric configuration per submission type. |
-| `engine.py` | Ownership preflight, execution, evidence flow, aggregation, safe step telemetry, and grading preparation. |
+| `engine.py` | Ownership preflight, execution, evidence flow, aggregation, step tracing, and grading preparation. |
 | `execution.py` | Persisted message/result projection, not the engine core. |
 
 To add a check, define a public async function in a focused check module and
@@ -752,7 +752,32 @@ Session rejections use bounded reasons without exception details; expected
 expiry, unknown-session, and cutover outcomes are informational, not automatic
 compromise warnings. Ordinary anonymous access emits no event. Failed OAuth attempts do not clear an
 existing valid login or unrelated authorization state.
-See the [telemetry schema](observability/telemetry-schema.html).
+See [Telemetry](#telemetry).
+
+### Telemetry
+
+Use OpenTelemetry/Application Insights for requests, dependencies, timing,
+correlation and unexpected exception diagnostics. Add application events for
+meaningful actions and saved outcomes, not another copy of every SDK signal.
+There is no global field registry: keep fields useful and review them with the
+code. Preserve event names and fields used by alerts. Unique attempt IDs belong
+in logs/traces, not metric dimensions.
+
+Telemetry explains what happened; the database holds submitted values and
+feedback. Investigate using the operation ID and `verification.attempt.id`,
+then look up the database record when authorized. Not every fetched file or
+grading prompt is stored there; some failures need reproduction. Do not
+deliberately attach credentials, cookies, submitted bodies, evidence, or model
+prompts/results to logs or spans. SQL parameter hiding and small URL filters
+remain because OAuth/polling query values are credentials the SDK does not
+automatically remove. Normal paths and native exception details are useful;
+we do not guarantee redaction of public profile values or arbitrary error text.
+
+The browser SDK collects dependencies and errors without cookies or browser
+storage. Two HTMX hooks record page views because SDK history tracking counts
+HTMX's `replaceState` and `pushState` twice. Do not enable both approaches.
+Provider error classification still controls learner feedback and incomplete
+verification; it is not a reason to suppress unrelated programming errors.
 
 ## Conventions
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -779,10 +779,10 @@ HTMX's `replaceState` and `pushState` twice. Do not enable both approaches.
 Provider error classification still controls learner feedback and incomplete
 verification; it is not a reason to suppress unrelated programming errors.
 
-The API configures FastAPI instrumentation once for both Azure Monitor and local
-OTLP, excluding low-level ASGI receive/send spans while retaining request spans,
-metrics, dependencies and errors. Azure Monitor's automatic FastAPI setup is
-disabled because it does not forward that exclusion option.
+Azure Monitor owns FastAPI instrumentation in production. Local OTLP configures
+the same instrumentation explicitly with SDK defaults. Keep the default ASGI
+receive/send spans rather than replacing Azure Monitor's setup just to reduce
+trace noise.
 
 Local Functions send application logs directly through the existing OTLP
 handler, without forwarding the same records to the Functions host. The host

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -779,6 +779,19 @@ HTMX's `replaceState` and `pushState` twice. Do not enable both approaches.
 Provider error classification still controls learner feedback and incomplete
 verification; it is not a reason to suppress unrelated programming errors.
 
+The API configures FastAPI instrumentation once for both Azure Monitor and local
+OTLP, excluding low-level ASGI receive/send spans while retaining request spans,
+metrics, dependencies and errors. Azure Monitor's automatic FastAPI setup is
+disabled because it does not forward that exclusion option.
+
+Local Functions send application logs directly through the existing OTLP
+handler, without forwarding the same records to the Functions host. The host
+still collects framework logs. Leave `PYTHON_ENABLE_OPENTELEMETRY` unset:
+runtime 1.2.1 crashes async invocations with that flag
+([upstream issue](https://github.com/Azure/azure-functions-python-worker/issues/1881)).
+Production continues to use `PYTHON_APPLICATIONINSIGHTS_ENABLE_TELEMETRY=true`
+and its worker-owned Azure Monitor pipeline.
+
 ## Conventions
 
 - Async/await everywhere -- no sync database calls

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Architecture, contributor, and operations documentation for the
 - [Curriculum architecture](curriculum.html)
 - [Progression system](progression-system.html)
 - [Database migrations](migrations.html)
-- [Telemetry schema](observability/telemetry-schema.html)
+- [Telemetry](contributing.html#telemetry)
 - [Contributing](contributing.html)
 - [Authentication and sessions](contributing.html#authentication-and-sessions)
 - [GitHub Powering Your AI SDLC presentation](scaling-with-github/)

--- a/docs/runbooks/alerts.md
+++ b/docs/runbooks/alerts.md
@@ -4,6 +4,13 @@ These guides cover the first response to production alerts. Run queries in the
 Application Insights **Logs** blade unless a section says to use the Log
 Analytics workspace. Replace `dev` if the alert came from another environment.
 
+Start with the action or error, follow its operation/attempt ID through related
+telemetry, then use `verification.attempt.id` to look up the saved submission
+and feedback in the database when authorized. Do not duplicate those payloads
+in logs or public incident notes. Native URL paths and unexpected exception
+details are available; query credentials are removed from URL fields. See
+[Telemetry](../contributing.html#telemetry) for the collection boundaries.
+
 ## Signal contracts
 
 | Alert resource | Canonical source | Audit result |
@@ -209,7 +216,7 @@ requires a separately scoped retention decision, not an assumed timer.
 A persisted OAuth identity that differs from the validated provider identity is
 an application invariant failure. It should not commit or issue a new session;
 investigate it through the existing unhandled-exception guide above.
-See the [telemetry schema](../observability/telemetry-schema.html) for reason values.
+See [Authentication and sessions](../contributing.html#authentication-and-sessions).
 
 ## Ignored optional profile names and staged schema rollout
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
@@ -1,10 +1,9 @@
 """Single-pipeline Azure Monitor and OTLP configuration.
 
-The API calls this before constructing FastAPI. Azure Monitor owns FastAPI
-instrumentation in production; local OTLP configures it explicitly. HTTPX and
-SQLAlchemy remain application-owned because the Azure distro does not bundle
-those instrumentations. Verification Functions reuse only the dependency setup
-and their host-owned OTLP pipeline.
+The API configures FastAPI explicitly so both exporters omit ASGI internal
+spans. HTTPX and SQLAlchemy are also application-owned. Production Functions
+use the worker-owned Azure pipeline; local Functions export app logs directly
+to OTLP while the host owns framework logs.
 """
 
 from __future__ import annotations
@@ -20,6 +19,7 @@ from opentelemetry.trace import Span
 from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE
 
 logger = logging.getLogger(__name__)
+_OTLP_HANDLER_NAME = "learn_to_cloud.otlp"
 
 _telemetry_enabled: bool = False
 _dependency_tracing_enabled: bool = False
@@ -69,6 +69,8 @@ def _configure_azure_monitor(resource: Resource) -> None:
         enable_live_metrics=True,
         enable_trace_based_sampling_for_logs=False,
         logger_name=APP_LOGGER_NAMESPACE,
+        # The distro does not forward FastAPI's exclude_spans option.
+        instrumentation_options={"fastapi": {"enabled": False}},
         resource=resource,
     )
 
@@ -138,7 +140,9 @@ def _configure_otlp_exporters(
     log_provider = LoggerProvider(resource=resource)
     log_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter_cls()))
     set_logger_provider(log_provider)
-    logging.getLogger().addHandler(LoggingHandler(logger_provider=log_provider))
+    handler = LoggingHandler(logger_provider=log_provider)
+    handler.set_name(_OTLP_HANDLER_NAME)
+    logging.getLogger().addHandler(handler)
 
     from opentelemetry import metrics
     from opentelemetry.sdk.metrics import MeterProvider
@@ -179,14 +183,11 @@ def _configure_observability(*, allow_azure_monitor: bool) -> bool:
     )
     otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
     resource = _build_resource()
-    instrument_fastapi_for_otlp = False
-
     try:
         if conn_str:
             _configure_azure_monitor(resource)
         elif otlp_endpoint:
             _configure_otlp(resource)
-            instrument_fastapi_for_otlp = allow_azure_monitor
         else:
             logger.error(
                 "telemetry.configure.failed",
@@ -203,14 +204,14 @@ def _configure_observability(*, allow_azure_monitor: bool) -> bool:
         return False
 
     _telemetry_enabled = True
-    if instrument_fastapi_for_otlp:
+    if allow_azure_monitor:
         configure_fastapi_instrumentation()
     configure_dependency_instrumentation()
     return True
 
 
 def configure_fastapi_instrumentation() -> bool:
-    """Instrument FastAPI when the Azure Monitor distro is not active."""
+    """Instrument requests without low-level ASGI receive/send spans."""
     global _fastapi_instrumented
 
     if _fastapi_instrumented:
@@ -219,7 +220,7 @@ def configure_fastapi_instrumentation() -> bool:
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
     try:
-        FastAPIInstrumentor().instrument()
+        FastAPIInstrumentor().instrument(exclude_spans=["receive", "send"])
     except Exception as exc:
         logger.warning(
             "telemetry.fastapi.failed",
@@ -261,8 +262,19 @@ def configure_observability() -> bool:
 
 
 def configure_otlp_observability() -> bool:
-    """Set up OTLP without adding an application-owned Azure exporter."""
-    return _configure_observability(allow_azure_monitor=False)
+    """Export Functions app logs once, without forwarding them to the host."""
+    if not _configure_observability(allow_azure_monitor=False):
+        return False
+
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        if handler.get_name() == _OTLP_HANDLER_NAME:
+            for name in (APP_LOGGER_NAMESPACE, "learn_to_cloud_shared"):
+                app_logger = logging.getLogger(name)
+                app_logger.addHandler(handler)
+                app_logger.propagate = False
+            root.removeHandler(handler)
+    return True
 
 
 def instrument_database(engine: Any) -> None:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any
-from urllib.parse import urlsplit
 
-from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor, RequestInfo
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.trace import Span
 
 from learn_to_cloud_shared.core.logger import APP_LOGGER_NAMESPACE
 
@@ -27,42 +27,17 @@ _fastapi_instrumented: bool = False
 _httpx_instrumented: bool = False
 
 
-def _httpx_origin(request: Any) -> str:
-    url = request.url
-    if isinstance(url, tuple):
-        scheme, host, port, _ = url
-        scheme_text = scheme.decode() if isinstance(scheme, bytes) else scheme
-        host_text = host.decode() if isinstance(host, bytes) else host
-        return (
-            f"{scheme_text}://{host_text}:{port}"
-            if port is not None
-            else f"{scheme_text}://{host_text}"
-        )
-
-    parsed = urlsplit(str(url))
-    host = parsed.hostname or ""
-    if ":" in host:
-        host = f"[{host}]"
-    return (
-        f"{parsed.scheme}://{host}:{parsed.port}"
-        if parsed.port is not None
-        else f"{parsed.scheme}://{host}"
-    )
-
-
-def _sanitize_httpx_span(span: Any, request: Any) -> None:
+def _sanitize_httpx_span(span: Span, request: RequestInfo) -> None:
     if not span.is_recording():
         return
 
-    origin = _httpx_origin(request)
-    span.set_attribute("http.target", "/")
-    span.set_attribute("http.url", origin)
-    span.set_attribute("url.full", origin)
-    span.set_attribute("url.path", "/")
+    url = request.url.copy_with(username="", password="", query=None, fragment=None)
+    span.set_attribute("http.url", str(url))
+    span.set_attribute("url.full", str(url))
     span.set_attribute("url.query", "")
 
 
-async def _sanitize_async_httpx_span(span: Any, request: Any) -> None:
+async def _sanitize_async_httpx_span(span: Span, request: RequestInfo) -> None:
     _sanitize_httpx_span(span, request)
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/core/observability.py
@@ -1,9 +1,9 @@
 """Single-pipeline Azure Monitor and OTLP configuration.
 
-The API configures FastAPI explicitly so both exporters omit ASGI internal
-spans. HTTPX and SQLAlchemy are also application-owned. Production Functions
-use the worker-owned Azure pipeline; local Functions export app logs directly
-to OTLP while the host owns framework logs.
+Azure Monitor owns FastAPI instrumentation in production; local OTLP configures
+it explicitly with SDK defaults. HTTPX and SQLAlchemy are application-owned.
+Production Functions use the worker-owned Azure pipeline; local Functions export
+app logs directly to OTLP while the host owns framework logs.
 """
 
 from __future__ import annotations
@@ -69,8 +69,6 @@ def _configure_azure_monitor(resource: Resource) -> None:
         enable_live_metrics=True,
         enable_trace_based_sampling_for_logs=False,
         logger_name=APP_LOGGER_NAMESPACE,
-        # The distro does not forward FastAPI's exclude_spans option.
-        instrumentation_options={"fastapi": {"enabled": False}},
         resource=resource,
     )
 
@@ -183,11 +181,14 @@ def _configure_observability(*, allow_azure_monitor: bool) -> bool:
     )
     otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
     resource = _build_resource()
+    instrument_fastapi_for_otlp = False
+
     try:
         if conn_str:
             _configure_azure_monitor(resource)
         elif otlp_endpoint:
             _configure_otlp(resource)
+            instrument_fastapi_for_otlp = allow_azure_monitor
         else:
             logger.error(
                 "telemetry.configure.failed",
@@ -204,14 +205,14 @@ def _configure_observability(*, allow_azure_monitor: bool) -> bool:
         return False
 
     _telemetry_enabled = True
-    if allow_azure_monitor:
+    if instrument_fastapi_for_otlp:
         configure_fastapi_instrumentation()
     configure_dependency_instrumentation()
     return True
 
 
 def configure_fastapi_instrumentation() -> bool:
-    """Instrument requests without low-level ASGI receive/send spans."""
+    """Instrument FastAPI when the Azure Monitor distro is not active."""
     global _fastapi_instrumented
 
     if _fastapi_instrumented:
@@ -220,7 +221,7 @@ def configure_fastapi_instrumentation() -> bool:
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
     try:
-        FastAPIInstrumentor().instrument(exclude_spans=["receive", "send"])
+        FastAPIInstrumentor().instrument()
     except Exception as exc:
         logger.warning(
             "telemetry.fastapi.failed",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -1,4 +1,4 @@
-"""Execute verification workflows, record safe telemetry, and prepare grading."""
+"""Execute verification workflows, trace steps, and prepare grading."""
 
 from __future__ import annotations
 
@@ -211,13 +211,6 @@ def _step_result_state(result: StepResult) -> str:
     return "failed"
 
 
-def _record_step_error(span: trace.Span, exc: Exception) -> None:
-    """Mark unexpected failures without exporting exception details."""
-    span.set_attribute("verification.step.result", "error")
-    span.set_attribute("error.type", type(exc).__name__)
-    span.set_status(Status(StatusCode.ERROR))
-
-
 async def _run_step(step: Step, context: StepContext) -> StepResult:
     with _tracer.start_as_current_span(
         "verification.step",
@@ -225,8 +218,6 @@ async def _run_step(step: Step, context: StepContext) -> StepResult:
             "verification.check.name": step.name,
             "verification.task.id": step.task_id,
         },
-        record_exception=False,
-        set_status_on_exception=False,
     ) as span:
         try:
             result = await step.check(context)
@@ -242,10 +233,6 @@ async def _run_step(step: Step, context: StepContext) -> StepResult:
                 stop_on_fail=True,
                 validation_result=exc.to_validation_result(),
             )
-        except Exception as exc:
-            _record_step_error(span, exc)
-            raise
-
         result_state = _step_result_state(result)
         span.set_attribute("verification.step.result", result_state)
         if result_state == "unavailable":
@@ -302,14 +289,8 @@ async def run_verification(
         with _tracer.start_as_current_span(
             "verification.step",
             attributes={"verification.check.name": "github_repository_ownership"},
-            record_exception=False,
-            set_status_on_exception=False,
         ) as span:
-            try:
-                ownership = await check_repository_ownership(target, job.user_id)
-            except Exception as exc:
-                _record_step_error(span, exc)
-                raise
+            ownership = await check_repository_ownership(target, job.user_id)
             if isinstance(ownership, ValidationResult):
                 span.set_attribute(
                     "verification.step.result",

--- a/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_verification_attempt_executor.py
@@ -180,9 +180,11 @@ async def test_prepare_rejects_reconstructed_attempt(
         await prepare_verification_attempt(attempt.id, session_maker=session_maker)
 
 
+@pytest.mark.parametrize("passed", [False, True])
 async def test_finalize_is_compare_and_set_idempotent(
     session_maker: async_sessionmaker[AsyncSession],
     caplog: pytest.LogCaptureFixture,
+    passed: bool,
 ) -> None:
     attempt = await _create_attempt(session_maker)
     preparation = await prepare_verification_attempt(
@@ -191,8 +193,15 @@ async def test_finalize_is_compare_and_set_idempotent(
     run_result = VerificationRunResult(
         attempt=preparation.attempt,
         validation_result=ValidationResult(
-            is_valid=True,
-            message="Verified.",
+            is_valid=passed,
+            message="Submission validation details",
+            task_results=[
+                TaskResult(
+                    task_name="Check",
+                    passed=passed,
+                    feedback="Submission feedback sentinel",
+                )
+            ],
         ),
     )
 
@@ -209,8 +218,9 @@ async def test_finalize_is_compare_and_set_idempotent(
 
     assert first.won is True
     assert second.won is False
-    assert first.state.outcome == "succeeded"
-    assert second.state.outcome == "succeeded"
+    outcome = "succeeded" if passed else "failed"
+    assert first.state.outcome == outcome
+    assert second.state.outcome == outcome
     assert first.state.completed_at == second.state.completed_at
     records = [
         record
@@ -219,7 +229,15 @@ async def test_finalize_is_compare_and_set_idempotent(
     ]
     assert len(records) == 1
     assert records[0].__dict__["verification.attempt.id"] == str(attempt.id)
-    assert records[0].__dict__["verification.outcome"] == "succeeded"
+    assert records[0].__dict__["verification.outcome"] == outcome
+    async with session_maker() as db:
+        stored = await db.get(VerificationAttempt, attempt.id)
+        assert stored.submitted_value == attempt.submitted_value
+        assert stored.feedback_json[0]["feedback"] == "Submission feedback sentinel"
+    telemetry = str([vars(record) for record in records])
+    assert attempt.submitted_value not in telemetry
+    assert "Submission feedback sentinel" not in telemetry
+    assert "Submission validation details" not in telemetry
 
 
 async def test_finalize_persists_structured_criterion_feedback(

--- a/packages/learn-to-cloud-shared/tests/test_observability.py
+++ b/packages/learn-to-cloud-shared/tests/test_observability.py
@@ -3,8 +3,14 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
+import httpx
 import pytest
+from opentelemetry.instrumentation.httpx import AsyncOpenTelemetryTransport, RequestInfo
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 
 from learn_to_cloud_shared.core import observability
 
@@ -476,20 +482,66 @@ def test_httpx_instrumentation_is_process_wide_and_idempotent():
 
 
 @pytest.mark.unit
-def test_httpx_hook_keeps_only_dependency_origin():
+def test_httpx_hook_preserves_dependency_path_without_credentials():
     span = MagicMock()
     span.is_recording.return_value = True
-    request = SimpleNamespace(url="https://api.example.com/users/123?token=sensitive")
+    request = RequestInfo(
+        b"GET",
+        httpx.URL(
+            "https://user:password@api.example.com/users/123?token=sensitive#secret"
+        ),
+        None,
+        None,
+        None,
+    )
 
     observability._sanitize_httpx_span(span, request)
 
     assert span.set_attribute.call_args_list == [
-        call("http.target", "/"),
-        call("http.url", "https://api.example.com"),
-        call("url.full", "https://api.example.com"),
-        call("url.path", "/"),
+        call("http.url", "https://api.example.com/users/123"),
+        call("url.full", "https://api.example.com/users/123"),
         call("url.query", ""),
     ]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("failed", [False, True])
+async def test_httpx_exports_native_dependency_without_query_credentials(failed):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    def respond(request):
+        assert request.url.params["token"] == "query-credential-sentinel"
+        if failed:
+            raise httpx.ConnectError("Connection failed", request=request)
+        return httpx.Response(200)
+
+    transport = AsyncOpenTelemetryTransport(
+        httpx.MockTransport(respond),
+        tracer_provider=provider,
+        request_hook=observability._sanitize_async_httpx_span,
+    )
+    try:
+        async with httpx.AsyncClient(transport=transport) as client:
+            url = "https://example.com/users/123?token=query-credential-sentinel"
+            if failed:
+                with pytest.raises(httpx.ConnectError, match="Connection failed"):
+                    await client.get(url)
+            else:
+                assert (await client.get(url)).status_code == 200
+        (span,) = exporter.get_finished_spans()
+        assert span.name == "GET"
+        assert span.attributes["url.full"] == "https://example.com/users/123"
+        assert span.end_time >= span.start_time
+        assert "query-credential-sentinel" not in span.to_json()
+        assert span.status.status_code == (
+            StatusCode.ERROR if failed else StatusCode.UNSET
+        )
+        if failed:
+            assert any(event.name == "exception" for event in span.events)
+    finally:
+        provider.shutdown()
 
 
 @pytest.mark.unit

--- a/packages/learn-to-cloud-shared/tests/test_observability.py
+++ b/packages/learn-to-cloud-shared/tests/test_observability.py
@@ -1,11 +1,19 @@
 """Unit tests for observability instrumentation helpers."""
 
+import logging
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import httpx
 import pytest
 from opentelemetry.instrumentation.httpx import AsyncOpenTelemetryTransport, RequestInfo
+from opentelemetry.instrumentation.logging.handler import LoggingHandler
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import (
+    InMemoryLogRecordExporter,
+    SimpleLogRecordProcessor,
+)
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -148,7 +156,9 @@ def test_configure_observability_uses_azure_monitor_when_connection_string_set()
         request_hook=observability._sanitize_httpx_span,
         async_request_hook=observability._sanitize_async_httpx_span,
     )
-    fastapi_instrumentor.assert_not_called()
+    fastapi_instrumentor.return_value.instrument.assert_called_once_with(
+        exclude_spans=["receive", "send"]
+    )
     assert observability._telemetry_enabled is True
     assert configured is True
 
@@ -185,7 +195,9 @@ def test_configure_observability_uses_otlp_when_endpoint_set():
         request_hook=observability._sanitize_httpx_span,
         async_request_hook=observability._sanitize_async_httpx_span,
     )
-    fastapi_instrumentor.return_value.instrument.assert_called_once_with()
+    fastapi_instrumentor.return_value.instrument.assert_called_once_with(
+        exclude_spans=["receive", "send"]
+    )
     assert observability._telemetry_enabled is True
     assert configured is True
 
@@ -318,7 +330,7 @@ def test_configure_observability_noops_when_already_enabled():
 
 
 @pytest.mark.unit
-def test_configure_azure_monitor_uses_distro_instrumentation_defaults():
+def test_configure_azure_monitor_leaves_fastapi_to_the_application():
     resource = observability._build_resource()
     with patch(
         "azure.monitor.opentelemetry.configure_azure_monitor"
@@ -330,8 +342,159 @@ def test_configure_azure_monitor_uses_distro_instrumentation_defaults():
     assert kwargs["enable_live_metrics"] is True
     assert kwargs["enable_trace_based_sampling_for_logs"] is False
     assert kwargs["logger_name"] == "learn_to_cloud"
-    assert "instrumentation_options" not in kwargs
+    assert kwargs["instrumentation_options"] == {"fastapi": {"enabled": False}}
     assert kwargs["resource"] is resource
+
+
+@pytest.mark.unit
+def test_local_functions_export_app_logs_once_without_host_forwarding():
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    app_loggers = [
+        logging.getLogger(name) for name in ("learn_to_cloud", "learn_to_cloud_shared")
+    ]
+    original_loggers = [
+        (logger, logger.handlers[:], logger.propagate, logger.level)
+        for logger in app_loggers
+    ]
+    exporter = InMemoryLogRecordExporter()
+    provider = LoggerProvider()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+    handler = LoggingHandler(logger_provider=provider)
+    handler.set_name(observability._OTLP_HANDLER_NAME)
+    host_handler = MagicMock(spec=logging.Handler)
+    host_handler.level = logging.NOTSET
+    root.handlers = [handler, host_handler]
+    try:
+        with patch.object(observability, "_configure_observability", return_value=True):
+            assert observability.configure_otlp_observability() is True
+            assert observability.configure_otlp_observability() is True
+
+        for app_logger in app_loggers:
+            app_logger.setLevel(logging.INFO)
+            logging.getLogger(f"{app_logger.name}.verification").info(
+                "verification.attempt.completed",
+                extra={"verification.attempt.id": "attempt-probe"},
+            )
+
+        records = exporter.get_finished_logs()
+        assert len(records) == 2
+        for record in records:
+            assert record.log_record.body == "verification.attempt.completed"
+            assert record.log_record.attributes["verification.attempt.id"] == (
+                "attempt-probe"
+            )
+        host_handler.handle.assert_not_called()
+        logging.getLogger("azure.functions").warning("framework-probe")
+        host_handler.handle.assert_called_once()
+        assert host_handler.handle.call_args.args[0].getMessage() == "framework-probe"
+        assert root.handlers == [host_handler]
+    finally:
+        root.handlers = original_handlers
+        for app_logger, handlers, propagate, level in original_loggers:
+            app_logger.handlers = handlers
+            app_logger.propagate = propagate
+            app_logger.setLevel(level)
+        provider.shutdown()
+
+
+@pytest.mark.unit
+def test_failed_local_setup_does_not_change_log_routing():
+    root = logging.getLogger()
+    handlers = root.handlers[:]
+    app_logger = logging.getLogger("learn_to_cloud")
+    propagation = app_logger.propagate
+    with patch.object(observability, "_configure_observability", return_value=False):
+        assert observability.configure_otlp_observability() is False
+    assert root.handlers == handlers
+    assert app_logger.propagate is propagation
+
+
+@pytest.mark.unit
+def test_fastapi_instrumentation_is_process_wide_and_idempotent():
+    with patch(
+        "opentelemetry.instrumentation.fastapi.FastAPIInstrumentor"
+    ) as instrumentor:
+        assert observability.configure_fastapi_instrumentation() is True
+        assert observability.configure_fastapi_instrumentation() is True
+    instrumentor.return_value.instrument.assert_called_once_with(
+        exclude_spans=["receive", "send"]
+    )
+
+
+@pytest.mark.unit
+async def test_fastapi_keeps_request_errors_and_metrics_without_asgi_spans():
+    import fastapi
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+    from opentelemetry.trace import SpanKind
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    reader = InMemoryMetricReader()
+    meters = MeterProvider(metric_readers=[reader])
+    instrumentor = FastAPIInstrumentor()
+    try:
+        with patch.object(
+            instrumentor,
+            "instrument",
+            side_effect=partial(
+                instrumentor.instrument,
+                tracer_provider=provider,
+                meter_provider=meters,
+            ),
+        ):
+            assert observability.configure_fastapi_instrumentation() is True
+        app = fastapi.FastAPI()
+
+        @app.post("/probe/{probe_id}")
+        async def probe(probe_id: str, request: fastapi.Request):
+            body = await request.body()
+            if probe_id == "error":
+                raise RuntimeError("Native request failure")
+            return {"bytes": len(body)}
+
+        transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            assert (await client.post("/probe/ok", content="body")).status_code == 200
+            assert (await client.post("/probe/error", content="body")).status_code == (
+                500
+            )
+
+        success, failure = exporter.get_finished_spans()
+        for span in (success, failure):
+            assert span.kind == SpanKind.SERVER
+            assert span.name == "POST /probe/{probe_id}"
+            assert span.end_time >= span.start_time
+        assert success.status.status_code == StatusCode.UNSET
+        assert failure.status.status_code == StatusCode.ERROR
+        assert any(
+            event.name == "exception"
+            and event.attributes["exception.type"] == "RuntimeError"
+            and event.attributes["exception.stacktrace"]
+            for event in failure.events
+        )
+        data = reader.get_metrics_data()
+        durations = [
+            point
+            for resource in data.resource_metrics
+            for scope in resource.scope_metrics
+            for metric in scope.metrics
+            if metric.name == "http.server.duration"
+            for point in metric.data.data_points
+        ]
+        assert sum(point.count for point in durations) == 2
+        assert {point.attributes["http.target"] for point in durations} == {
+            "/probe/{probe_id}"
+        }
+    finally:
+        instrumentor.uninstrument()
+        provider.shutdown()
+        meters.shutdown()
 
 
 @pytest.mark.unit

--- a/packages/learn-to-cloud-shared/tests/test_observability.py
+++ b/packages/learn-to-cloud-shared/tests/test_observability.py
@@ -1,7 +1,6 @@
 """Unit tests for observability instrumentation helpers."""
 
 import logging
-from functools import partial
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
@@ -125,12 +124,18 @@ def test_build_resource_maps_function_instance_identity():
 
 
 @pytest.mark.unit
-def test_configure_observability_uses_azure_monitor_when_connection_string_set():
+@pytest.mark.parametrize("otlp_endpoint", ["", "http://localhost:4317"])
+def test_configure_observability_uses_azure_monitor_when_connection_string_set(
+    otlp_endpoint,
+):
     resource = MagicMock(spec=Resource)
     with (
         patch.dict(
             "os.environ",
-            {"APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test"},
+            {
+                "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": otlp_endpoint,
+            },
             clear=True,
         ),
         patch(
@@ -156,9 +161,7 @@ def test_configure_observability_uses_azure_monitor_when_connection_string_set()
         request_hook=observability._sanitize_httpx_span,
         async_request_hook=observability._sanitize_async_httpx_span,
     )
-    fastapi_instrumentor.return_value.instrument.assert_called_once_with(
-        exclude_spans=["receive", "send"]
-    )
+    fastapi_instrumentor.assert_not_called()
     assert observability._telemetry_enabled is True
     assert configured is True
 
@@ -195,9 +198,7 @@ def test_configure_observability_uses_otlp_when_endpoint_set():
         request_hook=observability._sanitize_httpx_span,
         async_request_hook=observability._sanitize_async_httpx_span,
     )
-    fastapi_instrumentor.return_value.instrument.assert_called_once_with(
-        exclude_spans=["receive", "send"]
-    )
+    fastapi_instrumentor.return_value.instrument.assert_called_once_with()
     assert observability._telemetry_enabled is True
     assert configured is True
 
@@ -330,7 +331,7 @@ def test_configure_observability_noops_when_already_enabled():
 
 
 @pytest.mark.unit
-def test_configure_azure_monitor_leaves_fastapi_to_the_application():
+def test_configure_azure_monitor_uses_distro_instrumentation_defaults():
     resource = observability._build_resource()
     with patch(
         "azure.monitor.opentelemetry.configure_azure_monitor"
@@ -342,7 +343,7 @@ def test_configure_azure_monitor_leaves_fastapi_to_the_application():
     assert kwargs["enable_live_metrics"] is True
     assert kwargs["enable_trace_based_sampling_for_logs"] is False
     assert kwargs["logger_name"] == "learn_to_cloud"
-    assert kwargs["instrumentation_options"] == {"fastapi": {"enabled": False}}
+    assert "instrumentation_options" not in kwargs
     assert kwargs["resource"] is resource
 
 
@@ -417,84 +418,7 @@ def test_fastapi_instrumentation_is_process_wide_and_idempotent():
     ) as instrumentor:
         assert observability.configure_fastapi_instrumentation() is True
         assert observability.configure_fastapi_instrumentation() is True
-    instrumentor.return_value.instrument.assert_called_once_with(
-        exclude_spans=["receive", "send"]
-    )
-
-
-@pytest.mark.unit
-async def test_fastapi_keeps_request_errors_and_metrics_without_asgi_spans():
-    import fastapi
-    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-    from opentelemetry.sdk.metrics import MeterProvider
-    from opentelemetry.sdk.metrics.export import InMemoryMetricReader
-    from opentelemetry.trace import SpanKind
-
-    exporter = InMemorySpanExporter()
-    provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
-    reader = InMemoryMetricReader()
-    meters = MeterProvider(metric_readers=[reader])
-    instrumentor = FastAPIInstrumentor()
-    try:
-        with patch.object(
-            instrumentor,
-            "instrument",
-            side_effect=partial(
-                instrumentor.instrument,
-                tracer_provider=provider,
-                meter_provider=meters,
-            ),
-        ):
-            assert observability.configure_fastapi_instrumentation() is True
-        app = fastapi.FastAPI()
-
-        @app.post("/probe/{probe_id}")
-        async def probe(probe_id: str, request: fastapi.Request):
-            body = await request.body()
-            if probe_id == "error":
-                raise RuntimeError("Native request failure")
-            return {"bytes": len(body)}
-
-        transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
-        async with httpx.AsyncClient(
-            transport=transport, base_url="http://testserver"
-        ) as client:
-            assert (await client.post("/probe/ok", content="body")).status_code == 200
-            assert (await client.post("/probe/error", content="body")).status_code == (
-                500
-            )
-
-        success, failure = exporter.get_finished_spans()
-        for span in (success, failure):
-            assert span.kind == SpanKind.SERVER
-            assert span.name == "POST /probe/{probe_id}"
-            assert span.end_time >= span.start_time
-        assert success.status.status_code == StatusCode.UNSET
-        assert failure.status.status_code == StatusCode.ERROR
-        assert any(
-            event.name == "exception"
-            and event.attributes["exception.type"] == "RuntimeError"
-            and event.attributes["exception.stacktrace"]
-            for event in failure.events
-        )
-        data = reader.get_metrics_data()
-        durations = [
-            point
-            for resource in data.resource_metrics
-            for scope in resource.scope_metrics
-            for metric in scope.metrics
-            if metric.name == "http.server.duration"
-            for point in metric.data.data_points
-        ]
-        assert sum(point.count for point in durations) == 2
-        assert {point.attributes["http.target"] for point in durations} == {
-            "/probe/{probe_id}"
-        }
-    finally:
-        instrumentor.uninstrument()
-        provider.shutdown()
-        meters.shutdown()
+    instrumentor.return_value.instrument.assert_called_once_with()
 
 
 @pytest.mark.unit

--- a/packages/learn-to-cloud-shared/tests/verification/test_engine.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_engine.py
@@ -118,6 +118,24 @@ class _Tracer:
         return span
 
 
+@pytest.fixture
+def step_spans(monkeypatch):
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(
+        engine_module, "_tracer", provider.get_tracer(engine_module.__name__)
+    )
+    yield exporter
+    provider.shutdown()
+
+
 def _job(requirement=None) -> PreparedVerificationAttempt:
     requirement = requirement or repo_fork_requirement()
     return PreparedVerificationAttempt(
@@ -193,42 +211,40 @@ async def test_run_verification_uses_declared_steps(monkeypatch):
         "verification.check.name": "github_repository_ownership",
         "verification.step.result": "passed",
     }
-    name, span, options = tracer.spans[-1]
+    name, span, _ = tracer.spans[-1]
     assert name == "verification.step"
     assert span.attributes == {
         "verification.check.name": "test_gate_pass",
         "verification.task.id": "gate",
         "verification.step.result": "passed",
     }
-    assert options["record_exception"] is False
-    assert options["set_status_on_exception"] is False
 
 
 @pytest.mark.asyncio
-async def test_step_span_records_error_type_without_exception_details(monkeypatch):
+async def test_step_span_records_native_exception(monkeypatch, step_spans):
     async def _explode(context: StepContext) -> StepResult:
-        raise RuntimeError("sensitive failure details")
+        raise RuntimeError("Unexpected step failure")
 
     monkeypatch.setattr(
         engine_module,
         "workflow_for",
         lambda _t: _workflow(_step(_explode, "explode", name="exploding")),
     )
-    tracer = _Tracer()
-    monkeypatch.setattr(engine_module, "_tracer", tracer)
-
-    with pytest.raises(RuntimeError, match="sensitive failure details"):
+    with pytest.raises(RuntimeError, match="Unexpected step failure"):
         await run_verification(_job())
 
-    _, span, _ = tracer.spans[-1]
+    span = step_spans.get_finished_spans()[-1]
     assert span.attributes == {
         "verification.check.name": "exploding",
         "verification.task.id": "explode",
-        "verification.step.result": "error",
-        "error.type": "RuntimeError",
     }
     assert span.status is not None
     assert span.status.status_code is StatusCode.ERROR
+    (event,) = span.events
+    assert event.name == "exception"
+    assert event.attributes["exception.type"] == "RuntimeError"
+    assert event.attributes["exception.message"] == "Unexpected step failure"
+    assert "_explode" in event.attributes["exception.stacktrace"]
 
 
 @pytest.mark.asyncio
@@ -560,23 +576,11 @@ async def test_ownership_exports_bounded_telemetry(
 
 
 @pytest.mark.parametrize("error_type", [RuntimeError, asyncio.CancelledError])
-async def test_ownership_exception_exports_only_safe_error_state(
-    monkeypatch, repository_metadata, caplog, error_type
+async def test_ownership_failure_keeps_native_diagnostics_and_correlation(
+    monkeypatch, repository_metadata, caplog, error_type, step_spans
 ):
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
-        InMemorySpanExporter,
-    )
-
-    exporter = InMemorySpanExporter()
-    provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
-    tracer = provider.get_tracer(engine_module.__name__)
-    monkeypatch.setattr(engine_module, "_tracer", tracer)
-    error = error_type(
-        "private-provider-body private-token https://github.com/private-owner/private-repo"
-    )
+    tracer = engine_module._tracer
+    error = error_type("Repository metadata parser failed")
 
     async def fail_lookup(*_args):
         raise error
@@ -591,62 +595,43 @@ async def test_ownership_exception_exports_only_safe_error_state(
     monkeypatch.setattr(engine_module, "record_evidence_decision", evidence_decision)
     job = _job()
 
-    try:
-        with (
-            caplog.at_level(logging.INFO),
-            tracer.start_as_current_span(
-                "verification.attempt",
-                attributes={"verification.attempt.id": str(job.id)},
-                record_exception=False,
-                set_status_on_exception=False,
-            ),
-            pytest.raises(error_type) as raised,
-        ):
-            await run_verification(job)
+    with (
+        caplog.at_level(logging.INFO),
+        tracer.start_as_current_span(
+            "verification.attempt",
+            attributes={"verification.attempt.id": str(job.id)},
+        ),
+        pytest.raises(error_type) as raised,
+    ):
+        await run_verification(job)
 
-        assert raised.value is error
-        assert "fail_lookup" in {
-            frame.name for frame in traceback.extract_tb(raised.value.__traceback__)
-        }
-        lookup.assert_awaited_once_with(job.target.owner, job.target.repo)
-        step.assert_not_awaited()
-        counter.add.assert_not_called()
-        evidence_decision.assert_not_called()
-        ownership_span, attempt_span = exporter.get_finished_spans()
-        assert ownership_span.name == "verification.step"
-        assert ownership_span.instrumentation_scope.name == engine_module.__name__
-        assert ownership_span.parent.span_id == attempt_span.context.span_id
-        assert ownership_span.context.trace_id == attempt_span.context.trace_id
-        assert attempt_span.attributes["verification.attempt.id"] == str(job.id)
-        expected_attributes = {
-            "verification.check.name": "github_repository_ownership",
-        }
-        if error_type is RuntimeError:
-            expected_attributes.update(
-                {"verification.step.result": "error", "error.type": "RuntimeError"}
-            )
-        assert dict(ownership_span.attributes) == expected_attributes
-        assert ownership_span.status.status_code is (
-            StatusCode.ERROR if error_type is RuntimeError else StatusCode.UNSET
-        )
-        exported = caplog.text
-        for span in (ownership_span, attempt_span):
-            assert span.status.description is None
-            assert not span.events
-            exported += span.to_json()
-        for sentinel in (
-            "private-provider-body",
-            "private-token",
-            "private-owner",
-            "private-repo",
-            "exception.message",
-            "exception.stacktrace",
-            "verification.evidence.assembled",
-            "verification.attempt.completed",
-        ):
-            assert sentinel not in exported
-    finally:
-        provider.shutdown()
+    assert raised.value is error
+    assert "fail_lookup" in {
+        frame.name for frame in traceback.extract_tb(raised.value.__traceback__)
+    }
+    lookup.assert_awaited_once_with(job.target.owner, job.target.repo)
+    step.assert_not_awaited()
+    counter.add.assert_not_called()
+    evidence_decision.assert_not_called()
+    ownership_span, attempt_span = step_spans.get_finished_spans()
+    assert ownership_span.name == "verification.step"
+    assert ownership_span.parent.span_id == attempt_span.context.span_id
+    assert ownership_span.context.trace_id == attempt_span.context.trace_id
+    assert attempt_span.attributes["verification.attempt.id"] == str(job.id)
+    assert ownership_span.attributes["verification.check.name"] == (
+        "github_repository_ownership"
+    )
+    assert ownership_span.status.status_code == (
+        StatusCode.ERROR if error_type is RuntimeError else StatusCode.UNSET
+    )
+    if error_type is RuntimeError:
+        (event,) = ownership_span.events
+        assert event.attributes["exception.message"] == str(error)
+        assert "fail_lookup" in event.attributes["exception.stacktrace"]
+    else:
+        assert not ownership_span.events
+    assert not attempt_span.events
+    assert "verification.attempt.completed" not in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Use OpenTelemetry and Application Insights for requests, dependencies, timing, correlation, and ordinary errors. Application events describe actions and outcomes; maintainers use attempt IDs to look up submission details in the database.

Removes the global telemetry field scanner, custom route reconstruction, origin-only dependency URLs, and blanket exception suppression. Restores native browser request/error collection. Keeps small credential/query filters, hidden SQL parameters, and browser cookies/storage disabled. Two small HTMX page-view hooks remain because SDK history tracking double-counts navigation.

Updates existing contributor, troubleshooting, privacy, FAQ, and account wording without adding a review document or changing retention, deletion, authentication, or infrastructure behavior.

Verified the full quality gate, fresh API startup, and actual browser SDK telemetry, including navigation counts and synthetic credential exclusions.

Addresses #843.

The live-audit follow-up keeps local Functions application logs on one export path instead of also forwarding them to the host. Azure Monitor retains its default FastAPI instrumentation; local OTLP uses the same instrumentation with default options. The temporary ASGI send/receive exclusions were removed to avoid replacing Azure Monitor's supported setup merely to reduce trace noise. A fresh Azure SDK capture confirmed one request per smoke-test endpoint and correctly correlated default ASGI spans, using local ingestion rather than production.
