### PR TITLE
Simplify verification service error messaging

### DIFF
--- a/api/src/learn_to_cloud/rendering/feedback.py
+++ b/api/src/learn_to_cloud/rendering/feedback.py
@@ -12,6 +12,20 @@ def incomplete_verification_message(
     cause: str | None, error_code: str | None = None
 ) -> str:
     """Explain an incomplete outcome alongside its saved learner-safe cause."""
+    if error_code in {
+        "authentication",
+        "authorization",
+        "client_error",
+        "network",
+        "provider_unavailable",
+        "rate_limit",
+    }:
+        return (
+            "Verification is temporarily unavailable because the service could not "
+            "retrieve the required evidence. Your work was not evaluated. "
+            "Try again in a few minutes. If the problem continues, report the issue."
+        )
+
     explanation = (
         "Verification stopped before it could finish. "
         "Your work was not judged to have failed."
@@ -38,19 +52,6 @@ def incomplete_verification_message(
             "The repository changed while evidence was being collected. "
             "Try again later, after the repository stops changing. "
             "If this keeps happening, report the issue."
-        )
-    elif error_code in {
-        "authentication",
-        "authorization",
-        "client_error",
-        "network",
-        "provider_unavailable",
-        "rate_limit",
-    }:
-        recovery = (
-            "The verifier could not retrieve the required evidence. "
-            "Try again later. If this keeps happening, report the issue. "
-            "You do not need to change your work to fix a verification-service problem."
         )
     return " ".join(part for part in (explanation, cause, recovery) if part)
 

--- a/api/src/learn_to_cloud/templates/partials/requirement_card.html
+++ b/api/src/learn_to_cloud/templates/partials/requirement_card.html
@@ -27,12 +27,9 @@
     >
         <div class="animate-spin h-5 w-5 border-2 border-blue-500 border-t-transparent rounded-full" aria-hidden="true"></div>
         <span class="text-sm text-gray-600 dark:text-gray-400">
-            Your submission is queued or being verified. You can return later to see the result.
+            Verification continues in the background. Leaving this page will not stop it.
+            Return later to see the result.
         </span>
-    </div>
-    {% elif card.kind == 'checking' %}
-    <div class="text-amber-600 dark:text-amber-400 text-sm p-2" role="status">
-        Verification is running. Refresh the page to check for results.
     </div>
     {% elif card.kind != 'passed' %}
     {% if card.kind == 'unavailable' %}

--- a/api/tests/rendering/test_feedback.py
+++ b/api/tests/rendering/test_feedback.py
@@ -82,11 +82,16 @@ def test_changed_evidence_recommends_stable_repository_retry():
     ],
 )
 def test_retrieval_failure_recommends_retry_later(error_code):
-    message = incomplete_verification_message(None, error_code)
+    message = incomplete_verification_message(
+        "GitHub API error (401). Try again later.", error_code
+    )
 
-    assert "Your work was not judged" in message
-    assert "Try again later." in message
-    assert "You do not need to change your work" in message
+    assert message == (
+        "Verification is temporarily unavailable because the service could not "
+        "retrieve the required evidence. Your work was not evaluated. "
+        "Try again in a few minutes. If the problem continues, report the issue."
+    )
+    assert "401" not in message
 
 
 @pytest.mark.parametrize("error_code", [None, "historical.unknown"])

--- a/api/tests/rendering/test_requirement_cards.py
+++ b/api/tests/rendering/test_requirement_cards.py
@@ -252,7 +252,9 @@ class TestBuildRequirementCardContextCardState:
             in html
         )
         assert "token=" not in html
-        assert "queued or being verified" in html
+        assert "Verification continues in the background." in html
+        assert "Leaving this page will not stop it." in html
+        assert "Return later to see the result." in html
         assert "Analyzing your code" not in html
         assert 'hx-trigger="load delay:2s"' in html
 


### PR DESCRIPTION
Replaces repetitive verification service failure text with one clear message that explains the service is temporarily unavailable, confirms the learner work was not evaluated, and gives a concrete retry and report path. Raw upstream details such as GitHub HTTP status codes remain in telemetry but are no longer shown to learners. Validation: uv run poe check.