### PR TITLE
Fix the legacy verification stop-state deployment check

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -127,7 +127,16 @@ jobs:
 
           az functionapp stop --ids "$function_id"
           for i in {1..30}; do
-            state=$(az functionapp show --ids "$function_id" --query state --output tsv)
+            state=$(
+              az rest --method get \
+                --url "https://management.azure.com${function_id}?api-version=2024-04-01" \
+                --query properties.state --output tsv
+            )
+            if [[ -z "$state" ]]; then
+              echo "::error::Azure did not return the Function App state." >&2
+              exit 1
+            fi
+            echo "Legacy verification Function App state: $state"
             if [[ "$state" == "Stopped" ]]; then
               echo "Legacy verification Function App is stopped."
               exit 0

--- a/api/tests/test_verification_cutover_workflow.py
+++ b/api/tests/test_verification_cutover_workflow.py
@@ -1,0 +1,105 @@
+"""Exercise the deployed stop script against ARM's nested state response."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[2]
+_FUNCTION_ID = (
+    "/subscriptions/test/resourceGroups/rg-ltc-dev"
+    "/providers/Microsoft.Web/sites/func-ltc-verification-dev"
+)
+_AZ_STUB = """\
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+calls = Path(os.environ["CALLS"])
+with calls.open("a") as stream:
+    stream.write(json.dumps(args) + "\\n")
+if args[:2] == ["resource", "list"]:
+    if os.environ["FAIL"] == "lookup":
+        sys.exit(1)
+    print(os.environ["FUNCTION_ID"])
+elif args[:2] == ["functionapp", "stop"]:
+    sys.exit(1 if os.environ["FAIL"] == "stop" else 0)
+elif args[:3] == ["rest", "--method", "get"]:
+    if os.environ["FAIL"] == "read":
+        sys.exit(1)
+    expected_url = (
+        "https://management.azure.com" + os.environ["FUNCTION_ID"]
+        + "?api-version=2024-04-01"
+    )
+    assert args[args.index("--url") + 1] == expected_url
+    states = json.loads(os.environ["STATES"])
+    reads = sum(
+        json.loads(line)[:1] == ["rest"]
+        for line in calls.read_text().splitlines()
+    )
+    payload = {"properties": {"state": states[min(reads - 1, len(states) - 1)]}}
+    value = payload
+    for field in args[args.index("--query") + 1].split("."):
+        value = value.get(field, {}) if isinstance(value, dict) else {}
+    if isinstance(value, str):
+        print(value)
+else:
+    sys.exit("Unexpected Azure command")
+"""
+
+
+@pytest.mark.parametrize(
+    ("states", "failure", "present", "success", "message"),
+    [
+        (["Stopped"], "", True, True, "is stopped"),
+        (["Running", "Stopped"], "", True, True, "is stopped"),
+        (["Running"], "", True, False, "did not stop"),
+        ([""], "", True, False, "did not return the Function App state"),
+        (["Stopped"], "", False, True, "is absent"),
+        (["Stopped"], "lookup", True, False, ""),
+        (["Stopped"], "stop", True, False, ""),
+        (["Stopped"], "read", True, False, ""),
+    ],
+)
+def test_stop_script(tmp_path, states, failure, present, success, message):
+    workflow = yaml.safe_load((_ROOT / ".github/workflows/app-deploy.yml").read_text())
+    script = next(
+        step["run"]
+        for step in workflow["jobs"]["stop_legacy_verification"]["steps"]
+        if "run" in step
+    )
+    az = tmp_path / "az"
+    az.write_text(f"#!{sys.executable}\n{_AZ_STUB}")
+    az.chmod(0o700)
+    sleep = tmp_path / "sleep"
+    sleep.write_text("#!/bin/sh\nexit 0\n")
+    sleep.chmod(0o700)
+    calls = tmp_path / "calls"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "AZURE_ENV_NAME": "dev",
+            "FUNCTION_ID": _FUNCTION_ID if present else "",
+            "STATES": json.dumps(states),
+            "FAIL": failure,
+            "CALLS": str(calls),
+        },
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    assert (result.returncode == 0) is success, result.stdout + result.stderr
+    assert message in result.stdout + result.stderr
+    commands = [json.loads(line) for line in calls.read_text().splitlines()]
+    if not present or failure == "lookup":
+        assert len(commands) == 1
+    if failure == "stop":
+        assert len(commands) == 2


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? -->

Fix the verification cutover's stopped-state check. Azure successfully stopped the old Function, but the workflow queried a missing top-level `state` field and timed out before Terraform or API deployment could run.

Read `properties.state` from a pinned Azure Resource Manager response instead of relying on the Function CLI's response shape. Log each observed state and fail explicitly if Azure returns no state.

The corrected read returns `Stopped` against the existing Function. Eight regression cases cover stopped/running responses, a missing state, an absent app, and lookup/stop/read failures. The full quality gate passes.

The old Function remains stopped as requested. Merging this fix starts a new deployment; rerunning the old failed run would still use the broken workflow.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.

N/A: workflow and regression-test changes only.