### PR TITLE
Remove redundant OAuth callback HTTPS rewrite

### DIFF
--- a/api/src/learn_to_cloud/routes/auth_routes.py
+++ b/api/src/learn_to_cloud/routes/auth_routes.py
@@ -75,12 +75,6 @@ async def login(request: Request) -> RedirectResponse:
     previous_states = _prepare_oauth_state(request)
     github.framework.expires_in = get_web_settings().session.oauth_state_max_age_seconds
     redirect_uri = str(request.url_for("auth_callback"))
-    # Azure Container Apps terminates TLS at the load balancer; ensure
-    # the redirect URI uses https so it matches the GitHub OAuth config.
-    if get_web_settings().web_security.require_https and redirect_uri.startswith(
-        "http://"
-    ):
-        redirect_uri = redirect_uri.replace("http://", "https://", 1)
     response = await github.authorize_redirect(request, redirect_uri)
     for key, value in previous_states.items():
         request.session.setdefault(key, value)

--- a/api/tests/routes/test_auth_routes.py
+++ b/api/tests/routes/test_auth_routes.py
@@ -74,46 +74,17 @@ class TestLoginRoute:
 
         with (
             patch("learn_to_cloud.routes.auth_routes.oauth") as mock_oauth,
-            patch(
-                "learn_to_cloud.routes.auth_routes.get_web_settings"
-            ) as mock_settings,
+            patch("learn_to_cloud.routes.auth_routes.get_web_settings"),
         ):
-            mock_settings.return_value.web_security.require_https = False
             mock_oauth.create_client.return_value = mock_github
 
             result = await login(request)
 
         mock_oauth.create_client.assert_called_once_with("github")
         mock_github.authorize_redirect.assert_awaited_once_with(
-            request, "http://testserver/auth/callback"
+            request, str(request.url_for.return_value)
         )
         assert isinstance(result, RedirectResponse)
-
-    async def test_login_forces_https_redirect_uri_when_required(self):
-        """When require_https=True, redirect_uri is rewritten to https."""
-        request = _mock_request()
-        mock_github = MagicMock()
-        mock_github.authorize_redirect = AsyncMock(
-            return_value=RedirectResponse(
-                url="https://github.com/login/oauth/authorize"
-            )
-        )
-
-        with (
-            patch("learn_to_cloud.routes.auth_routes.oauth") as mock_oauth,
-            patch(
-                "learn_to_cloud.routes.auth_routes.get_web_settings"
-            ) as mock_settings,
-        ):
-            mock_settings.return_value.web_security.require_https = True
-            mock_oauth.create_client.return_value = mock_github
-
-            await login(request)
-
-        # The redirect_uri should have been rewritten to https
-        call_args = mock_github.authorize_redirect.call_args
-        redirect_uri = call_args[0][1]
-        assert redirect_uri.startswith("https://")
 
     async def test_login_returns_home_redirect_when_github_not_configured(self):
         """When GitHub OAuth is not configured, redirects to /."""


### PR DESCRIPTION
The OAuth login route now uses the callback URL generated from the request scheme instead of manually replacing HTTP with HTTPS. Azure Container Apps supplies and overwrites `X-Forwarded-Proto`, and the deployed Uvicorn command trusts proxy headers, so HTTPS is handled before the route builds the URL.

The test that required the manual rewrite is removed. The general login test now checks that the generated callback URL is passed through unchanged.

Closes #847