### PR TITLE
Remove confirmed unused code and redundant work

### DIFF
--- a/api/alembic.ini
+++ b/api/alembic.ini
@@ -2,9 +2,6 @@
 # path to migration scripts
 script_location = alembic
 
-# This value is overridden by alembic/env.py using core.config Settings.
-sqlalchemy.url = postgresql+asyncpg://postgres:postgres@localhost:55432/learntocloud
-
 [loggers]
 keys = root,sqlalchemy,alembic
 

--- a/api/alembic/versions/0063_drop_orphan_typed_value_function.py
+++ b/api/alembic/versions/0063_drop_orphan_typed_value_function.py
@@ -1,0 +1,67 @@
+"""Drop the typed-value trigger function left behind by legacy table removal."""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "0063_drop_orphan_typed_value_function"
+down_revision: str | None = "0062_api_verification_worker"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+    op.execute("DROP FUNCTION IF EXISTS public.set_typed_submitted_value() RESTRICT")
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+    op.execute(
+        """
+CREATE FUNCTION public.set_typed_submitted_value()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    expected_kind text;
+BEGIN
+    SELECT submission_value_kind
+    INTO expected_kind
+    FROM requirements
+    WHERE uuid = NEW.requirement_uuid;
+
+    IF expected_kind IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    NEW.submission_value_kind = COALESCE(
+        NEW.submission_value_kind,
+        expected_kind
+    );
+
+    IF NEW.submission_value_kind = 'github_url'
+        AND NEW.github_url IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.github_url = NEW.submitted_value;
+    ELSIF NEW.submission_value_kind = 'token'
+        AND NEW.token_value IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.token_value = NEW.submitted_value;
+    ELSIF NEW.submission_value_kind = 'deployed_url'
+        AND NEW.deployed_url IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.deployed_url = NEW.submitted_value;
+    ELSIF NEW.submission_value_kind = 'text'
+        AND NEW.text_value IS NULL
+        AND NEW.submitted_value IS NOT NULL THEN
+        NEW.text_value = NEW.submitted_value;
+    END IF;
+
+    RETURN NEW;
+END
+$$
+"""
+    )

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -18,10 +18,7 @@ addopts =
 markers =
     unit: unit tests (fast, no I/O)
     integration: integration tests (database required)
-    slow: tests that take > 1s
     smoke: minimal smoke test subset
-    skip_until_fixed: temporarily skipped tests tied to issues
-    migration_chain: migration chain tests (runs alembic against fixture data)
 
 # Coverage config is in pyproject.toml [tool.coverage.*]
 # Run with coverage: uv run pytest --cov=. --cov-report=term-missing --cov-report=html:htmlcov --cov-report=xml:coverage.xml

--- a/api/scripts/run_migrations.py
+++ b/api/scripts/run_migrations.py
@@ -24,8 +24,6 @@ import logging
 import alembic.command
 import alembic.config
 
-logger = logging.getLogger(__name__)
-
 
 def main() -> None:
     cfg = alembic.config.Config("alembic.ini")

