### PR TITLE
Improve phase completion and progression UX

### DIFF
--- a/api/src/learn_to_cloud/rendering/topic_navigation.py
+++ b/api/src/learn_to_cloud/rendering/topic_navigation.py
@@ -13,8 +13,10 @@ def build_topic_nav(
     current_slug: str,
     phase_id: int,
     phase_name: str,
+    *,
+    has_verification: bool = False,
 ) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
-    """Return previous/next topic links, using the phase page at either end."""
+    """Return topic links, continuing to verification after the final topic."""
     current_idx = next((i for i, t in enumerate(topics) if t.slug == current_slug), -1)
     if current_idx == -1:
         return None, None
@@ -34,7 +36,15 @@ def build_topic_nav(
         }
 
     if current_idx == len(topics) - 1:
-        next_topic = phase_link
+        next_topic = (
+            {
+                "label": "Next step",
+                "name": f"Continue to Phase {phase_id} verification",
+                "url": f"/verifications/phase/{phase_id}",
+            }
+            if has_verification
+            else phase_link
+        )
     else:
         next_t = topics[current_idx + 1]
         next_topic = {

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -11,7 +11,9 @@ from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from learn_to_cloud_shared.content_service import (
     get_curriculum_overview,
+    get_next_phase,
     get_phase_by_slug,
+    get_phase_start_url,
 )
 from learn_to_cloud_shared.core.database import DbSession
 from learn_to_cloud_shared.models import User
@@ -36,6 +38,10 @@ from learn_to_cloud.services.community_service import get_community_page_data
 from learn_to_cloud.services.dashboard_service import get_dashboard_data
 from learn_to_cloud.services.progress_service import fetch_phase_progress
 from learn_to_cloud.services.steps_service import get_valid_completed_steps
+from learn_to_cloud.services.transition_telemetry import (
+    build_phase_transition_id,
+    is_valid_phase_transition_id,
+)
 from learn_to_cloud.services.verification_page_service import (
     get_phase_verification_workspace,
     get_verifications_overview,
@@ -111,6 +117,22 @@ async def phase_page(
     has_verification = bool(
         phase.hands_on_verification and phase.hands_on_verification.requirements
     )
+    next_phase = get_next_phase(phase.order)
+    phase_transition_id = (
+        build_phase_transition_id(
+            account.id,
+            source_phase=phase.order,
+            target_phase=next_phase.order,
+        )
+        if next_phase is not None
+        else None
+    )
+    next_phase_start_url = get_phase_start_url(next_phase) if next_phase else None
+    if next_phase_start_url and phase_transition_id:
+        next_phase_start_url = (
+            f"{next_phase_start_url}?from_phase={phase.order}"
+            f"&transition={phase_transition_id}"
+        )
 
     return templates.TemplateResponse(
         request,
@@ -121,6 +143,9 @@ async def phase_page(
             topics=topics,
             phase_progress=detail,
             has_verification=has_verification,
+            next_phase=next_phase,
+            next_phase_start_url=next_phase_start_url,
+            phase_transition_id=phase_transition_id,
         ),
     )
 
@@ -173,6 +198,22 @@ async def phase_verification_page(
         account.github_username,
         history_page=history_page,
     )
+    next_phase = get_next_phase(phase.order)
+    phase_transition_id = (
+        build_phase_transition_id(
+            account.id,
+            source_phase=phase.order,
+            target_phase=next_phase.order,
+        )
+        if next_phase is not None
+        else None
+    )
+    next_phase_start_url = get_phase_start_url(next_phase) if next_phase else None
+    if next_phase_start_url and phase_transition_id:
+        next_phase_start_url = (
+            f"{next_phase_start_url}?from_phase={phase.order}"
+            f"&transition={phase_transition_id}"
+        )
     return templates.TemplateResponse(
         request,
         "pages/verification_phase.html",
@@ -185,6 +226,9 @@ async def phase_verification_page(
             verification_locked=workspace.verification_locked,
             prerequisite_phase_id=workspace.prerequisite_phase_id,
             history=workspace.history,
+            next_phase=next_phase,
+            next_phase_start_url=next_phase_start_url,
+            phase_transition_id=phase_transition_id,
         ),
     )
 
@@ -217,6 +261,26 @@ async def topic_page(
         )
 
     completed_step_uuids = await get_valid_completed_steps(db, account.id, topic)
+    phase_started_transition_id: str | None = None
+    source_phase_value = request.query_params.get("from_phase")
+    transition_id = request.query_params.get("transition")
+    if transition_id and source_phase_value and topic == phase.topics[0]:
+        try:
+            source_phase = int(source_phase_value)
+        except ValueError:
+            source_phase = -1
+        previous_next_phase = get_next_phase(source_phase)
+        if (
+            previous_next_phase is not None
+            and previous_next_phase.order == phase.order
+            and is_valid_phase_transition_id(
+                transition_id,
+                account.id,
+                source_phase=source_phase,
+                target_phase=phase.order,
+            )
+        ):
+            phase_started_transition_id = transition_id
 
     all_topics = phase.topics
     prev_topic, next_topic = build_topic_nav(
@@ -243,6 +307,8 @@ async def topic_page(
             prev_topic=prev_topic,
             next_topic=next_topic,
             progress=progress,
+            phase_started_transition_id=phase_started_transition_id,
+            source_phase=source_phase_value,
         ),
     )
 

--- a/api/src/learn_to_cloud/routes/pages_routes.py
+++ b/api/src/learn_to_cloud/routes/pages_routes.py
@@ -284,7 +284,13 @@ async def topic_page(
 
     all_topics = phase.topics
     prev_topic, next_topic = build_topic_nav(
-        all_topics, topic_slug, phase_id, phase.name
+        all_topics,
+        topic_slug,
+        phase_id,
+        phase.name,
+        has_verification=bool(
+            phase.hands_on_verification and phase.hands_on_verification.requirements
+        ),
     )
 
     total_steps = len(topic.learning_steps)

--- a/api/src/learn_to_cloud/services/community_service.py
+++ b/api/src/learn_to_cloud/services/community_service.py
@@ -39,8 +39,11 @@ async def get_community_page_data(db: AsyncSession) -> CommunityPageData:
         completers_by_phase.setdefault(order, set()).add(user_id)
 
     # Only phases with at least one requirement are "completable".
+    required_orders = {phase.order for phase in phases if phase.required_for_graduation}
     completable_orders = sorted(
-        order for order, total in requirement_counts.items() if total > 0
+        order
+        for order, total in requirement_counts.items()
+        if total > 0 and order in required_orders
     )
 
     activity_rows = await attempt_repository.get_community_activity(

--- a/api/src/learn_to_cloud/services/dashboard_service.py
+++ b/api/src/learn_to_cloud/services/dashboard_service.py
@@ -32,6 +32,7 @@ def _build_phase_summary(
     return PhaseSummaryData(
         order=phase.order,
         name=phase.name,
+        required_for_graduation=phase.required_for_graduation,
         progress=progress_data,
     )
 
@@ -85,4 +86,7 @@ async def get_dashboard_data(
         total_phases=user_progress.total_phases,
         is_program_complete=is_program_complete,
         continue_phase=continue_phase,
+        optional_phases=[
+            phase for phase in phase_summaries if not phase.required_for_graduation
+        ],
     )

--- a/api/src/learn_to_cloud/services/progress_service.py
+++ b/api/src/learn_to_cloud/services/progress_service.py
@@ -115,7 +115,10 @@ async def fetch_user_progress(
 
     return UserProgress(
         phases=phase_progress_map,
-        total_phases=len(phase_overview),
+        total_phases=sum(phase.required_for_graduation for phase in phase_overview),
+        required_phase_orders=frozenset(
+            phase.order for phase in phase_overview if phase.required_for_graduation
+        ),
     )
 
 

--- a/api/src/learn_to_cloud/services/transition_telemetry.py
+++ b/api/src/learn_to_cloud/services/transition_telemetry.py
@@ -1,0 +1,34 @@
+"""Privacy-preserving identifiers for phase transition measurements."""
+
+import hashlib
+import hmac
+
+from learn_to_cloud_shared.core.config import get_web_settings
+
+
+def build_phase_transition_id(
+    user_id: int,
+    *,
+    source_phase: int,
+    target_phase: int,
+) -> str:
+    """Create an opaque identifier scoped to one learner phase transition."""
+    payload = f"phase-transition:v1:{user_id}:{source_phase}:{target_phase}".encode()
+    secret = get_web_settings().session.secret_key.encode()
+    return hmac.new(secret, payload, hashlib.sha256).hexdigest()[:24]
+
+
+def is_valid_phase_transition_id(
+    transition_id: str,
+    user_id: int,
+    *,
+    source_phase: int,
+    target_phase: int,
+) -> bool:
+    """Validate a transition identifier without exposing learner identity."""
+    expected = build_phase_transition_id(
+        user_id,
+        source_phase=source_phase,
+        target_phase=target_phase,
+    )
+    return hmac.compare_digest(transition_id, expected)

--- a/api/src/learn_to_cloud/static/js/frontend-telemetry.js
+++ b/api/src/learn_to_cloud/static/js/frontend-telemetry.js
@@ -44,10 +44,54 @@
     telemetry.loadAppInsights();
     telemetry.trackPageView();
 
+    function eventProperties(element) {
+        return {
+            phase: element.dataset.telemetryPhase || '',
+            nextPhase: element.dataset.telemetryNextPhase || '',
+            phaseOptional: element.dataset.telemetryPhaseOptional || '',
+            nextPhaseOptional: element.dataset.telemetryNextPhaseOptional || '',
+            transitionId: element.dataset.telemetryTransitionId || ''
+        };
+    }
+
+    function trackViewEvents(root) {
+        if (!root || !root.querySelectorAll) {
+            return;
+        }
+        root.querySelectorAll('[data-telemetry-view-event]').forEach(function (element) {
+            if (element.dataset.telemetryTracked === 'true') {
+                return;
+            }
+            element.dataset.telemetryTracked = 'true';
+            telemetry.trackEvent(
+                { name: element.dataset.telemetryViewEvent },
+                eventProperties(element)
+            );
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        trackViewEvents(document);
+    });
+    document.addEventListener('click', function (event) {
+        if (!event.target || !event.target.closest) {
+            return;
+        }
+        var element = event.target.closest('[data-telemetry-event]');
+        if (!element) {
+            return;
+        }
+        telemetry.trackEvent(
+            { name: element.dataset.telemetryEvent },
+            eventProperties(element)
+        );
+    });
+
     // SDK history tracking counts HTMX's replaceState + pushState twice.
     document.addEventListener('htmx:afterSettle', function (event) {
         if (event.detail && event.detail.boosted) {
             telemetry.trackPageView();
+            trackViewEvents(event.detail.elt || document);
         }
     });
     document.addEventListener('htmx:historyRestore', function () {

--- a/api/src/learn_to_cloud/templates/pages/community.html
+++ b/api/src/learn_to_cloud/templates/pages/community.html
@@ -71,7 +71,7 @@
         Curriculum graduates
         <span class="ml-1 text-base font-normal text-gray-500 dark:text-gray-400">({{ community.graduates | length }})</span>
     </h2>
-    <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">Learners who have verified every project across all phases.</p>
+    <p class="mt-3 text-base leading-7 text-gray-600 dark:text-gray-400">Learners who have verified every project in the required technical curriculum.</p>
     {% if community.graduates %}
     <ul class="mt-6 flex flex-wrap gap-x-6 gap-y-3">
         {% for member in community.graduates %}
@@ -89,7 +89,7 @@
         {% endfor %}
     </ul>
     {% else %}
-    <p class="mt-5 text-sm leading-6 text-gray-600 dark:text-gray-400">No learner has verified the entire curriculum yet. The first graduate will appear here.</p>
+    <p class="mt-5 text-sm leading-6 text-gray-600 dark:text-gray-400">No learner has verified the required technical curriculum yet. The first graduate will appear here.</p>
     {% endif %}
 </section>
 

--- a/api/src/learn_to_cloud/templates/pages/dashboard.html
+++ b/api/src/learn_to_cloud/templates/pages/dashboard.html
@@ -27,8 +27,15 @@
 </section>
 {% elif dashboard.is_program_complete and dashboard.phases %}
 <section class="border-b border-gray-200 pb-10 dark:border-gray-700" aria-labelledby="complete-heading">
-    <h2 id="complete-heading" class="section-title">You completed the program.</h2>
-    <p class="mt-2 text-base leading-7 text-gray-600 dark:text-gray-400">Your learning steps and verifications are complete. Your dashboard remains a record of your work.</p>
+    <h2 id="complete-heading" class="section-title">You completed the technical curriculum.</h2>
+    <p class="mt-2 max-w-2xl text-base leading-7 text-gray-600 dark:text-gray-400">Every required learning step and verification is complete. Your dashboard remains a record of your work.</p>
+    {% if dashboard.optional_phases %}
+    {% set optional = dashboard.optional_phases[0] %}
+    <div class="mt-5">
+        <p class="text-sm text-gray-500 dark:text-gray-400">Optional next step</p>
+        <a href="/phase/{{ optional.order }}" class="text-link mt-1">Explore Phase {{ optional.order }}: {{ optional.name }}</a>
+    </div>
+    {% endif %}
 </section>
 {% elif dashboard.phases %}
 <section class="border-b border-gray-200 pb-10 dark:border-gray-700" aria-labelledby="start-heading">
@@ -63,7 +70,7 @@
             <dd class="mt-1 text-xs text-gray-500 dark:text-gray-400">Requirements verified</dd>
         </div>
     </dl>
-    <p class="mt-5 text-sm text-gray-500 dark:text-gray-400">Complete learning steps and verifications in each phase.</p>
+    <p class="mt-5 text-sm text-gray-500 dark:text-gray-400">Progress totals include the phases required for curriculum graduation.</p>
 </section>
 
 <section aria-labelledby="phase-progress-heading">
@@ -79,6 +86,9 @@
             <span class="pt-0.5 font-mono text-sm text-gray-500 dark:text-gray-400">{{ phase.order }}</span>
             <span class="min-w-0">
                 <span class="block text-base font-medium text-gray-950 transition-colors group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ phase.name }}</span>
+                {% if not phase.required_for_graduation %}
+                <span class="mt-1 block text-xs font-medium text-blue-700 dark:text-blue-300">Optional enrichment</span>
+                {% endif %}
                 {% if p and (p.verification.requirements_required > 0 or p.learning.steps_required > 0) %}
                 <span class="mt-1 block text-xs leading-5 text-gray-500 dark:text-gray-400">
                     {%- if p.learning.steps_required > 0 -%}

--- a/api/src/learn_to_cloud/templates/pages/phase.html
+++ b/api/src/learn_to_cloud/templates/pages/phase.html
@@ -26,8 +26,44 @@
         {{ status_pill("Steps remaining", "info") }}
         {% endif %}
         {% endif %}
+        {% if not phase.required_for_graduation %}
+        {{ status_pill("Optional", "info") }}
+        {% endif %}
     </div>
     <div class="phase-description mt-4 max-w-3xl text-base leading-7 text-gray-600 dark:text-gray-300 [&>p]:m-0">{{ phase.description | md | safe }}</div>
+
+    <div class="mt-7 grid gap-5 border-y border-gray-200 py-6 text-sm dark:border-gray-700 sm:grid-cols-2">
+        <div>
+            <h2 class="font-medium text-gray-950 dark:text-white">Estimated time to completion</h2>
+            <p class="mt-2 text-gray-600 dark:text-gray-300">
+                {{ phase.estimated_learning_time.minimum_hours | int }}–{{ phase.estimated_learning_time.maximum_hours | int }} hours learning
+                &middot;
+                {{ phase.estimated_project_time.minimum_hours | int }}–{{ phase.estimated_project_time.maximum_hours | int }} hours project work
+            </p>
+        </div>
+        <div>
+            <h2 class="font-medium text-gray-950 dark:text-white">What completion requires</h2>
+            <p class="mt-2 text-gray-600 dark:text-gray-300">
+                {{ phase_progress.learning.steps_required }} learning steps
+                {% if phase_progress.verification.requirements_required > 0 %}
+                and {{ phase_progress.verification.requirements_required }} verified {% if phase_progress.verification.requirements_required == 1 %}project{% else %}projects{% endif %}
+                {% endif %}
+            </p>
+            <p class="mt-2 text-gray-600 dark:text-gray-300">{{ phase.project_summary }}</p>
+        </div>
+        <div>
+            <h2 class="font-medium text-gray-950 dark:text-white">Before you start</h2>
+            <ul class="mt-2 space-y-1 text-gray-600 dark:text-gray-300">
+                {% for prerequisite in phase.prerequisites %}
+                <li>{{ prerequisite }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+        <div>
+            <h2 class="font-medium text-gray-950 dark:text-white">Expected cost</h2>
+            <p class="mt-2 text-gray-600 dark:text-gray-300">{{ phase.cost_note }}</p>
+        </div>
+    </div>
 
     {% set next_topic = namespace(item=none) %}
     {% for topic in topics %}
@@ -107,10 +143,6 @@
 {% endif %}
 
 {% if phase_progress and phase_progress.status == 'completed' %}
-<section class="mt-14 border-t border-gray-200 pt-8 dark:border-gray-700" aria-labelledby="phase-complete-heading">
-    <h2 id="phase-complete-heading" class="section-title">Phase complete</h2>
-    <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-400">Your learning steps and verification work are complete.</p>
-    <a href="/dashboard" class="text-link mt-4">Return to dashboard</a>
-</section>
+{% include "partials/phase_completion.html" %}
 {% endif %}
 {% endblock %}

--- a/api/src/learn_to_cloud/templates/pages/privacy.html
+++ b/api/src/learn_to_cloud/templates/pages/privacy.html
@@ -93,7 +93,10 @@
             credential, not your profile or user ID. On the server, we store only its digest, account link,
             creation and activity times, and absolute expiry. We do not store IP addresses or device details
             with sessions. We do not use tracking cookies, analytics cookies, or any third-party cookies. Browser
-            telemetry is configured without cookies or browser storage.
+            telemetry is configured without cookies or browser storage. We record aggregate curriculum navigation
+            events, such as opening a phase or selecting the next-phase action, without attaching a GitHub identity.
+            Completion and next-phase events share a one-way, phase-specific identifier so we can measure whether
+            learners continue within one or seven days without tracking their activity across unrelated phases.
         </p>
     </section>
 

--- a/api/src/learn_to_cloud/templates/pages/topic.html
+++ b/api/src/learn_to_cloud/templates/pages/topic.html
@@ -13,6 +13,15 @@
 {% endblock %}
 
 {% block page_header %}
+{% if phase_started_transition_id %}
+<span
+    class="hidden"
+    data-telemetry-view-event="next_phase_started"
+    data-telemetry-phase="{{ source_phase }}"
+    data-telemetry-next-phase="{{ phase_id }}"
+    data-telemetry-transition-id="{{ phase_started_transition_id }}"
+></span>
+{% endif %}
 <h1 class="page-title">{{ topic.name }}</h1>
 {% if topic.description %}
 <p class="mt-3 max-w-3xl text-base leading-7 text-gray-600 dark:text-gray-300">{{ topic.description }}</p>

--- a/api/src/learn_to_cloud/templates/pages/topic.html
+++ b/api/src/learn_to_cloud/templates/pages/topic.html
@@ -101,7 +101,7 @@
 
     <a href="{{ next_topic.url }}" class="group flex min-h-11 min-w-0 items-center justify-end gap-3 rounded-md p-3 text-right hover:bg-gray-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700 dark:hover:bg-gray-800/50 sm:col-start-2">
         <span class="min-w-0">
-            <span class="block text-xs font-bold text-gray-500 dark:text-gray-400">Next topic</span>
+            <span class="block text-xs font-bold text-gray-500 dark:text-gray-400">{{ next_topic.label | default("Next topic", true) }}</span>
             <span class="mt-1 block break-words text-sm font-bold text-gray-950 group-hover:text-blue-700 dark:text-white dark:group-hover:text-blue-300">{{ next_topic.name }}</span>
         </span>
         <svg class="h-5 w-5 shrink-0 text-gray-500 group-hover:text-blue-700 dark:text-gray-400 dark:group-hover:text-blue-300" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="m8 5 5 5-5 5"/></svg>

--- a/api/src/learn_to_cloud/templates/pages/verification_phase.html
+++ b/api/src/learn_to_cloud/templates/pages/verification_phase.html
@@ -52,19 +52,15 @@
     {% endif %}
 </header>
 
-{% if phase_progress.verification.is_complete %}
-<section class="verification-celebration mt-8" data-phase-celebration aria-labelledby="phase-verified-heading" tabindex="-1">
-    <span class="verification-seal" aria-hidden="true">
-        <svg class="h-8 w-8" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path class="verification-checkmark" pathLength="1" stroke-linecap="round" stroke-linejoin="round" d="m5 12 4 4L19 6"/>
-        </svg>
-    </span>
-    <div>
-        <p class="text-xs font-medium uppercase tracking-wider text-green-700 dark:text-green-300">Milestone reached</p>
-        <h2 id="phase-verified-heading" class="mt-1 text-xl font-medium text-gray-900 dark:text-white">Phase {{ phase.order }} verified</h2>
-        <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">Your hands-on work met every requirement. Take a moment to appreciate what you've built.</p>
-        <a href="/verifications" class="text-link mt-2">View your verification journey <span aria-hidden="true">&rarr;</span></a>
-    </div>
+{% if phase_progress.is_complete %}
+<div data-phase-celebration tabindex="-1">
+{% include "partials/phase_completion.html" %}
+</div>
+{% elif phase_progress.verification.is_complete %}
+<section class="mt-8 border-l-2 border-blue-600 pl-5">
+    <h2 class="section-title">Verification complete</h2>
+    <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">Your project passed. Check the remaining learning steps before moving to the next phase.</p>
+    <a href="/phase/{{ phase.order }}" class="text-link mt-3">Finish Phase {{ phase.order }} learning</a>
 </section>
 {% endif %}
 

--- a/api/src/learn_to_cloud/templates/pages/verification_phase.html
+++ b/api/src/learn_to_cloud/templates/pages/verification_phase.html
@@ -36,6 +36,7 @@
         <a href="/phase/{{ phase.order }}" class="text-link">
             Review Phase {{ phase.order }} learning
         </a>
+        <a href="/dashboard" class="text-link">Return to dashboard</a>
     </div>
 
     {% if phase_progress.verification.requirements_required > 0 %}

--- a/api/src/learn_to_cloud/templates/partials/phase_completion.html
+++ b/api/src/learn_to_cloud/templates/partials/phase_completion.html
@@ -1,0 +1,64 @@
+<section
+    class="mt-8 border-l-2 border-green-600 pl-5"
+    aria-labelledby="phase-complete-heading"
+    data-telemetry-view-event="phase_completion_viewed"
+    data-telemetry-phase="{{ phase.order }}"
+    {% if next_phase %}data-telemetry-next-phase="{{ next_phase.order }}"{% endif %}
+    {% if phase_transition_id %}data-telemetry-transition-id="{{ phase_transition_id }}"{% endif %}
+>
+    {% if next_phase and not next_phase.required_for_graduation and phase.required_for_graduation %}
+    <p class="text-xs font-medium uppercase tracking-wider text-green-700 dark:text-green-300">Technical curriculum complete</p>
+    <h2 id="phase-complete-heading" class="mt-1 section-title">You completed the required curriculum.</h2>
+    {% elif phase.required_for_graduation %}
+    <p class="text-xs font-medium uppercase tracking-wider text-green-700 dark:text-green-300">Milestone reached</p>
+    <h2 id="phase-complete-heading" class="mt-1 section-title">Phase {{ phase.order }} complete</h2>
+    {% else %}
+    <p class="text-xs font-medium uppercase tracking-wider text-green-700 dark:text-green-300">Optional milestone reached</p>
+    <h2 id="phase-complete-heading" class="mt-1 section-title">Phase {{ phase.order }} complete</h2>
+    {% endif %}
+
+    <p class="mt-3 max-w-3xl text-sm leading-6 text-gray-600 dark:text-gray-300">{{ phase.completion_summary }}</p>
+
+    {% if next_phase %}
+    <div class="mt-7 max-w-3xl border-t border-gray-200 pt-6 dark:border-gray-700">
+        <p class="text-sm text-gray-500 dark:text-gray-400">
+            {% if next_phase.required_for_graduation %}Up next{% else %}Optional next step{% endif %}
+        </p>
+        <h3 class="mt-1 text-lg font-medium text-gray-950 dark:text-white">Phase {{ next_phase.order }}: {{ next_phase.name }}</h3>
+        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">{{ next_phase.short_description }}</p>
+        <dl class="mt-4 grid gap-3 text-sm text-gray-600 dark:text-gray-300 sm:grid-cols-2">
+            <div>
+                <dt class="font-medium text-gray-950 dark:text-white">Estimated time</dt>
+                <dd class="mt-1">
+                    {{ (next_phase.estimated_learning_time.minimum_hours + next_phase.estimated_project_time.minimum_hours) | int }}–{{ (next_phase.estimated_learning_time.maximum_hours + next_phase.estimated_project_time.maximum_hours) | int }} hours
+                </dd>
+            </div>
+            <div>
+                <dt class="font-medium text-gray-950 dark:text-white">What you will build</dt>
+                <dd class="mt-1">{{ next_phase.project_summary }}</dd>
+            </div>
+        </dl>
+        <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">{{ next_phase.cost_note }}</p>
+        <div class="mt-5 flex flex-wrap items-center gap-x-5 gap-y-3">
+            <a
+                href="{{ next_phase_start_url }}"
+                class="button-primary"
+                data-telemetry-event="next_phase_cta_clicked"
+                data-telemetry-phase="{{ phase.order }}"
+                data-telemetry-next-phase="{{ next_phase.order }}"
+                data-telemetry-next-phase-optional="{{ 'true' if not next_phase.required_for_graduation else 'false' }}"
+                {% if phase_transition_id %}data-telemetry-transition-id="{{ phase_transition_id }}"{% endif %}
+            >
+                {% if next_phase.required_for_graduation %}Start Phase {{ next_phase.order }}{% else %}Explore optional Phase {{ next_phase.order }}{% endif %}
+            </a>
+            <a href="/dashboard" class="text-link">Return to dashboard</a>
+            <a href="/verifications" class="text-link">View verification journey</a>
+        </div>
+    </div>
+    {% else %}
+    <div class="mt-5 flex flex-wrap gap-x-5 gap-y-3">
+        <a href="/dashboard" class="button-primary">Return to dashboard</a>
+        <a href="/verifications" class="text-link">View verification journey</a>
+    </div>
+    {% endif %}
+</section>

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -532,6 +532,8 @@ class TestPhaseVerificationCardStates:
         assert ':disabled="!valid"' in html
         assert 'href="/phase/1"' in html
         assert "Review Phase 1 learning" in html
+        assert 'href="/dashboard"' in html
+        assert "Return to dashboard" in html
 
     def test_token_form_uses_configured_length_limits(self):
         from learn_to_cloud_shared_test_support.requirement_factories import (

--- a/api/tests/rendering/test_template_rendering.py
+++ b/api/tests/rendering/test_template_rendering.py
@@ -756,7 +756,17 @@ def test_phase_progress_uses_distinct_labels_without_explanatory_copy():
     )
     html = _render(
         "pages/phase.html",
-        phase=SimpleNamespace(name="Phase 1", description="", order=1),
+        phase=SimpleNamespace(
+            name="Phase 1",
+            description="",
+            order=1,
+            estimated_learning_time=SimpleNamespace(minimum_hours=4, maximum_hours=6),
+            estimated_project_time=SimpleNamespace(minimum_hours=2, maximum_hours=4),
+            project_summary="Complete the project.",
+            prerequisites=["Phase 0"],
+            cost_note="Free.",
+            required_for_graduation=True,
+        ),
         topics=[],
         phase_progress=phase_progress,
         has_verification=False,
@@ -787,7 +797,17 @@ def test_phase_page_links_to_verification_workspace_without_rendering_form():
 
     html = _render(
         "pages/phase.html",
-        phase=SimpleNamespace(name="Phase 4", description="", order=4),
+        phase=SimpleNamespace(
+            name="Phase 4",
+            description="",
+            order=4,
+            estimated_learning_time=SimpleNamespace(minimum_hours=4, maximum_hours=6),
+            estimated_project_time=SimpleNamespace(minimum_hours=2, maximum_hours=4),
+            project_summary="Deploy the project.",
+            prerequisites=["Phase 3"],
+            cost_note="Cloud charges may apply.",
+            required_for_graduation=True,
+        ),
         topics=[],
         phase_progress=phase_progress,
         has_verification=True,
@@ -796,6 +816,44 @@ def test_phase_page_links_to_verification_workspace_without_rendering_form():
     assert 'href="/verifications/phase/4"' in html
     assert "Continue verification" in html
     assert 'hx-post="/htmx/github/submit"' not in html
+
+
+@pytest.mark.unit
+def test_phase_completion_links_directly_to_next_phase_first_topic():
+    phases = get_all_phases_from_yaml()
+    phase = phases[1]
+    next_phase = phases[2]
+
+    html = _render(
+        "partials/phase_completion.html",
+        phase=phase,
+        next_phase=next_phase,
+        next_phase_start_url=f"/phase/{next_phase.order}/{next_phase.topics[0].slug}",
+    )
+
+    assert phase.completion_summary in html
+    assert "Start Phase 2" in html
+    assert f'href="/phase/2/{next_phase.topics[0].slug}"' in html
+    assert "Estimated time" in html
+    assert 'data-telemetry-event="next_phase_cta_clicked"' in html
+
+
+@pytest.mark.unit
+def test_required_curriculum_completion_offers_optional_job_prep():
+    phases = get_all_phases_from_yaml()
+    phase = phases[6]
+    next_phase = phases[7]
+
+    html = _render(
+        "partials/phase_completion.html",
+        phase=phase,
+        next_phase=next_phase,
+        next_phase_start_url=f"/phase/{next_phase.order}/{next_phase.topics[0].slug}",
+    )
+
+    assert "You completed the required curriculum." in html
+    assert "Optional next step" in html
+    assert "Explore optional Phase 7" in html
 
 
 @pytest.mark.unit
@@ -1122,7 +1180,7 @@ class TestDashboardPrimaryState:
             help_links=[],
         )
 
-        assert "You completed the program." in html
+        assert "You completed the technical curriculum." in html
 
     def test_missing_curriculum_sees_recovery_state(self):
         html = _render(
@@ -1237,7 +1295,10 @@ class TestDashboardPhaseRow:
             requirements_required=2,
         )
         html = self._render_dashboard(progress)
-        assert "Complete learning steps and verifications in each phase." in html
+        assert (
+            "Progress totals include the phases required for curriculum graduation."
+            in html
+        )
         assert "Verification progress" in html
         assert "Learning progress" in html
         assert "Requirements verified" in html

--- a/api/tests/rendering/test_topic_navigation.py
+++ b/api/tests/rendering/test_topic_navigation.py
@@ -40,6 +40,22 @@ class TestBuildTopicNav:
         assert prev_t == {"name": "Second", "url": "/phase/0/second"}
         assert next_t == {"name": "Phase 0", "url": "/phase/0"}
 
+    def test_last_topic_continues_to_verification_when_available(self):
+        prev_t, next_t = build_topic_nav(
+            self._topics(),
+            "third",
+            1,
+            "Linux and Bash",
+            has_verification=True,
+        )
+
+        assert prev_t == {"name": "Second", "url": "/phase/1/second"}
+        assert next_t == {
+            "label": "Next step",
+            "name": "Continue to Phase 1 verification",
+            "url": "/verifications/phase/1",
+        }
+
     def test_unknown_slug_returns_none(self):
         prev_t, next_t = build_topic_nav(self._topics(), "nonexistent", 0, "Phase 0")
         assert prev_t is None

--- a/api/tests/services/test_community_service.py
+++ b/api/tests/services/test_community_service.py
@@ -44,7 +44,12 @@ async def test_graduates_are_full_curriculum_completers(
     db_session: AsyncSession,
 ) -> None:
     counts = get_requirement_counts_by_phase()
-    completable = sorted(order for order, count in counts.items() if count > 0)
+    catalog = get_curriculum_catalog()
+    completable = sorted(
+        phase.order
+        for phase in catalog.phases
+        if phase.required_for_graduation and counts[phase.order] > 0
+    )
     db_session.add_all(
         [
             User(

--- a/api/tests/services/test_progress_service.py
+++ b/api/tests/services/test_progress_service.py
@@ -20,6 +20,7 @@ from learn_to_cloud_shared.schemas import (
     PhaseHandsOnVerificationOverview,
     PhaseProgress,
     Topic,
+    UserProgress,
     VerificationProgress,
 )
 from learn_to_cloud_shared_test_support.requirement_factories import (
@@ -34,6 +35,34 @@ from learn_to_cloud.services.progress_service import (
     phase_progress_to_data,
     resolve_continue_destination,
 )
+
+
+def test_optional_phase_does_not_block_program_completion() -> None:
+    progress = UserProgress(
+        phases={
+            0: PhaseProgress(
+                learning=LearningProgress(steps_completed=1, steps_required=1),
+                verification=VerificationProgress(
+                    requirements_verified=1, requirements_required=1
+                ),
+            ),
+            1: PhaseProgress(
+                learning=LearningProgress(steps_completed=0, steps_required=1),
+                verification=VerificationProgress(
+                    requirements_verified=0, requirements_required=1
+                ),
+            ),
+        },
+        total_phases=1,
+        required_phase_orders=frozenset({0}),
+    )
+
+    assert progress.phases_completed == 1
+    assert progress.is_program_complete is True
+    assert progress.current_phase == 0
+    assert progress.overall_learning_percentage == 100.0
+    assert progress.overall_verification_percentage == 100.0
+
 
 # ---------------------------------------------------------------------------
 # Test helpers

--- a/api/tests/services/test_transition_telemetry.py
+++ b/api/tests/services/test_transition_telemetry.py
@@ -1,0 +1,49 @@
+"""Tests for privacy-preserving phase transition identifiers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from learn_to_cloud.services.transition_telemetry import (
+    build_phase_transition_id,
+    is_valid_phase_transition_id,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_transition_id_is_stable_and_scoped() -> None:
+    settings = MagicMock()
+    settings.session.secret_key = "test-secret"
+
+    with patch(
+        "learn_to_cloud.services.transition_telemetry.get_web_settings",
+        return_value=settings,
+    ):
+        transition_id = build_phase_transition_id(12345, source_phase=1, target_phase=2)
+        repeated = build_phase_transition_id(12345, source_phase=1, target_phase=2)
+        different_phase = build_phase_transition_id(
+            12345, source_phase=2, target_phase=3
+        )
+
+    assert transition_id == repeated
+    assert transition_id != different_phase
+    assert "12345" not in transition_id
+    assert len(transition_id) == 24
+
+    with patch(
+        "learn_to_cloud.services.transition_telemetry.get_web_settings",
+        return_value=settings,
+    ):
+        assert is_valid_phase_transition_id(
+            transition_id,
+            12345,
+            source_phase=1,
+            target_phase=2,
+        )
+        assert not is_valid_phase_transition_id(
+            transition_id,
+            54321,
+            source_phase=1,
+            target_phase=2,
+        )

--- a/api/tests/test_telemetry_contracts.py
+++ b/api/tests/test_telemetry_contracts.py
@@ -118,6 +118,75 @@ console.log(JSON.stringify({{ items, calls }}));
     assert exception["data"] == {"url": url}
     assert exception["baseData"]["exceptions"] == [{"message": "Script failed"}]
     assert event["baseData"]["name"] == "action"
+
+
+def test_frontend_tracks_only_phase_transition_metadata():
+    script = _ROOT / "api/src/learn_to_cloud/static/js/frontend-telemetry.js"
+    test_script = f"""
+const events = [];
+const listeners = {{}};
+const viewElement = {{
+  dataset: {{
+    telemetryViewEvent: 'phase_completion_viewed',
+    telemetryPhase: '1',
+    telemetryNextPhase: '2'
+  }}
+}};
+const clickElement = {{
+  dataset: {{
+    telemetryEvent: 'next_phase_cta_clicked',
+    telemetryPhase: '1',
+    telemetryNextPhase: '2',
+    telemetryNextPhaseOptional: 'false',
+    telemetryTransitionId: 'opaque-transition'
+  }}
+}};
+global.document = {{
+  addEventListener: (name, callback) => {{ listeners[name] = callback; }},
+  querySelectorAll: () => [viewElement]
+}};
+global.window = {{
+  location: {{ origin: 'https://learntocloud.guide' }},
+  appInsights: {{
+    addTelemetryInitializer: () => {{}},
+    loadAppInsights: () => {{}},
+    trackPageView: () => {{}},
+    trackEvent: (event, properties) => events.push({{ event, properties }})
+  }}
+}};
+require({str(script)!r});
+listeners['DOMContentLoaded']();
+listeners.click({{
+  target: {{ closest: () => clickElement }}
+}});
+console.log(JSON.stringify(events));
+"""
+    result = subprocess.run(
+        ["node", "-e", test_script], check=True, capture_output=True, text=True
+    )
+    events = json.loads(result.stdout)
+    assert events == [
+        {
+            "event": {"name": "phase_completion_viewed"},
+            "properties": {
+                "phase": "1",
+                "nextPhase": "2",
+                "phaseOptional": "",
+                "nextPhaseOptional": "",
+                "transitionId": "",
+            },
+        },
+        {
+            "event": {"name": "next_phase_cta_clicked"},
+            "properties": {
+                "phase": "1",
+                "nextPhase": "2",
+                "phaseOptional": "",
+                "nextPhaseOptional": "false",
+                "transitionId": "opaque-transition",
+            },
+        },
+    ]
     assert "secret" not in result.stdout
     assert "password" not in result.stdout
 

--- a/docs/curriculum.md
+++ b/docs/curriculum.md
@@ -16,6 +16,18 @@ Authored YAML lives under
 Each phase directory contains `_phase.yaml`, topic files, and requirement files.
 The phase file owns topic and requirement order.
 
+Each phase also declares learner-facing completion metadata: broad learning and
+project time ranges, prerequisites, expected cost, a completion summary, and
+whether the phase is required for graduation. Optional phases remain available
+in progress and verification views but do not block curriculum graduation.
+
+Completion pages emit anonymous browser events for the completion view and
+next-phase action. Both events use the same one-way, phase-specific transition
+identifier. The first topic in the destination phase validates that identifier
+and emits `next_phase_started`, allowing aggregate 1-day and 7-day conversion
+queries without sending a GitHub username or database user ID to browser
+telemetry.
+
 `scripts/compile_curriculum.py` validates the complete tree and writes the
 packaged `content/curriculum.json` artifact. CI rejects a branch when generated
 artifact content differs from the committed artifact.

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.json
@@ -1,10 +1,20 @@
 {
   "artifact_schema_version": 1,
-  "content_hash": "1f50db3980694cd2010c0e2ec3dff60ba5ab23b6115003b6f1303e4fdcff8d16",
-  "curriculum_version": 21,
+  "content_hash": "b68511e3d848e398b14cd843bdc0706805498740c9e447d78d57053db419ed53",
+  "curriculum_version": 22,
   "phases": [
     {
+      "completion_summary": "You built a foundation in Linux, networking, programming, cloud computing, and DevOps and created a public learning profile.",
+      "cost_note": "Free. This phase does not require paid cloud resources.",
       "description": "This phase is designed for complete beginners who are starting from zero and want to build toward cloud engineering. You will learn the core ideas behind Linux, networking, programming, cloud computing, and DevOps in a beginner-friendly sequence. A strong foundation here will make every later phase easier to understand and apply in real projects.",
+      "estimated_learning_time": {
+        "maximum_hours": 12.0,
+        "minimum_hours": 8.0
+      },
+      "estimated_project_time": {
+        "maximum_hours": 2.0,
+        "minimum_hours": 1.0
+      },
       "hands_on_verification": {
         "requirement_slugs": [
           "profile-readme"
@@ -22,6 +32,12 @@
       },
       "name": "Starting from Zero",
       "order": 0,
+      "prerequisites": [
+        "A GitHub account",
+        "A computer with a modern web browser"
+      ],
+      "project_summary": "Create a public GitHub profile README that introduces your learning goals.",
+      "required_for_graduation": true,
       "short_description": "Build your beginner-friendly IT foundation across Linux, networking, programming, cloud computing, and DevOps.",
       "slug": "phase0",
       "topic_slugs": [
@@ -673,7 +689,17 @@
       "uuid": "be385f44-1086-4b97-bfbb-b652540ad228"
     },
     {
+      "completion_summary": "You demonstrated practical Linux navigation, permissions, Bash, Git, cloud CLI, Infrastructure as Code, and SSH skills.",
+      "cost_note": "Free. The Linux CTF and supporting tools do not require paid cloud resources.",
       "description": "Phase 1 gets you hands-on immediately with Linux and Bash through a Capture The Flag (CTF) lab. You\u2019ll build the foundation needed to access and complete the lab by setting up your environment, learning core command-line workflows, and practicing the tools you\u2019ll use throughout the rest of the curriculum.",
+      "estimated_learning_time": {
+        "maximum_hours": 16.0,
+        "minimum_hours": 10.0
+      },
+      "estimated_project_time": {
+        "maximum_hours": 8.0,
+        "minimum_hours": 4.0
+      },
       "hands_on_verification": {
         "requirement_slugs": [
           "linux-ctfs-fork",
@@ -706,6 +732,13 @@
       },
       "name": "Linux and Bash",
       "order": 1,
+      "prerequisites": [
+        "Completion of Phase 0",
+        "A GitHub account",
+        "A local Linux environment or WSL"
+      ],
+      "project_summary": "Complete all 18 Linux CTF challenges and submit the completion token.",
+      "required_for_graduation": true,
       "short_description": "Build practical Linux and Bash skills with Git, cloud CLI, SSH, and Infrastructure as Code fundamentals through hands-on CTF lab work.",
       "slug": "phase1",
       "topic_slugs": [
@@ -1434,7 +1467,17 @@
       "uuid": "2cc27dfe-e922-4e98-89bb-c0555af94472"
     },
     {
+      "completion_summary": "You demonstrated how IP addressing, routing, DNS, HTTP, ports, and network troubleshooting fit together.",
+      "cost_note": "Free. The networking lab runs locally and does not require paid cloud resources.",
       "description": "Welcome to Phase 2! This phase covers the core networking concepts you need before diving into cloud infrastructure. Understanding how networks work\u2014IP addressing, routing, DNS, and common protocols\u2014is essential for cloud engineering. You'll learn to troubleshoot connectivity issues and build a mental model of how data flows across networks.",
+      "estimated_learning_time": {
+        "maximum_hours": 12.0,
+        "minimum_hours": 8.0
+      },
+      "estimated_project_time": {
+        "maximum_hours": 6.0,
+        "minimum_hours": 3.0
+      },
       "hands_on_verification": {
         "requirement_slugs": [
           "networking-lab-fork",
@@ -1467,6 +1510,12 @@
       },
       "name": "Networking Fundamentals",
       "order": 2,
+      "prerequisites": [
+        "Completion of Phase 1",
+        "A local Linux environment or WSL"
+      ],
+      "project_summary": "Complete the networking troubleshooting lab and submit its completion token.",
+      "required_for_graduation": true,
       "short_description": "Learn core networking: IP/subnetting, routing, DNS, HTTP, ports, and troubleshooting. Build the foundation for cloud networking.",
       "slug": "phase2",
       "topic_slugs": [
@@ -1972,7 +2021,17 @@
       "uuid": "9a45b1ee-ff89-4b59-9708-6c7c6229e8bb"
     },
     {
+      "completion_summary": "You built and tested a Python API with FastAPI, database persistence, and an external AI integration.",
+      "cost_note": "The project can be completed locally. Optional external AI APIs may have usage charges.",
       "description": "Welcome to Phase 3! This phase is all about programming with Python and building real applications. Programming is a fundamental skill for cloud engineering, enabling you to create, manage, and optimize cloud resources efficiently. You'll build a working API with database integration\u2014the foundation for everything that follows.",
+      "estimated_learning_time": {
+        "maximum_hours": 30.0,
+        "minimum_hours": 18.0
+      },
+      "estimated_project_time": {
+        "maximum_hours": 20.0,
+        "minimum_hours": 12.0
+      },
       "hands_on_verification": {
         "requirement_slugs": [
           "journal-api-implementation"
@@ -1992,6 +2051,13 @@
       },
       "name": "Programming Fundamentals",
       "order": 3,
+      "prerequisites": [
+        "Completion of Phase 2",
+        "Python and Git installed locally",
+        "A GitHub account"
+      ],
+      "project_summary": "Build a working Journal API with FastAPI, database persistence, tests, and AI integration.",
+      "required_for_graduation": true,
       "short_description": "Learn Python programming, FastAPI, and databases. Build a real-world Journal API project.",
       "slug": "phase3",
       "topic_slugs": [
@@ -2570,7 +2636,17 @@
       "uuid": "5edbc820-fe9c-4b17-bdb1-91991f0fe9f6"
     },
     {
+      "completion_summary": "You deployed an application on a cloud platform and worked with compute, networking, identity, databases, and managed services.",
+      "cost_note": "Cloud resources may incur charges. Use free tiers where available and remove resources after each exercise.",
       "description": "This phase focuses on cloud platform fundamentals - the core concepts and skills you need to work effectively with cloud services. You'll learn everything from virtual machines and networking to security and application deployment. Through hands-on practice and real-world projects, you'll build the practical experience needed to work with cloud platforms professionally.",
+      "estimated_learning_time": {
+        "maximum_hours": 35.0,
+        "minimum_hours": 20.0
+      },
+      "estimated_project_time": {
+        "maximum_hours": 24.0,
+        "minimum_hours": 12.0
+      },
       "hands_on_verification": {
         "requirement_slugs": [
           "deployed-journal-api"
@@ -2592,6 +2668,13 @@
       },
       "name": "Cloud Platform Fundamentals",
       "order": 4,
+      "prerequisites": [
+        "Completion of Phase 3",
+        "An AWS, Azure, or Google Cloud account",
+        "A working Journal API"
+      ],
+      "project_summary": "Deploy the Journal API publicly on AWS, Azure, or Google Cloud.",
+      "required_for_graduation": true,
       "short_description": "Deploy on AWS, Azure, or GCP: virtual machines, cloud networking, IAM security, databases, and application hosting.",
       "slug": "phase4",
       "topic_slugs": [
@@ -3559,7 +3642,17 @@
       "uuid": "0308493d-4c94-4ea9-b643-6a7f534bacda"
     },
     {
+      "completion_summary": "You containerized, automated, provisioned, deployed, and instrumented your application using modern DevOps practices.",
+      "cost_note": "Cloud and container resources may incur charges. Follow cleanup steps when exercises are complete.",
       "description": "This phase covers DevOps fundamentals - the practices and tools that enable teams to deliver software faster and more reliably. You'll learn containerization, CI/CD pipelines, Infrastructure as Code, container orchestration, and how to instrument your application with OpenTelemetry for cloud-native monitoring.",
+      "estimated_learning_time": {
+        "maximum_hours": 40.0,
+        "minimum_hours": 24.0
+      },
+      "estimated_project_time": {
+        "maximum_hours": 30.0,
+        "minimum_hours": 16.0
+      },
       "hands_on_verification": {
         "requirement_slugs": [
           "devops-implementation"
@@ -3579,6 +3672,13 @@
       },
       "name": "DevOps Fundamentals",
       "order": 5,
+      "prerequisites": [
+        "Completion of Phase 4",
+        "A deployed Journal API",
+        "GitHub Actions and cloud platform access"
+      ],
+      "project_summary": "Add containers, CI/CD, Infrastructure as Code, orchestration, and observability to the deployed Journal API.",
+      "required_for_graduation": true,
       "short_description": "Master Docker containers, Kubernetes orchestration, CI/CD pipelines, Terraform IaC, and OpenTelemetry observability with your cloud provider.",
       "slug": "phase5",
       "topic_slugs": [
@@ -4935,7 +5035,17 @@
       "uuid": "9f4fb0fa-407b-4fe5-9020-dc9c6b44f9e0"
     },
     {
+      "completion_summary": "You hardened a cloud application with identity, secret, network, monitoring, vulnerability-management, and incident-response controls.",
+      "cost_note": "Existing cloud resources may continue to incur charges while you complete and verify the security work.",
       "description": "You've built your Journal API, deployed it to the cloud, and set up CI/CD pipelines. Now it's time to lock it down. Security isn't a separate thing you bolt on at the end\u2014it's something every cloud engineer needs to think about from day one. In this phase, we'll walk you through the key security practices that keep real production apps safe. By the end, your Journal API will be hardened and production-ready.",
+      "estimated_learning_time": {
+        "maximum_hours": 20.0,
+        "minimum_hours": 12.0
+      },
+      "estimated_project_time": {
+        "maximum_hours": 16.0,
+        "minimum_hours": 8.0
+      },
       "hands_on_verification": {
         "requirement_slugs": [
           "security-scanning"
@@ -4955,6 +5065,13 @@
       },
       "name": "Securing Your Cloud Applications",
       "order": 6,
+      "prerequisites": [
+        "Completion of Phase 5",
+        "A deployed Journal API with CI/CD",
+        "Access to your cloud platform security controls"
+      ],
+      "project_summary": "Harden the Journal API and provide verifiable evidence from its security controls and scans.",
+      "required_for_graduation": true,
       "short_description": "Secure your Journal API with IAM, secrets management, network controls, monitoring, and incident response. Make it production-ready.",
       "slug": "phase6",
       "topic_slugs": [
@@ -5781,7 +5898,17 @@
       "uuid": "4fb2871c-ba79-4de7-933c-76bad9639f8e"
     },
     {
+      "completion_summary": "You turned your technical work into a focused resume, interview stories, networking plan, and repeatable job-search strategy.",
+      "cost_note": "Free. This optional phase does not require paid services.",
       "description": "Finishing this curriculum proves discipline, but it does not make you unique. What makes you stand out is what you explored, improved, and built beyond the outline, and this phase helps you turn that into interviews and opportunities. A lot of it is inspired by Cassidoo's [getting-a-gig](https://github.com/cassidoo/getting-a-gig) guide and her excellent [weekly newsletter](https://cassidoo.co/newsletter/), and by [some thoughts I wrote in a community discussion](https://github.com/learntocloud/learn-to-cloud-app/discussions/330#discussioncomment-16742472).",
+      "estimated_learning_time": {
+        "maximum_hours": 12.0,
+        "minimum_hours": 8.0
+      },
+      "estimated_project_time": {
+        "maximum_hours": 6.0,
+        "minimum_hours": 3.0
+      },
       "hands_on_verification": {
         "requirement_slugs": [
           "career-reflection"
@@ -5815,6 +5942,12 @@
       },
       "name": "Interview & Job Prep",
       "order": 7,
+      "prerequisites": [
+        "Completion of the technical curriculum through Phase 6",
+        "Access to your completed project repositories"
+      ],
+      "project_summary": "Produce a focused resume, interview stories, networking plan, and repeatable job-search workflow.",
+      "required_for_graduation": false,
       "short_description": "Turn your cloud skills into a job. Network, tailor your resume, prepare your interview stories, and learn to talk about your work with confidence.",
       "slug": "phase7",
       "topic_slugs": [

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/curriculum.meta.yaml
@@ -5,4 +5,4 @@
 # steps, objectives, or requirements). The compiler enforces that this
 # value strictly increases relative to the previously committed
 # curriculum.json artifact -- it will refuse to compile otherwise.
-curriculum_version: 21
+curriculum_version: 22

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase0/_phase.yaml
@@ -5,6 +5,19 @@ slug: phase0
 description: This phase is designed for complete beginners who are starting from zero and want to build toward cloud engineering. You will learn the core ideas behind Linux, networking, programming, cloud computing, and DevOps in a beginner-friendly sequence. A strong foundation here will make every later phase easier to understand and apply in real projects.
 short_description: Build your beginner-friendly IT foundation across Linux, networking, programming, cloud computing, and DevOps.
 order: 0
+estimated_learning_time:
+  minimum_hours: 8
+  maximum_hours: 12
+estimated_project_time:
+  minimum_hours: 1
+  maximum_hours: 2
+project_summary: Create a public GitHub profile README that introduces your learning goals.
+completion_summary: You built a foundation in Linux, networking, programming, cloud computing, and DevOps and created a public learning profile.
+prerequisites:
+- A GitHub account
+- A computer with a modern web browser
+cost_note: Free. This phase does not require paid cloud resources.
+required_for_graduation: true
 hands_on_verification:
   requirements:
   - profile-readme

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase1/_phase.yaml
@@ -5,6 +5,20 @@ slug: phase1
 description: Phase 1 gets you hands-on immediately with Linux and Bash through a Capture The Flag (CTF) lab. You’ll build the foundation needed to access and complete the lab by setting up your environment, learning core command-line workflows, and practicing the tools you’ll use throughout the rest of the curriculum.
 short_description: Build practical Linux and Bash skills with Git, cloud CLI, SSH, and Infrastructure as Code fundamentals through hands-on CTF lab work.
 order: 1
+estimated_learning_time:
+  minimum_hours: 10
+  maximum_hours: 16
+estimated_project_time:
+  minimum_hours: 4
+  maximum_hours: 8
+project_summary: Complete all 18 Linux CTF challenges and submit the completion token.
+completion_summary: You demonstrated practical Linux navigation, permissions, Bash, Git, cloud CLI, Infrastructure as Code, and SSH skills.
+prerequisites:
+- Completion of Phase 0
+- A GitHub account
+- A local Linux environment or WSL
+cost_note: Free. The Linux CTF and supporting tools do not require paid cloud resources.
+required_for_graduation: true
 hands_on_verification:
   requirements:
   - linux-ctfs-fork

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase2/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase2/_phase.yaml
@@ -5,6 +5,19 @@ slug: phase2
 description: Welcome to Phase 2! This phase covers the core networking concepts you need before diving into cloud infrastructure. Understanding how networks work—IP addressing, routing, DNS, and common protocols—is essential for cloud engineering. You'll learn to troubleshoot connectivity issues and build a mental model of how data flows across networks.
 short_description: 'Learn core networking: IP/subnetting, routing, DNS, HTTP, ports, and troubleshooting. Build the foundation for cloud networking.'
 order: 2
+estimated_learning_time:
+  minimum_hours: 8
+  maximum_hours: 12
+estimated_project_time:
+  minimum_hours: 3
+  maximum_hours: 6
+project_summary: Complete the networking troubleshooting lab and submit its completion token.
+completion_summary: You demonstrated how IP addressing, routing, DNS, HTTP, ports, and network troubleshooting fit together.
+prerequisites:
+- Completion of Phase 1
+- A local Linux environment or WSL
+cost_note: Free. The networking lab runs locally and does not require paid cloud resources.
+required_for_graduation: true
 hands_on_verification:
   requirements:
   - networking-lab-fork

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase3/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase3/_phase.yaml
@@ -5,6 +5,20 @@ slug: phase3
 description: Welcome to Phase 3! This phase is all about programming with Python and building real applications. Programming is a fundamental skill for cloud engineering, enabling you to create, manage, and optimize cloud resources efficiently. You'll build a working API with database integration—the foundation for everything that follows.
 short_description: Learn Python programming, FastAPI, and databases. Build a real-world Journal API project.
 order: 3
+estimated_learning_time:
+  minimum_hours: 18
+  maximum_hours: 30
+estimated_project_time:
+  minimum_hours: 12
+  maximum_hours: 20
+project_summary: Build a working Journal API with FastAPI, database persistence, tests, and AI integration.
+completion_summary: You built and tested a Python API with FastAPI, database persistence, and an external AI integration.
+prerequisites:
+- Completion of Phase 2
+- Python and Git installed locally
+- A GitHub account
+cost_note: The project can be completed locally. Optional external AI APIs may have usage charges.
+required_for_graduation: true
 hands_on_verification:
   requirements:
   - journal-api-implementation

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase4/_phase.yaml
@@ -5,6 +5,20 @@ name: Cloud Platform Fundamentals
 description: This phase focuses on cloud platform fundamentals - the core concepts and skills you need to work effectively with cloud services. You'll learn everything from virtual machines and networking to security and application deployment. Through hands-on practice and real-world projects, you'll build the practical experience needed to work with cloud platforms professionally.
 short_description: 'Deploy on AWS, Azure, or GCP: virtual machines, cloud networking, IAM security, databases, and application hosting.'
 order: 4
+estimated_learning_time:
+  minimum_hours: 20
+  maximum_hours: 35
+estimated_project_time:
+  minimum_hours: 12
+  maximum_hours: 24
+project_summary: Deploy the Journal API publicly on AWS, Azure, or Google Cloud.
+completion_summary: You deployed an application on a cloud platform and worked with compute, networking, identity, databases, and managed services.
+prerequisites:
+- Completion of Phase 3
+- An AWS, Azure, or Google Cloud account
+- A working Journal API
+cost_note: Cloud resources may incur charges. Use free tiers where available and remove resources after each exercise.
+required_for_graduation: true
 topics:
 - vms-compute
 - security-iam

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase5/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase5/_phase.yaml
@@ -5,6 +5,20 @@ name: DevOps Fundamentals
 description: This phase covers DevOps fundamentals - the practices and tools that enable teams to deliver software faster and more reliably. You'll learn containerization, CI/CD pipelines, Infrastructure as Code, container orchestration, and how to instrument your application with OpenTelemetry for cloud-native monitoring.
 short_description: Master Docker containers, Kubernetes orchestration, CI/CD pipelines, Terraform IaC, and OpenTelemetry observability with your cloud provider.
 order: 5
+estimated_learning_time:
+  minimum_hours: 24
+  maximum_hours: 40
+estimated_project_time:
+  minimum_hours: 16
+  maximum_hours: 30
+project_summary: Add containers, CI/CD, Infrastructure as Code, orchestration, and observability to the deployed Journal API.
+completion_summary: You containerized, automated, provisioned, deployed, and instrumented your application using modern DevOps practices.
+prerequisites:
+- Completion of Phase 4
+- A deployed Journal API
+- GitHub Actions and cloud platform access
+cost_note: Cloud and container resources may incur charges. Follow cleanup steps when exercises are complete.
+required_for_graduation: true
 topics:
 - containers
 - cicd

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase6/_phase.yaml
@@ -5,6 +5,20 @@ name: Securing Your Cloud Applications
 description: You've built your Journal API, deployed it to the cloud, and set up CI/CD pipelines. Now it's time to lock it down. Security isn't a separate thing you bolt on at the end—it's something every cloud engineer needs to think about from day one. In this phase, we'll walk you through the key security practices that keep real production apps safe. By the end, your Journal API will be hardened and production-ready.
 short_description: Secure your Journal API with IAM, secrets management, network controls, monitoring, and incident response. Make it production-ready.
 order: 6
+estimated_learning_time:
+  minimum_hours: 12
+  maximum_hours: 20
+estimated_project_time:
+  minimum_hours: 8
+  maximum_hours: 16
+project_summary: Harden the Journal API and provide verifiable evidence from its security controls and scans.
+completion_summary: You hardened a cloud application with identity, secret, network, monitoring, vulnerability-management, and incident-response controls.
+prerequisites:
+- Completion of Phase 5
+- A deployed Journal API with CI/CD
+- Access to your cloud platform security controls
+cost_note: Existing cloud resources may continue to incur charges while you complete and verify the security work.
+required_for_graduation: true
 topics:
 - iam-secrets
 - network-security

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase7/_phase.yaml
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/phases/phase7/_phase.yaml
@@ -5,6 +5,19 @@ name: Interview & Job Prep
 description: Finishing this curriculum proves discipline, but it does not make you unique. What makes you stand out is what you explored, improved, and built beyond the outline, and this phase helps you turn that into interviews and opportunities. A lot of it is inspired by Cassidoo's [getting-a-gig](https://github.com/cassidoo/getting-a-gig) guide and her excellent [weekly newsletter](https://cassidoo.co/newsletter/), and by [some thoughts I wrote in a community discussion](https://github.com/learntocloud/learn-to-cloud-app/discussions/330#discussioncomment-16742472).
 short_description: Turn your cloud skills into a job. Network, tailor your resume, prepare your interview stories, and learn to talk about your work with confidence.
 order: 7
+estimated_learning_time:
+  minimum_hours: 8
+  maximum_hours: 12
+estimated_project_time:
+  minimum_hours: 3
+  maximum_hours: 6
+project_summary: Produce a focused resume, interview stories, networking plan, and repeatable job-search workflow.
+completion_summary: You turned your technical work into a focused resume, interview stories, networking plan, and repeatable job-search strategy.
+prerequisites:
+- Completion of the technical curriculum through Phase 6
+- Access to your completed project repositories
+cost_note: Free. This optional phase does not require paid services.
+required_for_graduation: false
 topics:
 - you-are-not-unique
 - resume-and-applications

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/schemas/phase.schema.json
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content/schemas/phase.schema.json
@@ -843,6 +843,27 @@
       "title": "StepAction",
       "type": "string"
     },
+    "TimeEstimate": {
+      "description": "A deliberately broad estimate for self-paced curriculum work.",
+      "properties": {
+        "maximum_hours": {
+          "minimum": 0,
+          "title": "Maximum Hours",
+          "type": "number"
+        },
+        "minimum_hours": {
+          "minimum": 0,
+          "title": "Minimum Hours",
+          "type": "number"
+        }
+      },
+      "required": [
+        "minimum_hours",
+        "maximum_hours"
+      ],
+      "title": "TimeEstimate",
+      "type": "object"
+    },
     "TipItem": {
       "description": "A tip, note, or warning callout for a learning step.",
       "properties": {
@@ -925,10 +946,26 @@
   },
   "description": "A phase in the curriculum.\n\nPhases use ``slug`` (e.g. ``\"phase0\"``) and ``order`` (int ``0..7``)\nas their human keys. The slug is what shows up in URLs and is the\nprimary lookup key; ``order`` drives display ordering and is also\nused in URL paths today (``/phase/{order}``).",
   "properties": {
+    "completion_summary": {
+      "default": "",
+      "title": "Completion Summary",
+      "type": "string"
+    },
+    "cost_note": {
+      "default": "",
+      "title": "Cost Note",
+      "type": "string"
+    },
     "description": {
       "default": "",
       "title": "Description",
       "type": "string"
+    },
+    "estimated_learning_time": {
+      "$ref": "#/$defs/TimeEstimate"
+    },
+    "estimated_project_time": {
+      "$ref": "#/$defs/TimeEstimate"
     },
     "hands_on_verification": {
       "anyOf": [
@@ -949,6 +986,23 @@
       "default": 0,
       "title": "Order",
       "type": "integer"
+    },
+    "prerequisites": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Prerequisites",
+      "type": "array"
+    },
+    "project_summary": {
+      "default": "",
+      "title": "Project Summary",
+      "type": "string"
+    },
+    "required_for_graduation": {
+      "default": true,
+      "title": "Required For Graduation",
+      "type": "boolean"
     },
     "short_description": {
       "default": "",

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/content_service.py
@@ -44,6 +44,13 @@ def get_curriculum_overview() -> tuple[PhaseOverview, ...]:
             slug=phase.slug,
             description=phase.description,
             short_description=phase.short_description,
+            estimated_learning_time=phase.estimated_learning_time,
+            estimated_project_time=phase.estimated_project_time,
+            project_summary=phase.project_summary,
+            completion_summary=phase.completion_summary,
+            prerequisites=phase.prerequisites,
+            cost_note=phase.cost_note,
+            required_for_graduation=phase.required_for_graduation,
             topics=[
                 TopicOverview(slug=topic.slug, name=topic.name)
                 for topic in phase.topics
@@ -51,6 +58,21 @@ def get_curriculum_overview() -> tuple[PhaseOverview, ...]:
         )
         for phase in catalog.phases
     )
+
+
+def get_next_phase(order: int) -> Phase | None:
+    """Return the phase immediately after ``order``."""
+    candidates = [
+        phase for phase in get_curriculum_catalog().phases if phase.order > order
+    ]
+    return min(candidates, key=lambda phase: phase.order) if candidates else None
+
+
+def get_phase_start_url(phase: Phase) -> str:
+    """Link directly to a phase's first actionable topic."""
+    if phase.topics:
+        return f"/phase/{phase.order}/{phase.topics[0].slug}"
+    return f"/phase/{phase.order}"
 
 
 def get_topic_containing_step(step_uuid: UUID) -> tuple[Topic, LearningStep] | None:

--- a/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
+++ b/packages/learn-to-cloud-shared/src/learn_to_cloud_shared/schemas.py
@@ -449,6 +449,21 @@ class PhaseHandsOnVerificationOverview(FrozenModel):
     requirements: list[HandsOnRequirement] = Field(default_factory=list)
 
 
+class TimeEstimate(FrozenModel):
+    """A deliberately broad estimate for self-paced curriculum work."""
+
+    minimum_hours: float = Field(ge=0)
+    maximum_hours: float = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_range(self) -> Self:
+        if self.maximum_hours < self.minimum_hours:
+            raise ValueError(
+                "maximum_hours must be greater than or equal to minimum_hours"
+            )
+        return self
+
+
 class Phase(FrozenModel):
     """A phase in the curriculum.
 
@@ -467,6 +482,17 @@ class Phase(FrozenModel):
     description: str = ""
     short_description: str = ""
     order: int = 0
+    estimated_learning_time: TimeEstimate = Field(
+        default_factory=lambda: TimeEstimate(minimum_hours=0, maximum_hours=0)
+    )
+    estimated_project_time: TimeEstimate = Field(
+        default_factory=lambda: TimeEstimate(minimum_hours=0, maximum_hours=0)
+    )
+    project_summary: str = ""
+    completion_summary: str = ""
+    prerequisites: list[str] = Field(default_factory=list)
+    cost_note: str = ""
+    required_for_graduation: bool = True
     hands_on_verification: PhaseHandsOnVerificationOverview | None = None
     topic_slugs: list[str] = Field(default_factory=list)
     topics: list[Topic] = Field(default_factory=list)
@@ -490,6 +516,17 @@ class PhaseOverview(FrozenModel):
     slug: str
     description: str = ""
     short_description: str = ""
+    estimated_learning_time: TimeEstimate = Field(
+        default_factory=lambda: TimeEstimate(minimum_hours=0, maximum_hours=0)
+    )
+    estimated_project_time: TimeEstimate = Field(
+        default_factory=lambda: TimeEstimate(minimum_hours=0, maximum_hours=0)
+    )
+    project_summary: str = ""
+    completion_summary: str = ""
+    prerequisites: list[str] = Field(default_factory=list)
+    cost_note: str = ""
+    required_for_graduation: bool = True
     topics: list[TopicOverview] = Field(default_factory=list)
 
 
@@ -576,6 +613,7 @@ class PhaseSummaryData(FrozenModel):
 
     order: int
     name: str
+    required_for_graduation: bool = True
     progress: PhaseProgressData | None = None
 
 
@@ -608,6 +646,7 @@ class DashboardData(FrozenModel):
     total_phases: int
     is_program_complete: bool
     continue_phase: ContinuePhaseData | None = None
+    optional_phases: list[PhaseSummaryData] = Field(default_factory=list)
 
 
 class CommunityMember(FrozenModel):
@@ -728,47 +767,68 @@ class UserProgress(FrozenModel):
 
     phases: dict[int, PhaseProgress]
     total_phases: int
+    required_phase_orders: frozenset[int] = frozenset()
+
+    @property
+    def graduation_phase_orders(self) -> frozenset[int]:
+        """Phase orders that count toward curriculum graduation."""
+        return self.required_phase_orders or frozenset(self.phases)
 
     @computed_field
     @property
     def phases_completed(self) -> int:
-        """Count of fully completed phases (learning AND verification)."""
-        return sum(1 for p in self.phases.values() if p.is_complete)
+        """Count completed phases that are required for graduation."""
+        return sum(
+            1
+            for order, progress in self.phases.items()
+            if order in self.graduation_phase_orders and progress.is_complete
+        )
 
     @computed_field
     @property
     def current_phase(self) -> int:
-        """First incomplete phase, or last phase if all done."""
-        for phase_id in sorted(self.phases.keys()):
+        """First incomplete required phase, or the last required phase."""
+        required_orders = sorted(self.graduation_phase_orders)
+        for phase_id in required_orders:
             if not self.phases[phase_id].is_complete:
                 return phase_id
-        return max(self.phases.keys()) if self.phases else 0
+        return required_orders[-1] if required_orders else 0
 
     @computed_field
     @property
     def is_program_complete(self) -> bool:
-        """True if all phases are completed."""
+        """True if all graduation-required phases are completed."""
         return self.phases_completed >= self.total_phases
 
     @computed_field
     @property
     def overall_learning_percentage(self) -> float:
-        """Item-weighted learning percentage across all phases' current steps."""
-        total_required = sum(p.learning.steps_required for p in self.phases.values())
+        """Item-weighted learning percentage across graduation phases."""
+        required_progress = [
+            progress
+            for order, progress in self.phases.items()
+            if order in self.graduation_phase_orders
+        ]
+        total_required = sum(p.learning.steps_required for p in required_progress)
         if total_required == 0:
             return 100.0
         completed = sum(
             min(p.learning.steps_completed, p.learning.steps_required)
-            for p in self.phases.values()
+            for p in required_progress
         )
         return round((completed / total_required) * 100, 1)
 
     @computed_field
     @property
     def overall_verification_percentage(self) -> float:
-        """Item-weighted verification percentage across all phases' requirements."""
+        """Item-weighted verification percentage across graduation phases."""
+        required_progress = [
+            progress
+            for order, progress in self.phases.items()
+            if order in self.graduation_phase_orders
+        ]
         total_required = sum(
-            p.verification.requirements_required for p in self.phases.values()
+            p.verification.requirements_required for p in required_progress
         )
         if total_required == 0:
             return 100.0
@@ -777,7 +837,7 @@ class UserProgress(FrozenModel):
                 p.verification.requirements_verified,
                 p.verification.requirements_required,
             )
-            for p in self.phases.values()
+            for p in required_progress
         )
         return round((completed / total_required) * 100, 1)
 

--- a/packages/learn-to-cloud-shared/tests/services/test_content_catalog.py
+++ b/packages/learn-to-cloud-shared/tests/services/test_content_catalog.py
@@ -81,6 +81,20 @@ class TestLoadCurriculumCatalog:
         assert catalog.phases
         assert catalog.artifact_schema_version == ARTIFACT_SCHEMA_VERSION
 
+    def test_every_phase_has_completion_metadata(self):
+        catalog = load_curriculum_catalog()
+
+        assert [
+            phase.order for phase in catalog.phases if not phase.required_for_graduation
+        ] == [7]
+        for phase in catalog.phases:
+            assert phase.estimated_learning_time.maximum_hours > 0
+            assert phase.estimated_project_time.maximum_hours > 0
+            assert phase.project_summary
+            assert phase.completion_summary
+            assert phase.prerequisites
+            assert phase.cost_note
+
     def test_missing_artifact_raises(self):
         with (
             _patched_resource(None),


### PR DESCRIPTION
This makes phase completion lead directly into the next phase instead of sending learners through the dashboard or verification overview. Each phase now shows broad learning and project time estimates, prerequisites, expected cost, the project outcome, and a completion summary so learners know what the work requires and what they achieved.

Phase 7 is now explicitly optional and no longer blocks technical curriculum graduation or graduate counts. The dashboard and community page describe that distinction, while completed Phase 6 learners are invited to continue into job preparation as optional enrichment.

Completion views, next-phase clicks, and successful destination loads emit privacy-preserving transition events. A one-way identifier scoped to one learner transition supports aggregate one-day and seven-day continuation analysis without sending GitHub usernames or database user IDs to browser telemetry.

Validation: uv run poe check