### PR TITLE
Consolidate tests and repair regression coverage

### DIFF
--- a/api/tests/rendering/test_markdown.py
+++ b/api/tests/rendering/test_markdown.py
@@ -40,9 +40,6 @@ class TestRenderMd:
         b = render_md("# Hello")
         assert a is b
 
-
-@pytest.mark.unit
-class TestProcessAdmonitions:
     @pytest.mark.parametrize(
         "admon_type,expected_class,expected_label",
         [
@@ -54,13 +51,32 @@ class TestProcessAdmonitions:
         ],
     )
     def test_admonition_types(self, admon_type, expected_class, expected_label):
-        html = render_md(f"> [!{admon_type}] Body here")
-        processed = _process_admonitions(html)
-        assert expected_class in processed
-        assert expected_label in processed
+        result = render_md(f"> [!{admon_type}] Body here")
+        assert expected_class in result
+        assert expected_label in result
+
+    def test_reference_definitions_do_not_leak_between_documents(self):
+        first = render_md(
+            "[first-document-only]: https://example.com/first-document\n\n"
+            "[reference][first-document-only]"
+        )
+        second = render_md("[reference][first-document-only]")
+
+        assert '<a href="https://example.com/first-document">' in first
+        assert "[reference][first-document-only]" in second
+        assert "<a " not in second
+
+
+@pytest.mark.unit
+class TestProcessAdmonitions:
+    def test_admonition_markup_is_converted(self):
+        result = _process_admonitions(
+            "<blockquote><p>[!NOTE] Keep this body.</p></blockquote>"
+        )
+        assert 'class="callout callout-note"' in result
+        assert "<strong>Note:</strong> Keep this body." in result
+        assert "<blockquote>" not in result
 
     def test_blockquote_without_admonition_is_preserved(self):
-        html = render_md("> Plain quote")
-        processed = _process_admonitions(html)
-        assert "<blockquote>" in processed
-        assert "callout-" not in processed
+        html = "<blockquote><p>Plain quote</p></blockquote>"
+        assert _process_admonitions(html) == html

--- a/api/tests/rendering/test_requirement_cards.py
+++ b/api/tests/rendering/test_requirement_cards.py
@@ -125,25 +125,6 @@ class TestBuildRequirementCardContext:
         assert isinstance(ctx, NotStartedCardContext)
         assert not hasattr(ctx, "graded_url")
 