--- a/api/src/learn_to_cloud/rendering/feedback.py
+++ b/api/src/learn_to_cloud/rendering/feedback.py
@@ -118,9 +118,7 @@ def feedback_tasks_and_passed(
     return tasks, passed
 
 
-def _feedback_criterion(raw: object) -> FeedbackCriterionContext:
-    if not isinstance(raw, dict):
-        raise TypeError("Feedback criterion must be an object")
+def _feedback_criterion(raw: dict) -> FeedbackCriterionContext:
     kind = raw.get("kind", "required")
     if kind not in {"required", "quality", "bonus"}:
         kind = "required"

--- a/api/src/learn_to_cloud/routes/htmx_routes.py
+++ b/api/src/learn_to_cloud/routes/htmx_routes.py
@@ -351,7 +351,6 @@ async def htmx_submit_reflection_verification(
 
 @router.post("/github/submit", response_class=HTMLResponse)
 async def htmx_submit_verification(
-    request: Request,
     current_user: CurrentUser,
 ) -> HTMLResponse:
     """Refresh a page that still contains the retired submission form."""

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -4,7 +4,6 @@ These routes serve full Jinja2 pages. They call the same services as the
 JSON API routes but render HTML templates instead of returning JSON.
 """
 
-import logging
 from datetime import UTC, datetime
 from typing import Annotated
 
@@ -41,8 +40,6 @@ from learn_to_cloud.services.verification_page_service import (
     get_phase_verification_workspace,
     get_verifications_overview,
 )
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter(
     tags=["pages"], include_in_schema=False, route_class=LoginRedirectRoute

--- a/api/src/learn_to_cloud/services/community_service.py
+++ b/api/src/learn_to_cloud/services/community_service.py
@@ -1,6 +1,5 @@
 """Assemble aggregate data for the public community experience."""
 
-import logging
 from datetime import timedelta
 
 from learn_to_cloud_shared.content_catalog import get_curriculum_catalog
@@ -21,8 +20,6 @@ from learn_to_cloud_shared.schemas import (
     CommunityPhaseActivity,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
-
-logger = logging.getLogger(__name__)
 
 
 async def get_community_page_data(db: AsyncSession) -> CommunityPageData:

--- a/api/src/learn_to_cloud/services/progress_service.py
+++ b/api/src/learn_to_cloud/services/progress_service.py
@@ -16,7 +16,6 @@ Step completion and verification state come from their authoritative tables.
 Curriculum shape comes from the packaged in-memory catalog.
 """
 
-import logging
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from uuid import UUID
@@ -44,8 +43,6 @@ from learn_to_cloud_shared.schemas import (
     VerificationProgress,
 )
 from sqlalchemy.ext.asyncio import AsyncSession
-
-logger = logging.getLogger(__name__)
 
 
 def _count_by_phase(

--- a/api/src/learn_to_cloud/services/steps_service.py
+++ b/api/src/learn_to_cloud/services/steps_service.py
@@ -24,7 +24,6 @@ class StepNotFoundError(StepValidationError):
     """Raised when a step_uuid does not exist in the loaded curriculum."""
 
     def __init__(self, step_uuid: UUID):
-        self.step_uuid = step_uuid
         super().__init__(f"Unknown step_uuid: {step_uuid}")
 
 

--- a/api/src/learn_to_cloud/services/verification_worker.py
+++ b/api/src/learn_to_cloud/services/verification_worker.py
@@ -138,8 +138,6 @@ async def run_verification_worker(
                 await asyncio.sleep(config.poll_interval_seconds)
             else:
                 await _execute(attempt_id, session_maker, config)
-    except asyncio.CancelledError:
-        raise
     except Exception as exc:
         logger.error(
             "verification.worker.failed", extra={"error.type": type(exc).__name__}

--- a/api/src/learn_to_cloud/templates/macros/step_body.html
+++ b/api/src/learn_to_cloud/templates/macros/step_body.html
@@ -9,13 +9,13 @@ Macros:
 #}
 
 {% macro provider_tabs(options) %}
-<div class="mt-3" x-data="{ tab: '{{ options[0].provider | default('option-0') }}' }">
+<div class="mt-3" x-data="{ tab: '{{ options[0].provider }}' }">
     <div class="flex gap-1 border-b border-gray-200 dark:border-gray-700">
         {% for option in options %}
         <button
             type="button"
-            @click.stop="tab = '{{ option.provider | default(loop.index0) }}'"
-            :class="tab === '{{ option.provider | default(loop.index0) }}' ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'"
+            @click.stop="tab = '{{ option.provider }}'"
+            :class="tab === '{{ option.provider }}' ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'"
             class="px-3 py-2 text-sm font-medium border-b-2 -mb-px"
         >
             {{ option.provider }}
@@ -23,10 +23,10 @@ Macros:
         {% endfor %}
     </div>
     {% for option in options %}
-    <div x-show="tab === '{{ option.provider | default(loop.index0) }}'" class="mt-2 text-sm text-gray-700 dark:text-gray-300">
+    <div x-show="tab === '{{ option.provider }}'" class="mt-2 text-sm text-gray-700 dark:text-gray-300">
         {{ option.description | md | safe }}
         {% if option.url %}
-        <a href="{{ option.url }}" target="_blank" rel="noopener" hx-boost="false" class="text-blue-600 hover:underline dark:text-blue-400" @click.stop>{{ option.title | default('Learn more') }}</a>
+        <a href="{{ option.url }}" target="_blank" rel="noopener" hx-boost="false" class="text-blue-600 hover:underline dark:text-blue-400" @click.stop>{{ option.title }}</a>
         {% endif %}
     </div>
     {% endfor %}

--- a/api/src/learn_to_cloud/templates/pages/curriculum.html
+++ b/api/src/learn_to_cloud/templates/pages/curriculum.html
@@ -79,7 +79,7 @@
                     {% endif %}
                 </div>
                 <span id="phase-{{ phase.order }}-description" class="mt-2 block max-w-2xl text-sm leading-6 text-gray-600 dark:text-gray-400">
-                    {{ phase.short_description | default(phase.description) }}
+                    {{ phase.short_description }}
                 </span>
                 <span id="phase-{{ phase.order }}-topic-count" class="mt-3 block text-xs text-gray-500 dark:text-gray-400">
                     {{ phase.topics | length }} topic{% if phase.topics | length != 1 %}s{% endif %}

--- a/api/src/learn_to_cloud/templates/pages/topic.html
+++ b/api/src/learn_to_cloud/templates/pages/topic.html
@@ -82,7 +82,6 @@
 {% endif %}
 
 <nav class="mt-12 grid gap-3 border-t border-gray-200 pt-6 dark:border-gray-700 sm:grid-cols-2" aria-label="Topic navigation">
-    {% if prev_topic %}
     <a href="{{ prev_topic.url }}" class="group flex min-h-11 min-w-0 items-center gap-3 rounded-md p-3 text-left hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:bg-gray-800/50">
         <svg class="h-5 w-5 shrink-0 text-gray-500 group-hover:text-blue-700 dark:text-gray-400 dark:group-hover:text-blue-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m12 5-5 5 5 5"/></svg>
         <span class="min-w-0">
@@ -90,11 +89,7 @@
             <span class="mt-1 block break-words text-sm font-bold text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ prev_topic.name }}</span>
         </span>
     </a>
-    {% else %}
-    <span></span>
-    {% endif %}
 
-    {% if next_topic %}
     <a href="{{ next_topic.url }}" class="group flex min-h-11 min-w-0 items-center justify-end gap-3 rounded-md p-3 text-right hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:bg-gray-800/50 sm:col-start-2">
         <span class="min-w-0">
             <span class="block text-xs font-bold text-gray-500 dark:text-gray-400">Next topic</span>
@@ -102,7 +97,6 @@
         </span>
         <svg class="h-5 w-5 shrink-0 text-gray-500 group-hover:text-blue-700 dark:text-gray-400 dark:group-hover:text-blue-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m8 5 5 5-5 5"/></svg>
     </a>
-    {% endif %}
 </nav>
 
 <div class="mt-8 flex justify-center">

--- a/api/src/learn_to_cloud/templates/partials/requirement_card.html
+++ b/api/src/learn_to_cloud/templates/partials/requirement_card.html
@@ -4,9 +4,7 @@
 <div id="requirement-{{ card.requirement.slug }}" class="border-y border-gray-200 py-6 dark:border-gray-700">
     <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
         <h3 class="font-medium text-gray-900 dark:text-gray-100">{{ card.requirement.name }}</h3>
-        {% if card.kind == 'passed' %}
-        {{ status_pill("Verified", "success") }}
-        {% elif card.kind == 'unavailable' %}
+        {% if card.kind == 'unavailable' %}
         {{ status_pill("Verification incomplete", "warning") }}
         {% elif card.kind == 'failed' %}
         {{ status_pill("Needs work", "error") }}
@@ -31,7 +29,7 @@
             Return later to see the result.
         </span>
     </div>
-    {% elif card.kind != 'passed' %}
+    {% else %}
     {% if card.kind == 'unavailable' %}
     {{ banner(
         card.message,
@@ -94,12 +92,6 @@
             organization, rename it or fork it to your own account before verifying.
         </p>
     </details>
-    {% endif %}
-
-    {% if card.kind != 'failed' and card.feedback_tasks %}
-    {% with feedback_tasks=card.feedback_tasks, feedback_passed=card.feedback_passed, requirement_slug=card.requirement.slug %}
-    {% include "partials/verification_feedback.html" %}
-    {% endwith %}
     {% endif %}
     {% endif %}
 

--- a/api/src/learn_to_cloud/templates/partials/topic_step.html
+++ b/api/src/learn_to_cloud/templates/partials/topic_step.html
@@ -15,7 +15,6 @@
     x-data="{ expanded: {{ 'true' if initially_open else 'false' }} }"
 >
     <div class="flex items-start gap-2 py-4 sm:items-center">
-        {% if user %}
         <label class="flex h-11 w-11 shrink-0 cursor-pointer items-center justify-center rounded-md hover:bg-gray-100 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-blue-700 dark:hover:bg-gray-800">
             <span class="sr-only">Mark {{ step_label }} complete</span>
             <input
@@ -36,11 +35,6 @@
                 @keydown.enter.stop
             >
         </label>
-        {% else %}
-        <span class="flex h-11 w-11 shrink-0 items-center justify-center" aria-hidden="true">
-            <span class="h-5 w-5 rounded border-2 border-gray-300 dark:border-gray-600"></span>
-        </span>
-        {% endif %}
 
         <span class="mt-2.5 sm:mt-0">{{ step_number_badge(step.order, is_completed) }}</span>
 

--- a/api/tests/routes/test_htmx_routes.py
+++ b/api/tests/routes/test_htmx_routes.py
@@ -407,7 +407,6 @@ class TestHtmxSubmitVerification:
 
     async def test_legacy_route_refreshes_open_pages(self):
         result = await htmx_submit_verification(
-            _mock_request(),
             AuthenticatedUser(user_id=1, github_username="user"),
         )
 

--- a/api/tests/routes/test_pages_routes.py
+++ b/api/tests/routes/test_pages_routes.py
@@ -70,7 +70,7 @@ def _fake_phase(*, order: int = 1, name: str = "Phase 1", slug: str = "phase1"):
     return phase
 
 
-def _fake_topic(*, topic_id: str = "topic-1", slug: str = "linux-basics"):
+def _fake_topic(*, slug: str = "linux-basics"):
     """Build a minimal mock topic object."""
     topic = MagicMock()
     topic.uuid = uuid4()

--- a/api/tests/services/test_progress_service.py
+++ b/api/tests/services/test_progress_service.py
@@ -47,7 +47,6 @@ def _make_step(step_id: str, order: int = 0) -> LearningStep:
 
 
 def _make_topic(
-    topic_id: str = "phase0-topic1",
     steps: list[str] | None = None,
 ) -> Topic:
     step_ids = steps if steps is not None else ["s1", "s2", "s3"]
@@ -430,7 +429,7 @@ class TestFetchPhaseProgress:
             journal_api_verifier_requirement,
         )
 
-        topic = _make_topic(topic_id="phase3-topic1", steps=["s1", "s2"])
+        topic = _make_topic(steps=["s1", "s2"])
         req = journal_api_verifier_requirement(slug="req1", name="R", description="d")
         phase = _make_phase(3, topics=[topic])
         phase = phase.model_copy(
@@ -469,7 +468,7 @@ class TestFetchPhaseProgress:
             journal_api_verifier_requirement,
         )
 
-        topic = _make_topic(topic_id="phase3-topic1", steps=["s1", "s2"])
+        topic = _make_topic(steps=["s1", "s2"])
         req = journal_api_verifier_requirement(slug="req1", name="R", description="d")
         phase = _make_phase(3, topics=[topic])
         phase = phase.model_copy(
@@ -525,8 +524,8 @@ class TestFetchPhaseProgress:
 @pytest.mark.unit
 class TestFindFirstIncompleteStep:
     def test_returns_first_unchecked_step_in_topic_order(self):
-        first_topic = _make_topic("t1", steps=["s1", "s2"])
-        second_topic = _make_topic("t2", steps=["s3"])
+        first_topic = _make_topic(steps=["s1", "s2"])
+        second_topic = _make_topic(steps=["s3"])
         phase = _make_phase(0, topics=[first_topic, second_topic])
         completed = {first_topic.learning_steps[0].uuid}
 
@@ -538,7 +537,7 @@ class TestFindFirstIncompleteStep:
         assert step.slug == "s2"
 
     def test_returns_none_when_every_step_checked(self):
-        topic = _make_topic("t1", steps=["s1", "s2"])
+        topic = _make_topic(steps=["s1", "s2"])
         phase = _make_phase(0, topics=[topic])
         completed = {s.uuid for s in topic.learning_steps}
 
@@ -553,7 +552,7 @@ class TestFindFirstIncompleteStep:
 class TestResolveContinueDestination:
     @pytest.mark.asyncio
     async def test_links_to_first_incomplete_steps_topic(self):
-        topic = _make_topic("t1", steps=["s1", "s2"])
+        topic = _make_topic(steps=["s1", "s2"])
         phase = _make_phase(3, topics=[topic])
 
         with patch(
@@ -568,7 +567,7 @@ class TestResolveContinueDestination:
 
     @pytest.mark.asyncio
     async def test_falls_back_to_verification_workspace_when_all_steps_checked(self):
-        topic = _make_topic("t1", steps=["s1"])
+        topic = _make_topic(steps=["s1"])
         phase = _with_requirement(_make_phase(3, topics=[topic]))
         completed = {s.uuid for s in topic.learning_steps}
 

--- a/api/tests/test_migration_chain.py
+++ b/api/tests/test_migration_chain.py
@@ -48,6 +48,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import InternalError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import Session, registry
 
@@ -178,6 +179,88 @@ def test_api_worker_cutover_closes_only_unfinished_attempts(
             attempt = db.get(VerificationAttempt, attempt_id)
             assert attempt is not None
             assert attempt.outcome is not None
+
+
+@pytest.mark.parametrize("function_exists", [True, False])
+def test_orphan_typed_value_function_roundtrip(
+    alembic_runner, alembic_engine, function_exists
+) -> None:
+    previous = "0062_api_verification_worker"
+    cleanup = "0063_drop_orphan_typed_value_function"
+    alembic_runner.migrate_up_to(previous)
+    definition_query = text(
+        "SELECT pg_get_functiondef("
+        "to_regprocedure('public.set_typed_submitted_value()'))"
+    )
+    step_uuid = uuid4()
+    attempt_id = uuid4()
+    with Session(alembic_engine) as db:
+        definition = db.scalar(definition_query)
+        assert definition is not None
+        db.add(User(id=85102, github_username="function-cleanup"))
+        db.flush()
+        db.add(LearnerStepCompletion(user_id=85102, step_uuid=step_uuid))
+        db.add(
+            VerificationAttempt(
+                id=attempt_id,
+                user_id=85102,
+                requirement_uuid=uuid4(),
+                snapshot_source="reconstructed",
+                submission_value_kind="github_url",
+                submitted_value="https://github.com/function-cleanup/repo",
+                outcome="succeeded",
+                completed_at=datetime.now(UTC),
+            )
+        )
+        if not function_exists:
+            db.execute(text("DROP FUNCTION public.set_typed_submitted_value()"))
+        db.commit()
+
+    alembic_runner.migrate_up_to(cleanup)
+    with Session(alembic_engine) as db:
+        assert db.scalar(definition_query) is None
+        assert db.get(User, 85102) is not None
+        assert db.get(LearnerStepCompletion, (85102, step_uuid)) is not None
+        attempt = db.get(VerificationAttempt, attempt_id)
+        assert attempt is not None
+        assert attempt.outcome == "succeeded"
+
+    alembic_runner.migrate_down_to(previous)
+    with alembic_engine.connect() as conn:
+        assert conn.scalar(definition_query) == definition
+    alembic_runner.migrate_up_to(cleanup)
+    with alembic_engine.connect() as conn:
+        assert conn.scalar(definition_query) is None
+
+
+def test_orphan_typed_value_function_refuses_to_drop_dependents(
+    alembic_runner, alembic_engine
+) -> None:
+    previous = "0062_api_verification_worker"
+    alembic_runner.migrate_up_to(previous)
+    with alembic_engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TRIGGER unexpected_typed_value_dependency "
+                "BEFORE INSERT ON users FOR EACH ROW "
+                "EXECUTE FUNCTION public.set_typed_submitted_value()"
+            )
+        )
+
+    with pytest.raises(InternalError, match="other objects depend"):
+        alembic_runner.migrate_up_to("0063_drop_orphan_typed_value_function")
+
+    with alembic_engine.connect() as conn:
+        assert conn.scalar(text("SELECT version_num FROM alembic_version")) == previous
+        assert (
+            conn.scalar(
+                text(
+                    "SELECT count(*) FROM pg_trigger "
+                    "WHERE tgname = 'unexpected_typed_value_dependency'"
+                )
+            )
+            == 1
+        )
 
 
 def test_contract_removes_legacy_database_objects(

--- a/api/tests/test_operator_scripts.py
+++ b/api/tests/test_operator_scripts.py
@@ -1,0 +1,139 @@
+"""Regression coverage for local and operational script cleanup."""
+
+import json
+import runpy
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("scenario", "exit_code"),
+    [("success", 0), ("failed_checks", 2), ("exception", 1)],
+)
+def test_issue_report_closes_browser_before_exit(scenario, exit_code):
+    harness = """
+const fs = require("node:fs");
+const vm = require("node:vm");
+const script = process.argv[1];
+const scenario = process.argv[2];
+let closed = false;
+let currentUrl = "";
+const page = {
+  on() {},
+  async goto(url) {
+    if (scenario === "exception") throw new Error("Navigation failed");
+    currentUrl = url;
+  },
+  async waitForSelector() {},
+  async evaluate() {},
+  async waitForTimeout() {},
+  async getAttribute(selector) {
+    if (selector.startsWith('a[href^=')) return "/phase/1/test-topic";
+    const dashboard = currentUrl.endsWith("/dashboard");
+    const issue = new URL("https://github.com/example/project/issues/new");
+    issue.searchParams.set("title", dashboard ? "Dashboard Issue" : "Issue with topic");
+    issue.searchParams.set("labels", "content");
+    issue.searchParams.set("body", scenario === "failed_checks" ? "" : [
+      "**Page:** " + currentUrl,
+      "**Title:** Example",
+      "**When:** Now",
+      "## Environment",
+      "Browser: Test",
+      dashboard ? "page=dashboard" : "**Context:** phase=1, topic=test-topic"
+    ].join("\\n"));
+    return issue.toString();
+  }
+};
+const browser = {
+  async newContext() {
+    return { async addCookies() {}, async newPage() { return page; } };
+  },
+  async close() {
+    await new Promise(resolve => setImmediate(resolve));
+    closed = true;
+  }
+};
+const sandbox = {
+  __dirname: require("node:path").dirname(script),
+  URL,
+  process,
+  console: { log() {}, error() {} },
+  require(name) {
+    if (name === "playwright") {
+      return { chromium: { async launch() { return browser; } } };
+    }
+    if (name === "child_process") {
+      return { execSync() { return JSON.stringify({
+        cookie_name: "local-session", cookie_value: "local-only",
+        domain: "localhost", path: "/"
+      }); } };
+    }
+    return require(name);
+  }
+};
+(async () => {
+  await vm.runInNewContext(fs.readFileSync(script, "utf8"), sandbox);
+  process.stdout.write(JSON.stringify({ closed }));
+})().catch(error => { console.error(error); process.exitCode = 1; });
+"""
+    result = subprocess.run(
+        [
+            "node",
+            "-e",
+            harness,
+            str(SCRIPTS / "dogfood_report_issue_prefill.js"),
+            scenario,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+    assert result.returncode == exit_code, result.stderr
+    assert json.loads(result.stdout) == {"closed": True}
+
+
+@pytest.mark.unit
+async def test_user_count_preserves_output_without_duplicate_query(monkeypatch, capsys):
+    namespace = runpy.run_path(str(SCRIPTS / "count_users.py"))
+    count_users = namespace["count_users"]
+    result = MagicMock()
+    result.first.return_value = (3, 2, 4, 5)
+    connection = AsyncMock()
+    connection.execute.return_value = result
+    engine = MagicMock()
+    engine.connect.return_value.__aenter__.return_value = connection
+    engine.dispose = AsyncMock()
+    monkeypatch.setitem(
+        count_users.__globals__, "create_async_engine", MagicMock(return_value=engine)
+    )
+    monkeypatch.setitem(
+        count_users.__globals__,
+        "subprocess",
+        SimpleNamespace(
+            run=MagicMock(return_value=SimpleNamespace(stdout="local-only"))
+        ),
+    )
+    monkeypatch.setenv("DATABASE_HOST", "127.0.0.1")
+
+    await count_users()
+
+    assert capsys.readouterr().out.splitlines() == [
+        "Total users: 3",
+        "Users with GitHub: 3",
+        "Users with attempts: 2",
+        "Total attempts: 4",
+        "Total steps completed: 5",
+    ]
+    assert "github_username IS NOT NULL" not in str(
+        connection.execute.call_args.args[0]
+    )
+    engine.dispose.assert_awaited_once()

--- a/packages/learn-to-cloud-shared/pyproject.toml
+++ b/packages/learn-to-cloud-shared/pyproject.toml
@@ -104,7 +104,5 @@ addopts = [
 markers = [
     "unit: unit tests (fast, no I/O)",
     "integration: integration tests (database required)",
-    "slow: tests that take > 1s",
     "smoke: minimal smoke test subset",
-    "skip_until_fixed: temporarily skipped tests tied to issues",
 ]

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/ctf-lab.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/ctf-lab.yaml
@@ -3,7 +3,6 @@ uuid: 3fa502ac-3a8e-4878-9f82-516785b4bcbc
 slug: ctf-lab
 name: 'Capstone: Linux CTF Lab'
 description: Time to put your Linux skills to the test! Complete 18 progressive Capture The Flag challenges covering file navigation, permissions, networking, and more. The curriculum may not have covered everything you need — that's intentional. Researching what you don't know is part of the job.
-short_description: Complete 18 hands-on Linux CTF challenges in a real cloud environment to prove your command line skills.
 learning_objectives:
 - uuid: 9a98bb7e-ab14-4591-9321-011958ca7d1d
   text: Deploy and configure the Linux CTF lab environment successfully.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase3/build-the-app.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase3/build-the-app.yaml
@@ -3,7 +3,6 @@ uuid: e8852e92-83a5-4e92-92f1-a450324278f3
 slug: build-the-app
 name: 'Capstone: Learning Journal API'
 description: Time to put everything together! In this capstone project, you'll build a working Learning Journal API that combines Python, FastAPI, databases, and LLM integration. This project synthesizes all Phase 3 skills into a complete application.
-short_description: Build a Learning Journal API with FastAPI, PostgreSQL, and AI-powered entry analysis using LLMs.
 learning_objectives:
 - uuid: a52a062c-bc9b-4140-8948-aabe16deef8c
   text: Integrate FastAPI routing, request/response models, PostgreSQL data access, and LLM analysis into one working API.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/capstone.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/capstone.yaml
@@ -3,7 +3,6 @@ uuid: ddd726e7-818e-4672-b33a-579718b1a8f3
 slug: capstone
 name: 'Capstone: Secure Cloud Deployment'
 description: Deploy your Phase 3 Journal API on your chosen cloud. You own the architecture, service choices, and deployment approach. Use the earlier topics as references, not a deployment recipe. Researching what you do not yet know is part of this project.
-short_description: Deploy the Journal API over HTTPS with private database connectivity, secure administration, and live cloud AI analysis.
 learning_objectives:
 - uuid: a8283b86-24bb-4e2e-8a20-7679cd19741a
   text: Choose and justify a cloud architecture with separate application and database tiers.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase5/capstone.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase5/capstone.yaml
@@ -3,7 +3,6 @@ uuid: bcef3efa-8416-4ac8-a99e-eef16cd88e2a
 slug: capstone
 name: 'Capstone: DevOps Project'
 description: Now that you've learned the fundamentals of DevOps, it's time to apply these practices to the Journal API app you built in Phase 3 and deployed in Phase 4. In this capstone, you'll containerize the app, automate its deployment, manage infrastructure as code, set up monitoring, and orchestrate containers with Kubernetes—demonstrating your end-to-end DevOps skills. The curriculum may not have covered everything you need — that's intentional. Researching what you don't know is part of the job.
-short_description: Containerize your app with Docker, deploy to Kubernetes, automate with CI/CD, and instrument with OpenTelemetry for cloud-native observability.
 learning_objectives:
 - uuid: a8da24c4-65e0-45a6-88c3-f6ea7c851706
   text: Integrate containerization, CI/CD, IaC, and orchestration into one delivery workflow.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/capstone.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/capstone.yaml
@@ -3,7 +3,6 @@ uuid: ca57ab23-c56b-4352-bb47-9cbd0530e78b
 slug: capstone
 name: 'Capstone: Secure Your Journal API'
 description: Apply everything from this phase to harden your Journal API with real security controls. By the end, your app will be production-ready.
-short_description: Harden your Journal API with IAM, secrets management, network controls, and monitoring.
 learning_objectives:
 - uuid: f48146c0-831d-49a1-ab8d-4f431bf9e347
   text: Apply layered security controls to harden your deployed Journal API.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -101,16 +101,8 @@ _TIP_TEXT_CLASSES: dict[TipType, str] = {
 }
 
 
-def _normalize_step_action(raw: str | StepAction | None) -> StepAction | None:
-    """Accept YAML strings like ``"Practice:"`` and normalize to StepAction.
-
-    Returns None for missing/empty values; raises ValueError for unknown
-    labels so authoring mistakes (typos) fail at load time.
-    """
-    if raw is None:
-        return None
-    if isinstance(raw, StepAction):
-        return raw
+def _normalize_step_action(raw: str) -> StepAction | None:
+    """Normalize a YAML action label, returning None for an empty string."""
     cleaned = raw.strip().rstrip(":").strip().lower()
     if not cleaned:
         return None

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/submission_values.py
@@ -120,15 +120,12 @@ def submitted_value_from_raw(
 
     match kind:
         case SubmissionValueKind.GITHUB_URL:
-            _validate_github_url(value)
             return GitHubUrlValue(value)
         case SubmissionValueKind.TOKEN:
             return TokenValue(value)
         case SubmissionValueKind.DEPLOYED_URL:
-            _validate_http_url(value, field_name="deployed API URL")
             return DeployedUrlValue(value)
         case SubmissionValueKind.TEXT:
-            _validate_text(value)
             return TextValue(value)
 
 

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/engine.py
@@ -125,7 +125,7 @@ def _grading_requests_for(
         if len(result.evidence) != 1:
             raise EvidenceError("evidence.selection")
         validate_evidence_bundle(task, result.evidence[0])
-        evidence = result.evidence[0].model_dump(mode="json") if result.evidence else {}
+        evidence = result.evidence[0].model_dump(mode="json")
         allowed_evidence_refs = [
             str(item["path"])
             for item in evidence.get("items", [])

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/grading_requests.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/verification/grading_requests.py
@@ -68,12 +68,7 @@ def _validated_evidence_payload(
     except ValidationError as exc:
         raise EvidenceError("evidence.selection") from exc
     validate_evidence_bundle(task, bundle)
-    payload = bundle.model_dump(mode="json")
-    payload["optional_presence"] = {
-        path: any(item.path == path for item in bundle.items)
-        for path in task.evidence.optional_files
-    }
-    return payload
+    return bundle.model_dump(mode="json")
 
 
 def validate_grading_request(request: LLMGradingRequest) -> None:

--- a/packages/learn-to-cloud-shared/tests/verification/test_codeql_status.py
+++ b/packages/learn-to-cloud-shared/tests/verification/test_codeql_status.py
@@ -77,20 +77,13 @@ class TestCodeQLStatusCheck:
         assert "still" in result.message
 
     async def test_run_succeeded_on_current_head_passes(self):
+        # CodeQL alerts do not fail the run; conclusion success is what matters.
         runs = InMemoryWorkflowRuns(_run())
         result = await verify_codeql_status(
             _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(_HEAD)
         )
         assert result.is_valid
         assert "#10" in result.message
-
-    async def test_successful_run_with_findings_still_passes(self):
-        # CodeQL alerts do not fail the run; conclusion success is what matters.
-        runs = InMemoryWorkflowRuns(_run(conclusion="success"))
-        result = await verify_codeql_status(
-            _TEST_OWNER, _TEST_REPO, runs, InMemoryRepoRef(_HEAD)
-        )
-        assert result.is_valid
 
     async def test_green_but_stale_head_is_rejected(self):
         runs = InMemoryWorkflowRuns(_run(head_sha="oldsha000"))

--- a/scripts/count_users.py
+++ b/scripts/count_users.py
@@ -38,7 +38,6 @@ async def count_users():
             query = sqlalchemy.text("""
                 SELECT
                     (SELECT COUNT(*) FROM users) as total_users,
-                    (SELECT COUNT(*) FROM users WHERE github_username IS NOT NULL) as users_with_github,
                     (
                         SELECT COUNT(DISTINCT user_id)
                         FROM verification_attempts
@@ -56,10 +55,10 @@ async def count_users():
             row = result.first()
 
             print(f"Total users: {row[0]}")
-            print(f"Users with GitHub: {row[1]}")
-            print(f"Users with attempts: {row[2]}")
-            print(f"Total attempts: {row[3]}")
-            print(f"Total steps completed: {row[4]}")
+            print(f"Users with GitHub: {row[0]}")
+            print(f"Users with attempts: {row[1]}")
+            print(f"Total attempts: {row[2]}")
+            print(f"Total steps completed: {row[3]}")
     finally:
         await engine.dispose()
 

--- a/scripts/dogfood_report_issue_prefill.js
+++ b/scripts/dogfood_report_issue_prefill.js
@@ -99,10 +99,10 @@ function validateIssueUrl(href, expectations) {
     };
 
     console.log(JSON.stringify(output, null, 2));
-    process.exit(output.ok ? 0 : 2);
+    process.exitCode = output.ok ? 0 : 2;
   } catch (err) {
     console.error("ERROR:", err && err.message ? err.message : err);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     await browser.close();
   }


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? -->

Remove confirmed unused code and redundant work identified by a repository-wide audit. This cleans up unused bindings, arguments, configuration and curriculum fields, unreachable template branches, repeated validation, and duplicate test coverage. Public routes, authentication dependencies, and conditional compatibility contracts remain unchanged.

Fix the issue-report utility so browser shutdown runs before exit, and preserve the user-count script's output without repeating a database count.

Add a bounded, reversible migration to remove the orphan `set_typed_submitted_value()` function left after its legacy tables were dropped. The migration refuses to remove dependent objects. App cleanup does not depend on this migration, and existing migration history is unchanged.

Validation: `uv run poe check` passed (980 API tests and 1,183 shared tests). Migration round trips, populated data preservation, and dependency protection are covered. A fresh API served all 69 learner pages and processed local verification failure/success against an isolated copy of the existing local PostgreSQL database. Compiled curriculum output is unchanged; the original database was untouched.

## Checklist

- [ ] This PR changes both `api/alembic/versions/` AND app code that depends on the new schema. If checked, explain why the split isn't being followed.