-    def test_missing_required_repo_is_rejected_by_schema(self):
-        """Required repository configuration is enforced before rendering."""
-        from learn_to_cloud_shared.schemas import HandsOnRequirementAdapter
-        from pydantic import ValidationError
-
-        # Construct via TypeAdapter with raw dict so static analysis
-        # doesn't catch the deliberate validation error.
-        with pytest.raises(ValidationError):
-            HandsOnRequirementAdapter.validate_python(
-                {
-                    "uuid": "00000000-0000-0000-0000-000000000001",
-                    "id": "journal",
-                    "submission_type": "journal_api_verifier",
-                    "name": "Test",
-                    "description": "Test",
-                    "type_config": {},
-                }
-            )
-
 
 def _make_submission(
     *,

--- a/api/tests/routes/test_auth_http.py
+++ b/api/tests/routes/test_auth_http.py
@@ -62,17 +62,15 @@ _PAGE_PATHS = [
     "/verifications",
     "/verifications/phase/1",
 ]
-_INVALID_IDENTITIES = (
-    [
-        pytest.param(
-            {"user_id": value, "github_username": "private-name"}, id=f"id-{index}"
-        )
+_LEGACY_IDENTITIES = {
+    **{
+        f"id-{index}": {"user_id": value, "github_username": "private-name"}
         for index, value in enumerate(
             [True, False, 42.0, 42.5, "42", "private-id", None, [], {}, 0, -1, 2**63]
         )
-    ]
-    + [
-        pytest.param({"user_id": 42, "github_username": value}, id=f"name-{index}")
+    },
+    **{
+        f"name-{index}": {"user_id": 42, "github_username": value}
         for index, value in enumerate(
             [
                 None,
@@ -86,16 +84,41 @@ _INVALID_IDENTITIES = (
                 "private\ud800name",
             ]
         )
-    ]
-    + [
-        pytest.param(
-            {"user_id": 42, "github_username": "testuser"},
-            id="complete-legacy-identity",
-        ),
-        pytest.param({"user_id": 42}, id="missing-name"),
-        pytest.param({"github_username": "private-name"}, id="missing-id"),
-    ]
+    },
+    "complete-legacy-identity": {"user_id": 42, "github_username": "testuser"},
+    "missing-name": {"user_id": 42},
+    "missing-id": {"github_username": "private-name"},
+}
+_LEGACY_ROUTE_IDENTITIES = {
+    "id-0",
+    "complete-legacy-identity",
+    "missing-name",
+    "missing-id",
+}
+_LEGACY_ROUTES = (
+    ("/", False, 200),
+    ("/curriculum", False, 200),
+    ("/api/user/me", False, 401),
+    ("/account", False, 303),
+    ("/account", True, 401),
+    ("/htmx/verification/attempts/status?token=private-token", False, 401),
+    ("/htmx/verification/attempts/status?token=private-token", True, 401),
 )
+# Exercise every payload on one route and each cleanup shape across route policies.
+_LEGACY_HTTP_CASES = [
+    pytest.param(
+        identity,
+        preserve_oauth,
+        path,
+        htmx,
+        status,
+        id=f"{path}-{htmx}-{status}-{preserve_oauth}-{identity_id}",
+    )
+    for path, htmx, status in _LEGACY_ROUTES
+    for preserve_oauth in (False, True)
+    for identity_id, identity in _LEGACY_IDENTITIES.items()
+    if path == "/" or identity_id in _LEGACY_ROUTE_IDENTITIES
+]
 
 
 def _session_cookie(session: dict, *, expired: bool = False) -> str:
@@ -319,6 +342,7 @@ async def test_htmx_endpoint_auth_failure(client, method, path, data, htmx):
 @pytest.mark.parametrize("path", _PAGE_PATHS)
 async def test_browser_pages_follow_login_with_get(client, github, path):
     response = await client.get(path, follow_redirects=True)
+    assert len(response.history) == 2
     first, login = response.history
     assert first.status_code == 303
     assert first.headers["location"] == "/auth/login"
@@ -375,6 +399,7 @@ async def test_page_policy_does_not_redirect_unrelated_errors(
 @pytest.mark.parametrize("method", ["POST", "DELETE"])
 async def test_browser_mutation_redirect_changes_method_to_get(client, method):
     response = await client.request(method, "/browser-mutation", follow_redirects=True)
+    assert len(response.history) == 2
     first, login = response.history
     assert first.request.method == method
     assert first.status_code == 303
@@ -404,6 +429,7 @@ async def test_logout_expires_cookie_and_is_repeatable(client, github, cookie_ki
 
     for _ in range(2):
         response = await client.post("/auth/logout", follow_redirects=True)
+        assert len(response.history) == 1
         (logout,) = response.history
         assert logout.request.method == "POST"
         assert logout.status_code == 303
@@ -532,22 +558,12 @@ async def test_authenticated_api_delete_keeps_204_contract(
     api_services[1].assert_awaited_once()
 
 
-@pytest.mark.parametrize("identity", _INVALID_IDENTITIES)
-@pytest.mark.parametrize("preserve_oauth", [False, True])
 @pytest.mark.parametrize(
-    ("path", "htmx", "status"),
-    [
-        ("/", False, 200),
-        ("/curriculum", False, 200),
-        ("/api/user/me", False, 401),
-        ("/account", False, 303),
-        ("/account", True, 401),
-        ("/htmx/verification/attempts/status?token=private-token", False, 401),
-        ("/htmx/verification/attempts/status?token=private-token", True, 401),
-    ],
+    ("identity", "preserve_oauth", "path", "htmx", "status"),
+    _LEGACY_HTTP_CASES,
 )
 async def test_malformed_identity_is_cleaned_over_http(
-    client, app, api_services, caplog, identity, preserve_oauth, path, htmx, status
+    client, api_services, caplog, identity, preserve_oauth, path, htmx, status
 ):
     caplog.set_level(logging.INFO)
     unrelated = (
@@ -572,6 +588,7 @@ async def test_malformed_identity_is_cleaned_over_http(
     assert response.headers.get_list("set-cookie")
     if preserve_oauth:
         cookie = client.cookies.get(SESSION_COOKIE_NAME)
+        assert cookie is not None
         cleaned = json.loads(b64decode(TimestampSigner(_SECRET).unsign(cookie)))
         assert cleaned == unrelated
     else:

--- a/api/tests/routes/test_session_lifecycle.py
+++ b/api/tests/routes/test_session_lifecycle.py
@@ -627,14 +627,15 @@ async def test_login_waits_for_account_global_revocation_order(
             await release.wait()
             await repo.delete_all(42)
 
-    revocation = asyncio.create_task(revoke())
-    await acquired.wait()
-    issuance = asyncio.create_task(mint(second, test_settings))
-    await asyncio.sleep(0.03)
-    assert not issuance.done()
-    release.set()
-    await revocation
-    new = await issuance
+    async with asyncio.timeout(5), asyncio.TaskGroup() as tasks:
+        revocation = tasks.create_task(revoke())
+        await acquired.wait()
+        issuance = tasks.create_task(mint(second, test_settings))
+        await asyncio.sleep(0.03)
+        assert not issuance.done()
+        release.set()
+        await revocation
+        new = await issuance
     async with browser(second, old) as client:
         assert (await client.get("/api/user/me")).status_code == 401
     async with browser(first, new) as client:
@@ -741,15 +742,17 @@ async def test_account_deletion_serializes_with_submission_and_preserves_foreign
             inserted.set()
             await release.wait()
 
-    submission = asyncio.create_task(submit())
-    await asyncio.wait_for(inserted.wait(), timeout=5)
     async with browser(second, token) as client:
-        deletion = asyncio.create_task(client.delete("/api/user/me"))
-        await asyncio.sleep(0.03)
-        assert not deletion.done()
-        release.set()
-        await submission
-        assert (await deletion).status_code == 204
+        # Cancel and join lock-holding tasks before database teardown on failure.
+        async with asyncio.timeout(5), asyncio.TaskGroup() as tasks:
+            submission = tasks.create_task(submit())
+            await inserted.wait()
+            deletion = tasks.create_task(client.delete("/api/user/me"))
+            await asyncio.sleep(0.03)
+            assert not deletion.done()
+            release.set()
+            await submission
+            assert (await deletion).status_code == 204
     async with first.state.session_maker() as db:
         assert await db.get(User, 42) is None
         assert (

--- a/apps/verification-functions/tests/test_attempt_orchestrations.py
+++ b/apps/verification-functions/tests/test_attempt_orchestrations.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
+from azure.durable_functions import RetryOptions
 from learn_to_cloud_shared.models import VerificationAttemptOutcome
 from learn_to_cloud_shared.repositories.verification_attempt_repository import (
     AttemptStatusRow,
@@ -51,10 +52,18 @@ import function_app
 
 
 class _RecordedCall:
-    def __init__(self, kind: str, name: str, payload: object) -> None:
+    def __init__(
+        self,
+        kind: str,
+        name: str,
+        payload: object,
+        *,
+        retry_options: RetryOptions | None = None,
+    ) -> None:
         self.kind = kind
         self.name = name
         self.payload = payload
+        self.retry_options = retry_options
 
     def as_tuple(self) -> tuple[str, str]:
         return (self.kind, self.name)
@@ -75,9 +84,11 @@ class _FakeOrchestrationContext:
         return _RecordedCall("activity", name, input_)
 
     def call_activity_with_retry(
-        self, name: str, retry_options: object, input_: object = None
+        self, name: str, retry_options: RetryOptions, input_: object = None
     ) -> _RecordedCall:
-        return _RecordedCall("activity_with_retry", name, input_)
+        return _RecordedCall(
+            "activity_with_retry", name, input_, retry_options=retry_options
+        )
 
 
 class _Raise:
@@ -88,9 +99,9 @@ class _Raise:
 Responder = Callable[[_RecordedCall], object]
 
 
-def _reflection_request() -> LLMGradingRequest:
+def _reflection_request(text: str = "Complete text 雲") -> LLMGradingRequest:
     task = CAREER_REFLECTION_RUBRIC_TASK
-    bundle = apply_evidence_cap(task, [("career-reflection.md", "Complete text 雲")])
+    bundle = apply_evidence_cap(task, [("career-reflection.md", text)])
     return LLMGradingRequest(
         task=task,
         message=build_text_rubric_message(
@@ -152,6 +163,53 @@ async def test_complete_restored_request_reaches_provider(historical):
 
     assert result == {"outcome": "content_filtered"}
     provider.assert_awaited_once_with(request_payload["message"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("text", "oversized"),
+    [
+        ("abcd", False),
+        ("éé", False),
+        ("🦊", False),
+        ("abcde", True),
+        ("ééé", True),
+        ("🦊a", True),
+    ],
+    ids=[
+        "ascii-boundary",
+        "two-byte-boundary",
+        "four-byte-boundary",
+        "ascii-oversized",
+        "two-byte-oversized",
+        "four-byte-oversized",
+    ],
+)
+async def test_restored_utf8_item_budget_is_checked_before_provider(text, oversized):
+    request = _reflection_request(text)
+    policy = request.task.evidence.model_copy(update={"max_file_size_bytes": 4})
+    task = request.task.model_copy(update={"evidence": policy})
+    prefix, raw = request.message.split("\n\n", 1)
+    message = json.loads(raw)
+    message["task"]["evidence_contract"] = policy.model_dump(mode="json")
+    assert message["evidence"]["total_bytes"] == len(text.encode("utf-8"))
+    assert message["evidence"]["total_bytes"] < policy.max_total_bytes
+    request_payload = request.model_dump(mode="json")
+    request_payload["task"] = task.model_dump(mode="json")
+    request_payload["message"] = f"{prefix}\n\n{json.dumps(message)}"
+    provider = AsyncMock(side_effect=function_app.ContentFilteredError())
+    with (
+        patch("function_app._attached_invocation_context", return_value=nullcontext()),
+        patch("function_app.grade_evidence", provider),
+    ):
+        result = await function_app.run_llm_grading({"request": request_payload}, None)
+
+    if oversized:
+        assert result == {"outcome": "error", "error_type": "evidence.item_limit"}
+        provider.assert_not_awaited()
+    else:
+        assert result == {"outcome": "content_filtered"}
+        provider.assert_awaited_once_with(request_payload["message"])
 
 
 @pytest.mark.asyncio
@@ -359,6 +417,10 @@ class TestAttemptOrchestration:
             ("activity_with_retry", "execute_requirement_verification"),
             ("activity_with_retry", "finalize_verification_attempt"),
         ]
+        retry_options = calls[1].retry_options
+        assert isinstance(retry_options, RetryOptions)
+        assert retry_options.max_number_of_attempts == 3
+        assert retry_options.first_retry_interval_in_milliseconds == 5000
         assert result == {"attempt_id": "a-1", "outcome": "succeeded"}
 
     def test_llm_sequence(self) -> None:
@@ -506,15 +568,35 @@ class TestAttemptOrchestration:
         )
         assert calls[-1].payload["error_type"] == "llm.unknown"
 
-    def test_prepare_failure_terminalizes(self) -> None:
+    @pytest.mark.parametrize(
+        ("fail_activity", "expected_activities", "terminal_source"),
+        [
+            (
+                "prepare_verification_attempt",
+                ["prepare_verification_attempt", "terminalize_verification_attempt"],
+                "orchestrator_prepare_exception",
+            ),
+            (
+                "execute_requirement_verification",
+                [
+                    "prepare_verification_attempt",
+                    "execute_requirement_verification",
+                    "terminalize_verification_attempt",
+                ],
+                "orchestrator_verification_exception",
+            ),
+        ],
+        ids=["prepare", "verify"],
+    )
+    def test_activity_failure_terminalizes(
+        self, fail_activity, expected_activities, terminal_source
+    ) -> None:
         payload = _prepared_payload(
             repo_fork_requirement(slug="fork", required_repo="owner/repo"),
             "https://github.com/alice/repo",
         )
         ctx = _FakeOrchestrationContext({"attempt_id": "a-1"})
-        responder = _make_responder(
-            payload, fail_activity="prepare_verification_attempt"
-        )
+        responder = _make_responder(payload, fail_activity=fail_activity)
         calls: list[_RecordedCall] = []
         with pytest.raises(RuntimeError, match="activity failed"):
             _drive(
@@ -523,37 +605,9 @@ class TestAttemptOrchestration:
                 calls=calls,
             )
         assert _sequence(calls) == [
-            ("activity_with_retry", "prepare_verification_attempt"),
-            ("activity_with_retry", "terminalize_verification_attempt"),
+            ("activity_with_retry", name) for name in expected_activities
         ]
-        assert calls[-1].payload["terminal_source"] == (
-            "orchestrator_prepare_exception"
-        )
-
-    def test_verify_failure_terminalizes(self) -> None:
-        payload = _prepared_payload(
-            repo_fork_requirement(slug="fork", required_repo="owner/repo"),
-            "https://github.com/alice/repo",
-        )
-        ctx = _FakeOrchestrationContext({"attempt_id": "a-1"})
-        responder = _make_responder(
-            payload, fail_activity="execute_requirement_verification"
-        )
-        calls: list[_RecordedCall] = []
-        with pytest.raises(RuntimeError, match="activity failed"):
-            _drive(
-                function_app._run_attempt_orchestration(ctx),
-                responder,
-                calls=calls,
-            )
-        assert _sequence(calls) == [
-            ("activity_with_retry", "prepare_verification_attempt"),
-            ("activity_with_retry", "execute_requirement_verification"),
-            ("activity_with_retry", "terminalize_verification_attempt"),
-        ]
-        assert calls[-1].payload["terminal_source"] == (
-            "orchestrator_verification_exception"
-        )
+        assert calls[-1].payload["terminal_source"] == terminal_source
 
 
 class TestVersionedOrchestratorRegistered:

--- a/apps/verification-functions/tests/test_verification_agents.py
+++ b/apps/verification-functions/tests/test_verification_agents.py
@@ -99,6 +99,39 @@ def test_grade_evidence_maps_unknown_errors_without_raw_detail(monkeypatch) -> N
     assert str(caught.value) == "llm.unknown"
 
 
+def test_grade_evidence_propagates_cancellation(monkeypatch) -> None:
+    cancellation = asyncio.CancelledError("Grading was cancelled")
+    agent = _FakeAgent(cancellation)
+    monkeypatch.setattr(verification_agents, "get_verification_grader", lambda: agent)
+
+    with pytest.raises(asyncio.CancelledError) as caught:
+        asyncio.run(grade_evidence("grade this"))
+
+    assert caught.value is cancellation
+
+
+@pytest.mark.parametrize("status", [502, 503, 504])
+def test_grade_evidence_preserves_safe_provider_outage_category(
+    monkeypatch, status
+) -> None:
+    request = httpx.Request("POST", "https://example.com")
+    response = httpx.Response(status, request=request)
+    error = openai.InternalServerError(
+        "private provider response",
+        response=response,
+        body={"code": "service_unavailable", "message": "private provider response"},
+    )
+    agent = _FakeAgent(error)
+    monkeypatch.setattr(verification_agents, "get_verification_grader", lambda: agent)
+
+    with pytest.raises(LLMGradingError) as caught:
+        asyncio.run(grade_evidence("grade this"))
+
+    assert caught.value.error_type == "llm.provider_unavailable"
+    assert caught.value.http_status == status
+    assert str(caught.value) == "llm.provider_unavailable"
+
+
 @pytest.mark.parametrize(
     ("exc", "expected"),
     [

--- a/packages/learn-to-cloud-shared/tests/services/test_content_catalog.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_catalog.py
@@ -11,6 +11,7 @@ Covers:
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
@@ -24,6 +25,7 @@ from learn_to_cloud_shared.content_catalog import (
 from learn_to_cloud_shared.content_compiler import (
     ARTIFACT_SCHEMA_VERSION,
     compile_curriculum_artifact,
+    compute_content_hash,
 )
 
 pytestmark = pytest.mark.unit
@@ -36,10 +38,15 @@ def _clear_catalog_cache():
     get_curriculum_catalog.cache_clear()
 
 
-@pytest.fixture
-def real_payload() -> dict:
-    """Compile the real authored curriculum for use as fake package data."""
+@pytest.fixture(scope="module")
+def compiled_payload() -> dict:
     return compile_curriculum_artifact()
+
+
+@pytest.fixture
+def real_payload(compiled_payload: dict) -> dict:
+    """Give each test an independent copy of the real compiled curriculum."""
+    return deepcopy(compiled_payload)
 
 
 class _FakeResource:
@@ -96,9 +103,12 @@ class TestLoadCurriculumCatalog:
             load_curriculum_catalog()
 
     def test_schema_version_mismatch_raises(self, real_payload: dict):
-        bad_payload = {**real_payload, "artifact_schema_version": 999}
+        real_payload["artifact_schema_version"] = ARTIFACT_SCHEMA_VERSION + 1
+        real_payload["content_hash"] = compute_content_hash(
+            {k: v for k, v in real_payload.items() if k != "content_hash"}
+        )
         with (
-            _patched_resource(json.dumps(bad_payload)),
+            _patched_resource(json.dumps(real_payload)),
             pytest.raises(CurriculumCatalogError, match="schema_version"),
         ):
             load_curriculum_catalog()
@@ -113,10 +123,9 @@ class TestLoadCurriculumCatalog:
 
     def test_tampered_payload_fails_hash_check(self, real_payload: dict):
         """Hand-editing a field without recomputing the hash must be caught."""
-        tampered = json.loads(json.dumps(real_payload))
-        tampered["phases"][0]["name"] = "Tampered Name"
+        real_payload["phases"][0]["name"] = "Tampered Name"
         with (
-            _patched_resource(json.dumps(tampered)),
+            _patched_resource(json.dumps(real_payload)),
             pytest.raises(CurriculumCatalogError, match="content_hash does not match"),
         ):
             load_curriculum_catalog()

--- a/packages/learn-to-cloud-shared/tests/services/test_url_derivation.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_url_derivation.py
@@ -7,7 +7,10 @@ is_derivable / fork_name_from_required_repo helpers.
 import pytest
 
 from learn_to_cloud_shared.models import SubmissionType
-from learn_to_cloud_shared.schemas import HandsOnRequirement
+from learn_to_cloud_shared.schemas import (
+    HandsOnRequirement,
+    HandsOnRequirementAdapter,
+)
 from learn_to_cloud_shared.submission_derivation import (
     derive_submission_value,
     fork_name_from_required_repo,
@@ -154,22 +157,20 @@ class TestDeriveSubmissionValue:
         )
 
     def test_repo_fork_missing_required_repo_raises(self):
-        """Bypasses the factory's default to test the runtime guard.
-
-        Constructs the requirement via direct class with an explicit
-        empty required_repo would be rejected by Pydantic, so we test
-        that the runtime guard fires when required_repo is somehow empty
-        (defense in depth -- shouldn't happen via normal construction).
-        """
-        # Build a real requirement, then access via dict to simulate a
-        # corrupted state where required_repo ended up empty at runtime.
-        # Easier: just construct one without required_repo using None
-        # via the discriminator -- if pydantic rejects, we skip.
-        pytest.skip(
-            "required_repo is enforced at Pydantic construction since #470; "
-            "runtime guard remains as defense-in-depth but is unreachable "
-            "through normal construction."
+        req = HandsOnRequirementAdapter.validate_python(
+            {
+                "uuid": "00000000-0000-0000-0000-000000000001",
+                "slug": "req-1",
+                "submission_type": "repo_fork",
+                "name": "Test",
+                "description": "Test",
+                "type_config": {"required_repo": ""},
+            }
         )
+        with pytest.raises(
+            ValueError, match="Requirement 'req-1' is missing required_repo"
+        ):
+            derive_submission_value(req, "alice")
 
     @pytest.mark.parametrize(
         "submission_type",

--- a/packages/learn-to-cloud-shared/tests/test_schemas.py
+++ b/packages/learn-to-cloud-shared/tests/test_schemas.py
@@ -1,4 +1,4 @@
-"""Unit tests for schema-derived constants."""
+"""Unit tests for shared schema contracts."""
 
 from __future__ import annotations
 
@@ -7,10 +7,11 @@ from datetime import UTC, datetime
 import pytest
 from pydantic import ValidationError
 
-from learn_to_cloud_shared.models import User
+from learn_to_cloud_shared.models import SubmissionType, User
 from learn_to_cloud_shared.schemas import (
     KNOWN_HANDS_ON_SUBMISSION_TYPES,
     CtfTokenConfig,
+    HandsOnRequirementAdapter,
     UserResponse,
 )
 
@@ -37,6 +38,38 @@ def test_known_submission_types_matches_union() -> None:
 def test_input_length_range_must_be_ordered() -> None:
     with pytest.raises(ValidationError, match="min_length cannot exceed max_length"):
         CtfTokenConfig(min_length=200, max_length=100)
+
+
+@pytest.mark.parametrize(
+    "submission_type",
+    [
+        SubmissionType.REPO_FORK,
+        SubmissionType.JOURNAL_API_VERIFIER,
+        SubmissionType.DEVOPS_ANALYSIS,
+        SubmissionType.SECURITY_SCANNING,
+    ],
+)
+def test_repo_requirement_requires_required_repo(
+    submission_type: SubmissionType,
+) -> None:
+    required_repo = "learntocloud/journal-starter"
+    payload = {
+        "uuid": "00000000-0000-0000-0000-000000000001",
+        "slug": "repo-check",
+        "submission_type": submission_type.value,
+        "name": "Repository check",
+        "description": "Test",
+        "type_config": {"required_repo": required_repo},
+    }
+    requirement = HandsOnRequirementAdapter.validate_python(payload)
+    assert requirement.type_config.model_dump()["required_repo"] == required_repo
+
+    payload["type_config"] = {}
+    with pytest.raises(ValidationError) as exc_info:
+        HandsOnRequirementAdapter.validate_python(payload)
+    assert [(error["loc"], error["type"]) for error in exc_info.value.errors()] == [
+        ((submission_type.value, "type_config", "required_repo"), "missing")
+    ]
 
 
 @pytest.mark.parametrize("name", [None, "  李 e\u0301  🛰️  ", "名" * 600])

--- a/packages/learn-to-cloud-shared/tests/verification/test_evidence_contract.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_evidence_contract.py
@@ -298,7 +298,11 @@ def test_restored_tampered_packet_is_rejected_at_prompt_construction(tamper):
     elif tamper == "hash":
         data["items"][0]["sha256"] = "wrong"
     elif tamper == "content":
-        data["items"][0]["content"] += "changed"
+        data["items"][0]["content"] = "codeql"
+        assert (
+            sum(len(item["content"].encode("utf-8")) for item in data["items"])
+            == data["total_bytes"]
+        )
     elif tamper == "total":
         data["total_bytes"] += 1
     elif tamper == "task":
@@ -397,6 +401,49 @@ def test_prompt_boundary_recomputes_all_budget_limits(field, value, code):
             task=limited_task,
             evidence=bundle.model_dump(mode="json"),
         )
+
+
+@pytest.mark.parametrize(
+    ("text", "oversized"),
+    [
+        ("abcd", False),
+        ("éé", False),
+        ("🦊", False),
+        ("abcde", True),
+        ("ééé", True),
+        ("🦊a", True),
+    ],
+    ids=[
+        "ascii-boundary",
+        "two-byte-boundary",
+        "four-byte-boundary",
+        "ascii-oversized",
+        "two-byte-oversized",
+        "four-byte-oversized",
+    ],
+)
+def test_restored_prompt_enforces_utf8_item_budget(text, oversized):
+    task = CAREER_REFLECTION_RUBRIC_TASK
+    bundle = apply_evidence_cap(task, [("career-reflection.md", text)])
+    restored = EvidenceBundle.model_validate(bundle.model_dump(mode="json"))
+    limited_task = _with_policy(task, max_file_size_bytes=4)
+    assert restored.items[0].sha256 == sha256(text.encode("utf-8")).hexdigest()
+    assert restored.total_bytes == len(text.encode("utf-8"))
+    assert restored.total_bytes < limited_task.evidence.max_total_bytes
+    kwargs = {
+        "requirement_slug": "reflection",
+        "requirement_name": "Reflection",
+        "deterministic_result": ValidationResult(is_valid=True, message="Passed"),
+        "task": limited_task,
+        "evidence": restored.model_dump(mode="json"),
+    }
+
+    if oversized:
+        with pytest.raises(EvidenceError, match="evidence.item_limit"):
+            build_text_rubric_message(**kwargs)
+    else:
+        message = build_text_rubric_message(**kwargs)
+        assert json.loads(message.split("\n\n", 1)[1])["evidence"] == kwargs["evidence"]
 
 
 def test_valid_legacy_packet_without_new_selection_fields_still_validates():


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? -->

Reduce legacy-cookie HTTP coverage from 336 combinations to 96 representative cases while retaining every input, route-policy category, and OAuth-state scenario. Compile the catalog fixture once per module and give each test an independent copy, keeping all 12 immutability checks.

Repair missing coverage for repository configuration, markdown rendering, restored Unicode input limits, cancellation, retry settings, and provider outages. Replace a skipped guard test, isolate negative test inputs, and combine similar orchestration-failure cases without losing either stage. Bound concurrency-test tasks so an early failure cannot leave a transaction blocking teardown.

Based on the latest main, including the telemetry simplification in #869. Only tests change: production behavior, telemetry implementation, and CI scheduling remain untouched.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.